### PR TITLE
Use export "C" consistently

### DIFF
--- a/libdnf/dnf-advisorypkg-private.h
+++ b/libdnf/dnf-advisorypkg-private.h
@@ -26,8 +26,6 @@
 
 #include "dnf-advisorypkg.h"
 
-G_BEGIN_DECLS
-
 DnfAdvisoryPkg  *dnf_advisorypkg_new            (void);
 void             dnf_advisorypkg_set_name       (DnfAdvisoryPkg *advisorypkg,
                                                  const char     *value);
@@ -37,7 +35,5 @@ void             dnf_advisorypkg_set_arch       (DnfAdvisoryPkg *advisorypkg,
                                                  const char     *value);
 void             dnf_advisorypkg_set_filename   (DnfAdvisoryPkg *advisorypkg,
                                                  const char     *value);
-
-G_END_DECLS
 
 #endif /* __DNF_ADVISORYPKG_PRIVATE_H */

--- a/libdnf/dnf-goal.h
+++ b/libdnf/dnf-goal.h
@@ -27,6 +27,8 @@
 #include "hy-goal.h"
 #include "hy-package.h"
 
+G_BEGIN_DECLS
+
 gboolean         dnf_goal_depsolve                      (HyGoal          goal,
                                                          DnfGoalActions  flags,
                                                          GError          **error);
@@ -36,5 +38,7 @@ void             dnf_goal_add_protected                 (HyGoal goal,
                                                          DnfPackageSet  *pset);
 void             dnf_goal_set_protected                 (HyGoal goal,
                                                          DnfPackageSet  *pset);
+
+G_END_DECLS
 
 #endif /* __DNF_GOAL_H */

--- a/libdnf/dnf-keyring.h
+++ b/libdnf/dnf-keyring.h
@@ -26,6 +26,8 @@
 
 #include <rpm/rpmkeyring.h>
 
+G_BEGIN_DECLS
+
 gboolean         dnf_keyring_add_public_key     (rpmKeyring              keyring,
                                                  const gchar            *filename,
                                                  GError                 **error);
@@ -34,5 +36,7 @@ gboolean         dnf_keyring_add_public_keys    (rpmKeyring              keyring
 gboolean         dnf_keyring_check_untrusted_file (rpmKeyring            keyring,
                                                  const gchar            *filename,
                                                  GError                 **error);
+
+G_END_DECLS
 
 #endif /* __DNF_KEYRING_H */

--- a/libdnf/dnf-package.h
+++ b/libdnf/dnf-package.h
@@ -29,6 +29,8 @@
 #include "dnf-repo.h"
 #include "dnf-state.h"
 
+G_BEGIN_DECLS
+
 /**
  * DnfPackageInfo:
  * @DNF_PACKAGE_INFO_UNKNOWN:                   Unknown state
@@ -95,5 +97,7 @@ gboolean         dnf_package_array_download             (GPtrArray      *package
                                                          DnfState       *state,
                                                          GError         **error);
 guint64          dnf_package_array_get_download_size    (GPtrArray      *packages);
+
+G_END_DECLS
 
 #endif /* __DNF_PACKAGE_H */

--- a/libdnf/dnf-packagedelta-private.h
+++ b/libdnf/dnf-packagedelta-private.h
@@ -25,10 +25,6 @@
 
 #include "dnf-packagedelta.h"
 
-G_BEGIN_DECLS
-
 DnfPackageDelta *dnf_packagedelta_new                  (Pool *pool);
-
-G_END_DECLS
 
 #endif /* __DNF_PACKAGEDELTA_PRIVATE_H */

--- a/libdnf/dnf-reldep-list-private.h
+++ b/libdnf/dnf-reldep-list-private.h
@@ -24,11 +24,7 @@
 
 #include "dnf-reldep-list.h"
 
-G_BEGIN_DECLS
-
 DnfReldepList *dnf_reldep_list_from_queue (Pool          *pool,
                                            Queue          queue);
 void           dnf_reldep_list_extend     (DnfReldepList *rl1,
                                            DnfReldepList *rl2);
-
-G_END_DECLS

--- a/libdnf/dnf-rpmts.h
+++ b/libdnf/dnf-rpmts.h
@@ -26,6 +26,8 @@
 #include <rpm/rpmts.h>
 #include "hy-package.h"
 
+G_BEGIN_DECLS
+
 gboolean         dnf_rpmts_add_install_filename (rpmts           ts,
                                                  const gchar    *filename,
                                                  gboolean        allow_untrusted,
@@ -36,5 +38,7 @@ gboolean         dnf_rpmts_add_remove_pkg       (rpmts           ts,
                                                  GError         **error);
 gboolean         dnf_rpmts_look_for_problems    (rpmts           ts,
                                                  GError         **error);
+
+G_END_DECLS
 
 #endif /* __DNF_RPMTS_H */

--- a/libdnf/dnf-solution-private.h
+++ b/libdnf/dnf-solution-private.h
@@ -24,9 +24,4 @@
 
 #include "dnf-solution.h"
 
-G_BEGIN_DECLS
-
 DnfSolution  *dnf_solution_new            (void);
-
-G_END_DECLS
-

--- a/libdnf/dnf-swdb-db.h
+++ b/libdnf/dnf-swdb-db.h
@@ -28,6 +28,8 @@
 #include <sqlite3.h>
 #include "dnf-swdb.h"
 
+G_BEGIN_DECLS
+
 gint            _create_db          (sqlite3        *db);
 void            _db_step            (sqlite3_stmt   *res);
 gint            _db_find_int        (sqlite3_stmt   *res);
@@ -67,4 +69,7 @@ gint            dnf_swdb_create_db  (DnfSwdb        *self);
 gint            dnf_swdb_reset_db   (DnfSwdb        *self);
 gint            dnf_swdb_open       (DnfSwdb        *self);
 void            dnf_swdb_close      (DnfSwdb        *self);
+
+G_END_DECLS
+
 #endif

--- a/libdnf/dnf-types.h
+++ b/libdnf/dnf-types.h
@@ -37,6 +37,8 @@ typedef struct _DnfPackageSet           DnfPackageSet;
 typedef struct _DnfReldep               DnfReldep;
 typedef struct _DnfReldepList           DnfReldepList;
 
+G_BEGIN_DECLS
+
 /**
  * DnfError:
  * @DNF_ERROR_FAILED:                           Failed with a non-specific error
@@ -97,6 +99,8 @@ typedef enum {
 
 #define DNF_ERROR                       (dnf_error_quark ())
 GQuark           dnf_error_quark        (void);
+
+G_END_DECLS
 
 #endif
 

--- a/libdnf/dnf-utils.h
+++ b/libdnf/dnf-utils.h
@@ -24,6 +24,8 @@
 
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 gchar           *dnf_realpath                       (const gchar            *path);
 gboolean         dnf_remove_recursive               (const gchar            *directory,
                                                      GError                 **error);
@@ -36,5 +38,7 @@ gboolean         dnf_get_file_contents_allow_noent  (const gchar            *pat
                                                      gchar                  **out_contents,
                                                      gsize                  *length,
                                                      GError                 **error);
+
+G_END_DECLS
 
 #endif /* __DNF_UTILS_H */

--- a/libdnf/hy-iutil.h
+++ b/libdnf/hy-iutil.h
@@ -33,6 +33,8 @@
 
 #define CHKSUM_BYTES 32
 
+G_BEGIN_DECLS
+
 /* crypto utils */
 int checksum_cmp(const unsigned char *cs1, const unsigned char *cs2);
 int checksum_fp(unsigned char *out, FILE *fp);
@@ -105,5 +107,7 @@ const char *id2nevra(Pool *pool, Id id);
         if (!is_package(pool, pool_id2solvable(pool, p)))               \
             continue;                                                   \
         else
+
+G_END_DECLS
 
 #endif


### PR DESCRIPTION
Export "C" was used randomly.
This patch adds export "C" to all public .h files and
removes it from all private .h files.