### PR TITLE
DnfPackage: cache nevra from libsolv

### DIFF
--- a/libdnf/hy-package.cpp
+++ b/libdnf/hy-package.cpp
@@ -339,7 +339,9 @@ dnf_package_evr_cmp(DnfPackage *pkg1, DnfPackage *pkg2)
  * dnf_package_get_location:
  * @pkg: a #DnfPackage instance.
  *
- * Gets the location (XXX??) for the package.
+ * Gets the location (XXX??) for the package. Note that the returned string has
+ * an undefined lifetime and may become invalid at a later time. You should copy
+ * the string if storing it into a long-lived data structure.
  *
  * Returns: (transfer none): string
  *
@@ -376,7 +378,9 @@ dnf_package_get_baseurl(DnfPackage *pkg)
  * dnf_package_get_nevra:
  * @pkg: a #DnfPackage instance.
  *
- * Gets the package NEVRA.
+ * Gets the package NEVRA. Note that the returned string has an undefined
+ * lifetime and may become invalid at a later time. You should copy the string
+ * if storing it into a long-lived data structure.
  *
  * Returns: (transfer none): a string, or %NULL
  *


### PR DESCRIPTION
Unlike other getters, `dnf_package_get_nevra` uses `pool_solvable2str`,
which actually builds the NEVRA on-the-fly and stores it in the pool's
temporary buffer. The actual pointer returned can become invalid simply
by subsequent calls to `pool_solvable2str` until a `realloc` is
triggered. This can lead to undefined behaviour in clients that assume
the string has at least the same lifetime as the `DnfPackage` object.

Let's just cache the NEVRA ourselves to save some cycles and more
importantly tie their lifetimes together.