### PR TITLE
repo: Expose generated timestamp

### DIFF
--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -285,6 +285,19 @@ dnf_repo_get_description(DnfRepo *repo)
 }
 
 /**
+ * dnf_repo_get_timestamp_generated:
+ * @repo: a #DnfRepo instance.
+ *
+ * Returns: Time in seconds since the epoch (UTC)
+ **/
+guint64
+dnf_repo_get_timestamp_generated (DnfRepo *repo)
+{
+    DnfRepoPrivate *priv = GET_PRIVATE(repo);
+    return priv->timestamp_generated;
+}
+
+/**
  * dnf_repo_get_enabled:
  * @repo: a #DnfRepo instance.
  *

--- a/libdnf/dnf-repo.h
+++ b/libdnf/dnf-repo.h
@@ -117,6 +117,7 @@ gchar          **dnf_repo_get_exclude_packages  (DnfRepo              *repo);
 gboolean         dnf_repo_get_gpgcheck          (DnfRepo              *repo);
 gboolean         dnf_repo_get_gpgcheck_md       (DnfRepo              *repo);
 gchar           *dnf_repo_get_description       (DnfRepo              *repo);
+guint64          dnf_repo_get_timestamp_generated(DnfRepo              *repo);
 const gchar     *dnf_repo_get_filename_md       (DnfRepo              *repo,
                                                  const gchar          *md_kind);
 #ifndef __GI_SCANNER__


### PR DESCRIPTION
The timestamp can be used a poor substitute for repository versions, for
projects like Fedora that don't ascribe versions to their rpm-md repos. I plan
to use this in rpm-ostree for informational purposes.