### PR TITLE
transaction: Set up keyring with context's root directory

### DIFF
--- a/libdnf/dnf-transaction.c
+++ b/libdnf/dnf-transaction.c
@@ -118,8 +118,6 @@ static void
 dnf_transaction_init(DnfTransaction *transaction)
 {
     DnfTransactionPrivate *priv = GET_PRIVATE(transaction);
-    priv->ts = rpmtsCreate();
-    priv->keyring = rpmtsGetKeyring(priv->ts, 1);
     priv->timer = g_timer_new();
     priv->pkgs_to_download = g_ptr_array_new_with_free_func((GDestroyNotify) g_object_unref);
 }
@@ -1602,6 +1600,9 @@ dnf_transaction_new(DnfContext *context)
     priv = GET_PRIVATE(transaction);
     priv->context = context;
     g_object_add_weak_pointer(G_OBJECT(priv->context),(void **) &priv->context);
+    priv->ts = rpmtsCreate();
+    rpmtsSetRootDir(priv->ts, dnf_context_get_install_root(context));
+    priv->keyring = rpmtsGetKeyring(priv->ts, 1);
     priv->db = dnf_db_new(context);
     /* propagate db enablement */
     dnf_db_set_enabled(priv->db, dnf_context_get_yumdb_enabled(context));


### PR DESCRIPTION
I'm trying to fix an issue in rpm-ostree where when we're doing `rpm-ostree
compose tree` (similar to `yum --installroot`) we still end up opening the host
rpmdb. This is wrong conceptually, and causes bugs or spurious warnings; an
example is that `rpm-ostree ex container` runs as non-root, and we'd print
errors.

Now, I do have some concerns here; specifically around GPG keys. rpm made the
decision (I think rather universally regarded as bad) to store the keys in the
rpmdb. In yum (and then libdnf), we auto-import everything from
`/etc/pki/rpm-gpg`.  With this behavior we'll drop out any keys from
the rpmdb, but we still do that import (and note it isn't prefixed by
the install root, which is perhaps bad...).

Anyways, thinking about this: I believe (but didn't verify) that if someone had
a key in the rpmdb but *not* in that path it'd no longer be trusted.

In the end though people usually end up writing
`gpgkey=file:///etc/pki/rpm-gpg/...`, so perhaps it doesn't matter?

Regardless, I think this change is right; if there are any real-world
regressions we can try to figure it out then.
