### PR TITLE
Add case for reason decision (RhBug:1452090)

### DIFF
--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -1263,7 +1263,8 @@ hy_goal_get_reason(HyGoal goal, DnfPackage *pkg)
 
     if ((reason == SOLVER_REASON_UNIT_RULE ||
          reason == SOLVER_REASON_RESOLVE_JOB) &&
-        solver_ruleclass(goal->solv, info) == SOLVER_RULE_JOB)
+        (solver_ruleclass(goal->solv, info) == SOLVER_RULE_JOB ||
+         solver_ruleclass(goal->solv, info) == SOLVER_RULE_BEST))
         return HY_REASON_USER;
     if (reason == SOLVER_REASON_CLEANDEPS_ERASE)
         return HY_REASON_CLEAN;


### PR DESCRIPTION
In case of install when only 2 packages with same NRVRA available, it return
reason user and not dep.

https://bugzilla.redhat.com/show_bug.cgi?id=1452090