### PR TITLE
WIP/RFC: DnfContext: add support for multiple repo dirs

### DIFF
--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -72,6 +72,7 @@ DnfContext      *dnf_context_new                        (void);
 
 /* getters */
 const gchar     *dnf_context_get_repo_dir               (DnfContext     *context);
+GPtrArray       *dnf_context_get_repo_dirs              (DnfContext     *context);
 const gchar     *dnf_context_get_base_arch              (DnfContext     *context);
 const gchar     *dnf_context_get_os_info                (DnfContext     *context);
 const gchar     *dnf_context_get_arch_info              (DnfContext     *context);


### PR DESCRIPTION
Allow the repo_dir member to be a comma-separated list of repo dirs.
This allows better compatibility with the reposdir yum config. We parse
out the list into a pointer array and expose it through a new function
dnf_context_get_repo_dirs(). We improve the repo loader pick up repo
files from all the dirs.

Closes: #258