### PR TITLE
Add support for tito for local builds

### DIFF
--- a/.tito/packages/.readme
+++ b/.tito/packages/.readme
@@ -1,0 +1,3 @@
+the .tito/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,5 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.VersionTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Building the documentation, from the build/ directory::
 
 Building RPMs:
 
-    tito init # Step is required due to removal of tito support from the project
     tito build --rpm --test
 
 Tests


### PR DESCRIPTION
Tito support is provided for dnf, dnf-plugins-core, and plugins-extras, therefore it would be nice to unify it also with libdnf. This commit makes life of developers that use tito much more better. Thanks a lot for understanding.