### PR TITLE
Add more #if WITH_SWDB to build without swdb

### DIFF
--- a/libdnf/hy-query.cpp
+++ b/libdnf/hy-query.cpp
@@ -1889,6 +1889,7 @@ hy_filter_duplicated(HyQuery query)
     }
 }
 
+#if WITH_SWDB
 int
 hy_filter_unneeded(HyQuery query, DnfSwdb *swdb, const gboolean debug_solver)
 {
@@ -1951,6 +1952,7 @@ hy_filter_unneeded(HyQuery query, DnfSwdb *swdb, const gboolean debug_solver)
     map_free(&result);
     return 0;
 }
+#endif
 
 HySelector
 hy_query_to_selector(HyQuery query)

--- a/libdnf/hy-query.h
+++ b/libdnf/hy-query.h
@@ -28,7 +28,9 @@ G_BEGIN_DECLS
 /* hawkey */
 #include "dnf-sack.h"
 #include "dnf-types.h"
+#if WITH_SWDB
 #include "dnf-swdb.h"
+#endif
 #include "hy-types.h"
 
 enum _hy_query_flags {
@@ -108,7 +110,9 @@ void hy_add_filter_nevra_object(HyQuery query, HyNevra nevra, gboolean icase);
 void hy_add_filter_extras(HyQuery query);
 void hy_filter_recent(HyQuery query, const long unsigned int recent_limit);
 void hy_filter_duplicated(HyQuery query);
+#if WITH_SWDB
 int hy_filter_unneeded(HyQuery query, DnfSwdb* swdb, const gboolean debug_solver);
+#endif
 
 static inline void
 hy_query_autofree (void *v)

--- a/python/hawkey/query-py.c
+++ b/python/hawkey/query-py.c
@@ -31,7 +31,10 @@
 #include "hy-subject.h"
 #include "dnf-reldep.h"
 #include "dnf-reldep-list.h"
+
+#if WITH_SWDB
 #include "dnf-swdb.h"
+#endif
 
 #include "exception-py.h"
 #include "hawkey-pysys.h"
@@ -703,6 +706,7 @@ q_difference(PyObject *self, PyObject *args)
 static PyObject *
 filter_unneeded(PyObject *self, PyObject *args, PyObject *kwds)
 {
+#if WITH_SWDB
     HyQuery self_query_copy = hy_query_clone(((_QueryObject *) self)->query);
     const char *kwlist[] = {"swdb", "debug_solver", NULL};
     PyObject *swdb;
@@ -724,6 +728,9 @@ filter_unneeded(PyObject *self, PyObject *args, PyObject *kwds)
                                             Py_TYPE(self));
     Py_INCREF(final_query);
     return final_query;
+#else
+    return NULL;
+#endif
 }
 
 static PyObject *


### PR DESCRIPTION
This lets rpm-ostree build with it off. As discussed earlier, rpm-ostree has its
own model for tracking package state; the swdb in its current form is not useful
for it.