### PR TITLE
Fix: memory leaks (incorrect usage of Py_INCREF/Py_XINCREF)

### DIFF
--- a/python/hawkey/exception-py.cpp
+++ b/python/hawkey/exception-py.cpp
@@ -39,37 +39,31 @@ init_exceptions(void)
      HyExc_Exception = PyErr_NewException((char*) "_hawkey.Exception", NULL, NULL);
      if (!HyExc_Exception)
          return 0;
-     Py_INCREF(HyExc_Exception);
 
      HyExc_Value = PyErr_NewException((char*) "_hawkey.ValueException", HyExc_Exception,
                                       NULL);
      if (!HyExc_Value)
          return 0;
-     Py_INCREF(HyExc_Value);
 
      HyExc_Query = PyErr_NewException((char*) "_hawkey.QueryException", HyExc_Value,
                                       NULL);
      if (!HyExc_Query)
          return 0;
-     Py_INCREF(HyExc_Query);
 
      HyExc_Arch = PyErr_NewException((char*) "_hawkey.ArchException", HyExc_Value,
                                       NULL);
      if (!HyExc_Arch)
          return 0;
-     Py_INCREF(HyExc_Arch);
 
      HyExc_Runtime = PyErr_NewException((char*) "_hawkey.RuntimeException",
                                         HyExc_Exception, NULL);
      if (!HyExc_Runtime)
          return 0;
-     Py_INCREF(HyExc_Runtime);
 
      HyExc_Validation = PyErr_NewException((char*) "_hawkey.ValidationException",
                                         HyExc_Exception, NULL);
      if (!HyExc_Validation)
          return 0;
-     Py_INCREF(HyExc_Validation);
 
      return 1;
 }

--- a/python/hawkey/nevra-py.cpp
+++ b/python/hawkey/nevra-py.cpp
@@ -291,7 +291,6 @@ iter(_NevraObject *self)
     UniquePtrPyObject res;
     auto nevra = self->nevra;
     if (nevra->getEpoch() == libdnf::Nevra::EPOCH_NOT_SET) {
-        Py_INCREF(Py_None);
         res.reset(Py_BuildValue("zOzzz",
             nevra->getName().c_str(),
             Py_None,

--- a/python/hawkey/nsvcap-py.cpp
+++ b/python/hawkey/nsvcap-py.cpp
@@ -177,7 +177,6 @@ iter(_NsvcapObject *self)
     UniquePtrPyObject res;
     libdnf::Nsvcap * nsvcap = self->nsvcap;
     if (nsvcap->getVersion() == libdnf::Nsvcap::VERSION_NOT_SET) {
-        Py_INCREF(Py_None);
         res.reset(Py_BuildValue("zzOzzz",
             nsvcap->getName().empty() ? nullptr : nsvcap->getName().c_str(),
             nsvcap->getStream().empty() ? nullptr : nsvcap->getStream().c_str(),

--- a/python/hawkey/query-py.cpp
+++ b/python/hawkey/query-py.cpp
@@ -771,7 +771,6 @@ query_get_item(PyObject *self, int index)
         return NULL;
     }
     PyObject *package = new_package(((_QueryObject *) self)->sack, id);
-    Py_INCREF(package);
     return package;
 }
 

--- a/python/hawkey/subject-py.cpp
+++ b/python/hawkey/subject-py.cpp
@@ -306,7 +306,6 @@ get_best_query(_SubjectObject *self, PyObject *args, PyObject *kwds)
     HyNevra nevra{nullptr};
     PyObject *py_query = get_best_parser(self, args, kwds, &nevra);
     delete nevra;
-    Py_XINCREF(py_query);
     return py_query;
 }
 
@@ -336,7 +335,6 @@ get_best_selector(_SubjectObject *self, PyObject *args, PyObject *kwds)
     HySelector c_selector = hy_subject_get_best_sltr(self->pattern, csack,
         cforms.empty() ? NULL : cforms.data(), c_obsoletes, reponame);
     PyObject *selector = SelectorToPyObject(c_selector, sack);
-    Py_INCREF(selector);
     return selector;
 }
 


### PR DESCRIPTION
Removes wrong Py_INCREF/Py_XINCREF calls.
Functions tp_alloc(), PyObject_CallObject(), PyErr_NewException() return new reference.
The function Py_BuildValue() increments the reference count to the passed Python object itself.

Please merge https://github.com/rpm-software-management/libdnf/pull/452 before this. (First two commit are the same.)