### PR TITLE
repo: Fix metadata signature checking in dnf_repo_check()

### DIFF
--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -1604,6 +1604,12 @@ dnf_repo_update(DnfRepo *repo,
     if (!ret)
         goto out;
 out:
+    if (!ret) {
+        /* remove the .tmp dir on failure */
+        g_autoptr(GError) error_remove = NULL;
+        if (!dnf_remove_recursive(priv->location_tmp, &error_remove))
+            g_debug("Failed to remove %s: %s", priv->location_tmp, error_remove->message);
+    }
     dnf_state_release_locks(state);
     lr_handle_setopt(priv->repo_handle, NULL, LRO_PROGRESSCB, NULL);
     lr_handle_setopt(priv->repo_handle, NULL, LRO_PROGRESSDATA, 0xdeadbeef);

--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -1113,6 +1113,8 @@ dnf_repo_check_internal(DnfRepo *repo,
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_MIRRORLIST, NULL))
         return FALSE;
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_GNUPGHOMEDIR, priv->keyring))
+        return FALSE;
     lr_result_clear(priv->repo_result);
     if (!lr_handle_perform(priv->repo_handle, priv->repo_result, &error_local)) {
         g_set_error(error,


### PR DESCRIPTION
This fixes dnf_repo_check() to correctly set up the gpg directories so that it can find all the keys needed to run a metadata verification. While at this, also fixed an unrelated issue with leaving behind .tmp directories in a separate commit.

https://bugzilla.redhat.com/show_bug.cgi?id=1285510