### PR TITLE
repo: Fix import of GPG keys via http(s)://

### DIFF
--- a/libdnf/dnf-repo.h
+++ b/libdnf/dnf-repo.h
@@ -108,7 +108,7 @@ const gchar     *dnf_repo_get_id                (DnfRepo              *repo);
 const gchar     *dnf_repo_get_location          (DnfRepo              *repo);
 const gchar     *dnf_repo_get_filename          (DnfRepo              *repo);
 const gchar     *dnf_repo_get_packages          (DnfRepo              *repo);
-const gchar     *dnf_repo_get_public_key        (DnfRepo              *repo);
+gchar **         dnf_repo_get_public_keys       (DnfRepo              *repo);
 DnfRepoEnabled   dnf_repo_get_enabled           (DnfRepo              *repo);
 gboolean         dnf_repo_get_required          (DnfRepo              *repo);
 guint            dnf_repo_get_cost              (DnfRepo              *repo);

--- a/libdnf/dnf-transaction.c
+++ b/libdnf/dnf-transaction.c
@@ -1203,14 +1203,16 @@ dnf_transaction_import_keys(DnfTransaction *transaction,
     /* import downloaded repo GPG keys */
     for (i = 0; i < priv->repos->len; i++) {
         DnfRepo *repo = g_ptr_array_index(priv->repos, i);
-        const gchar *pubkey;
+        g_auto(GStrv) pubkeys = dnf_repo_get_public_keys(repo);
 
         /* does this file actually exist */
-        pubkey = dnf_repo_get_public_key(repo);
-        if (g_file_test(pubkey, G_FILE_TEST_EXISTS)) {
-            /* import */
-            if (!dnf_keyring_add_public_key(priv->keyring, pubkey, error))
-                return FALSE;
+        for (char **iter = pubkeys; iter && *iter; iter++) {
+            const char *pubkey = *iter;
+            if (g_file_test(pubkey, G_FILE_TEST_EXISTS)) {
+                /* import */
+                if (!dnf_keyring_add_public_key(priv->keyring, pubkey, error))
+                    return FALSE;
+            }
         }
     }
 


### PR DESCRIPTION
Pretty sure this is a regression from commit: e7241f040c25c7f5b57b1e0008db5e63ef00b7f2
Currently we fail to import keys over `http(s)://`, as used
by e.g. COPR.

Previously, we had a single "repomd.pub" key name, and when I was changing
things to support a list, the name used for the download became the basename of
the URL, to avoid conflicts.

But I didn't notice that the API had a `get_pubkey` argument which
is used in the keyring import.
I tested with Fedora base repos that use
`gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch`
but we import everything in `/etc/pki/rpm-gpg` anyways, which masked
this problem.