### PR TITLE
Adjust compiler warning options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,10 @@ CMAKE_POLICY(SET CMP0003 NEW)
 include (VERSION.cmake)
 message ("Building libdnf version: ${LIBDNF_VERSION}")
 
-ADD_COMPILE_OPTIONS (-Wcast-align -Wno-uninitialized -Wmissing-declarations -Wredundant-decls -Wwrite-strings -Wreturn-type -Wformat-nonliteral -Wmissing-format-attribute -Wsign-compare -Wtype-limits -Wuninitialized -Wshadow -Winline -Wall -Werror=implicit-function-declaration -Wl,--as-needed)
+ADD_COMPILE_OPTIONS (-Wcast-align -Wno-uninitialized -Wredundant-decls -Wwrite-strings -Wformat-nonliteral -Wmissing-format-attribute -Wsign-compare -Wtype-limits -Wuninitialized -Winline -Wall -Werror=implicit-function-declaration -Wl,--as-needed)
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Waggregate-return")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Wmissing-prototypes -Waggregate-return -Wshadow")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wmissing-declarations")
 
 include (CheckSymbolExists)
 list (APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)


### PR DESCRIPTION
- remove "-Wreturn-type" because is turned on by "-Wall"
- C: use "-Wmissing-prototypes" instead of "-Wmissing-declarations"
- C++: remove "-Wshadow"