### PR TITLE
repo: Expose dnf_repo_get_n_solvables()

### DIFF
--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -298,6 +298,19 @@ dnf_repo_get_timestamp_generated (DnfRepo *repo)
 }
 
 /**
+ * dnf_repo_get_n_solvables:
+ * @repo: a #DnfRepo instance.
+ *
+ * Returns: Number of packages in the repo
+ **/
+guint
+dnf_repo_get_n_solvables (DnfRepo *repo)
+{
+    DnfRepoPrivate *priv = GET_PRIVATE(repo);
+    return hy_repo_get_n_solvables (priv->repo);
+}
+
+/**
  * dnf_repo_get_enabled:
  * @repo: a #DnfRepo instance.
  *

--- a/libdnf/dnf-repo.h
+++ b/libdnf/dnf-repo.h
@@ -118,6 +118,7 @@ gboolean         dnf_repo_get_gpgcheck          (DnfRepo              *repo);
 gboolean         dnf_repo_get_gpgcheck_md       (DnfRepo              *repo);
 gchar           *dnf_repo_get_description       (DnfRepo              *repo);
 guint64          dnf_repo_get_timestamp_generated(DnfRepo              *repo);
+guint            dnf_repo_get_n_solvables       (DnfRepo              *repo);
 const gchar     *dnf_repo_get_filename_md       (DnfRepo              *repo,
                                                  const gchar          *md_kind);
 #ifndef __GI_SCANNER__

--- a/libdnf/hy-repo.c
+++ b/libdnf/hy-repo.c
@@ -143,6 +143,12 @@ hy_repo_get_priority(HyRepo repo)
     return repo->priority;
 }
 
+guint
+hy_repo_get_n_solvables(HyRepo repo)
+{
+  return (guint)repo->libsolv_repo->nsolvables;
+}
+
 void
 hy_repo_set_cost(HyRepo repo, int value)
 {

--- a/libdnf/hy-repo.h
+++ b/libdnf/hy-repo.h
@@ -40,6 +40,7 @@ enum _hy_repo_param_e {
 HyRepo hy_repo_create(const char *name);
 int hy_repo_get_cost(HyRepo repo);
 int hy_repo_get_priority(HyRepo repo);
+guint hy_repo_get_n_solvables(HyRepo repo);
 void hy_repo_set_cost(HyRepo repo, int value);
 void hy_repo_set_priority(HyRepo repo, int value);
 void hy_repo_set_string(HyRepo repo, int which, const char *str_val);


### PR DESCRIPTION
This is mainly for debugging - rpm-ostree will print it out, and it should help
debugging if repodata is broken.