### PR TITLE
spec: do not enable RHSM plugin on CentOS

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -10,7 +10,7 @@
 %bcond_without python3
 %endif
 
-%if 0%{?rhel}
+%if 0%{?rhel} && 0%{!?centos}
 %bcond_without rhsm
 %else
 %bcond_with rhsm


### PR DESCRIPTION
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>