### PR TITLE
Fix memory leaks by using the PycompString class

### DIFF
--- a/python/hawkey/goal-py.cpp
+++ b/python/hawkey/goal-py.cpp
@@ -460,16 +460,12 @@ static PyObject *
 write_debugdata(_GoalObject *self, PyObject *dir_str)
 {
     g_autoptr(GError) error = NULL;
-    PyObject *tmp_py_str = NULL;
-    const char *dir = pycomp_get_string(dir_str, &tmp_py_str);
+    PycompString dir(dir_str);
 
-    if (dir == NULL) {
-        Py_XDECREF(tmp_py_str);
+    if (!dir.getCString())
         return NULL;
-    }
 
-    gboolean ret = hy_goal_write_debugdata(self->goal, dir, &error);
-    Py_XDECREF(tmp_py_str);
+    gboolean ret = hy_goal_write_debugdata(self->goal, dir.getCString(), &error);
     if (!ret) {
         op_error2exc(error);
         return NULL;

--- a/python/hawkey/hawkeymodule.cpp
+++ b/python/hawkey/hawkeymodule.cpp
@@ -85,18 +85,13 @@ chksum_name(PyObject *unused, PyObject *args)
 static PyObject *
 chksum_type(PyObject *unused, PyObject *str_o)
 {
-    PyObject *tmp_py_str = NULL;
-    const char *str = pycomp_get_string(str_o, &tmp_py_str);
-
-    if (str == NULL) {
-        Py_XDECREF(tmp_py_str);
+    PycompString str(str_o);
+    if (!str.getCString())
         return NULL;
-    }
-    int type = hy_chksum_type(str);
-    Py_XDECREF(tmp_py_str);
 
+    int type = hy_chksum_type(str.getCString());
     if (type == 0) {
-        PyErr_Format(PyExc_ValueError, "unrecognized chksum type: %s", str);
+        PyErr_Format(PyExc_ValueError, "unrecognized chksum type: %s", str.getCString());
         return NULL;
     }
     return PyLong_FromLong(type);
@@ -105,25 +100,18 @@ chksum_type(PyObject *unused, PyObject *str_o)
 static PyObject *
 split_nevra(PyObject *unused, PyObject *nevra_o)
 {
-    PyObject *tmp_py_str = NULL;
-    const char *nevra = pycomp_get_string(nevra_o, &tmp_py_str);
-
-    if (nevra == NULL) {
-        Py_XDECREF(tmp_py_str);
+    PycompString nevra(nevra_o);
+    if (!nevra.getCString())
         return NULL;
-    }
+
     int epoch;
     char *name, *version, *release, *arch;
-
-    int split_nevra_ret = hy_split_nevra(nevra, &name, &epoch, &version, &release, &arch);
-    Py_XDECREF(tmp_py_str); // release memory after unicode string conversion
+    int split_nevra_ret = hy_split_nevra(nevra.getCString(), &name, &epoch, &version, &release, &arch);
 
     if (ret2e(split_nevra_ret, "Failed parsing NEVRA."))
         return NULL;
 
     PyObject *ret = Py_BuildValue("slsss", name, epoch, version, release, arch);
-    if (ret == NULL)
-        return NULL;
     return ret;
 }
 

--- a/python/hawkey/iutil-py.cpp
+++ b/python/hawkey/iutil-py.cpp
@@ -228,26 +228,19 @@ pyseq_to_reldeplist(PyObject *obj, DnfSack *sack, int cmp_type)
                 goto fail;
             dnf_reldep_list_add(reldeplist, reldep);
         } else if (cmp_type == HY_GLOB) {
-            const char *reldep_str = NULL;
-            PyObject *tmp_py_str = NULL;
 
-            reldep_str = pycomp_get_string(item, &tmp_py_str);
-            if (reldep_str == NULL) {
-                Py_XDECREF(tmp_py_str);
+            PycompString reldep_str(item);
+            if (!reldep_str.getCString())
                 goto fail;
-            }
 
-            if (!hy_is_glob_pattern(reldep_str)) {
-                DnfReldep *reldep = reldep_from_str(sack, reldep_str);
-                Py_XDECREF(tmp_py_str);
-                if (reldep == NULL) {
+            if (!hy_is_glob_pattern(reldep_str.getCString())) {
+                DnfReldep *reldep = reldep_from_str(sack, reldep_str.getCString());
+                if (reldep == NULL)
                     goto fail;
-                }
                 dnf_reldep_list_add(reldeplist, reldep);
                 delete reldep;
             } else {
-                DnfReldepList * g_reldeplist = reldeplist_from_str(sack, reldep_str);
-                Py_XDECREF(tmp_py_str);
+                DnfReldepList * g_reldeplist = reldeplist_from_str(sack, reldep_str.getCString());
                 if (g_reldeplist == NULL)
                     goto fail;
                 dnf_reldep_list_extend(reldeplist, g_reldeplist);
@@ -325,18 +318,9 @@ reldeplist_to_pylist(DnfReldepList *reldeplist, PyObject *sack)
 DnfReldep *
 reldep_from_pystr(PyObject *o, DnfSack *sack)
 {
-    DnfReldep *reldep = NULL;
-    const char *reldep_str = NULL;
-    PyObject *tmp_py_str = NULL;
-
-    reldep_str = pycomp_get_string(o, &tmp_py_str);
-    if (reldep_str == NULL) {
-        Py_XDECREF(tmp_py_str);
+    PycompString reldep_str(o);
+    if (!reldep_str.getCString())
         return NULL;
-    }
 
-    reldep = reldep_from_str(sack, reldep_str);
-    Py_XDECREF(tmp_py_str);
-
-    return reldep;
+    return reldep_from_str(sack, reldep_str.getCString());
 }

--- a/python/hawkey/nevra-py.cpp
+++ b/python/hawkey/nevra-py.cpp
@@ -100,17 +100,10 @@ template<void (libdnf::Nevra::*setMethod)(std::string &&)>
 static int
 set_attr(_NevraObject *self, PyObject *value, void *closure)
 {
-    PyObject *tmp_py_str = NULL;
-    auto str_value = pycomp_get_string(value, &tmp_py_str);
-
-    if (str_value == NULL) {
-        Py_XDECREF(tmp_py_str);
+    PycompString str_value(value);
+    if (!str_value.getCString())
         return -1;
-    }
-
-    (self->nevra->*setMethod)(str_value);
-
-    Py_XDECREF(tmp_py_str);
+    (self->nevra->*setMethod)(str_value.getCString());
     return 0;
 }
 

--- a/python/hawkey/nsvcap-py.cpp
+++ b/python/hawkey/nsvcap-py.cpp
@@ -85,16 +85,10 @@ template<void (libdnf::Nsvcap::*setMethod)(std::string &&)>
 static int
 set_attr(_NsvcapObject *self, PyObject *value, void *closure)
 {
-    PyObject *tmp_py_str = NULL;
-    const char *str_value = pycomp_get_string(value, &tmp_py_str);
-
-    if (!str_value) {
-        Py_XDECREF(tmp_py_str);
+    PycompString str_value(value);
+    if (!str_value.getCString())
         return -1;
-    }
-    (self->nsvcap->*setMethod)(str_value);
-    Py_XDECREF(tmp_py_str);
-
+    (self->nsvcap->*setMethod)(str_value.getCString());
     return 0;
 }
 

--- a/python/hawkey/package-py.cpp
+++ b/python/hawkey/package-py.cpp
@@ -328,14 +328,10 @@ evr_cmp(_PackageObject *self, PyObject *other)
 static PyObject *
 get_delta_from_evr(_PackageObject *self, PyObject *evr_str)
 {
-    PyObject *tmp_py_str = NULL;
-    const char *evr = pycomp_get_string(evr_str, &tmp_py_str);
-    if (evr == NULL) {
-        Py_XDECREF(tmp_py_str);
+    PycompString evr(evr_str);
+    if (!evr.getCString())
         return NULL;
-    }
-    DnfPackageDelta *delta_c = dnf_package_get_delta_from_evr(self->package, evr);
-    Py_XDECREF(tmp_py_str);
+    DnfPackageDelta *delta_c = dnf_package_get_delta_from_evr(self->package, evr.getCString());
     if (delta_c)
         return packageDeltaToPyObject(delta_c);
     Py_RETURN_NONE;

--- a/python/hawkey/pycomp.cpp
+++ b/python/hawkey/pycomp.cpp
@@ -77,37 +77,3 @@ PycompString::~PycompString()
 {
     Py_XDECREF(pyString);
 }
-
-/**
- * bytes, basic string or unicode string in Python 2/3 to c string converter,
- * you need to call Py_XDECREF(tmp_py_str) after usage of returned string
- */
-const char *
-pycomp_get_string(PyObject *str, PyObject **tmp_py_str)
-{
-    char *res = NULL;
-    if (PyUnicode_Check(str))
-        res = pycomp_get_string_from_unicode(str, tmp_py_str);
-#if PY_MAJOR_VERSION < 3
-    else if (PyString_Check(str))
-        res = PyString_AsString(str);
-    else
-        PyErr_SetString(PyExc_TypeError, "Expected a string or a unicode object");
-#else
-    else if (PyBytes_Check(str))
-        res = PyBytes_AsString(str);
-    else
-        PyErr_SetString(PyExc_TypeError, "Expected a string or a unicode object");
-#endif
-
-    return res;
-}
-
-/* release PyObject array from memory */
-void
-pycomp_free_tmp_array(PyObject **tmp_py_strs, int count)
-{
-    for (int j = count; j >= 0; --j) {
-        Py_XDECREF(tmp_py_strs[j]);
-    }
-}

--- a/python/hawkey/pycomp.hpp
+++ b/python/hawkey/pycomp.hpp
@@ -72,8 +72,6 @@ private:
     PyObject * pyString;
 };
 
-const char *pycomp_get_string(PyObject *str_o, PyObject **tmp_py_str);
-void pycomp_free_tmp_array(PyObject **tmp_py_strs, int count);
 PYCOMP_MOD_INIT(_hawkey);
 
 #endif // PYCOMP_H

--- a/python/hawkey/pycomp.hpp
+++ b/python/hawkey/pycomp.hpp
@@ -56,6 +56,22 @@
         PyObject_HEAD_INIT(type) size,
 #endif
 
+/**
+* @brief bytes, basic string or unicode string in Python 2/3 to c string converter
+*/
+class PycompString {
+public:
+    constexpr PycompString() noexcept : cString(nullptr), pyString(nullptr) {}
+    explicit PycompString(PyObject * str);
+    PycompString(PycompString && src) noexcept;
+    ~PycompString();
+    PycompString & operator =(PycompString && src) noexcept;
+    const char * getCString() const noexcept { return cString; }
+private:
+    const char * cString;
+    PyObject * pyString;
+};
+
 const char *pycomp_get_string(PyObject *str_o, PyObject **tmp_py_str);
 void pycomp_free_tmp_array(PyObject **tmp_py_strs, int count);
 PYCOMP_MOD_INIT(_hawkey);

--- a/python/hawkey/reldep-py.cpp
+++ b/python/hawkey/reldep-py.cpp
@@ -111,28 +111,22 @@ static int
 reldep_init(_ReldepObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *sack;
-    const char *reldep_str = NULL;
-    PyObject *tmp_py_str = NULL;
     PyObject *reldep_str_py = NULL;
     if (!PyArg_ParseTuple(args, "O!O", &sack_Type, &sack, &reldep_str_py))
         return -1;
     DnfSack *csack = sackFromPyObject(sack);
     if (csack == NULL)
         return -1;
-    reldep_str = pycomp_get_string(reldep_str_py, &tmp_py_str);
-    if (reldep_str == NULL) {
-        Py_XDECREF(tmp_py_str);
+    PycompString reldep_str(reldep_str_py);
+    if (!reldep_str.getCString())
         return -1;
-    }
 
-    self->reldep = reldep_from_str (csack, reldep_str);
+    self->reldep = reldep_from_str(csack, reldep_str.getCString());
     if (self->reldep == NULL) {
-        PyErr_Format(HyExc_Value, "Wrong reldep format: %s", reldep_str);
-        Py_XDECREF(tmp_py_str);
+        PyErr_Format(HyExc_Value, "Wrong reldep format: %s", reldep_str.getCString());
         return -1;
     }
 
-    Py_XDECREF(tmp_py_str);
     return 0;
 }
 

--- a/python/hawkey/repo-py.cpp
+++ b/python/hawkey/repo-py.cpp
@@ -144,16 +144,10 @@ static int
 set_str(_RepoObject *self, PyObject *value, void *closure)
 {
     intptr_t str_key = (intptr_t)closure;
-    PyObject *tmp_py_str = NULL;
-    const char *str_value = pycomp_get_string(value, &tmp_py_str);
-
-    if (str_value == NULL) {
-        Py_XDECREF(tmp_py_str);
+    PycompString str_value(value);
+    if (!str_value.getCString())
         return -1;
-    }
-    hy_repo_set_string(self->repo, str_key, str_value);
-    Py_XDECREF(tmp_py_str);
-
+    hy_repo_set_string(self->repo, str_key, str_value.getCString());
     return 0;
 }
 

--- a/python/hawkey/subject-py.cpp
+++ b/python/hawkey/subject-py.cpp
@@ -98,14 +98,10 @@ subject_init(_SubjectObject *self, PyObject *args, PyObject *kwds)
         return -1;
     }
     self->icase = icase != NULL && PyObject_IsTrue(icase);
-    PyObject *tmp_py_str = NULL;
-    const char * pattern = pycomp_get_string(py_pattern, &tmp_py_str);
-    if (!pattern) {
-        Py_XDECREF(tmp_py_str);
+    PycompString pattern(py_pattern);
+    if (!pattern.getCString())
         return -1;
-    }
-    self->pattern = g_strdup(pattern);
-    Py_XDECREF(tmp_py_str);
+    self->pattern = g_strdup(pattern.getCString());
     return 0;
 }
 


### PR DESCRIPTION
The pycomp_get_string() function is designed unfriendly.
It uses temporary PyObject and the user is responsible for releasing it.
This approach is susceptible for memory leaks, especially in error conditions.

We found and fix a lot of memory leaks caused by bad usage of the pycomp_get_string() function.
And today I found next errors:
hawkeymodule.cpp: chksum_type() - in error case memory released too early (usage after release)
query-py.cpp: filter_add() - don't released last item in array
sack-py.cpp: sack_init() - don't released tmp2_py_str, when opening of log file is not succes

So, the PR removes pycomp_get_string() and pycomp_free_tmp_array() functions.
All their uses are replaced by the PycompString class.
All memory errors caused by incorrect using of removed functions gone out.
