### PR TITLE
spec: require glib2 >= 2.46

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -38,7 +38,7 @@ BuildRequires:  pkgconfig(check)
 %if %{with valgrind}
 BuildRequires:  valgrind
 %endif
-BuildRequires:  pkgconfig(gio-unix-2.0) >= 2.44.0
+BuildRequires:  pkgconfig(gio-unix-2.0) >= 2.46.0
 BuildRequires:  pkgconfig(gtk-doc)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  rpm-devel >= 4.11.0


### PR DESCRIPTION
After 7c54413559d14dc6b0dd99f8c3df0572b7d44540, glib2 >= 2.46 is now required to build libdnf.