### PR TITLE
spec: do not require librhsm on CentOS

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -10,7 +10,7 @@
 %bcond_without python3
 %endif
 
-%if 0%{?rhel}
+%if 0%{?rhel} && 0%{!?centos}
 %bcond_without rhsm
 %else
 %bcond_with rhsm


### PR DESCRIPTION
FYI @j-mracek @ignatenkobrain 

epel builds are failing otherwise:
https://copr-be.cloud.fedoraproject.org/results/rpmsoftwaremanagement/dnf-nightly/epel-7-x86_64/00516940-libdnf/root.log.gz