### PR TITLE
Subject does not choke on malformed pattern (RhBug 1525542)

### DIFF
--- a/python/hawkey/pycomp.cpp
+++ b/python/hawkey/pycomp.cpp
@@ -28,8 +28,12 @@
 static char *
 pycomp_get_string_from_unicode(PyObject *str_u, PyObject **tmp_py_str)
 {
-    *tmp_py_str = PyUnicode_AsUTF8String(str_u);
-    return PyBytes_AsString(*tmp_py_str);
+    *tmp_py_str = PyUnicode_AsEncodedString(str_u, "utf-8", "replace");
+    if (*tmp_py_str) {
+        return PyBytes_AsString(*tmp_py_str);
+    } else {
+        return NULL;
+    }
 }
 
 /**

--- a/python/hawkey/subject-py.cpp
+++ b/python/hawkey/subject-py.cpp
@@ -89,15 +89,22 @@ subject_dealloc(_SubjectObject *self)
 static int
 subject_init(_SubjectObject *self, PyObject *args, PyObject *kwds)
 {
-    const char * pattern;
+    PyObject *py_pattern;
     PyObject *icase = NULL;
     const char *kwlist[] = { "pattern", "ignore_case", NULL };
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|O!", (char**) kwlist, &pattern,
-        &PyBool_Type, &icase)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O!", (char**) kwlist,
+        &py_pattern, &PyBool_Type, &icase)) {
+        return -1;
+    }
+    self->icase = icase != NULL && PyObject_IsTrue(icase);
+    PyObject *tmp_py_str = NULL;
+    const char * pattern = pycomp_get_string(py_pattern, &tmp_py_str);
+    if (!pattern) {
+        Py_XDECREF(tmp_py_str);
         return -1;
     }
     self->pattern = g_strdup(pattern);
-    self->icase = icase != NULL && PyObject_IsTrue(icase);
+    Py_XDECREF(tmp_py_str);
     return 0;
 }
 


### PR DESCRIPTION
"s" format of python arguments parser uses "strict" error handling for
converting unicode value to utf-8 encoded C string. This patch does the
conversion with "ignore" error handler.

https://bugzilla.redhat.com/show_bug.cgi?id=1525542