### PR TITLE
Run default query filter only on solvable in result

### DIFF
--- a/libdnf/hy-query.c
+++ b/libdnf/hy-query.c
@@ -303,15 +303,17 @@ filter_dataiterator(HyQuery q, struct _Filter *f, Map *m)
     int flags = type2flags(f->cmp_type, f->keyname);
 
     assert(f->match_type == _HY_STR);
-    /* do an OR over all matches: */
-    for (int i = 0; i < f->nmatches; ++i) {
-        dataiterator_init(&di, pool, 0, 0,
-                          keyname,
-                          f->matches[i].str,
-                          flags);
-        while (dataiterator_step(&di))
-            MAPSET(m, di.solvid);
-        dataiterator_free(&di);
+
+    for (int mi = 0; mi < f->nmatches; ++mi) {
+        const char *match = f->matches[mi].str;
+        for (Id id = 1; id < pool->nsolvables; ++id) {
+            if (!MAPTST(q->result, id))
+                continue;
+            dataiterator_init(&di, pool, 0, id, keyname, match, flags);
+            while (dataiterator_step(&di))
+                MAPSET(m, di.solvid);
+            dataiterator_free(&di);
+        }
     }
 }
 


### PR DESCRIPTION
It can dramatically decrease required time for query with limited result (more
than 10x), but for query against full sack it adds 15%.

It can be tested with HY_PKG_FILE