### PR TITLE
Do not calculate checksum for cmdline pkgs by default (RhBug 1537981)

### DIFF
--- a/libdnf/dnf-sack-private.hpp
+++ b/libdnf/dnf-sack-private.hpp
@@ -63,5 +63,7 @@ Id           dnf_sack_last_solvable         (DnfSack    *sack);
 Queue       *dnf_sack_get_installonly       (DnfSack    *sack);
 void         dnf_sack_set_running_kernel_fn (DnfSack    *sack,
                                              dnf_sack_running_kernel_fn_t fn);
+DnfPackage  *dnf_sack_add_cmdline_package_flags   (DnfSack *sack,
+                            const char *fn, const int flags);
 
 #endif // HY_SACK_INTERNAL_H

--- a/libdnf/dnf-sack.h
+++ b/libdnf/dnf-sack.h
@@ -115,6 +115,8 @@ void         dnf_sack_set_installonly_limit (DnfSack        *sack,
 guint        dnf_sack_get_installonly_limit (DnfSack        *sack);
 DnfPackage  *dnf_sack_add_cmdline_package   (DnfSack        *sack,
                                              const char     *fn);
+DnfPackage  *dnf_sack_add_cmdline_package_nochecksum   (DnfSack        *sack,
+                                             const char     *fn);
 int          dnf_sack_count                 (DnfSack        *sack);
 void         dnf_sack_add_excludes          (DnfSack        *sack,
                                              DnfPackageSet  *pset);

--- a/python/hawkey/sack-py.cpp
+++ b/python/hawkey/sack-py.cpp
@@ -371,7 +371,7 @@ add_cmdline_package(_SackObject *self, PyObject *fn_obj)
 
     if (!fn.getCString())
         return NULL;
-    cpkg = dnf_sack_add_cmdline_package(self->sack, fn.getCString());
+    cpkg = dnf_sack_add_cmdline_package_nochecksum(self->sack, fn.getCString());
     if (cpkg == NULL) {
         PyErr_Format(PyExc_IOError, "Can not load RPM file: %s.", fn.getCString());
         return NULL;


### PR DESCRIPTION
PR https://github.com/rpm-software-management/libdnf/pull/273 made
repomanage command really slow for large rpm directories.

https://bugzilla.redhat.com/show_bug.cgi?id=1537981