### PR TITLE
Implement and use UniquePtrPyObject class (smart pointer to PyObject)

### DIFF
--- a/python/hawkey/advisory-py.cpp
+++ b/python/hawkey/advisory-py.cpp
@@ -152,12 +152,10 @@ get_datetime(_AdvisoryObject *self, void *closure)
 {
     guint64 (*func)(DnfAdvisory*);
     func = (guint64 (*)(DnfAdvisory*))closure;
-    PyObject *timestamp = PyLong_FromUnsignedLongLong(func(self->advisory));
-    PyObject *args = Py_BuildValue("(O)", timestamp);
+    UniquePtrPyObject timestamp(PyLong_FromUnsignedLongLong(func(self->advisory)));
+    UniquePtrPyObject args(Py_BuildValue("(O)", timestamp.get()));
     PyDateTime_IMPORT;
-    PyObject *datetime = PyDateTime_FromTimestamp(args);
-    Py_DECREF(args);
-    Py_DECREF(timestamp);
+    PyObject *datetime = PyDateTime_FromTimestamp(args.get());
     return datetime;
 }
 

--- a/python/hawkey/goal-py.cpp
+++ b/python/hawkey/goal-py.cpp
@@ -375,9 +375,8 @@ count_problems(_GoalObject *self, PyObject *unused)
 static PyObject *
 problem_rules(_GoalObject *self, PyObject *unused)
 {
-    PyObject *list_output = PyList_New(0);
-    PyObject *list;
-    if (list_output == NULL)
+    UniquePtrPyObject list_output(PyList_New(0));
+    if (!list_output)
         return NULL;
     int count_problems = hy_goal_count_problems(self->goal);
     for (int i = 0; i < count_problems; i++) {
@@ -386,13 +385,12 @@ problem_rules(_GoalObject *self, PyObject *unused)
             PyErr_SetString(PyExc_ValueError, "Index out of range.");
             continue;
         }
-        list = strlist_to_pylist((const char **)plist);
-        int rc = PyList_Append(list_output, list);
-        Py_DECREF(list);
+        UniquePtrPyObject list(strlist_to_pylist((const char **)plist));
+        int rc = PyList_Append(list_output.get(), list.get());
         if (rc == -1)
             return NULL;
     }
-    return list_output;
+    return list_output.release();
 }
 
 /**

--- a/python/hawkey/iutil-py.cpp
+++ b/python/hawkey/iutil-py.cpp
@@ -45,6 +45,27 @@
 #include "../../libdnf/repo/solvable/Dependency.hpp"
 #include "libdnf/repo/solvable/DependencyContainer.hpp"
 
+UniquePtrPyObject & UniquePtrPyObject::operator =(UniquePtrPyObject && src) noexcept
+{
+    if (this == &src)
+        return *this;
+    Py_XDECREF(pyObj);
+    pyObj = src.pyObj;
+    src.pyObj = NULL;
+    return *this;
+}
+
+void UniquePtrPyObject::reset(PyObject * pyObj) noexcept
+{
+    Py_XDECREF(this->pyObj);
+    this->pyObj = pyObj;
+}
+
+UniquePtrPyObject::~UniquePtrPyObject()
+{
+    Py_XDECREF(pyObj);
+}
+
 PyObject *
 advisorylist_to_pylist(const GPtrArray *advisorylist, PyObject *sack)
 {

--- a/python/hawkey/nevra-py.cpp
+++ b/python/hawkey/nevra-py.cpp
@@ -288,25 +288,24 @@ nevra_richcompare(PyObject *self, PyObject *other, int op)
 static PyObject *
 iter(_NevraObject *self)
 {
-    PyObject *res;
+    UniquePtrPyObject res;
     auto nevra = self->nevra;
     if (nevra->getEpoch() == libdnf::Nevra::EPOCH_NOT_SET) {
         Py_INCREF(Py_None);
-        res = Py_BuildValue("zOzzz",
-                            nevra->getName().c_str(),
-                            Py_None,
-                            nevra->getVersion().c_str(),
-                            nevra->getRelease().c_str(),
-                            nevra->getArch().c_str());
+        res.reset(Py_BuildValue("zOzzz",
+            nevra->getName().c_str(),
+            Py_None,
+            nevra->getVersion().c_str(),
+            nevra->getRelease().c_str(),
+            nevra->getArch().c_str()));
     } else
-        res = Py_BuildValue("zizzz",
-                            nevra->getName().c_str(),
-                            nevra->getEpoch(),
-                            nevra->getVersion().c_str(),
-                            nevra->getRelease().c_str(),
-                            nevra->getArch().c_str());
-    PyObject *iter = PyObject_GetIter(res);
-    Py_DECREF(res);
+        res.reset(Py_BuildValue("zizzz",
+            nevra->getName().c_str(),
+            nevra->getEpoch(),
+            nevra->getVersion().c_str(),
+            nevra->getRelease().c_str(),
+            nevra->getArch().c_str()));
+    PyObject *iter = PyObject_GetIter(res.get());
     return iter;
 }
 

--- a/python/hawkey/nsvcap-py.cpp
+++ b/python/hawkey/nsvcap-py.cpp
@@ -21,6 +21,7 @@
 #include <Python.h>
 
 // pyhawkey
+#include "iutil-py.hpp"
 #include "nsvcap-py.hpp"
 #include "pycomp.hpp"
 
@@ -173,27 +174,26 @@ nsvcapConverter(PyObject *o, libdnf::Nsvcap ** nsvcap_ptr)
 static PyObject *
 iter(_NsvcapObject *self)
 {
-    PyObject *res;
+    UniquePtrPyObject res;
     libdnf::Nsvcap * nsvcap = self->nsvcap;
     if (nsvcap->getVersion() == libdnf::Nsvcap::VERSION_NOT_SET) {
         Py_INCREF(Py_None);
-        res = Py_BuildValue("zzOzzz",
-                            nsvcap->getName().empty() ? nullptr : nsvcap->getName().c_str(),
-                            nsvcap->getStream().empty() ? nullptr : nsvcap->getStream().c_str(),
-                            Py_None,
-                            nsvcap->getContext().empty() ? nullptr : nsvcap->getContext().c_str(),
-                            nsvcap->getArch().empty() ? nullptr : nsvcap->getArch().c_str(),
-                            nsvcap->getProfile().empty() ? nullptr : nsvcap->getProfile().c_str());
+        res.reset(Py_BuildValue("zzOzzz",
+            nsvcap->getName().empty() ? nullptr : nsvcap->getName().c_str(),
+            nsvcap->getStream().empty() ? nullptr : nsvcap->getStream().c_str(),
+            Py_None,
+            nsvcap->getContext().empty() ? nullptr : nsvcap->getContext().c_str(),
+            nsvcap->getArch().empty() ? nullptr : nsvcap->getArch().c_str(),
+            nsvcap->getProfile().empty() ? nullptr : nsvcap->getProfile().c_str()));
     } else
-        res = Py_BuildValue("zzLzzz",
-                            nsvcap->getName().empty() ? nullptr : nsvcap->getName().c_str(),
-                            nsvcap->getStream().empty() ? nullptr : nsvcap->getStream().c_str(),
-                            nsvcap->getVersion(),
-                            nsvcap->getContext().empty() ? nullptr : nsvcap->getContext().c_str(),
-                            nsvcap->getArch().empty() ? nullptr : nsvcap->getArch().c_str(),
-                            nsvcap->getProfile().empty() ? nullptr : nsvcap->getProfile().c_str());
-    PyObject *iter = PyObject_GetIter(res);
-    Py_DECREF(res);
+        res.reset(Py_BuildValue("zzLzzz",
+            nsvcap->getName().empty() ? nullptr : nsvcap->getName().c_str(),
+            nsvcap->getStream().empty() ? nullptr : nsvcap->getStream().c_str(),
+            nsvcap->getVersion(),
+            nsvcap->getContext().empty() ? nullptr : nsvcap->getContext().c_str(),
+            nsvcap->getArch().empty() ? nullptr : nsvcap->getArch().c_str(),
+            nsvcap->getProfile().empty() ? nullptr : nsvcap->getProfile().c_str()));
+    PyObject *iter = PyObject_GetIter(res.get());
     return iter;
 }
 


### PR DESCRIPTION
UniquePtrPyObject is smart pinter to PyObject.
It owns and manages PyObject. Decrements the reference count for the PyObject (calls Py_XDECREF on it) when  UniquePtrPyObject goes out of scope.
Implements subset of standard std::unique_ptr methods.

PR minimizes using of Py_DECREF() and Py_XDECREF() macros.
Using smart pointers is easier and safer than manual decrementing of reference count,
especially in error conditions.
