### PR TITLE
WIP: Support comps groups

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1578,6 +1578,33 @@ hif_context_run(HifContext *context, GCancellable *cancellable, GError **error)
     return hif_state_done(priv->state, error);
 }
 
+static gboolean
+context_install_group (HifContext *context, const gchar *name, GError **error)
+{
+    HifContextPrivate *priv = GET_PRIVATE (context);
+    g_autoptr(GPtrArray) pkglist = NULL;
+    HifPackage *pkg;
+    hy_autoquery HyQuery query = NULL;
+    char *groupid = g_strconcat("group:", name + 1, NULL);
+
+    query = hy_query_create(priv->sack);
+    hy_query_filter(query, HY_GROUP_NAME, HY_EQ, groupid);
+    pkglist = hy_query_run(query);
+
+    if (pkglist->len == 0) {
+        g_set_error(error,
+                    HIF_ERROR,
+                    HIF_ERROR_PACKAGE_NOT_FOUND,
+                    "No group '%s' found", name);
+        return FALSE;
+    }
+
+    pkg = g_ptr_array_index (pkglist, 0);
+    hy_goal_install(priv->goal, pkg);
+
+    return TRUE;
+}
+
 /**
  * hif_context_install:
  * @context: a #HifContext instance.
@@ -1608,6 +1635,10 @@ hif_context_install (HifContext *context, const gchar *name, GError **error)
         if (!ret)
             return FALSE;
     }
+
+    if (name[0] == '@') {
+        return context_install_group(context, name, error);
+    } 
 
     /* find a newest remote package to install */
     query = hy_query_create(priv->sack);

--- a/libhif/hif-repo.c
+++ b/libhif/hif-repo.c
@@ -1084,6 +1084,7 @@ hif_repo_check_internal(HifRepo *repo,
     }
     tmp = lr_yum_repo_path(yum_repo, "group");
     if (tmp != NULL) {
+        hy_repo_set_string(priv->repo, HY_REPO_GROUP_FN, tmp);
         g_hash_table_insert(priv->filenames_md,
                             g_strdup("group"),
                             g_strdup(tmp));

--- a/libhif/hif-sack.c
+++ b/libhif/hif-sack.c
@@ -52,6 +52,7 @@
 #include <solv/repo_repomdxml.h>
 #include <solv/repo_updateinfoxml.h>
 #include <solv/repo_rpmmd.h>
+#include <solv/repo_comps.h>
 #include <solv/repo_rpmdb.h>
 #include <solv/repo_solv.h>
 #include <solv/repo_write.h>
@@ -677,6 +678,7 @@ load_yum_repo(HifSack *sack, HyRepo hrepo, GError **error)
     Repo *repo = repo_create(pool, name);
     const char *fn_repomd = hy_repo_get_string(hrepo, HY_REPO_MD_FN);
     char *fn_cache = hif_sack_give_cache_fn(sack, name, NULL);
+    const char *fn_group = hy_repo_get_string(hrepo, HY_REPO_GROUP_FN);
 
     FILE *fp_primary = NULL;
     FILE *fp_cache = fopen(fn_cache, "r");
@@ -721,6 +723,31 @@ load_yum_repo(HifSack *sack, HyRepo hrepo, GError **error)
             goto out;
         }
         hrepo->state_main = _HY_LOADED_FETCH;
+    }
+
+    /* For now, unconditionally adding comps.  It Shouldn't Break
+     * Anything(tm), and users want it.
+     */
+    if (fn_group != NULL) {
+        FILE *fp_group = fopen(fn_group, "r");
+        if (!fp_group) { 
+            g_set_error (error,
+                         HIF_ERROR,
+                         HIF_ERROR_FILE_INVALID,
+                         "can not read file %s: %s",
+                         fn_group, strerror(errno));
+            retval = FALSE;
+            goto out;
+        }
+        
+        if (repo_add_comps(repo, fp_group, 0)) {
+            g_set_error (error,
+                         HIF_ERROR,
+                         HIF_ERROR_INTERNAL_ERROR,
+                         "repo_add_comps failed");
+            retval = FALSE;
+            goto out;
+        }
     }
 out:
     if (fp_cache)

--- a/libhif/hif-sack.h
+++ b/libhif/hif-sack.h
@@ -80,6 +80,7 @@ typedef enum {
     HIF_SACK_LOAD_FLAG_USE_FILELISTS        = 1 << 1,
     HIF_SACK_LOAD_FLAG_USE_PRESTO           = 1 << 2,
     HIF_SACK_LOAD_FLAG_USE_UPDATEINFO       = 1 << 3,
+    HIF_SACK_LOAD_FLAG_USE_GROUP            = 1 << 4,
     /*< private >*/
     HIF_SACK_LOAD_FLAG_LAST
 } HifSackLoadFlags;

--- a/libhif/hy-goal.c
+++ b/libhif/hy-goal.c
@@ -301,6 +301,8 @@ list_results(HyGoal goal, Id type_filter1, Id type_filter2, GError **error)
     Queue transpkgs;
     Transaction *trans = goal->trans;
     GPtrArray *plist;
+    HifSack *sack = goal->sack;
+    Pool *pool = hif_sack_get_pool(sack);
 
     /* no transaction */
     if (trans == NULL) {
@@ -324,7 +326,16 @@ list_results(HyGoal goal, Id type_filter1, Id type_filter2, GError **error)
 
     for (int i = 0; i < trans->steps.count; ++i) {
         Id p = trans->steps.elements[i];
+	Solvable *s = pool_id2solvable(pool, p);
+	const char *name = pool_id2str(pool, s->name);
         Id type;
+
+	/* Skip "virtual" items like comps groups here.  They end up
+	 * in the goal solely for dependency generation, but we hide
+	 * them from the rest of libhif.
+	 */
+	if (g_str_has_prefix (name, "group:"))
+	  continue;
 
         switch (type_filter1) {
         case SOLVER_TRANSACTION_OBSOLETED:

--- a/libhif/hy-query.c
+++ b/libhif/hy-query.c
@@ -107,6 +107,7 @@ match_type_str(int keyname) {
     case HY_PKG_CONFLICTS:
     case HY_PKG_URL:
     case HY_PKG_VERSION:
+    case HY_GROUP_NAME:
         return 1;
     default:
         return 0;
@@ -132,6 +133,8 @@ di_keyname2id(int keyname)
         return SOLVABLE_SUMMARY;
     case HY_PKG_FILE:
         return SOLVABLE_FILELIST;
+    case HY_GROUP_NAME:
+        return SOLVABLE_NAME;
     default:
         assert(0);
         return 0;

--- a/libhif/hy-repo-private.h
+++ b/libhif/hy-repo-private.h
@@ -47,6 +47,7 @@ struct _HyRepo {
     char *filelists_fn;
     char *presto_fn;
     char *updateinfo_fn;
+    char *group_fn;
     enum _hy_repo_state state_main;
     enum _hy_repo_state state_filelists;
     enum _hy_repo_state state_presto;

--- a/libhif/hy-repo.c
+++ b/libhif/hy-repo.c
@@ -187,6 +187,10 @@ hy_repo_set_string(HyRepo repo, int which, const char *str_val)
         g_free(repo->updateinfo_fn);
         repo->updateinfo_fn = g_strdup(str_val);
         break;
+    case HY_REPO_GROUP_FN:
+        g_free(repo->group_fn);
+        repo->group_fn = g_strdup(str_val);
+        break;
     default:
         assert(0);
     }
@@ -208,6 +212,8 @@ hy_repo_get_string(HyRepo repo, int which)
         return repo->presto_fn;
     case HY_REPO_UPDATEINFO_FN:
         return repo->updateinfo_fn;
+    case HY_REPO_GROUP_FN:
+        return repo->group_fn;
     default:
         assert(0);
     }
@@ -228,5 +234,6 @@ hy_repo_free(HyRepo repo)
     g_free(repo->filelists_fn);
     g_free(repo->presto_fn);
     g_free(repo->updateinfo_fn);
+    g_free(repo->group_fn);
     g_free(repo);
 }

--- a/libhif/hy-repo.h
+++ b/libhif/hy-repo.h
@@ -34,7 +34,8 @@ enum _hy_repo_param_e {
     HY_REPO_PRESTO_FN = 2,
     HY_REPO_PRIMARY_FN = 3,
     HY_REPO_FILELISTS_FN = 4,
-    HY_REPO_UPDATEINFO_FN = 5
+    HY_REPO_UPDATEINFO_FN = 5,
+    HY_REPO_GROUP_FN = 6
 };
 
 HyRepo hy_repo_create(const char *name);

--- a/libhif/hy-types.h
+++ b/libhif/hy-types.h
@@ -78,7 +78,8 @@ enum _hy_key_name_e {
     HY_PKG_ADVISORY_BUG = 25,
     HY_PKG_ADVISORY_CVE = 26,
     HY_PKG_ADVISORY_SEVERITY = 27,
-    HY_PKG_ADVISORY_TYPE = 28
+    HY_PKG_ADVISORY_TYPE = 28,
+    HY_GROUP_NAME = 29
 };
 
 enum _hy_comparison_type_e {


### PR DESCRIPTION
There's a request from fedora releng to support parsing comps groups
for rpm-ostree, this is a RFC/WIP patch for it.  I think the main
architectural questions are:
- Use @ like yum to denote group names?
- Add them to the depsolver, but do not return them to the rest
  of the architecture.  This may make it harder to port dnf,
  since I think it currently has persistent groups enabled?

Related: #107
