### PR TITLE
Add option to disable GTK-Doc HTML documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ ADD_DEFINITIONS(-DG_LOG_DOMAIN=\\"libdnf\\")
 
 INCLUDE_DIRECTORIES (${CMAKE_SOURCE_DIR} libdnf/utils/)
 
+OPTION(WITH_GTKDOC "Enables libdnf GTK-Doc HTML documentation" ON)
+OPTION(WITH_MAN "Enables hawkey man page generation" ON)
+
 OPTION (ENABLE_SOLV_URPMREORDER "Build with support for URPM-like solution reordering?" OFF)
 option (ENABLE_RHSM_SUPPORT "Build with Red Hat Subscription Manager support?" OFF)
 

--- a/docs/hawkey/CMakeLists.txt
+++ b/docs/hawkey/CMakeLists.txt
@@ -7,8 +7,6 @@ else()
     SET(SPHINX_BUILD_NAME "sphinx-build-3")
 endif()
 
-OPTION(WITH_MAN "Enables hawkey man page generation" ON)
-
 ADD_CUSTOM_TARGET (doc-html
 		  PYTHONPATH=${CMAKE_BINARY_DIR}/src/python ${SPHINX_BUILD_NAME} -b html
 		  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/html

--- a/docs/libdnf/CMakeLists.txt
+++ b/docs/libdnf/CMakeLists.txt
@@ -1,8 +1,11 @@
-find_package(GtkDoc REQUIRED)
-
 configure_file("version.xml.in"  ${CMAKE_CURRENT_SOURCE_DIR}/version.xml)
 
-if (GTKDOC_FOUND)
+OPTION(WITH_GTKDOC "Enables libdnf GTK-Doc HTML documentation" ON)
+
+if (WITH_GTKDOC)
+    find_package(GtkDoc REQUIRED)
+
+    if (GTKDOC_FOUND)
         add_custom_command(OUTPUT doc-scan
             COMMAND ${GTKDOC_SCAN_EXE}
                     --source-dir=${CMAKE_SOURCE_DIR}/libdnf
@@ -22,9 +25,10 @@ if (GTKDOC_FOUND)
                     libdnf
                     ${CMAKE_SOURCE_DIR}/docs/libdnf/libdnf-docs.sgml
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/html")
-    add_custom_target(doc-gtk DEPENDS doc-scan doc-mkdb doc-mkhtml)
-else ()
-    message (FATAL_ERROR "gtk-doc not found")
-endif ()
+        add_custom_target(doc-gtk DEPENDS doc-scan doc-mkdb doc-mkhtml)
+    else ()
+        message (FATAL_ERROR "gtk-doc not found")
+    endif ()
 
-INSTALL(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/html DESTINATION share/gtk-doc/html/libdnf)
+    INSTALL(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/html DESTINATION share/gtk-doc/html/libdnf)
+endif ()

--- a/docs/libdnf/CMakeLists.txt
+++ b/docs/libdnf/CMakeLists.txt
@@ -1,7 +1,5 @@
 configure_file("version.xml.in"  ${CMAKE_CURRENT_SOURCE_DIR}/version.xml)
 
-OPTION(WITH_GTKDOC "Enables libdnf GTK-Doc HTML documentation" ON)
-
 if (WITH_GTKDOC)
     find_package(GtkDoc REQUIRED)
 


### PR DESCRIPTION
The documentation is pretty useless right now, and even if it wasn't, there's nothing that indicates that documentation must be generated for the library to function.