### PR TITLE
Fix gcc -Wsign-compare warnings

### DIFF
--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -532,7 +532,7 @@ filter_pkg2job(DnfSack *sack, const struct _Filter *f, Queue *job)
     Id id = -1;
     Queue pkgs;
     queue_init(&pkgs);
-    for (int i = 0; i < count; ++i) {
+    for (unsigned int i = 0; i < count; ++i) {
         id = dnf_packageset_get_pkgid(pset, i, id);
         queue_push(&pkgs, id);
     }
@@ -1135,7 +1135,7 @@ hy_goal_describe_protected_removal(HyGoal goal)
     unsigned int count = dnf_packageset_count(pset);
     Id id = -1;
     gboolean found = FALSE;
-    for (int i = 0; i < count; ++i) {
+    for (unsigned int i = 0; i < count; ++i) {
         id = dnf_packageset_get_pkgid(pset, i, id);
         if (MAPTST(goal->protected, id)) {
             s = pool_id2solvable(pool, id);

--- a/python/hawkey/iutil-py.c
+++ b/python/hawkey/iutil-py.c
@@ -165,7 +165,7 @@ packageset_to_pylist(DnfPackageSet *pset, PyObject *sack)
 
     unsigned int count = dnf_packageset_count(pset);
     Id id = -1;
-    for (int i = 0; i < count; ++i) {
+    for (unsigned int i = 0; i < count; ++i) {
         id = dnf_packageset_get_pkgid(pset, i, id);
         PyObject *package = new_package(sack, id);
         if (package == NULL)


### PR DESCRIPTION
Noticed these when building rpm-ostree.

libdnf/libdnf/hy-goal.c: In function ‘filter_pkg2job’:
libdnf/libdnf/hy-goal.c:535:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < count; ++i) {
                       ^
libdnf/libdnf/hy-goal.c: In function ‘hy_goal_describe_protected_removal’:
libdnf/libdnf/hy-goal.c:1138:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < count; ++i) {
                       ^
libdnf/python/hawkey/iutil-py.c: In function ‘packageset_to_pylist’:
libdnf/python/hawkey/iutil-py.c:168:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < count; ++i) {
                       ^