### PR TITLE
Remove auto-construction of selectors for goal

### DIFF
--- a/libdnf/hy-goal.cpp
+++ b/libdnf/hy-goal.cpp
@@ -967,12 +967,6 @@ hy_goal_run_flags(HyGoal goal, DnfGoalActions flags)
 }
 
 int
-hy_goal_run_all(HyGoal goal, hy_solution_callback cb, void *cb_data)
-{
-    return hy_goal_run_all_flags(goal, cb, cb_data, DNF_NONE);
-}
-
-int
 hy_goal_run_all_flags(HyGoal goal, hy_solution_callback cb, void *cb_data,
                       DnfGoalActions flags)
 {

--- a/libdnf/hy-goal.h
+++ b/libdnf/hy-goal.h
@@ -105,7 +105,6 @@ int hy_goal_req_length(HyGoal goal);
 /* resolving the goal */
 int hy_goal_run(HyGoal goal);
 int hy_goal_run_flags(HyGoal goal, DnfGoalActions flags);
-int hy_goal_run_all(HyGoal goal, hy_solution_callback cb, void *cb_data);
 int hy_goal_run_all_flags(HyGoal goal, hy_solution_callback cb, void *cb_data,
                           DnfGoalActions flags);
 

--- a/python/hawkey/__init__.py
+++ b/python/hawkey/__init__.py
@@ -259,22 +259,12 @@ class Goal(_hawkey.Goal):
             callback(self)
         return ret
 
-    def erase(self, *args, **kwargs):
-        super(Goal, self).erase(*args, **kwargs)
-
     def install(self, *args, **kwargs):
         if args:
             self._installs.extend(args)
         if 'select' in kwargs:
             self._installs.extend(kwargs['select'].matches())
         super(Goal, self).install(*args, **kwargs)
-
-    def downgrade_to(self, *args, **kwargs):
-        super(Goal, self).downgrade_to(*args, **kwargs)
-
-    def upgrade(self, *args, **kwargs):
-        super(Goal, self).upgrade(*args, **kwargs)
-
 
 def _encode(obj):
     """ Identity, except when obj is unicode then return a UTF-8 string.

--- a/python/hawkey/__init__.py
+++ b/python/hawkey/__init__.py
@@ -253,12 +253,6 @@ class Goal(_hawkey.Goal):
     def problems(self):
         return [self.describe_problem(i) for i in range(0, self.count_problems())]
 
-    def run(self, callback=None, **kwargs):
-        ret = super(Goal, self).run(**kwargs)
-        if callback:
-            callback(self)
-        return ret
-
     def install(self, *args, **kwargs):
         if args:
             self._installs.extend(args)

--- a/python/hawkey/__init__.py
+++ b/python/hawkey/__init__.py
@@ -208,8 +208,6 @@ class ModuleForm(_hawkey.ModuleForm):
 
 
 class Goal(_hawkey.Goal):
-    _reserved_kw = set(['package', 'select'])
-    _flag_kw = set(['clean_deps', 'check_installed'])
     _goal_actions = {
         ERASE,
         DISTUPGRADE,
@@ -251,20 +249,6 @@ class Goal(_hawkey.Goal):
     def actions(self):
         return {f for f in self._goal_actions if self._has_actions(f)}
 
-    def _auto_selector(fn):
-        def tweaked_fn(self, *args, **kwargs):
-            if args or self._reserved_kw & set(kwargs):
-                return fn(self, *args, **kwargs)
-
-            # only the flags and unrecognized keywords remained, construct a
-            # Selector
-            new_kwargs = {}
-            for flag in self._flag_kw & set(kwargs):
-                new_kwargs[flag] = kwargs.pop(flag)
-            new_kwargs['select'] = Selector(self.sack).set(**kwargs)
-            return fn(self, **new_kwargs)
-        return tweaked_fn
-
     @property
     def problems(self):
         return [self.describe_problem(i) for i in range(0, self.count_problems())]
@@ -275,11 +259,9 @@ class Goal(_hawkey.Goal):
             callback(self)
         return ret
 
-    @_auto_selector
     def erase(self, *args, **kwargs):
         super(Goal, self).erase(*args, **kwargs)
 
-    @_auto_selector
     def install(self, *args, **kwargs):
         if args:
             self._installs.extend(args)
@@ -287,11 +269,9 @@ class Goal(_hawkey.Goal):
             self._installs.extend(kwargs['select'].matches())
         super(Goal, self).install(*args, **kwargs)
 
-    @_auto_selector
     def downgrade_to(self, *args, **kwargs):
         super(Goal, self).downgrade_to(*args, **kwargs)
 
-    @_auto_selector
     def upgrade(self, *args, **kwargs):
         super(Goal, self).upgrade(*args, **kwargs)
 

--- a/python/hawkey/goal-py.cpp
+++ b/python/hawkey/goal-py.cpp
@@ -433,29 +433,6 @@ py_solver_callback(HyGoal goal, void *data)
 }
 
 static PyObject *
-run_all(_GoalObject *self, PyObject *args, PyObject *kwds)
-{
-    int flags = 0;
-    PyObject *callback = NULL;
-    if (!args_run_parse(args, kwds, &flags, &callback))
-        return NULL;
-
-    PyObject *callback_tuple = Py_BuildValue("(O)", self);
-    if (!callback_tuple)
-        return NULL;
-
-    struct _PySolutionCallback cb_s = {callback_tuple, callback, 0};
-    int ret = hy_goal_run_all_flags(self->goal, py_solver_callback, &cb_s,
-                                    static_cast<DnfGoalActions>(flags));
-    Py_DECREF(callback_tuple);
-    if (cb_s.errors > 0)
-        return NULL;
-    if (!ret)
-        Py_RETURN_TRUE;
-    Py_RETURN_FALSE;
-}
-
-static PyObject *
 count_problems(_GoalObject *self, PyObject *unused)
 {
     return PyLong_FromLong(hy_goal_count_problems(self->goal));
@@ -754,8 +731,6 @@ static struct PyMethodDef goal_methods[] = {
      METH_NOARGS,        NULL},
     {"req_length",        (PyCFunction)req_length,        METH_NOARGS,        NULL},
     {"run",                (PyCFunction)run,
-     METH_VARARGS | METH_KEYWORDS, NULL},
-    {"run_all",        (PyCFunction)run_all,
      METH_VARARGS | METH_KEYWORDS, NULL},
     {"count_problems",        (PyCFunction)count_problems,        METH_NOARGS,        NULL},
     {"problem_conflicts",(PyCFunction)problem_conflicts,        METH_VARARGS | METH_KEYWORDS,                NULL},

--- a/python/hawkey/tests/tests/test_goal.py
+++ b/python/hawkey/tests/tests/test_goal.py
@@ -126,21 +126,6 @@ class GoalTest(base.TestCase):
         goal.erase(pkg, clean_deps=True)
         self.assertTrue(goal.req_has_erase())
 
-class Collector(object):
-    def __init__(self):
-        self.cnt = 0
-        self.erasures = set()
-        self.pkgs = set()
-
-    def new_solution_cb(self, goal):
-        self.cnt += 1
-        self.erasures.update(goal.list_erasures())
-        self.pkgs.update(goal.list_installs())
-
-    def new_solution_cb_borked(self, goal):
-        """ Raises AttributeError. """
-        self.pkgs_borked.update(goal.list_erasures())
-
 
 class GoalRunAll(base.TestCase):
     def setUp(self):
@@ -148,23 +133,6 @@ class GoalRunAll(base.TestCase):
         self.sack.load_system_repo()
         self.sack.load_test_repo("greedy", "greedy.repo")
         self.goal = hawkey.Goal(self.sack)
-
-    def test_cb(self):
-        pkg_a = base.by_name(self.sack, "A")
-        pkg_b = base.by_name(self.sack, "B")
-        pkg_c = base.by_name(self.sack, "C")
-        self.goal.install(pkg_a)
-
-        collector = Collector()
-        self.assertTrue(self.goal.run_all(collector.new_solution_cb))
-        self.assertItemsEqual(collector.pkgs, [pkg_a, pkg_b, pkg_c])
-
-    def test_cb_borked(self):
-        """ Check exceptions are propagated from the callback. """
-        self.goal.install(base.by_name(self.sack, "A"))
-        collector = Collector()
-        self.assertRaises(AttributeError,
-                          self.goal.run_all, collector.new_solution_cb_borked)
 
     def test_goal_install_weak_deps(self):
         pkg_b = base.by_name(self.sack, "B")

--- a/python/hawkey/tests/tests/test_goal.py
+++ b/python/hawkey/tests/tests/test_goal.py
@@ -36,8 +36,6 @@ class GoalTest(base.TestCase):
         self.assertEqual(set(), goal.actions)
         goal.upgrade(select=sltr)
         self.assertEqual(set([hawkey.UPGRADE]), goal.actions)
-        goal.install(name="semolina")
-        self.assertEqual(set([hawkey.UPGRADE, hawkey.INSTALL]), goal.actions)
 
     def test_clone(self):
         pkg = base.by_name(self.sack, "penny-lib")
@@ -83,25 +81,11 @@ class GoalTest(base.TestCase):
         # without checking versioning, the update is accepted:
         self.assertIsNone(hawkey.Goal(self.sack).upgrade(select=sltr))
 
-        goal = hawkey.Goal(self.sack)
-        goal.install(name="semolina")
-        goal.run()
-        self.assertEqual(str(goal.list_installs()[0]), 'semolina-2-0.x86_64')
-
     def test_install_selector_weak(self):
         sltr = hawkey.Selector(self.sack).set(name='hello')
         goal = hawkey.Goal(self.sack)
         goal.install(select=sltr, optional=True)
         self.assertTrue(goal.run())
-
-    def test_erase_selector(self):
-        """ Tests automatic Selector from keyword arguments, with special
-            keywords that don't become a part of the Selector.
-        """
-        goal = hawkey.Goal(self.sack)
-        goal.erase(clean_deps=True, name="flying")
-        goal.run()
-        self.assertEqual(len(goal.list_erasures()), 2)
 
     def test_install_selector_err(self):
         sltr = hawkey.Selector(self.sack)

--- a/python/hawkey/tests/tests/test_goal.py
+++ b/python/hawkey/tests/tests/test_goal.py
@@ -141,21 +141,6 @@ class Collector(object):
         """ Raises AttributeError. """
         self.pkgs_borked.update(goal.list_erasures())
 
-class GoalRun(base.TestCase):
-    def test_run_callback(self):
-        "Test goal.run() can use callback parameter just as well as run_all()"
-        sack = base.TestSack(repo_dir=self.repo_dir)
-        sack.load_system_repo()
-        sack.load_test_repo("main", "main.repo")
-
-        pkg = base.by_name(sack, "penny-lib")
-        goal = hawkey.Goal(sack)
-        goal.erase(pkg)
-        collector = Collector()
-        self.assertTrue(goal.run(allow_uninstall=True,
-                                 callback=collector.new_solution_cb))
-        self.assertEqual(collector.cnt, 1)
-        self.assertEqual(len(collector.erasures), 2)
 
 class GoalRunAll(base.TestCase):
     def setUp(self):

--- a/tests/hawkey/test_goal.cpp
+++ b/tests/hawkey/test_goal.cpp
@@ -1118,25 +1118,6 @@ solution_cb(HyGoal goal, void *data)
     return 0;
 }
 
-START_TEST(test_goal_run_all)
-{
-    DnfSack *sack = test_globals.sack;
-    HyGoal goal = hy_goal_create(sack);
-    DnfPackage *pkg = get_available_pkg(sack, "A");
-
-    fail_if(hy_goal_install(goal, pkg));
-
-    struct Solutions *solutions = solutions_create();
-    fail_if(hy_goal_run_all(goal, solution_cb, solutions));
-    fail_unless(solutions->solutions == 2);
-    fail_unless(solutions->installs->len == 3);
-    solutions_free(solutions);
-
-    hy_goal_free(goal);
-    g_object_unref(pkg);
-}
-END_TEST
-
 START_TEST(test_goal_installonly_limit)
 {
     const char *installonly[] = {"k", NULL};
@@ -1439,7 +1420,6 @@ goal_suite(void)
 
     tc = tcase_create("Greedy");
     tcase_add_unchecked_fixture(tc, fixture_greedy_only, teardown);
-    tcase_add_test(tc, test_goal_run_all);
     tcase_add_test(tc, test_goal_install_weak_deps);
     suite_add_tcase(s, tc);
 


### PR DESCRIPTION
This functionality is unused by dnf and anywhere documented (not API), therefore
it can be remove. Additionally it doesn't sound like a good idea to use any
unrecognized key for selector construction.