### PR TITLE
Enable install oldest kernel that installed (RhBug:1191611)

### DIFF
--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -159,6 +159,11 @@ sort_packages(const void *ap, const void *bp, void *s_cb)
         if (b == kernel || can_depend_on(pool, sb, kernel))
             return -1;
     }
+    if (pool->installed != sa->repo)
+        return 1;
+
+    if (pool->installed != sb->repo)
+        return -1;
 
     return pool_evrcmp(pool, sa->evr, sb->evr, EVRCMP_COMPARE);
 }

--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -153,17 +153,20 @@ sort_packages(const void *ap, const void *bp, void *s_cb)
         return name_diff;
 
     /* same name, if one is/depends on the running kernel put it last */
+
+    /* move available packages to end of the list */
+    if (pool->installed != sa->repo)
+        return 1;
+
+    if (pool->installed != sb->repo)
+        return -1;
+
     if (kernel >= 0) {
         if (a == kernel || can_depend_on(pool, sa, kernel))
             return 1;
         if (b == kernel || can_depend_on(pool, sb, kernel))
             return -1;
     }
-    if (pool->installed != sa->repo)
-        return 1;
-
-    if (pool->installed != sb->repo)
-        return -1;
 
     return pool_evrcmp(pool, sa->evr, sb->evr, EVRCMP_COMPARE);
 }

--- a/libdnf/hy-iutil.c
+++ b/libdnf/hy-iutil.c
@@ -360,10 +360,8 @@ running_kernel(DnfSack *sack)
         return -1;
     }
     char *fn = pool_tmpjoin(pool, "/boot/vmlinuz-", un.release, NULL);
-    if (access(fn, F_OK)) {
+    if (access(fn, F_OK)) 
         g_debug("running_kernel(): no matching file: %s.", fn);
-        return -1;
-    }
 
     Id kernel_id = -1;
     HyQuery q = hy_query_create_flags(sack, HY_IGNORE_EXCLUDES);


### PR DESCRIPTION
It changes an order which packages has to be removed. The new order that will
kept or install packages and remove packages over installonly limit: the package
of running kernel will be not removed, then available packages, than installed
packages according to EVR.

https://bugzilla.redhat.com/show_bug.cgi?id=1191611