### PR TITLE
Not filtrate out preun requires (RhBug:1382121)

### DIFF
--- a/libdnf/hy-package.c
+++ b/libdnf/hy-package.c
@@ -145,20 +145,32 @@ reldeps_for(DnfPackage *pkg, Id type)
     Pool *pool = dnf_package_get_pool(pkg);
     Solvable *s = get_solvable(pkg);
     DnfReldepList *reldeplist;
-    Queue q;
+    Queue q, q_final;
     Id marker = -1;
     Id solv_type = type;
+    Id rel_id;
+
+    if (type == SOLVABLE_REQUIRES)
+        marker = 0;
 
     if (type == SOLVABLE_PREREQMARKER) {
         solv_type = SOLVABLE_REQUIRES;
         marker = 1;
     }
     queue_init(&q);
+    queue_init(&q_final);
     solvable_lookup_deparray(s, solv_type, &q, marker);
 
-    reldeplist = dnf_reldep_list_from_queue (pool, q);
+    for (int i = 0; i < q.count; i++) {
+        rel_id = q.elements[i];
+        if (rel_id != SOLVABLE_PREREQMARKER)
+            queue_push(&q_final, rel_id);
+    }
+
+    reldeplist = dnf_reldep_list_from_queue (pool, q_final);
 
     queue_free(&q);
+    queue_free(&q_final);
     return reldeplist;
 }
 


### PR DESCRIPTION
Unfortunately libsolv returns a queue with SOLVABLE_PREREQMARKER element,
therefore it has to be removed from the queue.

https://bugzilla.redhat.com/show_bug.cgi?id=1382121