### PR TITLE
Improve dnf_context_update

### DIFF
--- a/libdnf/dnf-context.c
+++ b/libdnf/dnf-context.c
@@ -1792,40 +1792,39 @@ gboolean
 dnf_context_update(DnfContext *context, const gchar *name, GError **error)
 {
     DnfContextPrivate *priv = GET_PRIVATE(context);
-    GPtrArray *pkglist;
-    DnfPackage *pkg;
-    hy_autoquery HyQuery query = NULL;
-    gboolean ret = TRUE;
-    guint i;
+    g_autoptr(GPtrArray) selector_matches = NULL;
+    HySelector selector = NULL;
+    HySubject subject = NULL;
+    gboolean ret = FALSE;
 
     /* create sack and add repos */
     if (priv->sack == NULL) {
         dnf_state_reset(priv->state);
-        ret = dnf_context_setup_sack(context, priv->state, error);
-        if (!ret)
-            return FALSE;
+        if (!dnf_context_setup_sack(context, priv->state, error))
+            goto out;
     }
 
-    /* find a newest remote package to install */
-    query = hy_query_create(priv->sack);
-    hy_query_filter_latest_per_arch(query, TRUE);
-    hy_query_filter_in(query, HY_PKG_ARCH, HY_EQ,
-               (const gchar **) priv->native_arches);
-    hy_query_filter(query, HY_PKG_REPONAME, HY_NEQ, HY_SYSTEM_REPO_NAME);
-    hy_query_filter (query, HY_PKG_ARCH, HY_NEQ, "src");
-    hy_query_filter(query, HY_PKG_NAME, HY_EQ, name);
-    pkglist = hy_query_run(query);
-
-    /* add each package */
-    for (i = 0; i < pkglist->len; i++) {
-        pkg = g_ptr_array_index (pkglist, i);
-        if (dnf_package_is_installonly(pkg))
-            hy_goal_install(priv->goal, pkg);
-        else
-            hy_goal_upgrade_to(priv->goal, pkg);
+    subject = hy_subject_create(name);
+    selector = hy_subject_get_best_selector(subject, priv->sack);
+    selector_matches = hy_selector_matches(selector);
+    if (selector_matches->len == 0) {
+        g_set_error(error,
+                    DNF_ERROR,
+                    DNF_ERROR_PACKAGE_NOT_FOUND,
+                    "No package matches '%s'", name);
+        goto out;
     }
-    g_ptr_array_unref(pkglist);
-    return TRUE;
+
+    if (hy_goal_upgrade_to_selector(priv->goal, selector))
+        goto out;
+
+    ret = TRUE;
+ out:
+    if (selector)
+        hy_selector_free(selector);
+    if (subject)
+        hy_subject_free(subject);
+    return ret;
 }
 
 /**

--- a/libdnf/hy-selector.h
+++ b/libdnf/hy-selector.h
@@ -39,4 +39,6 @@ GPtrArray *hy_selector_matches(HySelector sltr);
 
 G_END_DECLS
 
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(HySelector, hy_selector_free, NULL)
+
 #endif

--- a/libdnf/hy-subject.h
+++ b/libdnf/hy-subject.h
@@ -73,4 +73,7 @@ HySelector hy_subject_get_best_selector(HySubject subject, DnfSack *sack);
 
 G_END_DECLS
 
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(HySubject, hy_subject_free, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(HyPossibilities, hy_possibilities_free, NULL)
+
 #endif


### PR DESCRIPTION
- **skip noninstalled package** (to be compatible with DNF)
- do not try reinstall package
- support full nevra (may cause downgrade until hy_subject_get_best_selector() func
  isn't in sync with implementation in DNF 2.5)

Fix this issue in microdnf https://github.com/rpm-software-management/microdnf/issues/18

Warning: Be sure that Atomic project does not use `update` command for installing!