### PR TITLE
Remove partially build of gobject-introspection

### DIFF
--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -185,10 +185,6 @@ if (GOBJECT_INTROSPECTION_FOUND)
                     --pkg=librepo
                     --warn-all
                     --quiet
-                    dnf-context.cpp dnf-context.h
-                    dnf-repo.cpp dnf-repo.h
-                    dnf-state.h dnf-state.cpp
-                    dnf-version.h
                     ${SWDB_headers}
                     ${SWDB_sources}
             DEPENDS libdnf


### PR DESCRIPTION
Removed part is so far unused by any user, and we would like remove the whole
goblect-intorspection and replace it by other binding, but not before we create
libdnf API.