### PR TITLE
don't fail when unlink fails but file is already gone (issue#238)

### DIFF
--- a/libdnf/dnf-utils.c
+++ b/libdnf/dnf-utils.c
@@ -29,6 +29,7 @@
  */
 
 
+#include <errno.h>
 #include <stdlib.h>
 #include <glib/gstdio.h>
 
@@ -118,7 +119,7 @@ dnf_remove_recursive(const gchar *directory, GError **error)
                 return FALSE;
         } else {
             g_debug("deleting file %s", src);
-            if ((g_unlink(src) != 0) && g_file_test(src, G_FILE_TEST_EXISTS)) {
+            if ((g_unlink(src) != 0) && errno != ENOENT) {
                 g_set_error(error,
                             DNF_ERROR,
                             DNF_ERROR_INTERNAL_ERROR,

--- a/libdnf/dnf-utils.c
+++ b/libdnf/dnf-utils.c
@@ -118,7 +118,7 @@ dnf_remove_recursive(const gchar *directory, GError **error)
                 return FALSE;
         } else {
             g_debug("deleting file %s", src);
-            if (g_unlink(src) != 0) {
+            if ((g_unlink(src) != 0) && g_file_test(src, G_FILE_TEST_EXISTS)) {
                 g_set_error(error,
                             DNF_ERROR,
                             DNF_ERROR_INTERNAL_ERROR,


### PR DESCRIPTION
Fixing:
2:  libdnf-DEBUG: simulating, so not switching to new metadata
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/repomd.pub
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/repodata/repomd.xml.asc
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/repodata/repomd.xml
2:  libdnf-DEBUG: deleting directory data/tests/gpg-asc.tmp/repodata
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/gpgdir/S.gpg-agent
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/gpgdir/S.gpg-agent.extra
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/gpgdir/pubring.kbx~
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/gpgdir/pubring.kbx
2:  libdnf-DEBUG: deleting directory data/tests/gpg-asc.tmp/gpgdir/private-keys-v1.d
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/gpgdir/S.gpg-agent.ssh
2:  libdnf-DEBUG: deleting file data/tests/gpg-asc.tmp/gpgdir/trustdb.gpg
2:  libdnf-DEBUG: deleting directory data/tests/gpg-asc.tmp/gpgdi**
2: dnf_repo_loader_gpg_asc_func: assertion failed (error == NULL): failed to unlink data/tests/gpg-asc.tmp/gpgdir/S.gpg-agent.ssh (DnfError, 4)
2: r
2: libdnf-DEBUG: deleting directory data/tests/gpg-asc.tmp
2: libdnf-DEBUG: releasing lock 1

The error was introduced by fd770a76636181b4fa7812558e920e050aa846a6.
The tmp dir contains (among others) files and unix sockets created by
gpg-agent which was started by gpgme_new() in
lr_gpg_import_key()@librepo. These fiels / sockets are also properly
cleaned when gpg-agent shuts down. Sometimes (especially on slower
machines like armv7) it may interfere with cleanup in dnf_repo_update().
So let's not fail when the file is gone anyway.