### PR TITLE
DNF-2.0: Fix System-upgrade

### DIFF
--- a/libdnf/hy-iutil.c
+++ b/libdnf/hy-iutil.c
@@ -362,7 +362,6 @@ running_kernel(DnfSack *sack)
 
     Id kernel_id = -1;
     HyQuery q = hy_query_create_flags(sack, HY_IGNORE_EXCLUDES);
-    dnf_sack_make_provides_ready(sack);
     hy_query_filter(q, HY_PKG_FILE, HY_EQ, fn);
     hy_query_filter(q, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
     DnfPackageSet *pset = hy_query_run_set(q);


### PR DESCRIPTION
With introduction of protected packages this line is causing problems with removing kernel. Removing of this line does not seem to cause some trouble.