### PR TITLE
Allow clients to lookup checksums on cmdline pkgs

### DIFF
--- a/libdnf/dnf-sack.c
+++ b/libdnf/dnf-sack.c
@@ -1121,7 +1121,8 @@ dnf_sack_add_cmdline_package(DnfSack *sack, const char *fn)
         g_warning("not a readable RPM file: %s, skipping", fn);
         return NULL;
     }
-    p = repo_add_rpm(repo, fn, REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE);
+    p = repo_add_rpm(repo, fn, REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE|
+                               RPM_ADD_WITH_HDRID|RPM_ADD_WITH_SHA256SUM);
     if (p == 0) {
         g_warning ("failed to read RPM: %s, skipping",
                    pool_errstr (dnf_sack_get_pool (sack)));

--- a/libdnf/hy-package.c
+++ b/libdnf/hy-package.c
@@ -499,6 +499,7 @@ dnf_package_get_chksum(DnfPackage *pkg, int *type)
     Solvable *s = get_solvable(pkg);
     const unsigned char* ret;
 
+    repo_internalize_trigger(s->repo);
     ret = solvable_lookup_bin_checksum(s, SOLVABLE_CHECKSUM, type);
     if (ret)
         *type = checksumt_l2h(*type);
@@ -522,6 +523,7 @@ dnf_package_get_hdr_chksum(DnfPackage *pkg, int *type)
     Solvable *s = get_solvable(pkg);
     const unsigned char *ret;
 
+    repo_internalize_trigger(s->repo);
     ret = solvable_lookup_bin_checksum(s, SOLVABLE_HDRID, type);
     if (ret)
         *type = checksumt_l2h(*type);


### PR DESCRIPTION
We previously didn't calculate checksums for packages provided through `dnf_sack_add_cmdline_package`, which meant that clients couldn't use `dnf_package_get_[hdr_]chksum`. The first patch ensures that we ask libsolv to do so, and the second patch fixes a bug which caused `dnf_package_get_chksum` to fail if the repo wasn't internalized.

This is needed for https://github.com/projectatomic/rpm-ostree/pull/657.