### PR TITLE
python/query: Only #include <pygobject> if building with SWDB

### DIFF
--- a/python/hawkey/query-py.c
+++ b/python/hawkey/query-py.c
@@ -24,7 +24,6 @@
 #include <solv/util.h>
 #include <time.h>
 
-#include <pygobject-3.0/pygobject.h>
 
 #include "hy-query.h"
 #include "hy-selector.h"
@@ -33,6 +32,7 @@
 #include "dnf-reldep-list.h"
 
 #if WITH_SWDB
+#include <pygobject-3.0/pygobject.h>
 #include "dnf-swdb.h"
 #endif
 


### PR DESCRIPTION
Mixing hand-generated Python bindings with pygobject gets messy;
it looks like that's what this code is trying to do.  We don't
need this though unless swdb is enabled.

Today rpm-ostree doesn't use the libdnf python bindings at all; we build with
them on because it's not worth writing a patch to turn them off. But having this
`#include` introduces a new build dependency which I'd like to avoid.