### PR TITLE
fix epoch concatenation order

### DIFF
--- a/libdnf/hy-subject.c
+++ b/libdnf/hy-subject.c
@@ -317,8 +317,8 @@ nevra_to_selector(HyNevra nevra, DnfSack *sack)
                 char buf[G_ASCII_DTOSTR_BUF_SIZE];
 
                 g_ascii_dtostr(buf, sizeof(buf), epoch);
-                g_string_prepend(evrbuf, buf);
                 g_string_prepend_c(evrbuf, ':');
+                g_string_prepend(evrbuf, buf);
             }
 
             str = hy_nevra_get_string(nevra, HY_NEVRA_RELEASE);


### PR DESCRIPTION
Because we _prepend_ the colon and the epoch, we have to add the colon first.

Otherwise `microdnf install openssl-1:1.0.1e-60.el7_3.1` will fail, because evrbuf will become `:11.0.1e-60.el7_3.1`.