### PR TITLE
context: Only add system repository if it exists

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -720,6 +720,7 @@ hif_context_setup_sack (HifContext *context, HifState *state, GError **error)
 	HifContextPrivate *priv = GET_PRIVATE (context);
 	gboolean ret;
 	gint rc;
+	_cleanup_free_ char *usr_path = g_build_filename (hif_context_get_install_root (context), "usr", NULL);
 
 	/* create empty sack */
 	priv->sack = hy_sack_create (priv->solv_dir, NULL, hif_context_get_install_root (context), HY_MAKE_CACHE_DIR);
@@ -734,10 +735,12 @@ hif_context_setup_sack (HifContext *context, HifState *state, GError **error)
 	hy_sack_set_installonly_limit (priv->sack, hif_context_get_installonly_limit (context));
 
 	/* add installed packages */
-	rc = hy_sack_load_system_repo (priv->sack, NULL, HY_BUILD_CACHE);
-	if (!hif_rc_to_gerror (rc, error)) {
-		g_prefix_error (error, "Failed to load system repo: ");
-		return FALSE;
+	if (g_file_test (usr_path, G_FILE_TEST_IS_DIR))  {
+		rc = hy_sack_load_system_repo (priv->sack, NULL, HY_BUILD_CACHE);
+		if (!hif_rc_to_gerror (rc, error)) {
+			g_prefix_error (error, "Failed to load system repo: ");
+			return FALSE;
+		}
 	}
 
 	/* creates repo for command line rpms */


### PR DESCRIPTION
For "rpm-ostree compose tree" libhif will be used to construct roots
from scratch.  In that case there's no system repository, and
unfortunately hawkey just tells us "I/O error", so we can't sanely
conditionalize on something like ENOENT.

Therefore, a simple hack is to just check for /usr being a directory
in the installroot; if it exists, then there's already a root.
