### PR TITLE
transaction: Don't g_warning() when installing unsigned packages

### DIFF
--- a/libdnf/dnf-transaction.c
+++ b/libdnf/dnf-transaction.c
@@ -385,12 +385,9 @@ dnf_transaction_gpgcheck_package(DnfTransaction *transaction,
         if ((priv->flags & DNF_TRANSACTION_FLAG_ONLY_TRUSTED) > 0) {
             g_propagate_error(error, error_local);
             return FALSE;
+        } else {
+            g_clear_error(&error_local);
         }
-
-        /* we can install unsigned packages */
-        g_warning("ignoring as allow-untrusted: %s",
-                error_local->message);
-        g_clear_error(&error_local);
     }
 
     return TRUE;


### PR DESCRIPTION
I think the PackageKit code libdnf originally came from is fairly `g_warning()`
heavy. In constrast for rpm-ostree our test suites set `G_DEBUG=fatal-warnings`.
Installing unsigned packages *if configured* should simply not emit warnings.

One could argue we should (in the system daemon case) log to the journal, but
even then I'm not sure. The package will show up as unsigned in the rpmdb etc.