### PR TITLE
Add functionality for query.filter(severity=)

### DIFF
--- a/libdnf/dnf-advisory.c
+++ b/libdnf/dnf-advisory.c
@@ -377,10 +377,7 @@ gboolean
 dnf_advisory_match_severity(DnfAdvisory *advisory, const char *s)
 {
     const char *severity_str = dnf_advisory_get_severity(advisory);
-    if (!g_strcmp0(severity_str,s)) {
-        return TRUE;
-    }
-    return FALSE;
+    return g_strcmp0(severity_str,s) == 0;
 }
 
 /**

--- a/libdnf/dnf-advisory.c
+++ b/libdnf/dnf-advisory.c
@@ -363,6 +363,27 @@ dnf_advisory_match_kind(DnfAdvisory *advisory, const char *s)
 }
 
 /**
+ * dnf_advisory_match_severity:
+ * @advisory: a #DnfAdvisory instance.
+ * @s: string
+ *
+ * Matches #DnfAdvisory severity against string
+ *
+ * Returns: %TRUE if they are the same
+ *
+ * Since: 0.8.0
+ */
+gboolean
+dnf_advisory_match_severity(DnfAdvisory *advisory, const char *s)
+{
+    const char *severity_str = dnf_advisory_get_severity(advisory);
+    if (!g_strcmp0(severity_str,s)) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/**
  * dnf_advisory_match_cve:
  * @advisory: a #DnfAdvisory instance.
  * @s: string

--- a/libdnf/dnf-advisory.h
+++ b/libdnf/dnf-advisory.h
@@ -66,6 +66,8 @@ gboolean             dnf_advisory_match_id          (DnfAdvisory *advisory,
                                                      const char  *s);
 gboolean             dnf_advisory_match_kind        (DnfAdvisory *advisory,
                                                      const char  *s);
+gboolean             dnf_advisory_match_severity    (DnfAdvisory *advisory,
+                                                     const char  *s);
 gboolean             dnf_advisory_match_cve         (DnfAdvisory *advisory,
                                                      const char  *s);
 gboolean             dnf_advisory_match_bug         (DnfAdvisory *advisory,

--- a/libdnf/hy-query.c
+++ b/libdnf/hy-query.c
@@ -811,6 +811,9 @@ filter_advisory(HyQuery q, struct _Filter *f, Map *m, int keyname)
             case HY_PKG_ADVISORY_TYPE:
                 eq = dnf_advisory_match_kind(advisory, match);
                 break;
+            case HY_PKG_ADVISORY_SEVERITY:
+                eq = dnf_advisory_match_severity(advisory, match);
+                break;
             default:
                 eq = FALSE;
             }


### PR DESCRIPTION
The filter severity was supported, but there were no implementation how it
should work. The patch add implementation.