### PR TITLE
Revert selector: prefer obsoletes 

### DIFF
--- a/data/tests/hawkey/greedy.repo
+++ b/data/tests/hawkey/greedy.repo
@@ -5,7 +5,5 @@
 =Pkg: B 1 0 noarch
 =Rec: C
 =Prv: somereq
-=Obs: somereq
 =Pkg: C 1 0 noarch
 =Prv: somereq
-=Pkg: somereq 1 0 noarch

--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -549,34 +549,6 @@ filter_name2job(DnfSack *sack, const struct _Filter *f, Queue *job)
     return 0;
 }
 
-/**
- * add_preferred_provide:
- * when searching by provides the packages that contain the same
- * name as provide or contain obsoletes with the same name as their
- * provide will be picked first
- */
-static void
-add_preferred_provide(DnfSack *sack, Queue *job, Id id)
-{
-    Pool *pool = dnf_sack_get_pool(sack);
-    const char *name = pool_dep2str(pool, id);
-    HyQuery q = hy_query_create(sack);
-    hy_query_filter(q, HY_PKG_NAME, HY_NEQ, name);
-    DnfPackageSet *pset = hy_query_run_set(q);
-    hy_query_filter(q, HY_PKG_PROVIDES, HY_EQ, name);
-    hy_query_filter_package_in(q, HY_PKG_OBSOLETES, HY_NEQ, pset);
-    DnfPackage *pkg;
-    g_autoptr(GPtrArray) plist = hy_query_run(q);
-    for (guint i = 0; i < plist->len; i++) {
-        pkg = g_ptr_array_index(plist, i);
-        queue_push2(job, SOLVER_DISFAVOR|SOLVER_SOLVABLE,
-                    dnf_package_get_id(pkg));
-    }
-    queue_push2(job, SOLVER_SOLVABLE_PROVIDES, id);
-    hy_query_free(q);
-    g_object_unref(pset);
-}
-
 static int
 filter_provides2job(DnfSack *sack, const struct _Filter *f, Queue *job)
 {
@@ -592,7 +564,7 @@ filter_provides2job(DnfSack *sack, const struct _Filter *f, Queue *job)
     switch (f->cmp_type) {
     case HY_EQ:
         id = dnf_reldep_get_id (f->matches[0].reldep);
-        add_preferred_provide(sack, job, id);
+        queue_push2(job, SOLVER_SOLVABLE_PROVIDES, id);
         break;
     case HY_GLOB:
         dataiterator_init(&di, pool, 0, 0, SOLVABLE_PROVIDES, name, SEARCH_GLOB);
@@ -603,7 +575,7 @@ filter_provides2job(DnfSack *sack, const struct _Filter *f, Queue *job)
         assert(di.idp);
         id = *di.idp;
         if (!job_has(job, SOLVABLE_PROVIDES, id))
-            add_preferred_provide(sack, job, id);
+            queue_push2(job, SOLVER_SOLVABLE_PROVIDES, id);
         dataiterator_free(&di);
         break;
     default:

--- a/tests/hawkey/test_goal.c
+++ b/tests/hawkey/test_goal.c
@@ -230,27 +230,6 @@ START_TEST(test_goal_install_selector)
 }
 END_TEST
 
-START_TEST(test_goal_install_selector_obsoletes_first)
-{
-    HySelector sltr;
-    HyGoal goal = hy_goal_create(test_globals.sack);
-
-    sltr = hy_selector_create(test_globals.sack);
-    hy_selector_set(sltr, HY_PKG_PROVIDES, HY_EQ, "somereq");
-    fail_if(!hy_goal_install_selector(goal, sltr, NULL));
-    hy_selector_free(sltr);
-
-    fail_if(hy_goal_run(goal));
-    assert_iueo(goal, 1, 0, 0, 0);
-
-    GPtrArray *plist = hy_goal_list_installs(goal, NULL);
-    const char *nvra = dnf_package_get_nevra(g_ptr_array_index(plist, 0));
-    ck_assert_str_eq(nvra, "B-1-0.noarch");
-    g_ptr_array_unref(plist);
-    hy_goal_free(goal);
-}
-END_TEST
-
 START_TEST(test_goal_install_selector_err)
 {
     int rc;
@@ -1456,7 +1435,6 @@ goal_suite(void)
     tc = tcase_create("Greedy");
     tcase_add_unchecked_fixture(tc, fixture_greedy_only, teardown);
     tcase_add_test(tc, test_goal_run_all);
-    tcase_add_test(tc, test_goal_install_selector_obsoletes_first);
     tcase_add_test(tc, test_goal_install_weak_deps);
     suite_add_tcase(s, tc);
 


### PR DESCRIPTION
The code is not used anymore by DNF, because obsoletes are handled on DNF level
using selector(pkg=hawkey.query).

Reverts: 94ac2e5