### PR TITLE
Don't error out when 'subscription-manager refresh' fails

### DIFF
--- a/libdnf/dnf-context.c
+++ b/libdnf/dnf-context.c
@@ -1470,6 +1470,7 @@ dnf_context_setup(DnfContext *context,
     gpointer hashkey, hashval;
     g_autoptr(GString) buf = NULL;
     g_autofree char *rpmdb_path = NULL;
+    g_autoptr(GError) error_local = NULL;
     g_autoptr(GFile) file_rpmdb = NULL;
 
     /* check essential things are set */
@@ -1570,8 +1571,8 @@ dnf_context_setup(DnfContext *context,
         return FALSE;
 
     /* initialize external frameworks where installed */
-    if (!dnf_context_setup_enrollments(context, error))
-        return FALSE;
+    if (!dnf_context_setup_enrollments(context, &error_local))
+        g_warning("Failed to setup enrollments: %s", error_local->message);
 
     return TRUE;
 }

--- a/libdnf/dnf-repo-loader.c
+++ b/libdnf/dnf-repo-loader.c
@@ -398,14 +398,15 @@ dnf_repo_loader_refresh(DnfRepoLoader *self, GError **error)
     const gchar *file;
     const gchar *repo_path;
     g_autoptr(GDir) dir = NULL;
+    g_autoptr(GError) error_local = NULL;
 
     /* no longer loaded */
     dnf_repo_loader_invalidate(self);
     g_ptr_array_set_size(priv->repos, 0);
 
     /* re-populate redhat.repo */
-    if (!dnf_context_setup_enrollments(priv->context, error))
-        return FALSE;
+    if (!dnf_context_setup_enrollments(priv->context, &error_local))
+        g_warning("Failed to setup enrollments: %s", error_local->message);
 
     /* open dir */
     repo_path = dnf_context_get_repo_dir(priv->context);


### PR DESCRIPTION
Instead, just print out the error and continue. This fixes a common
Fedora issue where a number of people have subscription-manager
installed, but not correctly configured, which makes packagekitd abort()
on startup with:

packagekitd[1329]: This system is not yet registered. Try 'subscription-manager register --help' for more information.
packagekitd[1329]: failed to setup context: Child process exited with code 1

https://bugzilla.redhat.com/show_bug.cgi?id=1398429