### PR TITLE
WIP: Add suppport for adding solvable to repository 

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -21,7 +21,7 @@
     %{nil}
 
 Name:           libdnf
-Version:        0.10.1
+Version:        0.10.2
 Release:        1%{?dist}
 Summary:        Library providing simplified C and Python API to libsolv
 License:        LGPLv2+

--- a/libdnf/dnf-sack.h
+++ b/libdnf/dnf-sack.h
@@ -84,6 +84,40 @@ typedef enum {
     DNF_SACK_LOAD_FLAG_LAST
 } DnfSackLoadFlags;
 
+typedef struct {
+    char *name;
+    unsigned int epoch;
+    char *version;
+    char *release;
+    char *arch;
+} DnfSolvableNevra;
+
+typedef struct {
+    DnfSolvableNevra nevra;
+    int flags;
+} DnfSolvableDependency;
+
+typedef struct {
+    unsigned int count; 
+    DnfSolvableDependency *deps;
+} DnfSolvableDependencies;
+
+typedef struct {
+    DnfSolvableNevra nevra;
+    char *vendor;
+
+    DnfSolvableDependencies provides;
+    DnfSolvableDependencies obsoletes;
+    DnfSolvableDependencies conflicts;
+
+    DnfSolvableDependencies requires;
+    DnfSolvableDependencies recommends;
+    DnfSolvableDependencies suggests;
+
+    DnfSolvableDependencies supplements;
+    DnfSolvableDependencies enhances;
+} DnfSolvable;
+
 DnfSack     *dnf_sack_new                   (void);
 
 void         dnf_sack_set_cachedir          (DnfSack        *sack,
@@ -115,6 +149,9 @@ void         dnf_sack_set_installonly_limit (DnfSack        *sack,
 guint        dnf_sack_get_installonly_limit (DnfSack        *sack);
 DnfPackage  *dnf_sack_add_cmdline_package   (DnfSack        *sack,
                                              const char     *fn);
+Id           dnf_sack_add_solvable          (DnfSack        *sack,
+                                             HyRepo          repo,
+                                             const DnfSolvable *dnf_solvable);
 int          dnf_sack_count                 (DnfSack        *sack);
 void         dnf_sack_add_excludes          (DnfSack        *sack,
                                              DnfPackageSet  *pset);

--- a/python/hawkey/pycomp.c
+++ b/python/hawkey/pycomp.c
@@ -19,13 +19,15 @@
  */
 
 #include <Python.h>
+
+#include <glib.h>
 #include "pycomp.h"
 
 /**
  * unicode string in Python 2/3 to c string converter,
  * you need to call Py_XDECREF(tmp_py_str) after usage of returned string
  */
-static char *
+static const char *
 pycomp_get_string_from_unicode(PyObject *str_u, PyObject **tmp_py_str)
 {
     *tmp_py_str = PyUnicode_AsUTF8String(str_u);
@@ -39,7 +41,7 @@ pycomp_get_string_from_unicode(PyObject *str_u, PyObject **tmp_py_str)
 const char *
 pycomp_get_string(PyObject *str, PyObject **tmp_py_str)
 {
-    char *res = NULL;
+    const char *res = NULL;
     if (PyUnicode_Check(str))
         res = pycomp_get_string_from_unicode(str, tmp_py_str);
 #if PY_MAJOR_VERSION < 3
@@ -55,6 +57,20 @@ pycomp_get_string(PyObject *str, PyObject **tmp_py_str)
 #endif
 
     return res;
+}
+
+/**
+ * bytes, basic string or unicode string in Python 2/3 to c string converter
+ * New memory is allocated. The returned string should be freed with g_free()
+ * when no longer needed.
+ */
+char *
+pycomp_get_string_copy(PyObject *str)
+{
+    PyObject *tmp_py_str = NULL;
+    char *cstr = g_strdup(pycomp_get_string(str, &tmp_py_str));
+    Py_XDECREF(tmp_py_str);
+    return cstr;
 }
 
 /* release PyObject array from memory */

--- a/python/hawkey/pycomp.h
+++ b/python/hawkey/pycomp.h
@@ -57,6 +57,7 @@
 #endif
 
 const char *pycomp_get_string(PyObject *str_o, PyObject **tmp_py_str);
+char *pycomp_get_string_copy(PyObject *str_o);
 void pycomp_free_tmp_array(PyObject **tmp_py_strs, int count);
 extern PYCOMP_MOD_INIT(_hawkey);
 


### PR DESCRIPTION
New C function:
Id dnf_sack_add_solvable(DnfSack *sack, HyRepo repo, const DnfSolvable *dnf_solvable);
and Python method:
sack.add_solvable

Example of usage:
solvable = {"repo": "fedora",
            "name": "virt_packageY", "epoch": 0, "version": "1.4", "release": "1.fc26", "arch": "x86_64",
            "vendor": "virtual_vendor",
            "requires": [{"name": "atop", "flags": ">=", "epoch": 0, "version": "2.3.0", "release": "1.fc26", "arch": "x86_64"},
                         {"name": "virt_packageX"}]}
solv_id = self.sack.add_solvable(**solvable)
print("Added solvable ", solv_id)