### PR TITLE
build: Use old-style private structs to build on GLib 2.36

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -55,9 +55,8 @@ struct _HifContextPrivate
 	gboolean		 keep_cache;
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE (HifContext, hif_context, G_TYPE_OBJECT)
-
-#define GET_PRIVATE(o) (hif_context_get_instance_private (o))
+G_DEFINE_TYPE (HifContext, hif_context, G_TYPE_OBJECT)
+#define GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), HIF_TYPE_CONTEXT, HifContextPrivate))
 
 /**
  * hif_context_finalize:
@@ -99,6 +98,7 @@ hif_context_class_init (HifContextClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	object_class->finalize = hif_context_finalize;
+	g_type_class_add_private (klass, sizeof (HifContextPrivate));
 }
 
 /**

--- a/libhif/hif-db.c
+++ b/libhif/hif-db.c
@@ -52,9 +52,8 @@ struct _HifDbPrivate
 	HifContext		*context;
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE (HifDb, hif_db, G_TYPE_OBJECT)
-
-#define GET_PRIVATE(o) (hif_db_get_instance_private (o))
+G_DEFINE_TYPE (HifDb, hif_db, G_TYPE_OBJECT)
+#define GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), HIF_TYPE_DB, HifDbPrivate))
 
 /**
  * hif_db_finalize:
@@ -86,6 +85,7 @@ hif_db_class_init (HifDbClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	object_class->finalize = hif_db_finalize;
+	g_type_class_add_private (klass, sizeof (HifDbPrivate));
 }
 
 

--- a/libhif/hif-lock.c
+++ b/libhif/hif-lock.c
@@ -54,9 +54,8 @@ typedef struct {
 	HifLockType		 type;
 } HifLockItem;
 
-G_DEFINE_TYPE_WITH_PRIVATE (HifLock, hif_lock, G_TYPE_OBJECT)
-
-#define GET_PRIVATE(o) (hif_lock_get_instance_private (o))
+G_DEFINE_TYPE (HifLock, hif_lock, G_TYPE_OBJECT)
+#define GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), HIF_TYPE_LOCK, HifLockPrivate))
 
 enum {
 	SIGNAL_STATE_CHANGED,
@@ -118,6 +117,7 @@ hif_lock_class_init (HifLockClass *klass)
 			      G_TYPE_NONE, 1, G_TYPE_UINT);
 
 	object_class->finalize = hif_lock_finalize;
+	g_type_class_add_private (klass, sizeof (HifLockPrivate));
 }
 
 /**

--- a/libhif/hif-repos.c
+++ b/libhif/hif-repos.c
@@ -56,9 +56,8 @@ enum {
 
 static guint signals[SIGNAL_LAST] = { 0 };
 
-G_DEFINE_TYPE_WITH_PRIVATE (HifRepos, hif_repos, G_TYPE_OBJECT)
-
-#define GET_PRIVATE(o) (hif_repos_get_instance_private (o))
+G_DEFINE_TYPE (HifRepos, hif_repos, G_TYPE_OBJECT)
+#define GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), HIF_TYPE_REPOS, HifReposPrivate))
 
 /**
  * hif_repos_finalize:
@@ -84,7 +83,7 @@ hif_repos_finalize (GObject *object)
 static void
 hif_repos_invalidate (HifRepos *repos)
 {
-	HifReposPrivate *priv = hif_repos_get_instance_private (repos);
+	HifReposPrivate *priv = GET_PRIVATE (repos);
 	priv->loaded = FALSE;
 	g_ptr_array_set_size (priv->sources, 0);
 }
@@ -135,6 +134,7 @@ hif_repos_class_init (HifReposClass *klass)
 			      G_TYPE_NONE, 0);
 
 	object_class->finalize = hif_repos_finalize;
+	g_type_class_add_private (klass, sizeof (HifReposPrivate));
 }
 
 /**
@@ -147,7 +147,7 @@ hif_repos_add_media (HifRepos *repos,
 		     GError **error)
 {
 	GKeyFile *treeinfo;
-	HifReposPrivate *priv = hif_repos_get_instance_private (repos);
+	HifReposPrivate *priv = GET_PRIVATE (repos);
 	HifSource *source;
 	gboolean ret = TRUE;
 	gchar *tmp;
@@ -337,7 +337,7 @@ hif_repos_source_parse (HifRepos *repos,
 			const gchar *filename,
 			GError **error)
 {
-	HifReposPrivate *priv = hif_repos_get_instance_private (repos);
+	HifReposPrivate *priv = GET_PRIVATE (repos);
 	gboolean has_enabled;
 	gboolean is_enabled;
 	gboolean ret = TRUE;
@@ -412,7 +412,7 @@ static gboolean
 hif_repos_refresh (HifRepos *repos, GError **error)
 {
 	GDir *dir = NULL;
-	HifReposPrivate *priv = hif_repos_get_instance_private (repos);
+	HifReposPrivate *priv = GET_PRIVATE (repos);
 	const gchar *file;
 	const gchar *repo_path;
 	gboolean ret = TRUE;
@@ -462,7 +462,7 @@ out:
 gboolean
 hif_repos_has_removable (HifRepos *repos)
 {
-	HifReposPrivate *priv = hif_repos_get_instance_private (repos);
+	HifReposPrivate *priv = GET_PRIVATE (repos);
 	HifSource *src;
 	guint i;
 
@@ -484,7 +484,7 @@ GPtrArray *
 hif_repos_get_sources (HifRepos *repos, GError **error)
 {
 	GPtrArray *sources = NULL;
-	HifReposPrivate *priv = hif_repos_get_instance_private (repos);
+	HifReposPrivate *priv = GET_PRIVATE (repos);
 	gboolean ret;
 
 	g_return_val_if_fail (HIF_IS_REPOS (repos), NULL);
@@ -509,7 +509,7 @@ out:
 HifSource *
 hif_repos_get_source_by_id (HifRepos *repos, const gchar *id, GError **error)
 {
-	HifReposPrivate *priv = hif_repos_get_instance_private (repos);
+	HifReposPrivate *priv = GET_PRIVATE (repos);
 	HifSource *src = NULL;
 	HifSource *tmp;
 	gboolean ret;
@@ -566,7 +566,7 @@ hif_repos_setup_watch (HifRepos *repos)
 	const gchar *repo_dir;
 	GError *error = NULL;
 	GFile *file_repos = NULL;
-	HifReposPrivate *priv = hif_repos_get_instance_private (repos);
+	HifReposPrivate *priv = GET_PRIVATE (repos);
 
 	/* setup a file monitor on the repos directory */
 	repo_dir = hif_context_get_repo_dir (priv->context);
@@ -606,7 +606,7 @@ hif_repos_new (HifContext *context)
 	HifReposPrivate *priv;
 	HifRepos *repos;
 	repos = g_object_new (HIF_TYPE_REPOS, NULL);
-	priv = hif_repos_get_instance_private (repos);
+	priv = GET_PRIVATE (repos);
 	priv->context = g_object_ref (context);
 	hif_repos_setup_watch (repos);
 	return HIF_REPOS (repos);

--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -71,9 +71,8 @@ struct _HifSourcePrivate
 
 #define HIF_CONFIG_GROUP_NAME			"PluginHawkey"
 
-G_DEFINE_TYPE_WITH_PRIVATE (HifSource, hif_source, G_TYPE_OBJECT)
-
-#define GET_PRIVATE(o) (hif_source_get_instance_private (o))
+G_DEFINE_TYPE (HifSource, hif_source, G_TYPE_OBJECT)
+#define GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), HIF_TYPE_SOURCE, HifSourcePrivate))
 
 /**
  * hif_source_finalize:
@@ -124,6 +123,7 @@ hif_source_class_init (HifSourceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	object_class->finalize = hif_source_finalize;
+	g_type_class_add_private (klass, sizeof (HifSourcePrivate));
 }
 
 /**

--- a/libhif/hif-state.c
+++ b/libhif/hif-state.c
@@ -135,9 +135,8 @@ enum {
 
 static guint signals [SIGNAL_LAST] = { 0 };
 
-G_DEFINE_TYPE_WITH_PRIVATE (HifState, hif_state, G_TYPE_OBJECT)
-
-#define GET_PRIVATE(o) (hif_state_get_instance_private (o))
+G_DEFINE_TYPE (HifState, hif_state, G_TYPE_OBJECT)
+#define GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), HIF_TYPE_STATE, HifStatePrivate))
 
 #define HIF_STATE_SPEED_SMOOTHING_ITEMS		5
 
@@ -277,6 +276,7 @@ hif_state_class_init (HifStateClass *klass)
 			      G_STRUCT_OFFSET (HifStateClass, package_progress_changed),
 			      NULL, NULL, g_cclosure_marshal_generic,
 			      G_TYPE_NONE, 3, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_UINT);
+	g_type_class_add_private (klass, sizeof (HifStatePrivate));
 }
 
 /**


### PR DESCRIPTION
G_DEFINE_TYPE_WITH_PRIVATE is new in 2.40, so let's stick with the old
style for now to work on RHEL7.0.
