### PR TITLE
Do dnf_repo_set_enabled() useable

### DIFF
--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -1215,9 +1215,11 @@ dnf_repo_check_internal(DnfRepo *repo,
                             g_strdup(tmp));
     }
 
+    DnfRepoEnabled enabled = dnf_repo_get_enabled(repo);
     /* ensure we reset the values from the keyfile */
     if (!dnf_repo_set_keyfile_data(repo, error))
         return FALSE;
+    dnf_repo_set_enabled(repo, enabled);
 
     return TRUE;
 }
@@ -1454,9 +1456,11 @@ dnf_repo_update(DnfRepo *repo,
         return FALSE;
     }
 
+    DnfRepoEnabled enabled = dnf_repo_get_enabled(repo);
     /* ensure we set the values from the keyfile */
     if (!dnf_repo_set_keyfile_data(repo, error))
         return FALSE;
+    dnf_repo_set_enabled(repo, enabled);
 
     /* take lock */
     ret = dnf_state_take_lock(state,
@@ -1926,9 +1930,11 @@ dnf_repo_download_packages(DnfRepo *repo,
     g_autoptr(GError) error_local = NULL;
     g_autofree gchar *directory_slash = NULL;
 
+    DnfRepoEnabled enabled = dnf_repo_get_enabled(repo);
     /* ensure we reset the values from the keyfile */
     if (!dnf_repo_set_keyfile_data(repo, error))
         goto out;
+    dnf_repo_set_enabled(repo, enabled);
 
     /* if nothing specified then use cachedir */
     if (directory == NULL) {


### PR DESCRIPTION
If repo was enabled by dnf_repo_set_enabled() then another functions
(dnf_repo_check_internal(), dnf_repo_update(), dnf_repo_download_packages()) disable repo
by calling dnf_repo_set_keyfile_data(). This is workaround.