### PR TITLE
Improve speed of nevra.parse() and nvscap.parse()

### DIFF
--- a/libdnf/nevra.cpp
+++ b/libdnf/nevra.cpp
@@ -31,19 +31,18 @@ namespace libdnf {
 #define PKG_RELEASE PKG_VERSION
 #define PKG_ARCH "([^-:.(/=<> ]+)"
 
-static constexpr const char * NEVRA_FORM_REGEX[] = {
-    "^" PKG_NAME "-" PKG_EPOCH PKG_VERSION "-" PKG_RELEASE "\\." PKG_ARCH "$",
-    "^" PKG_NAME "-" PKG_EPOCH PKG_VERSION "-" PKG_RELEASE          "()"  "$",
-    "^" PKG_NAME "-" PKG_EPOCH PKG_VERSION        "()"              "()"  "$",
-    "^" PKG_NAME      "()()"      "()"            "()"     "\\." PKG_ARCH "$",
-    "^" PKG_NAME      "()()"      "()"            "()"              "()"  "$"
+static const Regex NEVRA_FORM_REGEX[]{
+    Regex("^" PKG_NAME "-" PKG_EPOCH PKG_VERSION "-" PKG_RELEASE "\\." PKG_ARCH "$", REG_EXTENDED),
+    Regex("^" PKG_NAME "-" PKG_EPOCH PKG_VERSION "-" PKG_RELEASE          "()"  "$", REG_EXTENDED),
+    Regex("^" PKG_NAME "-" PKG_EPOCH PKG_VERSION        "()"              "()"  "$", REG_EXTENDED),
+    Regex("^" PKG_NAME      "()()"      "()"            "()"     "\\." PKG_ARCH "$", REG_EXTENDED),
+    Regex("^" PKG_NAME      "()()"      "()"            "()"              "()"  "$", REG_EXTENDED)
 };
 
 bool Nevra::parse(const char * nevraStr, HyForm form)
 {
     enum { NAME = 1, EPOCH = 3, VERSION = 4, RELEASE = 5, ARCH = 6, _LAST_ };
-    Regex reg(NEVRA_FORM_REGEX[form - 1], REG_EXTENDED);
-    auto matchResult = reg.match(nevraStr, false, _LAST_);
+    auto matchResult = NEVRA_FORM_REGEX[form - 1].match(nevraStr, false, _LAST_);
     if (!matchResult.isMatched() || matchResult.getMatchedLen(NAME) == 0)
         return false;
     name = matchResult.getMatchedString(NAME);

--- a/libdnf/nsvcap.cpp
+++ b/libdnf/nsvcap.cpp
@@ -31,30 +31,29 @@ namespace libdnf {
 #define MODULE_ARCH MODULE_NAME
 #define MODULE_PROFILE MODULE_NAME
 
-static constexpr const char * NSVCAP_FORM_REGEX[] = {
-    "^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION ":" MODULE_CONTEXT "::?" MODULE_ARCH "\\/"  MODULE_PROFILE "$",
-    "^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION ":" MODULE_CONTEXT "::?" MODULE_ARCH "\\/?" "()"           "$",
-    "^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION     "()"           "::"  MODULE_ARCH "\\/"  MODULE_PROFILE "$",
-    "^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION     "()"           "::"  MODULE_ARCH "\\/?" "()"           "$",
-    "^" MODULE_NAME ":" MODULE_STREAM     "()"               "()"           "::"  MODULE_ARCH "\\/"  MODULE_PROFILE "$",
-    "^" MODULE_NAME ":" MODULE_STREAM     "()"               "()"           "::"  MODULE_ARCH "\\/?" "()"           "$",
-    "^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION ":" MODULE_CONTEXT       "()"        "\\/"  MODULE_PROFILE "$",
-    "^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION     "()"                 "()"        "\\/"  MODULE_PROFILE "$",
-    "^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION ":" MODULE_CONTEXT       "()"        "\\/?" "()"           "$",
-    "^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION     "()"                 "()"        "\\/?" "()"           "$",
-    "^" MODULE_NAME ":" MODULE_STREAM     "()"               "()"                 "()"        "\\/"  MODULE_PROFILE "$",
-    "^" MODULE_NAME ":" MODULE_STREAM     "()"               "()"                 "()"        "\\/?" "()"           "$",
-    "^" MODULE_NAME     "()"              "()"               "()"           "::"  MODULE_ARCH "\\/"  MODULE_PROFILE "$",
-    "^" MODULE_NAME     "()"              "()"               "()"           "::"  MODULE_ARCH "\\/?" "()"           "$",
-    "^" MODULE_NAME     "()"              "()"               "()"                 "()"        "\\/"  MODULE_PROFILE "$",
-    "^" MODULE_NAME     "()"              "()"               "()"                 "()"        "\\/?" "()"           "$"
+static const Regex NSVCAP_FORM_REGEX[]{
+    Regex("^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION ":" MODULE_CONTEXT "::?" MODULE_ARCH "\\/"  MODULE_PROFILE "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION ":" MODULE_CONTEXT "::?" MODULE_ARCH "\\/?" "()"           "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION     "()"           "::"  MODULE_ARCH "\\/"  MODULE_PROFILE "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION     "()"           "::"  MODULE_ARCH "\\/?" "()"           "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM     "()"               "()"           "::"  MODULE_ARCH "\\/"  MODULE_PROFILE "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM     "()"               "()"           "::"  MODULE_ARCH "\\/?" "()"           "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION ":" MODULE_CONTEXT       "()"        "\\/"  MODULE_PROFILE "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION     "()"                 "()"        "\\/"  MODULE_PROFILE "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION ":" MODULE_CONTEXT       "()"        "\\/?" "()"           "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM ":" MODULE_VERSION     "()"                 "()"        "\\/?" "()"           "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM     "()"               "()"                 "()"        "\\/"  MODULE_PROFILE "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME ":" MODULE_STREAM     "()"               "()"                 "()"        "\\/?" "()"           "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME     "()"              "()"               "()"           "::"  MODULE_ARCH "\\/"  MODULE_PROFILE "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME     "()"              "()"               "()"           "::"  MODULE_ARCH "\\/?" "()"           "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME     "()"              "()"               "()"                 "()"        "\\/"  MODULE_PROFILE "$", REG_EXTENDED),
+    Regex("^" MODULE_NAME     "()"              "()"               "()"                 "()"        "\\/?" "()"           "$", REG_EXTENDED)
 };
 
 bool Nsvcap::parse(const char *nsvcapStr, HyModuleForm form)
 {
     enum { NAME = 1, STREAM = 2, VERSION = 3, CONTEXT = 4, ARCH = 5, PROFILE = 6, _LAST_ };
-    Regex reg(NSVCAP_FORM_REGEX[form - 1], REG_EXTENDED);
-    auto matchResult = reg.match(nsvcapStr, false, _LAST_);
+    auto matchResult = NSVCAP_FORM_REGEX[form - 1].match(nsvcapStr, false, _LAST_);
     if (!matchResult.isMatched() || matchResult.getMatchedLen(NAME) == 0)
         return false;
     name = matchResult.getMatchedString(NAME);

--- a/libdnf/utils/regex/regex.cpp
+++ b/libdnf/utils/regex/regex.cpp
@@ -47,7 +47,7 @@ Regex::operator=(Regex && src) noexcept
 }
 
 Regex::Result
-Regex::match(const char * str, bool copyStr, std::size_t count)
+Regex::match(const char * str, bool copyStr, std::size_t count) const
 {
     if (freed)
         throw InvalidException();

--- a/libdnf/utils/regex/regex.hpp
+++ b/libdnf/utils/regex/regex.hpp
@@ -155,7 +155,7 @@ public:
     * @param str string to match
     * @return true if string is matched
     */
-    bool match(const char * str);
+    bool match(const char * str) const;
 
     /**
     * @brief Match input string to precompiled regular expression
@@ -167,7 +167,7 @@ public:
     * @param count Max number of matches we want to get
     * @return object providing information regarding the location of any matches
     */
-    Result match(const char * str, bool copyStr, std::size_t count);
+    Result match(const char * str, bool copyStr, std::size_t count) const;
     ~Regex();
 private:
     void free() noexcept;
@@ -188,7 +188,7 @@ inline std::size_t Regex::getSubexprCount() const
     return exp.re_nsub; 
 }
 
-inline bool Regex::match(const char * str)
+inline bool Regex::match(const char * str) const
 {
     if (freed)
         throw InvalidException();


### PR DESCRIPTION
Compiles the regular expressions only once and uses they repeatedly.
It improves speed of the parse() methods more then 5 times.