### PR TITLE
WIP - An approach how to provide same behavior for package - selector goal jobs

### DIFF
--- a/libdnf/hy-package.cpp
+++ b/libdnf/hy-package.cpp
@@ -43,6 +43,7 @@
 #include "hy-package-private.hpp"
 #include "dnf-reldep-list-private.hpp"
 #include "hy-repo-private.hpp"
+#include "hy-selector.h"
 
 #define BLOCK_SIZE 31
 
@@ -1067,4 +1068,15 @@ dnf_package_get_delta_from_evr(DnfPackage *pkg, const char *from_evr)
     dataiterator_free(&di);
 
     return delta;
+}
+
+HySelector
+hy_package_to_selector(DnfPackage *pkg)
+{
+    DnfSack *sack = dnf_package_get_sack(pkg);
+    HySelector selector = hy_selector_create(sack);
+    DnfPackageSet *pset = dnf_packageset_new(sack);
+    dnf_packageset_add(pset, pkg);
+    hy_selector_pkg_set(selector, HY_PKG, HY_EQ, pset);
+    return selector;
 }

--- a/libdnf/hy-package.h
+++ b/libdnf/hy-package.h
@@ -97,6 +97,14 @@ GPtrArray   *dnf_package_get_advisories (DnfPackage *pkg, int cmp_type);
 
 DnfPackageDelta *dnf_package_get_delta_from_evr(DnfPackage *pkg, const char *from_evr);
 
+/**
+* @brief Convert DnfPackage to selector
+*
+* @param pkg p_pkg:...
+* @return HySelector
+*/
+HySelector hy_package_to_selector(DnfPackage *pkg);
+
 G_END_DECLS
 
 #endif /* __HY_PACKAGE_H */


### PR DESCRIPTION
The second possibility would be to refactor functions like hy_goal_install() that will end up with SOLVER_SOLVABLE_ONE_OF.

The work flow in the pull request allows to remove package goal functions in future, but the performance point of view is not nice: DnfPackage -> DnfPackageset -> Queue of one ID ...