### PR TITLE
[swdb]: remove indexes on expressions for epel7 compatibility

### DIFF
--- a/libdnf/dnf-swdb-db-sql.h
+++ b/libdnf/dnf-swdb-db-sql.h
@@ -136,17 +136,13 @@
     "   tw_id INTEGER PRIMARY KEY," \
     "   t_id INTEGER REFERENCES trans(t_id)," \
     "   p_id INTEGER REFERENCES package(p_id));" \
-    "CREATE INDEX nevra ON PACKAGE(" \
-    "   name || '-' || epoch || ':' || version || '-' || release || '.' || arch);" \
-    "CREATE INDEX nvra on PACKAGE(" \
-    "   name || '-' || version || '-' || release || '.' || arch);" \
+    "CREATE INDEX name_index ON PACKAGE(name);" \
     "CREATE TABLE config (" \
     "   key TEXT PRIMARY KEY," \
     "   value TEXT NOT NULL);" \
-    "INSERT INTO config values("\
-    "   'version',"\
+    "INSERT INTO config values(" \
+    "   'version'," \
     "   '1.0');"
-
 
 #define S_OUTPUT "SELECT msg FROM OUTPUT WHERE T_ID=@tid and type=@type"
 

--- a/libdnf/dnf-swdb-db.c
+++ b/libdnf/dnf-swdb-db.c
@@ -152,7 +152,7 @@ _db_prepare (sqlite3 *db, const gchar *sql, sqlite3_stmt **res)
     gint rc = sqlite3_prepare_v2 (db, sql, -1, res, NULL);
     if (rc != SQLITE_OK) {
         sqlite3_finalize (*res);
-        g_error ("SWDB prepare error: %s", sqlite3_errmsg (db));
+        g_error ("SWDB prepare error: '%s' - %s", sql, sqlite3_errmsg (db));
     }
 }
 
@@ -194,7 +194,8 @@ _db_bind_int (sqlite3_stmt *res, const gchar *id, gint source)
     if (rc) {
         sqlite3 *db = sqlite3_db_handle (res);
         const gchar *err = sqlite3_errmsg (db);
-        g_error ("SWDB integer bind (args: %d|%s|%d): %s", idx, id, source, err);    }
+        g_error ("SWDB integer bind (args: %d|%s|%d): %s", idx, id, source, err);
+    }
 }
 
 /**

--- a/libdnf/dnf-swdb-sql.h
+++ b/libdnf/dnf-swdb-sql.h
@@ -98,20 +98,12 @@
 #define S_REPO_FROM_PID2 "SELECT name FROM PACKAGE_DATA join REPO using(R_ID) where P_ID=@pid"
 
 #define S_CHECKSUM_BY_NEVRA \
-    "SELECT checksum_data, checksum_type FROM PACKAGE WHERE name || '-' || epoch || ':' || " \
-    "version || '-' || release || '.' || arch=@nevra"
-
-#define S_CHECKSUM_BY_NVRA \
-    "SELECT checksum_data, checksum_type FROM PACKAGE WHERE name || '-' || version || '-' || " \
-    "release || '.' || arch=@nevra"
+    "SELECT checksum_data, checksum_type FROM PACKAGE WHERE name=@n and epoch=@e and version=@v " \
+    "and release=@r and arch=@a"
 
 #define S_PID_BY_NEVRA \
-    "SELECT P_ID FROM PACKAGE WHERE name || '-' || epoch || ':' || version || '-' || release || " \
-    "'.' || arch=@nevra"
-
-#define S_PID_BY_NVRA \
-    "SELECT P_ID FROM PACKAGE WHERE name || '-' || version || '-' || release || '.' || " \
-    "arch=@nevra"
+    "SELECT P_ID FROM PACKAGE WHERE name=@n and epoch=@e and version=@v and release=@r and " \
+    "arch=@a"
 
 #define S_REASON_ID_BY_PDID \
     "SELECT reason FROM PACKAGE_DATA join TRANS_DATA using(PD_ID) where PD_ID=@pdid"

--- a/libdnf/hy-subject-private.c
+++ b/libdnf/hy-subject-private.c
@@ -71,7 +71,7 @@ const char *module_form_regex[] = {
 #define MATCH_EMPTY(i) (matches[i].rm_so >= matches[i].rm_eo)
 
 int
-nevra_possibility(char *nevra_str, int form, HyNevra nevra)
+nevra_possibility(const char *nevra_str, int form, HyNevra nevra)
 {
     enum { NAME = 1, EPOCH = 3, VERSION = 4, RELEASE = 5, ARCH = 6 };
     regex_t reg;

--- a/libdnf/hy-subject-private.h
+++ b/libdnf/hy-subject-private.h
@@ -32,7 +32,7 @@ enum poss_type {
 
 extern const char *nevra_form_regex[];
 
-int nevra_possibility(char *nevra_str, int re, HyNevra nevra);
+int nevra_possibility(const char *nevra_str, int re, HyNevra nevra);
 int module_form_possibility(char *module_form_str, int re, HyModuleForm module_form);
 
 #endif

--- a/libdnf/hy-util.c
+++ b/libdnf/hy-util.c
@@ -165,7 +165,7 @@ hy_split_nevra(const char *nevra, char **name, int *epoch,
     if (len <= 0)
         return DNF_ERROR_INTERNAL_ERROR;
     HyNevra out_nevra = hy_nevra_create();
-    if (nevra_possibility((char *) nevra, HY_FORM_NEVRA, out_nevra) == 0) {
+    if (nevra_possibility(nevra, HY_FORM_NEVRA, out_nevra) == 0) {
         *arch = g_strdup(hy_nevra_get_string(out_nevra, HY_NEVRA_ARCH));
         *name = g_strdup(hy_nevra_get_string(out_nevra, HY_NEVRA_NAME));
         *release = g_strdup(hy_nevra_get_string(out_nevra, HY_NEVRA_RELEASE));

--- a/tests/hawkey/test_subject.c
+++ b/tests/hawkey/test_subject.c
@@ -67,7 +67,7 @@ START_TEST(nevra1)
     HyNevra nevra = hy_nevra_create();
 
     ck_assert_int_eq(
-        nevra_possibility((char *) inp_fof, HY_FORM_NEVRA, nevra), 0);
+        nevra_possibility(inp_fof, HY_FORM_NEVRA, nevra), 0);
     ck_assert_str_eq(hy_nevra_get_string(nevra, HY_NEVRA_NAME), "four-of-fish");
     ck_assert_int_eq(hy_nevra_get_epoch(nevra), 8);
     ck_assert_str_eq(hy_nevra_get_string(nevra, HY_NEVRA_VERSION), "3.6.9");
@@ -112,7 +112,7 @@ START_TEST(nevra2)
     HyNevra nevra = hy_nevra_create();
 
     ck_assert_int_eq(
-        nevra_possibility((char *) inp_fof_noepoch, HY_FORM_NEVRA, nevra), 0);
+        nevra_possibility(inp_fof_noepoch, HY_FORM_NEVRA, nevra), 0);
     ck_assert_str_eq(nevra->name, "four-of-fish");
     ck_assert_int_eq(nevra->epoch, -1);
     ck_assert_str_eq(nevra->version, "3.6.9");
@@ -128,7 +128,7 @@ START_TEST(nevr)
     HyNevra nevra = hy_nevra_create();
 
     ck_assert_int_eq(
-        nevra_possibility((char *) inp_fof, HY_FORM_NEVR, nevra), 0);
+        nevra_possibility(inp_fof, HY_FORM_NEVR, nevra), 0);
     ck_assert_str_eq(nevra->name, "four-of-fish");
     ck_assert_int_eq(nevra->epoch, 8);
     ck_assert_str_eq(nevra->version, "3.6.9");
@@ -144,7 +144,7 @@ START_TEST(nevr_fail)
     HyNevra nevra = hy_nevra_create();
 
     ck_assert_int_eq(
-        nevra_possibility((char *) "four-of", HY_FORM_NEVR, nevra), -1);
+        nevra_possibility("four-of", HY_FORM_NEVR, nevra), -1);
 
     hy_nevra_free(nevra);
 }
@@ -155,7 +155,7 @@ START_TEST(nev)
     HyNevra nevra = hy_nevra_create();
 
     ck_assert_int_eq(
-        nevra_possibility((char *) inp_fof_nev, HY_FORM_NEV, nevra), 0);
+        nevra_possibility(inp_fof_nev, HY_FORM_NEV, nevra), 0);
     ck_assert_str_eq(nevra->name, "four-of-fish");
     ck_assert_int_eq(nevra->epoch, 8);
     ck_assert_str_eq(nevra->version, "3.6.9");
@@ -171,7 +171,7 @@ START_TEST(na)
     HyNevra nevra = hy_nevra_create();
 
     ck_assert_int_eq(
-        nevra_possibility((char *) inp_fof_na, HY_FORM_NA, nevra), 0);
+        nevra_possibility(inp_fof_na, HY_FORM_NA, nevra), 0);
     ck_assert_str_eq(nevra->name, "four-of-fish-3.6.9");
     ck_assert_int_eq(nevra->epoch, -1);
     fail_unless(nevra->version == NULL);


### PR DESCRIPTION
RHEL 7 is running on sqlite 3.7.17, which lacks index on expression support (introduced in 3.9).

Index on nevra expression was replaced by index on name and nevra is being parsed.