### PR TITLE
Remove unused functions

### DIFF
--- a/python/hawkey/goal-py.cpp
+++ b/python/hawkey/goal-py.cpp
@@ -412,26 +412,6 @@ run(_GoalObject *self, PyObject *args, PyObject *kwds)
     Py_RETURN_FALSE;
 }
 
-struct _PySolutionCallback {
-    PyObject *callback_tuple;
-    PyObject *callback;
-    int errors;
-};
-
-static int
-py_solver_callback(HyGoal goal, void *data)
-{
-    struct _PySolutionCallback *cb_s = (struct _PySolutionCallback*)data;
-
-    PyObject *ret = PyObject_CallObject(cb_s->callback, cb_s->callback_tuple);
-    if (ret)
-        Py_DECREF(ret);
-    else
-        cb_s->errors++;
-
-    return 0; /* solution_callback() result is ignored in libsolv */
-}
-
 static PyObject *
 count_problems(_GoalObject *self, PyObject *unused)
 {

--- a/tests/hawkey/test_goal.cpp
+++ b/tests/hawkey/test_goal.cpp
@@ -1084,40 +1084,6 @@ struct Solutions {
     GPtrArray *installs;
 };
 
-static struct Solutions *
-solutions_create(void)
-{
-    auto solutions = static_cast<Solutions *>(g_malloc0(sizeof(struct Solutions)));
-    solutions->installs = hy_packagelist_create();
-    return solutions;
-}
-
-static void
-solutions_free(struct Solutions *solutions)
-{
-    g_ptr_array_unref(solutions->installs);
-    g_free(solutions);
-}
-
-static int
-solution_cb(HyGoal goal, void *data)
-{
-    struct Solutions *solutions = (struct Solutions*)data;
-    solutions->solutions++;
-
-    GPtrArray *new_installs = hy_goal_list_installs(goal, NULL);
-    guint i;
-
-    for(i = 0; i < new_installs->len; i++) {
-        auto pkg = static_cast<DnfPackage *>(g_ptr_array_index(new_installs, i));
-        if (!hy_packagelist_has(solutions->installs, pkg))
-            g_ptr_array_add(solutions->installs, g_object_ref(pkg));
-    }
-    g_ptr_array_unref(new_installs);
-
-    return 0;
-}
-
 START_TEST(test_goal_installonly_limit)
 {
     const char *installonly[] = {"k", NULL};


### PR DESCRIPTION
Functions solutions_create(), solutions_free(Solutions*), int solution_cb(HyGoal, void*)
are unused since commit f2e88fd03b25ab3f31b605ea8fdb4484deba555e "Remove unused function hy_goal_run_all()"

Function py_solver_callback(HyGoal, void*) is unused
since commit cdfa395c84b04b172fc3d372d857cb7e7c804a9c "Remove python binding Goal().run_all()"