### PR TITLE
Add API to tweak setup sack

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -113,6 +113,7 @@ typedef struct
     gboolean         check_disk_space;
     gboolean         check_transaction;
     gboolean         only_trusted;
+    gboolean         enable_filelists;
     gboolean         enable_yumdb;
     gboolean         keep_cache;
     gboolean         enrollment_valid;
@@ -196,6 +197,7 @@ dnf_context_init(DnfContext *context)
     priv->check_disk_space = TRUE;
     priv->check_transaction = TRUE;
     priv->enable_yumdb = TRUE;
+    priv->enable_filelists = TRUE;
     priv->state = dnf_state_new();
     priv->lock = dnf_lock_new();
     priv->cache_age = 60 * 60 * 24 * 7; /* 1 week */
@@ -713,6 +715,19 @@ dnf_context_get_yumdb_enabled(DnfContext *context)
 }
 
 /**
+ * dnf_context_get_enable_filelists:
+ * @context: a #DnfContext instance.
+ *
+ * Returns: %TRUE if filelists are enabled
+ */
+gboolean
+dnf_context_get_enable_filelists (DnfContext     *context)
+{
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    return priv->enable_filelists;
+}
+
+/**
  * dnf_context_get_cache_age:
  * @context: a #DnfContext instance.
  *
@@ -984,6 +999,21 @@ dnf_context_set_keep_cache(DnfContext *context, gboolean keep_cache)
 }
 
 /**
+ * dnf_context_set_enable_filelists:
+ * @context: a #DnfContext instance.
+ * @enable_filelists: %TRUE to download and parse filelist metadata
+ *
+ * Enables or disables download and parsing of filelists.
+ **/
+void
+dnf_context_set_enable_filelists (DnfContext     *context,
+                                  gboolean        enable_filelists)
+{
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    priv->enable_filelists = enable_filelists;
+}
+
+/**
  * dnf_context_set_only_trusted:
  * @context: a #DnfContext instance.
  * @only_trusted: %TRUE keep the packages after installing or updating
@@ -1203,7 +1233,7 @@ dnf_context_setup_sack(DnfContext *context, DnfState *state, GError **error)
     ret = dnf_sack_add_repos(priv->sack,
                              priv->repos,
                              priv->cache_age,
-                             DNF_SACK_ADD_FLAG_FILELISTS,
+                             priv->enable_filelists ? DNF_SACK_ADD_FLAG_FILELISTS : DNF_SACK_ADD_FLAG_NONE,
                              state,
                              error);
     if (!ret)

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -719,6 +719,8 @@ dnf_context_get_yumdb_enabled(DnfContext *context)
  * @context: a #DnfContext instance.
  *
  * Returns: %TRUE if filelists are enabled
+ *
+ * Since: 0.13.0
  */
 gboolean
 dnf_context_get_enable_filelists (DnfContext     *context)
@@ -1004,6 +1006,8 @@ dnf_context_set_keep_cache(DnfContext *context, gboolean keep_cache)
  * @enable_filelists: %TRUE to download and parse filelist metadata
  *
  * Enables or disables download and parsing of filelists.
+ *
+ * Since: 0.13.0
  **/
 void
 dnf_context_set_enable_filelists (DnfContext     *context,

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -108,6 +108,7 @@ gboolean         dnf_context_get_yumdb_enabled          (DnfContext     *context
 guint            dnf_context_get_cache_age              (DnfContext     *context);
 guint            dnf_context_get_installonly_limit      (DnfContext     *context);
 const gchar     *dnf_context_get_http_proxy             (DnfContext     *context);
+gboolean         dnf_context_get_enable_filelists       (DnfContext     *context);
 GPtrArray       *dnf_context_get_repos                  (DnfContext     *context);
 #ifndef __GI_SCANNER__
 DnfRepoLoader   *dnf_context_get_repo_loader            (DnfContext     *context);
@@ -145,6 +146,8 @@ void             dnf_context_set_check_transaction      (DnfContext     *context
                                                          gboolean        check_transaction);
 void             dnf_context_set_keep_cache             (DnfContext     *context,
                                                          gboolean        keep_cache);
+void             dnf_context_set_enable_filelists       (DnfContext     *context,
+                                                         gboolean        enable_filelists);
 void             dnf_context_set_only_trusted           (DnfContext     *context,
                                                          gboolean        only_trusted);
 void             dnf_context_set_yumdb_enabled          (DnfContext     *context,

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -82,6 +82,24 @@ typedef enum {
         DNF_CONTEXT_INVALIDATE_FLAG_LAST
 } DnfContextInvalidateFlags;
 
+/**
+ * DnfContextSetupSackFlags:
+ * @DNF_CONTEXT_SETUP_SACK_FLAG_NONE:             No special behaviours
+ * @DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB:       Don't load system's rpmdb
+ * @DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_FILELISTS:   Don't load filelists
+ * @DNF_CONTEXT_SETUP_SACK_FLAG_LOAD_UPDATEINFO:  Load updateinfo if available
+ *
+ * The sack setup flags.
+ *
+ * Since: 0.13.0
+ **/
+typedef enum {
+        DNF_CONTEXT_SETUP_SACK_FLAG_NONE            = (1 << 0),
+        DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB      = (1 << 1),
+        DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_FILELISTS  = (1 << 2),
+        DNF_CONTEXT_SETUP_SACK_FLAG_LOAD_UPDATEINFO = (1 << 3),
+} DnfContextSetupSackFlags;
+
 gboolean         dnf_context_globals_init               (GError **error);
 
 DnfContext      *dnf_context_new                        (void);
@@ -172,6 +190,10 @@ gboolean         dnf_context_setup_enrollments          (DnfContext     *context
 gboolean         dnf_context_setup_sack                 (DnfContext     *context,
                                                          DnfState       *state,
                                                          GError         **error);
+gboolean         dnf_context_setup_sack_with_flags      (DnfContext      *context,
+                                                         DnfState        *state,
+                                                         DnfContextSetupSackFlags flags,
+                                                         GError          **error);
 gboolean         dnf_context_commit                     (DnfContext     *context,
                                                          DnfState       *state,
                                                          GError         **error);

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1748,6 +1748,15 @@ dnf_repo_update(DnfRepo *repo,
     if (!ret)
         goto out;
 
+    /* see dnf_repo_check_internal */
+    if (dnf_context_get_enable_filelists(priv->context)) {
+        const gchar *blacklist[] = { "filelists", NULL };
+        ret = lr_handle_setopt(priv->repo_handle, error,
+                               LRO_YUMBLIST, blacklist);
+        if (!ret)
+            goto out;
+    }
+
     lr_result_clear(priv->repo_result);
     dnf_state_action_start(state_local,
                            DNF_STATE_ACTION_DOWNLOAD_METADATA, NULL);

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1749,7 +1749,7 @@ dnf_repo_update(DnfRepo *repo,
         goto out;
 
     /* see dnf_repo_check_internal */
-    if (dnf_context_get_enable_filelists(priv->context)) {
+    if (!dnf_context_get_enable_filelists(priv->context)) {
         const gchar *blacklist[] = { "filelists", NULL };
         ret = lr_handle_setopt(priv->repo_handle, error,
                                LRO_YUMBLIST, blacklist);

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -69,7 +69,7 @@ typedef struct
     gint64           timestamp_modified;    /* µs */
     GError          *last_check_error;
     GKeyFile        *keyfile;
-    GHashTable      *filenames_md;          /* key:filename */
+    GHashTable      *filenames_md;          /* md filename (e.g. "primary") -> file path */
     DnfContext      *context;               /* weak reference */
     DnfRepoKind      kind;
     HyRepo           repo;

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1258,14 +1258,18 @@ dnf_repo_check_internal(DnfRepo *repo,
                         GError **error)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    const gchar *download_list[] = {
-        "primary",
-        "filelists",
-        "group",
-        "updateinfo",
-        "appstream",
-        "appstream-icons",
-        NULL};
+    g_autoptr(GPtrArray) download_list = g_ptr_array_new ();
+    g_ptr_array_add (download_list, (char*)"primary");
+    g_ptr_array_add (download_list, (char*)"group");
+    g_ptr_array_add (download_list, (char*)"updateinfo");
+    g_ptr_array_add (download_list, (char*)"appstream");
+    g_ptr_array_add (download_list, (char*)"appstream-icons");
+    /* This one is huge, and at least rpm-ostree jigdo mode doesn't require it.
+     * https://github.com/projectatomic/rpm-ostree/issues/1127
+     */
+    if (dnf_context_get_enable_filelists (priv->context))
+        g_ptr_array_add (download_list, (char*)"filelists");
+    g_ptr_array_add (download_list, NULL);
     const gchar *tmp;
     gboolean ret;
     LrYumRepo *yum_repo;
@@ -1308,7 +1312,7 @@ dnf_repo_check_internal(DnfRepo *repo,
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_CHECKSUM, 1L))
         return FALSE;
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_YUMDLIST, download_list))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_YUMDLIST, download_list->pdata))
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_MIRRORLIST, NULL))
         return FALSE;

--- a/libdnf/dnf-sack.h
+++ b/libdnf/dnf-sack.h
@@ -162,7 +162,7 @@ Pool        *dnf_sack_get_pool              (DnfSack    *sack);
  * @DNF_SACK_ADD_FLAG_REMOTE:                   Use remote repos
  * @DNF_SACK_ADD_FLAG_UNAVAILABLE:              Add repos that are unavailable
  *
- * The error code.
+ * Flags to control repo loading into the sack.
  **/
 typedef enum {
         DNF_SACK_ADD_FLAG_NONE                  = 0,


### PR DESCRIPTION
Allow clients some flexibility in how the sack is set up. For example,
rpm-ostree has multiple use cases for not loading the rpmdb, nor
filelists. Others where we want to load updateinfo. Accomodate this by
adding a new `dnf_context_setup_sack_with_flags`.