### PR TITLE
Add APIs to disable fetching filelists

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -113,6 +113,7 @@ typedef struct
     gboolean         check_disk_space;
     gboolean         check_transaction;
     gboolean         only_trusted;
+    gboolean         enable_filelists;
     gboolean         enable_yumdb;
     gboolean         keep_cache;
     gboolean         enrollment_valid;
@@ -196,6 +197,7 @@ dnf_context_init(DnfContext *context)
     priv->check_disk_space = TRUE;
     priv->check_transaction = TRUE;
     priv->enable_yumdb = TRUE;
+    priv->enable_filelists = TRUE;
     priv->state = dnf_state_new();
     priv->lock = dnf_lock_new();
     priv->cache_age = 60 * 60 * 24 * 7; /* 1 week */
@@ -713,6 +715,19 @@ dnf_context_get_yumdb_enabled(DnfContext *context)
 }
 
 /**
+ * dnf_context_get_enable_filelists:
+ * @context: a #DnfContext instance.
+ *
+ * Returns: %TRUE if filelists are enabled
+ */
+gboolean
+dnf_context_get_enable_filelists (DnfContext     *context)
+{
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    return priv->enable_filelists;
+}
+
+/**
  * dnf_context_get_cache_age:
  * @context: a #DnfContext instance.
  *
@@ -984,6 +999,21 @@ dnf_context_set_keep_cache(DnfContext *context, gboolean keep_cache)
 }
 
 /**
+ * dnf_context_set_enable_filelists:
+ * @context: a #DnfContext instance.
+ * @enable_filelists: %TRUE to download and parse filelist metadata
+ *
+ * Enables or disables download and parsing of filelists.
+ **/
+void
+dnf_context_set_enable_filelists (DnfContext     *context,
+                                  gboolean        enable_filelists)
+{
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    priv->enable_filelists = enable_filelists;
+}
+
+/**
  * dnf_context_set_only_trusted:
  * @context: a #DnfContext instance.
  * @only_trusted: %TRUE keep the packages after installing or updating
@@ -1203,7 +1233,7 @@ dnf_context_setup_sack(DnfContext *context, DnfState *state, GError **error)
     ret = dnf_sack_add_repos(priv->sack,
                              priv->repos,
                              priv->cache_age,
-                             DNF_SACK_ADD_FLAG_FILELISTS,
+                             priv->enable_filelists ? DNF_SACK_ADD_FLAG_FILELISTS : DNF_SACK_ADD_FLAG_NONE,
                              state,
                              error);
     if (!ret)

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -108,6 +108,7 @@ gboolean         dnf_context_get_yumdb_enabled          (DnfContext     *context
 guint            dnf_context_get_cache_age              (DnfContext     *context);
 guint            dnf_context_get_installonly_limit      (DnfContext     *context);
 const gchar     *dnf_context_get_http_proxy             (DnfContext     *context);
+gboolean         dnf_context_get_enable_filelists       (DnfContext     *context);
 GPtrArray       *dnf_context_get_repos                  (DnfContext     *context);
 #ifndef __GI_SCANNER__
 DnfRepoLoader   *dnf_context_get_repo_loader            (DnfContext     *context);
@@ -145,6 +146,8 @@ void             dnf_context_set_check_transaction      (DnfContext     *context
                                                          gboolean        check_transaction);
 void             dnf_context_set_keep_cache             (DnfContext     *context,
                                                          gboolean        keep_cache);
+void             dnf_context_set_enable_filelists       (DnfContext     *context,
+                                                         gboolean        enable_filelists);
 void             dnf_context_set_only_trusted           (DnfContext     *context,
                                                          gboolean        only_trusted);
 void             dnf_context_set_yumdb_enabled          (DnfContext     *context,

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1258,14 +1258,18 @@ dnf_repo_check_internal(DnfRepo *repo,
                         GError **error)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    const gchar *download_list[] = {
-        "primary",
-        "filelists",
-        "group",
-        "updateinfo",
-        "appstream",
-        "appstream-icons",
-        NULL};
+    g_autoptr(GPtrArray) download_list = g_ptr_array_new ();
+    g_ptr_array_add (download_list, (char*)"primary");
+    g_ptr_array_add (download_list, (char*)"group");
+    g_ptr_array_add (download_list, (char*)"updateinfo");
+    g_ptr_array_add (download_list, (char*)"appstream");
+    g_ptr_array_add (download_list, (char*)"appstream-icons");
+    /* This one is huge, and at least rpm-ostree jigdo mode doesn't require it.
+     * https://github.com/projectatomic/rpm-ostree/issues/1127
+     */
+    if (dnf_context_get_enable_filelists (priv->context))
+        g_ptr_array_add (download_list, (char*)"filelists");
+    g_ptr_array_add (download_list, NULL);
     const gchar *tmp;
     gboolean ret;
     LrYumRepo *yum_repo;
@@ -1308,7 +1312,7 @@ dnf_repo_check_internal(DnfRepo *repo,
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_CHECKSUM, 1L))
         return FALSE;
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_YUMDLIST, download_list))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_YUMDLIST, download_list->pdata))
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_MIRRORLIST, NULL))
         return FALSE;


### PR DESCRIPTION
As part of [rpm-ostree jigdo ♲📦](https://github.com/projectatomic/rpm-ostree/issues/1081)
I'd like to make it cheaper to fetch metadata.  For Fedora currently
the filelists metadata is enormous.  In jigdo mode, we don't need it,
so let's add APIs to avoid fetching it.