### PR TITLE
lib/repo: Fix non gtk-doc comment

### DIFF
--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -896,10 +896,7 @@ dnf_repo_get_boolean(GKeyFile *keyfile,
     return FALSE;
 }
 
-/**
- * dnf_repo_set_keyfile_data: initialize (or potentially reset) repo & LrHandle
- * from keyfile values.
- */
+/* Initialize (or potentially reset) repo & LrHandle from keyfile values. */
 static gboolean
 dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
 {


### PR DESCRIPTION
`g-ir-scanner` warns about this.  For static functions let's
avoid repeating the function name since we don't have to.