### PR TITLE
Improve ARM detection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ Igor Gnatenko <ignatenko@redhat.com>
 Libdnf CONTRIBUTORS
 -------------------
 Zhang Xianwei <zhang.xianwei8@zte.com.cn>
+Bernhard Rosenkraenzer <bero@lindev.ch>
 
 --------------
 Hawkey AUTHORS


### PR DESCRIPTION
Unify armv* detection, detect newer armv8 variants
(should also have armv9, armv10 etc. covered once
they're released), detect crypto extensions,
don't rely on parsing /proc/cpuinfo (which, for
example, doesn't list neon on armv8)

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>