### PR TITLE
Not require spaces in provides (RhBug:1480176)

### DIFF
--- a/libdnf/hy-iutil.c
+++ b/libdnf/hy-iutil.c
@@ -694,13 +694,13 @@ parse_reldep_str(const char *reldep_str, char **name, char **evr,
     regex_t reg;
     const char *regex =
         "^([^ \t\r\n\v\f<=>!]*)\\s*(<=|>=|!=|<|>|=)?\\s*(.*)$";
-    regmatch_t matches[6];
+    regmatch_t matches[4];
     *cmp_type = 0;
     int ret = 0;
 
     regcomp(&reg, regex, REG_EXTENDED);
 
-    if(regexec(&reg, reldep_str, 6, matches, 0) == 0) {
+    if(regexec(&reg, reldep_str, 4, matches, 0) == 0) {
         if (copy_str_from_subexpr(name, reldep_str, matches, 1) == -1)
             ret = -1;
         // without comparator and evr

--- a/libdnf/hy-iutil.c
+++ b/libdnf/hy-iutil.c
@@ -693,7 +693,7 @@ parse_reldep_str(const char *reldep_str, char **name, char **evr,
 {
     regex_t reg;
     const char *regex =
-        "^(\\S*)\\s*(<=|>=|!=|<|>|=)?\\s*(.*)$";
+        "^([^ \t\r\n\v\f<=>!]*)\\s*(<=|>=|!=|<|>|=)?\\s*(.*)$";
     regmatch_t matches[6];
     *cmp_type = 0;
     int ret = 0;


### PR DESCRIPTION
The patch allows provides like "dnf>1". Previously spaces were mandatory like
"dnf > 1".

https://bugzilla.redhat.com/show_bug.cgi?id=1480176