### PR TITLE
Metadata_expire option added

### DIFF
--- a/data/tests/yum.repos.d/local.repo
+++ b/data/tests/yum.repos.d/local.repo
@@ -3,4 +3,4 @@ name=Local
 baseurl=file:///tmp/repo
 enabled=1
 gpgcheck=0
-metadata_expire=0
+metadata_expire=1d

--- a/libdnf/dnf-repo.h
+++ b/libdnf/dnf-repo.h
@@ -112,6 +112,7 @@ gchar **         dnf_repo_get_public_keys       (DnfRepo              *repo);
 DnfRepoEnabled   dnf_repo_get_enabled           (DnfRepo              *repo);
 gboolean         dnf_repo_get_required          (DnfRepo              *repo);
 guint            dnf_repo_get_cost              (DnfRepo              *repo);
+guint            dnf_repo_get_metadata_expire   (DnfRepo              *repo);
 DnfRepoKind      dnf_repo_get_kind              (DnfRepo              *repo);
 gchar          **dnf_repo_get_exclude_packages  (DnfRepo              *repo);
 gboolean         dnf_repo_get_gpgcheck          (DnfRepo              *repo);
@@ -155,6 +156,8 @@ void             dnf_repo_set_gpgcheck_md       (DnfRepo              *repo,
                                                  gboolean              gpgcheck_md);
 void             dnf_repo_set_keyfile           (DnfRepo              *repo,
                                                  GKeyFile             *keyfile);
+void             dnf_repo_set_metadata_expire   (DnfRepo              *repo,
+                                                 guint                 metadata_expire);
 gboolean         dnf_repo_setup                 (DnfRepo              *repo,
                                                  GError              **error);
 

--- a/tests/libdnf/dnf-self-test.c
+++ b/tests/libdnf/dnf-self-test.c
@@ -797,6 +797,7 @@ dnf_repo_loader_func(void)
     g_autofree gchar *repos_dir = NULL;
     g_autoptr(DnfContext) ctx = NULL;
     g_autoptr(DnfRepoLoader) repo_loader = NULL;
+    guint metadata_expire;
 
     /* set up local context */
     ctx = dnf_context_new();
@@ -846,6 +847,9 @@ dnf_repo_loader_func(void)
     /* try to refresh local repo */
     dnf_state_reset(state);
     ret = dnf_repo_update(repo, DNF_REPO_UPDATE_FLAG_NONE, state, &error);
+    /* check the metadata expire attribute */
+    metadata_expire = dnf_repo_get_metadata_expire(repo);
+    g_assert_cmpuint(metadata_expire, == , 60 * 60 * 24);
     g_assert_no_error(error);
     g_assert(ret);
 


### PR DESCRIPTION
For https://github.com/rpm-software-management/libdnf/issues/291, metadata_expire option was added to the libdnf repo, The metadata_expire option in the repo configuration can now be parsed.

The acceptable format for parsing metadata_expire can be:

 Valid inputs: 100, 1.5m, 90s, 1.2d, 1d, 0xF, 0.1, -1, never.
 Invalid inputs: -10, -0.1, 45.6Z, 1d6h, 1day, 1y.

A similar version of metadata_expire parsing can be found in dnf repo:
https://github.com/rpm-software-management/dnf/blob/master/dnf/conf/config.py#L300

A test is added for future regression