### PR TITLE
Remove private header file from public header

### DIFF
--- a/libdnf/hy-iutil.c
+++ b/libdnf/hy-iutil.c
@@ -46,6 +46,7 @@
 #include <glib/gi18n-lib.h>
 
 // hawkey
+#include "dnf-advisory-private.h"
 #include "dnf-types.h"
 #include "hy-iutil.h"
 #include "hy-package-private.h"
@@ -248,6 +249,12 @@ free_map_fully(Map *m)
     map_free(m);
     g_free(m);
     return NULL;
+}
+
+int
+is_package(const Pool *pool, const Solvable *s)
+{
+    return !g_str_has_prefix(pool_id2str(pool, s->name), SOLVABLE_NAME_ADVISORY_PREFIX);
 }
 
 int

--- a/libdnf/hy-iutil.h
+++ b/libdnf/hy-iutil.h
@@ -28,7 +28,6 @@
 #include <solv/rules.h>
 #include <solv/transaction.h>
 
-#include "dnf-advisory-private.h"
 #include "dnf-sack.h"
 
 #define CHKSUM_BYTES 32
@@ -65,10 +64,7 @@ void queue2plist(DnfSack *sack, Queue *q, GPtrArray *plist);
 Id what_upgrades(Pool *pool, Id p);
 Id what_downgrades(Pool *pool, Id p);
 Map *free_map_fully(Map *m);
-static inline int is_package(Pool *pool, Solvable *s)
-{
-    return !g_str_has_prefix(pool_id2str(pool, s->name), SOLVABLE_NAME_ADVISORY_PREFIX);
-}
+int is_package(const Pool *pool, const Solvable *s);
 
 /* package version utils */
 unsigned long pool_get_epoch(Pool *pool, const char *evr);

--- a/libdnf/hy-query.c
+++ b/libdnf/hy-query.c
@@ -30,6 +30,7 @@
 
 #include "dnf-types.h"
 #include "dnf-advisorypkg.h"
+#include "dnf-advisory-private.h"
 #include "hy-iutil.h"
 #include "hy-query-private.h"
 #include "hy-package-private.h"


### PR DESCRIPTION
Including private header file to public header file is bad idea. In fact we expose the private file by this include.
Implementation of "is_package()" was moved to .c file and "const" was used.