### PR TITLE
Use `python -m nose` instead of `nosetests-<python_version>` to run tests

### DIFF
--- a/python/hawkey/tests/tests/run_nosetests.in
+++ b/python/hawkey/tests/tests/run_nosetests.in
@@ -17,7 +17,7 @@ def fatal(msg):
 
 childenv = dict(os.environ)
 childenv['PYTHONPATH'] = '${CMAKE_BINARY_DIR}/python/hawkey'
-subprocess.check_call(['nosetests-${PYTHON_MAJOR_DOT_MINOR_VERSION}',
+subprocess.check_call(['${PYTHON_EXECUTABLE}', '-m', 'nose',
                        '--with-xunit', '--xunit-file=xunit.xml',
                        '-s', '-v', '${CMAKE_CURRENT_SOURCE_DIR}'],
                       env=childenv)


### PR DESCRIPTION
This change enables us to build libdnf with various Python versions even with nose available only as a module without binaries or with binaries in a different location.

This change is needed for creating a new platform-python stack for fedora and is also tested for Python 2 and 3.