### PR TITLE
Add private accessors for goal/sack

### DIFF
--- a/libhif/hif-context-private.h
+++ b/libhif/hif-context-private.h
@@ -39,6 +39,10 @@ GPtrArray	*hif_context_get_sources		(HifContext	*context);
 
 HifTransaction	*hif_context_get_transaction		(HifContext	*context);
 
+HySack   	 hif_context_get_sack			(HifContext	*context);
+
+HyGoal  	 hif_context_get_goal			(HifContext	*context);
+
 G_END_DECLS
 
 #endif /* __HIF_CONTEXT_PRIVATE_H */

--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -364,6 +364,35 @@ hif_context_get_transaction (HifContext *context)
 }
 
 /**
+ * hif_context_get_sack: (skip)
+ * @context: a #HifContext instance.
+ *
+ * Returns: (transfer none): the HySack object
+ *
+ * Since: 0.1.0
+ **/
+HySack
+hif_context_get_sack (HifContext	*context)
+{
+	HifContextPrivate *priv = GET_PRIVATE (context);
+	return priv->sack;
+}
+/**
+ * hif_context_get_goal: (skip)
+ * @context: a #HifContext instance.
+ *
+ * Returns: (transfer none): the HyGoal object
+ *
+ * Since: 0.1.0
+ **/
+HyGoal
+hif_context_get_goal (HifContext	*context)
+{
+	HifContextPrivate *priv = GET_PRIVATE (context);
+	return priv->goal;
+}
+
+/**
  * hif_context_get_check_disk_space:
  * @context: a #HifContext instance.
  *


### PR DESCRIPTION
For rpm-ostree, I'd like to be able to drive things at a lower level
than the API provided from HifContext.  Using hif-context-private.h
APIs helps me do that.

For example, I want to print a "what packages will be installed" line
between the depsolving and actually running the transaction.

(This patch should help initiate a larger discussion about what
 HifContext should do/expose)
