### PR TITLE
Add multiversion(kernel) as a recognized installonlypkg name

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -746,6 +746,7 @@ dnf_context_get_installonly_pkgs(DnfContext *context)
         "installonlypkg(kernel)",
         "installonlypkg(kernel-module)",
         "installonlypkg(vm)",
+        "multiversion(kernel)",
         NULL };
     return installonly_pkgs;
 }


### PR DESCRIPTION
The `multiversion(kernel)` Provides is used to mark kernel packages as `installonlypkgs` on SUSE Linux distribution family.
  