### PR TITLE
Compat patch for glib2 2.44

### DIFF
--- a/libdnf/dnf-types.h
+++ b/libdnf/dnf-types.h
@@ -98,5 +98,16 @@ typedef enum {
 #define DNF_ERROR                       (dnf_error_quark ())
 GQuark           dnf_error_quark        (void);
 
+#if !GLIB_CHECK_VERSION(2, 45, 8)
+static inline void
+g_autoptr_cleanup_gstring_free (GString *string)
+{
+  if (string)
+    g_string_free (string, TRUE);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GString, g_autoptr_cleanup_gstring_free)
+#endif
+
 #endif
 


### PR DESCRIPTION
In version 2.44 of glib2 the g_autoptr_cleanup_gstring_free method
does not exist. In order to make libdnf work with this version of
glib2 it needs to be provided by libdnf