### PR TITLE
DnfRepo: always reset LRO_URLS, even if NULL

### DIFF
--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -779,7 +779,8 @@ dnf_repo_get_boolean(GKeyFile *keyfile,
 }
 
 /**
- * dnf_repo_set_keyfile_data:
+ * dnf_repo_set_keyfile_data: initialize (or potentially reset) repo & LrHandle
+ * from keyfile values.
  */
 static gboolean
 dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
@@ -811,19 +812,19 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
     if (cost != 0)
         dnf_repo_set_cost(repo, cost);
 
-    /* baseurl is optional */
+    /* baseurl is optional; if missing, unset it */
     baseurls = g_key_file_get_string_list(priv->keyfile, priv->id, "baseurl", NULL, NULL);
-    if (baseurls && !lr_handle_setopt(priv->repo_handle, error, LRO_URLS, baseurls))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_URLS, baseurls))
         return FALSE;
 
-    /* mirrorlist is optional */
+    /* mirrorlist is optional; if missing, unset it */
     mirrorlist = g_key_file_get_string(priv->keyfile, priv->id, "mirrorlist", NULL);
-    if (mirrorlist && !lr_handle_setopt(priv->repo_handle, error, LRO_MIRRORLIST, mirrorlist))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_MIRRORLIST, mirrorlist))
         return FALSE;
 
-    /* metalink is optional */
+    /* metalink is optional; if missing, unset it */
     metalink = g_key_file_get_string(priv->keyfile, priv->id, "metalink", NULL);
-    if (metalink && !lr_handle_setopt(priv->repo_handle, error, LRO_METALINKURL, metalink))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_METALINKURL, metalink))
         return FALSE;
 
     /* file:// */


### PR DESCRIPTION
Previously, we would only set `LRO_URLS` and company if "baseurl" was
defined. But we should unconditionally set them (and let them be unset
if missing). The issue is that `dnf_repo_set_keyfile_data()` is not only
used to initialize the repo, but also to undo temporary modifications.

For example, in `dnf_check_repo_internal()`, we override the `LRO_URLS` to
point to our cached metadata in order to load it. But then, we never
set back `LRO_URLS` to `NULL` if we don't have a `baseurl`.

In rpm-ostree treecomposes, this is causing us to *never* actually
update our cache (at least starting from
https://github.com/projectatomic/rpm-ostree/pull/791), because we first
call `dnf_repo_check()` and then if the cache expired, `dnf_repo_update()`.
And at that time, we're still pointing librepo at our cache for its
`LRO_URLS`.