### PR TITLE
Python 3.6 invalid escape sequence deprecation fixes

### DIFF
--- a/docs/hawkey/conf.py
+++ b/docs/hawkey/conf.py
@@ -57,7 +57,7 @@ def version_readout():
     with open(fn) as f:
         lines = f.readlines()
 
-    pat = re.compile("\d+")
+    pat = re.compile(r"\d+")
     major = pat.findall(lines[0])[0]
     minor = pat.findall(lines[1])[0]
     micro = pat.findall(lines[2])[0]

--- a/python/hawkey/tests/tests/test_package.py
+++ b/python/hawkey/tests/tests/test_package.py
@@ -54,7 +54,7 @@ class PackageTest(base.TestCase):
         self.assertTrue(isinstance(self.pkg, hawkey.Package))
 
     def test_repr(self):
-        regexp = "<hawkey.Package object id \d+, flying-2-9\.noarch, @System>"
+        regexp = r"<hawkey.Package object id \d+, flying-2-9\.noarch, @System>"
         self.assertRegexpMatches(repr(self.pkg), regexp)
 
     def test_str(self):


### PR DESCRIPTION
Signed-off-by: Ville Skyttä <ville.skytta@iki.fi>