### PR TITLE
Double free in hy-iutil.cpp

### DIFF
--- a/libdnf/hy-iutil.cpp
+++ b/libdnf/hy-iutil.cpp
@@ -766,11 +766,11 @@ reldeplist_from_str(DnfSack *sack, const char *reldep_str)
     int cmp_type;
     char *name_glob = NULL;
     char *evr = NULL;
+    if (parse_reldep_str(reldep_str, &name_glob, &evr, &cmp_type) == -1)
+        return NULL;
     Dataiterator di;
     Pool *pool = dnf_sack_get_pool(sack);
-
     DnfReldepList *reldeplist = dnf_reldep_list_new (sack);
-    parse_reldep_str(reldep_str, &name_glob, &evr, &cmp_type);
 
     dataiterator_init(&di, pool, 0, 0, 0, name_glob, SEARCH_STRING | SEARCH_GLOB);
     while (dataiterator_step(&di)) {

--- a/libdnf/hy-query.cpp
+++ b/libdnf/hy-query.cpp
@@ -1352,6 +1352,8 @@ hy_query_filter(HyQuery q, int keyname, int cmp_type, const char *match)
 
     if (cmp_type == HY_GLOB) {
         DnfReldepList *reldeplist = reldeplist_from_str (sack, match);
+        if (reldeplist == NULL)
+            return hy_query_filter_empty(q);
         hy_query_filter_reldep_in(q, keyname, reldeplist);
         g_object_unref (reldeplist);
         return 0;

--- a/python/hawkey/iutil-py.c
+++ b/python/hawkey/iutil-py.c
@@ -242,8 +242,11 @@ pyseq_to_reldeplist(PyObject *obj, DnfSack *sack, int cmp_type)
         if (reldep_str == NULL)
             goto fail;
 
-        g_reldeplist = reldeplist_from_str (sack, reldep_str);
         Py_XDECREF(tmp_py_str);
+
+        g_reldeplist = reldeplist_from_str (sack, reldep_str);
+        if (g_reldeplist == NULL)
+            goto fail;
 
         dnf_reldep_list_extend (reldeplist, g_reldeplist);
         g_object_unref (g_reldeplist);


### PR DESCRIPTION
Return value of parse_reldep_str was not checked and this
could cause double free on name_glob variable - one in
parse_reldep_str and then another in reldeplist_from_str
function.
This command then dumped core:
$ dnf repoquery --resolve --queryformat "%{name} %{repoid}" libzip