### PR TITLE
DnfRepo: Add relasever and basearch suffix to cache directories

### DIFF
--- a/data/tests/cache-test/yum.repos.d/fedora.repo
+++ b/data/tests/cache-test/yum.repos.d/fedora.repo
@@ -1,0 +1,4 @@
+[fedora]
+name=Fedora $releasever - $basearch
+enabled=1
+skip_if_unavailable=False

--- a/libdnf/dnf-context.c
+++ b/libdnf/dnf-context.c
@@ -2009,6 +2009,101 @@ dnf_context_invalidate(DnfContext *context, const gchar *message)
 }
 
 /**
+ * dnf_context_clean_cache:
+ * @context: a #DnfContext instance.
+ * @flags: #DnfContextCleanFlags flag, e.g. %DNF_CONTEXT_CLEAN_EXPIRE_CACHE
+ * @error: a #GError instance
+ *
+ * Clean the cache content in the current cache directory based
+ * on the context flags. A valid cache directory and lock directory
+ * is expected to be set prior to using this function. Use it with care.
+ *
+ * Currently support four different clean flags:
+ * 1: DNF_CONTEXT_CLEAN_EXPIRE_CACHE: Elminate the entries that give information about cache entries' age. i.e: 'repomd.xml' will be deleted in libdnf case
+ * 2: DNF_CONTEXT_CLEAN_PACKAGES: Eliminate any cached packages. i.e: 'packages' folder will be deleted
+ * 3: DNF_CONTEXT_CLEAN_METADATA: Eliminate all of the files which libdnf uses to determine remote availability of packages. i.e: 'repodata'folder and 'metalink.xml' will be deleted
+ * 4: DNF_CONTEXT_CLEAN_ALL: Does all the actions above and clean up other files that are generated due to various reasons. e.g: cache directories from previous version of operating system
+ *
+ * Note: when DNF_CONTEXT_CLEAN_ALL flag is seen, the other flags will be ignored
+ *
+ * Since: 0.9.4
+ **/
+gboolean
+dnf_context_clean_cache(DnfContext *context,
+                        DnfContextCleanFlags flags,
+                        GError **error)
+{
+    DnfRepo *src;
+    g_autoptr(GPtrArray) suffix_list = g_ptr_array_new();
+    const gchar* directory_location;
+    gboolean ret;
+    guint lock_id = 0;
+
+    /* Set up the context if it hasn't been set earlier */
+    if (!dnf_context_setup(context, NULL, error))
+        return FALSE;
+
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    /* We expect cache directories to be set when cleaning cache entries */
+    if (priv->cache_dir == NULL) {
+        g_set_error_literal(error,
+                            DNF_ERROR,
+                            DNF_ERROR_INTERNAL_ERROR,
+                            "No cache dir set");
+        return FALSE;
+    }
+
+    /* When clean all flags show up, we remove everything from cache directory */
+    if (flags & DNF_CONTEXT_CLEAN_ALL) {
+        return dnf_remove_recursive(priv->cache_dir, error);
+    }
+
+    /* We acquire the metadata related lock */
+    lock_id = dnf_lock_take(priv->lock,
+                            DNF_LOCK_TYPE_METADATA,
+                            DNF_LOCK_MODE_PROCESS,
+                            error);
+    if (lock_id == 0)
+        return FALSE;
+
+    /* After the above setup is done, we prepare file extensions based on flag types */
+    if (flags & DNF_CONTEXT_CLEAN_PACKAGES)
+        g_ptr_array_add(suffix_list, (char*) "packages");
+    if (flags & DNF_CONTEXT_CLEAN_METADATA) {
+        g_ptr_array_add(suffix_list, (char*) "metalink.xml");
+        g_ptr_array_add(suffix_list, (char*) "repodata");
+    }
+    if (flags & DNF_CONTEXT_CLEAN_EXPIRE_CACHE)
+        g_ptr_array_add(suffix_list, (char*) "repomd.xml");
+
+    /* Add a NULL terminator and converts array to string list */
+    g_ptr_array_add(suffix_list, NULL);
+    g_autofree gchar** suffix_string_list = (gchar **)g_ptr_array_free(g_steal_pointer(&suffix_list), FALSE);
+
+    /* We then start looping all of the repos to perform file deletion */
+    for (guint counter = 0; counter < priv->repos->len; counter++) {
+        src = g_ptr_array_index(priv->repos, counter);
+        gboolean deleteable_repo = dnf_repo_get_kind(src) == DNF_REPO_KIND_REMOTE;
+        directory_location = dnf_repo_get_location(src);
+
+        /* We check if the repo is qualified to be cleaned */
+        if (deleteable_repo &&
+            g_file_test(directory_location, G_FILE_TEST_EXISTS)) {
+            ret = dnf_delete_files_matching(directory_location,
+                                            (const char* const*) suffix_string_list,
+                                            error);
+            if(!ret)
+                goto out;
+            }
+        }
+
+    out:
+        /* release the acquired lock */
+        if (!dnf_lock_release(priv->lock, lock_id, error))
+            return FALSE;
+        return ret;
+}
+/**
  * dnf_context_new:
  *
  * Creates a new #DnfContext.

--- a/libdnf/dnf-context.c
+++ b/libdnf/dnf-context.c
@@ -2026,6 +2026,8 @@ dnf_context_invalidate(DnfContext *context, const gchar *message)
  *
  * Note: when DNF_CONTEXT_CLEAN_ALL flag is seen, the other flags will be ignored
  *
+ * Returns: %TRUE for success, %FALSE otherwise
+ *
  * Since: 0.9.4
  **/
 gboolean
@@ -2076,9 +2078,8 @@ dnf_context_clean_cache(DnfContext *context,
     if (flags & DNF_CONTEXT_CLEAN_EXPIRE_CACHE)
         g_ptr_array_add(suffix_list, (char*) "repomd.xml");
 
-    /* Add a NULL terminator and converts array to string list */
+    /* Add a NULL terminator for future looping */
     g_ptr_array_add(suffix_list, NULL);
-    g_autofree gchar** suffix_string_list = (gchar **)g_ptr_array_free(g_steal_pointer(&suffix_list), FALSE);
 
     /* We then start looping all of the repos to perform file deletion */
     for (guint counter = 0; counter < priv->repos->len; counter++) {
@@ -2090,7 +2091,7 @@ dnf_context_clean_cache(DnfContext *context,
         if (deleteable_repo &&
             g_file_test(directory_location, G_FILE_TEST_EXISTS)) {
             ret = dnf_delete_files_matching(directory_location,
-                                            (const char* const*) suffix_string_list,
+                                            (const char* const*) suffix_list->pdata,
                                             error);
             if(!ret)
                 goto out;

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -51,6 +51,22 @@ struct _DnfContextClass
 };
 
 /**
+ * DnfContextCleanFlags:
+ * @DNF_CONTEXT_CLEAN_EXPIRE_CACHE:            Clean the indicator file for cache directories' age
+ * @DNF_CONTEXT_CLEAN_PACKAGES:                Clean the packages section for cache
+ * @DNF_CONTEXT_CLEAN_METADATA:                Clean the metadata section for cache directories
+ * @DNF_CONTEXT_CLEAN_ALL:                     Clean out all of the cache directories
+ *
+ * The clean flags for cache directories cleaning.
+ **/
+typedef enum {
+        DNF_CONTEXT_CLEAN_EXPIRE_CACHE          = (1 << 0),
+        DNF_CONTEXT_CLEAN_PACKAGES              = (1 << 1),
+        DNF_CONTEXT_CLEAN_METADATA              = (1 << 2),
+        DNF_CONTEXT_CLEAN_ALL                   = (1 << 3),
+} DnfContextCleanFlags;
+
+/**
  * DnfContextInvalidateFlags:
  * @DNF_CONTEXT_INVALIDATE_FLAG_NONE:           No caches are invalid
  * @DNF_CONTEXT_INVALIDATE_FLAG_RPMDB:          The rpmdb cache is invalid
@@ -161,6 +177,9 @@ void             dnf_context_invalidate                 (DnfContext     *context
 void             dnf_context_invalidate_full            (DnfContext     *context,
                                                          const gchar    *message,
                                                          DnfContextInvalidateFlags flags);
+gboolean         dnf_context_clean_cache                (DnfContext     *context,
+                                                         DnfContextCleanFlags      flags,
+                                                         GError         **error);
 gboolean         dnf_context_install                    (DnfContext     *context,
                                                          const gchar    *name,
                                                          GError         **error);

--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -985,10 +985,16 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
     /* set location if currently unset */
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_LOCAL, 0L))
         return FALSE;
+
     if (priv->location == NULL) {
         g_autofree gchar *tmp = NULL;
+        /* make each repo's cache directory name has releasever and basearch as its suffix */
+        g_autofree gchar *file_name  = g_strjoin("-", priv->id,
+                                                 dnf_context_get_release_ver(priv->context),
+                                                 dnf_context_get_base_arch(priv->context), NULL);
+
         tmp = g_build_filename(dnf_context_get_cache_dir(priv->context),
-                               priv->id, NULL);
+                               file_name, NULL);
         dnf_repo_set_location(repo, tmp);
     }
 

--- a/libdnf/dnf-utils.h
+++ b/libdnf/dnf-utils.h
@@ -27,7 +27,7 @@
 gchar           *dnf_realpath                       (const gchar            *path);
 gboolean         dnf_remove_recursive               (const gchar            *directory,
                                                      GError                 **error);
-gboolean         dnf_file_cleanup                   (const gchar            *src_path,
+gboolean         dnf_ensure_file_unlinked           (const gchar            *src_path,
                                                      GError                 **error);
 gboolean         dnf_delete_files_matching          (const gchar            *directory_path,
                                                      const char* const      *patterns,

--- a/libdnf/dnf-utils.h
+++ b/libdnf/dnf-utils.h
@@ -27,6 +27,11 @@
 gchar           *dnf_realpath                       (const gchar            *path);
 gboolean         dnf_remove_recursive               (const gchar            *directory,
                                                      GError                 **error);
+gboolean         dnf_file_cleanup                   (const gchar            *src_path,
+                                                     GError                 **error);
+gboolean         dnf_delete_files_matching          (const gchar            *directory_path,
+                                                     const char* const      *patterns,
+                                                     GError                 **error);
 gboolean         dnf_get_file_contents_allow_noent  (const gchar            *path,
                                                      gchar                  **out_contents,
                                                      gsize                  *length,


### PR DESCRIPTION
This is for issue https://github.com/rpm-software-management/libdnf/issues/148.

Before, all the cache generated does not have a suffix, now
a suffix will be added to the cache directory to diffrentiate
different releaseversions + basearch.

This fixes the old rpm-ostree rebase problem. A newer cache
will be downloaded when user tries to use rpm-ostree rebase
to a new version of system.