### PR TITLE
[swdb]: Consistently define namespace libdnf

### DIFF
--- a/bindings/swig/transaction.i
+++ b/bindings/swig/transaction.i
@@ -13,7 +13,7 @@
 %include <typemaps.i>
 
 
-%rename ("__hash__", fullname=1) "TransactionItem::getHash";
+%rename ("__hash__", fullname=1) "libdnf::TransactionItem::getHash";
 
 
 %exception {
@@ -34,35 +34,38 @@
 %shared_ptr(SQLite3)
 typedef std::shared_ptr< SQLite3 > SQLite3Ptr;
 
-%shared_ptr(Item)
-typedef std::shared_ptr< Item > ItemPtr;
+%shared_ptr(libdnf::Item)
+typedef std::shared_ptr< libdnf::Item > ItemPtr;
 
-%shared_ptr(RPMItem)
-typedef std::shared_ptr< RPMItem > RPMItemPtr;
+%shared_ptr(libdnf::RPMItem)
+typedef std::shared_ptr< libdnf::RPMItem > RPMItemPtr;
 
-%shared_ptr(CompsGroupItem)
-typedef std::shared_ptr< CompsGroupItem > CompsGroupItemPtr;
+%shared_ptr(libdnf::CompsGroupItem)
+typedef std::shared_ptr< libdnf::CompsGroupItem > CompsGroupItemPtr;
 
-%shared_ptr(CompsGroupPackage)
-typedef std::shared_ptr< CompsGroupPackage > CompsGroupPackagePtr;
+%shared_ptr(libdnf::CompsGroupPackage)
+typedef std::shared_ptr< libdnf::CompsGroupPackage > CompsGroupPackagePtr;
 
-%shared_ptr(CompsEnvironmentItem)
-typedef std::shared_ptr< CompsEnvironmentItem > CompsEnvironmentItemPtr;
+%shared_ptr(libdnf::CompsEnvironmentItem)
+typedef std::shared_ptr< libdnf::CompsEnvironmentItem > CompsEnvironmentItemPtr;
 
-%shared_ptr(CompsEnvironmentGroup)
-typedef std::shared_ptr< CompsEnvironmentGroup > CompsEnvironmentGroupPtr;
+%shared_ptr(libdnf::CompsEnvironmentGroup)
+typedef std::shared_ptr< libdnf::CompsEnvironmentGroup > CompsEnvironmentGroupPtr;
 
 %shared_ptr(libdnf::Transaction)
 typedef std::shared_ptr< libdnf::Transaction > TransactionPtr;
 
-%shared_ptr(TransactionItem)
-typedef std::shared_ptr< TransactionItem > TransactionItemPtr;
+%shared_ptr(libdnf::TransactionItem)
+typedef std::shared_ptr< libdnf::TransactionItem > TransactionItemPtr;
 
-%shared_ptr(MergedTransaction)
-typedef std::shared_ptr< MergedTransaction > MergedTransactionPtr;
+%shared_ptr(libdnf::MergedTransaction)
+typedef std::shared_ptr< libdnf::MergedTransaction > MergedTransactionPtr;
 
-%shared_ptr(TransactionItemBase)
-typedef std::shared_ptr< TransactionItemBase > TransactionItemBasePtr;
+%shared_ptr(libdnf::TransactionItemBase)
+typedef std::shared_ptr< libdnf::TransactionItemBase > TransactionItemBasePtr;
+
+// XXX workaround - because SWIG...
+typedef libdnf::CompsPackageType CompsPackageType;
 
 %{
     // make SWIG wrap following headers
@@ -76,6 +79,7 @@ typedef std::shared_ptr< TransactionItemBase > TransactionItemBasePtr;
     #include "libdnf/transaction/MergedTransaction.hpp"
     #include "libdnf/transaction/Transformer.hpp"
     #include "libdnf/transaction/Types.hpp"
+    using namespace libdnf;
 %}
 
 
@@ -84,11 +88,11 @@ typedef std::shared_ptr< TransactionItemBase > TransactionItemBasePtr;
 
 
 %template() std::vector<std::shared_ptr<libdnf::Transaction> >;
-%template() std::vector<std::shared_ptr<TransactionItem> >;
-%template() std::vector<std::shared_ptr<TransactionItemBase> >;
-%template() std::vector<std::shared_ptr<CompsGroupPackage> >;
-%template() std::vector<std::shared_ptr<CompsEnvironmentGroup> >;
-%template(TransactionStateVector) std::vector<TransactionState>;
+%template() std::vector<std::shared_ptr<libdnf::TransactionItem> >;
+%template() std::vector<std::shared_ptr<libdnf::TransactionItemBase> >;
+%template() std::vector<std::shared_ptr<libdnf::CompsGroupPackage> >;
+%template() std::vector<std::shared_ptr<libdnf::CompsEnvironmentGroup> >;
+%template(TransactionStateVector) std::vector<libdnf::TransactionState>;
 
 %template() std::vector<uint32_t>;
 %template() std::vector<int64_t>;

--- a/libdnf/hy-query-private.hpp
+++ b/libdnf/hy-query-private.hpp
@@ -38,7 +38,7 @@ enum _match_type {
     _HY_STR,
 };
 
-int hy_filter_unneeded(HyQuery query, const Swdb &swdb, const gboolean debug_solver);
+int hy_filter_unneeded(HyQuery query, const libdnf::Swdb &swdb, const gboolean debug_solver);
 
 /**
 * @brief Return HySelector from HyQuery

--- a/libdnf/hy-query.cpp
+++ b/libdnf/hy-query.cpp
@@ -331,7 +331,7 @@ hy_filter_duplicated(HyQuery query)
 }
 
 int
-hy_filter_unneeded(HyQuery query, const Swdb &swdb, const gboolean debug_solver)
+hy_filter_unneeded(HyQuery query, const libdnf::Swdb &swdb, const gboolean debug_solver)
 {
     hy_query_apply(query);
     HyGoal goal = hy_goal_create(query->getSack());

--- a/libdnf/transaction/CompsEnvironmentItem.cpp
+++ b/libdnf/transaction/CompsEnvironmentItem.cpp
@@ -22,6 +22,8 @@
 
 #include "CompsEnvironmentItem.hpp"
 
+namespace libdnf {
+
 typedef const char *string;
 
 CompsEnvironmentItem::CompsEnvironmentItem(SQLite3Ptr conn)
@@ -332,3 +334,5 @@ CompsEnvironmentGroup::dbInsert()
     query.step();
     setId(getEnvironment().conn->lastInsertRowID());
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/CompsEnvironmentItem.hpp
+++ b/libdnf/transaction/CompsEnvironmentItem.hpp
@@ -24,15 +24,20 @@
 #include <memory>
 #include <vector>
 
+namespace libdnf {
+
 class CompsEnvironmentItem;
 typedef std::shared_ptr< CompsEnvironmentItem > CompsEnvironmentItemPtr;
 
 class CompsEnvironmentGroup;
 typedef std::shared_ptr< CompsEnvironmentGroup > CompsEnvironmentGroupPtr;
+}
 
 #include "Item.hpp"
 #include "CompsGroupItem.hpp"
 #include "TransactionItem.hpp"
+
+namespace libdnf {
 
 class CompsEnvironmentItem : public Item {
 public:
@@ -115,5 +120,7 @@ protected:
 private:
     void dbInsert();
 };
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_COMPSENVIRONMENTITEM_HPP

--- a/libdnf/transaction/CompsGroupItem.cpp
+++ b/libdnf/transaction/CompsGroupItem.cpp
@@ -23,6 +23,8 @@
 #include "CompsGroupItem.hpp"
 #include "TransactionItem.hpp"
 
+namespace libdnf {
+
 CompsGroupItem::CompsGroupItem(SQLite3Ptr conn)
   : Item{conn}
   , packageTypes(CompsPackageType::DEFAULT)
@@ -360,3 +362,5 @@ CompsGroupPackage::dbSelectOrInsert()
         dbInsert();
     }
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/CompsGroupItem.hpp
+++ b/libdnf/transaction/CompsGroupItem.hpp
@@ -24,6 +24,8 @@
 #include <memory>
 #include <vector>
 
+namespace libdnf {
+
 enum class CompsPackageType : int {
     MANDATORY = 0,
     DEFAULT = 1,
@@ -37,8 +39,12 @@ class CompsGroupPackage;
 typedef std::shared_ptr< CompsGroupItem > CompsGroupItemPtr;
 typedef std::shared_ptr< CompsGroupPackage > CompsGroupPackagePtr;
 
+}
+
 #include "Item.hpp"
 #include "TransactionItem.hpp"
+
+namespace libdnf {
 
 class CompsGroupItem : public Item {
 public:
@@ -119,5 +125,7 @@ private:
     void dbSelectOrInsert();
     void dbUpdate();
 };
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_COMPSGROUPITEM_HPP

--- a/libdnf/transaction/Item.cpp
+++ b/libdnf/transaction/Item.cpp
@@ -20,6 +20,8 @@
 
 #include "Item.hpp"
 
+namespace libdnf {
+
 Item::Item(SQLite3Ptr conn)
   : conn{conn}
 {
@@ -50,3 +52,5 @@ Item::toStr() const
 {
     return "<Item #" + std::to_string(getId()) + ">";
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/Item.hpp
+++ b/libdnf/transaction/Item.hpp
@@ -26,10 +26,14 @@
 
 #include "../utils/sqlite3/Sqlite3.hpp"
 
+namespace libdnf {
 class Item;
 typedef std::shared_ptr< Item > ItemPtr;
+}
 
 #include "Types.hpp"
+
+namespace libdnf {
 
 class Item {
 public:
@@ -56,5 +60,7 @@ protected:
     int64_t id = 0;
     const ItemType itemType = ItemType::UNKNOWN;
 };
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_ITEM_HPP

--- a/libdnf/transaction/MergedTransaction.cpp
+++ b/libdnf/transaction/MergedTransaction.cpp
@@ -20,11 +20,13 @@
 
 #include "MergedTransaction.hpp"
 
+namespace libdnf {
+
 /**
  * Create a new MergedTransaction object with a single transaction
  * \param trans initial transaction
  */
-MergedTransaction::MergedTransaction(libdnf::TransactionPtr trans)
+MergedTransaction::MergedTransaction(TransactionPtr trans)
   : transactions{trans}
 {
 }
@@ -36,7 +38,7 @@ MergedTransaction::MergedTransaction(libdnf::TransactionPtr trans)
  * \param trans transaction to be merged with
  */
 void
-MergedTransaction::merge(libdnf::TransactionPtr trans)
+MergedTransaction::merge(TransactionPtr trans)
 {
     bool inserted = false;
     for (auto it = transactions.begin(); it < transactions.end(); ++it) {
@@ -391,3 +393,5 @@ MergedTransaction::mergeItem(ItemPairMap &itemPairMap, TransactionItemBasePtr mT
             break;
     }
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/MergedTransaction.hpp
+++ b/libdnf/transaction/MergedTransaction.hpp
@@ -27,17 +27,22 @@
 #include <map>
 #include <vector>
 
+namespace libdnf {
+
 class MergedTransaction;
 typedef std::shared_ptr< MergedTransaction > MergedTransactionPtr;
+}
 
 #include "RPMItem.hpp"
 #include "Transaction.hpp"
 #include "TransactionItem.hpp"
 
+namespace libdnf {
+
 class MergedTransaction {
 public:
-    explicit MergedTransaction(libdnf::TransactionPtr trans);
-    void merge(libdnf::TransactionPtr trans);
+    explicit MergedTransaction(TransactionPtr trans);
+    void merge(TransactionPtr trans);
 
     std::vector< int64_t > listIds() const;
     std::vector< uint32_t > listUserIds() const;
@@ -53,7 +58,7 @@ public:
     std::vector< TransactionItemBasePtr > getItems();
 
 protected:
-    std::vector< libdnf::TransactionPtr > transactions;
+    std::vector< TransactionPtr > transactions;
 
     struct ItemPair {
         ItemPair(TransactionItemBasePtr first, TransactionItemBasePtr second)
@@ -73,5 +78,7 @@ protected:
     void resolveErase(ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
     void resolveAltered(ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
 };
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_TRANSACTION_HPP

--- a/libdnf/transaction/RPMItem.cpp
+++ b/libdnf/transaction/RPMItem.cpp
@@ -27,6 +27,8 @@
 
 #include "RPMItem.hpp"
 
+namespace libdnf {
+
 static const std::map< TransactionItemReason, int > reasonPriorities = {
     {TransactionItemReason::UNKNOWN, 0},
     {TransactionItemReason::CLEAN, 1},
@@ -203,7 +205,7 @@ RPMItem::dbSelectOrInsert()
 TransactionItemPtr
 RPMItem::getTransactionItem(SQLite3Ptr conn, const std::string &nevra)
 {
-    libdnf::Nevra nevraObject;
+    Nevra nevraObject;
     if (!nevraObject.parse(nevra.c_str(), HY_FORM_NEVRA)) {
         return nullptr;
     }
@@ -402,3 +404,5 @@ RPMItem::searchTransactions(SQLite3Ptr conn, const std::vector< std::string > &p
     result.erase(last, result.end());
     return result;
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/RPMItem.hpp
+++ b/libdnf/transaction/RPMItem.hpp
@@ -24,12 +24,16 @@
 #include <memory>
 #include <vector>
 
+namespace libdnf {
 class RPMItem;
 typedef std::shared_ptr< RPMItem > RPMItemPtr;
+}
 
 #include "Item.hpp"
 #include "TransactionItem.hpp"
 #include "Types.hpp"
+
+namespace libdnf {
 
 class RPMItem : public Item {
 public:
@@ -80,5 +84,7 @@ protected:
     void dbInsert();
     void dbSelectOrInsert();
 };
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_RPMITEM_HPP

--- a/libdnf/transaction/Swdb.hpp
+++ b/libdnf/transaction/Swdb.hpp
@@ -27,8 +27,10 @@
 #include <sys/stat.h>
 #include <vector>
 
+namespace libdnf {
 class Swdb;
 class Transformer;
+}
 
 #include "../hy-types.h"
 #include "../sack/query.hpp"
@@ -38,6 +40,8 @@ class Transformer;
 #include "Transaction.hpp"
 #include "TransactionItem.hpp"
 #include "private/Transaction.hpp"
+
+namespace libdnf {
 
 class Swdb {
 public:
@@ -66,8 +70,8 @@ public:
     // TODO:
     std::vector< TransactionItemPtr > getItems() { return transactionInProgress->getItems(); }
 
-    libdnf::TransactionPtr getLastTransaction();
-    std::vector< libdnf::TransactionPtr >
+    TransactionPtr getLastTransaction();
+    std::vector< TransactionPtr >
     listTransactions(); // std::vector<long long> transactionIds);
 
     // TransactionItems
@@ -90,7 +94,7 @@ public:
                                                           const std::string &arch,
                                                           int64_t maxTransactionId);
     const std::string getRPMRepo(const std::string &nevra);
-    std::shared_ptr< const TransactionItem > getRPMTransactionItem(const std::string &nevra);
+    TransactionItemPtr getRPMTransactionItem(const std::string &nevra);
     std::vector< int64_t > searchTransactionsByRPM(const std::vector< std::string > &patterns);
 
     // Item: CompsGroup
@@ -114,10 +118,12 @@ protected:
     explicit Swdb(SQLite3Ptr conn, bool autoClose);
     SQLite3Ptr conn;
     bool autoClose;
-    std::unique_ptr< libdnf::swdb_private::Transaction > transactionInProgress = nullptr;
+    std::unique_ptr< swdb_private::Transaction > transactionInProgress = nullptr;
     std::map< std::string, TransactionItemPtr > itemsInProgress;
 
 private:
 };
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_SWDB_HPP

--- a/libdnf/transaction/Transaction.cpp
+++ b/libdnf/transaction/Transaction.cpp
@@ -24,19 +24,21 @@
 #include "RPMItem.hpp"
 #include "TransactionItem.hpp"
 
-libdnf::Transaction::Transaction(SQLite3Ptr conn, int64_t pk)
+namespace libdnf {
+
+Transaction::Transaction(SQLite3Ptr conn, int64_t pk)
   : conn{conn}
 {
     dbSelect(pk);
 }
 
-libdnf::Transaction::Transaction(SQLite3Ptr conn)
+Transaction::Transaction(SQLite3Ptr conn)
   : conn{conn}
 {
 }
 
 bool
-libdnf::Transaction::operator==(const libdnf::Transaction &other) const
+Transaction::operator==(const Transaction &other) const
 {
     return getId() == other.getId() && getDtBegin() == other.getDtBegin() &&
            getRpmdbVersionBegin() == other.getRpmdbVersionBegin();
@@ -51,7 +53,7 @@ libdnf::Transaction::operator==(const libdnf::Transaction &other) const
  * \return true if other transaction is older
  */
 bool
-libdnf::Transaction::operator<(const libdnf::Transaction &other) const
+Transaction::operator<(const Transaction &other) const
 {
     return getId() > other.getId() || getDtBegin() > other.getDtBegin() ||
            getRpmdbVersionBegin() > other.getRpmdbVersionBegin();
@@ -62,14 +64,14 @@ libdnf::Transaction::operator<(const libdnf::Transaction &other) const
  * \return true if other transaction is newer
  */
 bool
-libdnf::Transaction::operator>(const libdnf::Transaction &other) const
+Transaction::operator>(const Transaction &other) const
 {
     return getId() < other.getId() || getDtBegin() < other.getDtBegin() ||
            getRpmdbVersionBegin() < other.getRpmdbVersionBegin();
 }
 
 void
-libdnf::Transaction::dbSelect(int64_t pk)
+Transaction::dbSelect(int64_t pk)
 {
     const char *sql =
         "SELECT "
@@ -105,7 +107,7 @@ libdnf::Transaction::dbSelect(int64_t pk)
  * \return list of transaction items associated with the transaction
  */
 std::vector< TransactionItemPtr >
-libdnf::Transaction::getItems() const
+Transaction::getItems()
 {
     std::vector< TransactionItemPtr > result;
     auto rpms = RPMItem::getTransactionItems(conn, getId());
@@ -126,7 +128,7 @@ libdnf::Transaction::getItems() const
  * \return list of RPMItem objects that performed the transaction
  */
 const std::set< std::shared_ptr< RPMItem > >
-libdnf::Transaction::getSoftwarePerformedWith() const
+Transaction::getSoftwarePerformedWith() const
 {
     const char *sql = R"**(
         SELECT
@@ -150,7 +152,7 @@ libdnf::Transaction::getSoftwarePerformedWith() const
 }
 
 std::vector< std::pair< int, std::string > >
-libdnf::Transaction::getConsoleOutput() const
+Transaction::getConsoleOutput() const
 {
     const char *sql = R"**(
         SELECT
@@ -173,3 +175,5 @@ libdnf::Transaction::getConsoleOutput() const
     }
     return result;
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/Transaction.hpp
+++ b/libdnf/transaction/Transaction.hpp
@@ -28,15 +28,15 @@
 #include "../utils/sqlite3/Sqlite3.hpp"
 
 namespace libdnf {
-
 class Transaction;
 typedef std::shared_ptr< Transaction > TransactionPtr;
-};
+}
 
 #include "Item.hpp"
 #include "TransactionItem.hpp"
 
 namespace libdnf {
+
 class Transaction {
 public:
     // load from db
@@ -56,7 +56,7 @@ public:
     const std::string &getCmdline() const noexcept { return cmdline; }
     TransactionState getState() const noexcept { return state; }
 
-    virtual std::vector< TransactionItemPtr > getItems() const;
+    virtual std::vector< TransactionItemPtr > getItems();
     const std::set< std::shared_ptr< RPMItem > > getSoftwarePerformedWith() const;
     std::vector< std::pair< int, std::string > > getConsoleOutput() const;
 
@@ -65,7 +65,7 @@ protected:
     void dbSelect(int64_t transaction_id);
     std::set< std::shared_ptr< RPMItem > > softwarePerformedWith;
 
-    friend class ::TransactionItem;
+    friend class TransactionItem;
     SQLite3Ptr conn;
 
     int64_t id = 0;
@@ -79,6 +79,7 @@ protected:
     std::string cmdline;
     TransactionState state = TransactionState::UNKNOWN;
 };
-};
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_TRANSACTION_HPP

--- a/libdnf/transaction/TransactionItem.cpp
+++ b/libdnf/transaction/TransactionItem.cpp
@@ -22,6 +22,8 @@
 
 #include "TransactionItem.hpp"
 
+namespace libdnf {
+
 // TODO: translations
 static const std::map< TransactionItemAction, std::string > transactionItemActionName = {
     {TransactionItemAction::INSTALL, "Install"},
@@ -82,7 +84,7 @@ TransactionItemBase::getActionShort()
     return transactionItemActionShort.at(getAction());
 }
 
-TransactionItem::TransactionItem(libdnf::Transaction *trans)
+TransactionItem::TransactionItem(Transaction *trans)
   : trans(trans)
   , transID(0)
   , conn(trans->conn)
@@ -134,7 +136,7 @@ TransactionItem::dbInsert()
     SQLite3::Statement query(*(conn.get()), sql);
     query.bindv(trans->getId(),
                 getItem()->getId(),
-                libdnf::swdb_private::Repo::getCached(conn, getRepoid())->getId(),
+                swdb_private::Repo::getCached(conn, getRepoid())->getId(),
                 static_cast< int >(getAction()),
                 static_cast< int >(getReason()),
                 static_cast< int >(getState()));
@@ -203,10 +205,12 @@ TransactionItem::dbUpdate()
     SQLite3::Statement query(*(conn.get()), sql);
     query.bindv(trans->getId(),
                 getItem()->getId(),
-                libdnf::swdb_private::Repo::getCached(trans->conn, getRepoid())->getId(),
+                swdb_private::Repo::getCached(trans->conn, getRepoid())->getId(),
                 static_cast< int >(getAction()),
                 static_cast< int >(getReason()),
                 static_cast< int >(getState()),
                 getId());
     query.step();
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/TransactionItem.hpp
+++ b/libdnf/transaction/TransactionItem.hpp
@@ -26,8 +26,10 @@
 
 #include "../utils/sqlite3/Sqlite3.hpp"
 
+namespace libdnf {
 class TransactionItem;
 typedef std::shared_ptr< TransactionItem > TransactionItemPtr;
+}
 
 #include "Item.hpp"
 #include "CompsEnvironmentItem.hpp"
@@ -36,6 +38,8 @@ typedef std::shared_ptr< TransactionItem > TransactionItemPtr;
 #include "private/Repo.hpp"
 #include "Transaction.hpp"
 #include "Types.hpp"
+
+namespace libdnf {
 
 class TransactionItemBase {
 public:
@@ -80,7 +84,7 @@ typedef std::shared_ptr< TransactionItemBase > TransactionItemBasePtr;
 
 class TransactionItem : public TransactionItemBase {
 public:
-    explicit TransactionItem(libdnf::Transaction *trans);
+    explicit TransactionItem(Transaction *trans);
 
     TransactionItem(SQLite3Ptr conn, int64_t transID);
 
@@ -102,7 +106,7 @@ public:
 
 protected:
     int64_t id = 0;
-    libdnf::Transaction *trans;
+    Transaction *trans;
 
     const int64_t transID;
     SQLite3Ptr conn;
@@ -113,5 +117,7 @@ protected:
     void dbInsert();
     void dbUpdate();
 };
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_TRANSACTIONITEM_HPP

--- a/libdnf/transaction/Transformer.cpp
+++ b/libdnf/transaction/Transformer.cpp
@@ -39,6 +39,8 @@
 #include "TransactionItem.hpp"
 #include "Transformer.hpp"
 
+namespace libdnf {
+
 static const char *sql_create_tables =
 #include "sql/create_tables.sql"
     ;
@@ -519,7 +521,7 @@ Transformer::processGroupPersistor(SQLite3Ptr swdb, const Json::Value &root)
     Swdb swdbObj(swdb, false);
     auto lastTrans = swdbObj.getLastTransaction();
 
-    auto trans = libdnf::swdb_private::Transaction(swdb);
+    auto trans = swdb_private::Transaction(swdb);
 
     // load sequences
     const Json::Value groups = root["GROUPS"];
@@ -638,3 +640,5 @@ Transformer::historyPath()
     // return the path
     return historyDir + "/" + possibleFiles.back();
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/Transformer.hpp
+++ b/libdnf/transaction/Transformer.hpp
@@ -34,6 +34,8 @@
 #include "private/TransformerTransaction.hpp"
 #include "TransactionItem.hpp"
 
+namespace libdnf {
+
 /**
  * Class providing an interface to the database transformation
  */
@@ -83,5 +85,7 @@ private:
     const std::string outputFile;
     const std::string transformFile;
 };
+
+} // namespace libdnf
 
 #endif

--- a/libdnf/transaction/Types.hpp
+++ b/libdnf/transaction/Types.hpp
@@ -21,6 +21,8 @@
 #ifndef LIBDNF_TRANSACTION_TYPES_HPP
 #define LIBDNF_TRANSACTION_TYPES_HPP
 
+namespace libdnf {
+
 enum class TransactionState : int {
     UNKNOWN = 0,
     DONE = 1,
@@ -61,6 +63,7 @@ enum class TransactionItemAction : int {
     REASON_CHANGE = 11 // a package was kept on the system but it's reason has changed
 };
 
+} // namespace libdnf
 /*
 Install
 -------

--- a/libdnf/transaction/private/Repo.cpp
+++ b/libdnf/transaction/private/Repo.cpp
@@ -20,7 +20,8 @@
 
 #include "Repo.hpp"
 
-using namespace libdnf::swdb_private;
+namespace libdnf {
+namespace swdb_private {
 
 // initialize static variable Repo::cache
 std::map< std::string, RepoPtr > Repo::cache;
@@ -91,3 +92,6 @@ Repo::dbSelectOrInsert()
         dbInsert();
     }
 }
+
+} // namespace swdb_private
+} // namespace libdnf

--- a/libdnf/transaction/private/Repo.hpp
+++ b/libdnf/transaction/private/Repo.hpp
@@ -56,7 +56,8 @@ protected:
     std::string repoId;
     SQLite3Ptr conn;
 };
-};
-};
+
+} // namespace swdb_private
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_REPO_HPP

--- a/libdnf/transaction/private/Transaction.cpp
+++ b/libdnf/transaction/private/Transaction.cpp
@@ -27,13 +27,15 @@
 #include "Transaction.hpp"
 #include "TransactionItem.hpp"
 
-libdnf::swdb_private::Transaction::Transaction(SQLite3Ptr conn)
+namespace libdnf {
+
+swdb_private::Transaction::Transaction(SQLite3Ptr conn)
   : libdnf::Transaction(conn)
 {
 }
 
 void
-libdnf::swdb_private::Transaction::begin()
+swdb_private::Transaction::begin()
 {
     if (id != 0) {
         throw std::runtime_error(_("Transaction has already began!"));
@@ -43,7 +45,7 @@ libdnf::swdb_private::Transaction::begin()
 }
 
 void
-libdnf::swdb_private::Transaction::finish(TransactionState state)
+swdb_private::Transaction::finish(TransactionState state)
 {
     // save states to the database before checking for UNKNOWN state
     for (auto i : getItems()) {
@@ -62,7 +64,7 @@ libdnf::swdb_private::Transaction::finish(TransactionState state)
 }
 
 void
-libdnf::swdb_private::Transaction::dbInsert()
+swdb_private::Transaction::dbInsert()
 {
     const char *sql =
         "INSERT INTO "
@@ -119,7 +121,7 @@ libdnf::swdb_private::Transaction::dbInsert()
 }
 
 void
-libdnf::swdb_private::Transaction::dbUpdate()
+swdb_private::Transaction::dbUpdate()
 {
     const char *sql =
         "UPDATE "
@@ -149,7 +151,7 @@ libdnf::swdb_private::Transaction::dbUpdate()
 }
 
 TransactionItemPtr
-libdnf::swdb_private::Transaction::addItem(std::shared_ptr< Item > item,
+swdb_private::Transaction::addItem(std::shared_ptr< Item > item,
                                            const std::string &repoid,
                                            TransactionItemAction action,
                                            TransactionItemReason reason)
@@ -164,7 +166,7 @@ libdnf::swdb_private::Transaction::addItem(std::shared_ptr< Item > item,
 }
 
 void
-libdnf::swdb_private::Transaction::saveItems()
+swdb_private::Transaction::saveItems()
 {
     // TODO: remove all existing items from the database first?
     for (auto i : items) {
@@ -184,7 +186,7 @@ libdnf::swdb_private::Transaction::saveItems()
  * \return list of transaction items associated with the transaction
  */
 std::vector< TransactionItemPtr >
-libdnf::swdb_private::Transaction::getItems()
+swdb_private::Transaction::getItems()
 {
     if (items.empty()) {
         items = libdnf::Transaction::getItems();
@@ -199,7 +201,7 @@ libdnf::swdb_private::Transaction::getItems()
  * \param software RPMItem used to perform the transaction
  */
 void
-libdnf::swdb_private::Transaction::addSoftwarePerformedWith(std::shared_ptr< RPMItem > software)
+swdb_private::Transaction::addSoftwarePerformedWith(std::shared_ptr< RPMItem > software)
 {
     softwarePerformedWith.insert(software);
 }
@@ -211,7 +213,7 @@ libdnf::swdb_private::Transaction::addSoftwarePerformedWith(std::shared_ptr< RPM
  * \param line console output content
  */
 void
-libdnf::swdb_private::Transaction::addConsoleOutputLine(int fileDescriptor, const std::string &line)
+swdb_private::Transaction::addConsoleOutputLine(int fileDescriptor, const std::string &line)
 {
     if (!getId()) {
         throw std::runtime_error(_("Can't add console output to unsaved transaction"));
@@ -231,3 +233,5 @@ libdnf::swdb_private::Transaction::addConsoleOutputLine(int fileDescriptor, cons
     query.bindv(getId(), fileDescriptor, line);
     query.step();
 }
+
+} // namespace libdnf

--- a/libdnf/transaction/private/Transaction.hpp
+++ b/libdnf/transaction/private/Transaction.hpp
@@ -44,7 +44,7 @@ public:
     void setCmdline(const std::string &value) { cmdline = value; }
     void setState(TransactionState value) { state = value; }
 
-    virtual std::vector< TransactionItemPtr > getItems();
+    std::vector< TransactionItemPtr > getItems() override;
 
     void begin();
     void finish(TransactionState state);
@@ -63,7 +63,8 @@ protected:
     void dbInsert();
     void dbUpdate();
 };
-};
-};
+
+}
+}
 
 #endif // LIBDNF_TRANSACTION_TRANSACTION_PRIVATE_HPP

--- a/libdnf/transaction/private/TransformerTransaction.hpp
+++ b/libdnf/transaction/private/TransformerTransaction.hpp
@@ -23,18 +23,22 @@
 
 #include "Transaction.hpp"
 
+namespace libdnf {
+
 /**
  * Class overrides default behavior with
  * inserting rows with explicitly set IDs
  */
-class TransformerTransaction : public libdnf::swdb_private::Transaction {
+class TransformerTransaction : public swdb_private::Transaction {
 public:
-    using libdnf::swdb_private::Transaction::Transaction;
+    using swdb_private::Transaction::Transaction;
     void begin()
     {
         dbInsert();
         saveItems();
     }
 };
+
+} // namespace libdnf
 
 #endif // LIBDNF_TRANSACTION_TRANSFORMERTRANSACTION_HPP

--- a/python/hawkey/query-py.cpp
+++ b/python/hawkey/query-py.cpp
@@ -674,7 +674,7 @@ q_difference(PyObject *self, PyObject *args)
 
 typedef struct {
     PyObject_HEAD
-    Swdb *ptr;
+    libdnf::Swdb *ptr;
     void *ty;
     int own;
     PyObject *next;
@@ -713,7 +713,7 @@ filter_unneeded(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    Swdb *swdb = swigSwdb->ptr;
+    libdnf::Swdb *swdb = swigSwdb->ptr;
 
     if (swdb == NULL) {
         PyErr_SetString(PyExc_SystemError, "Unable to parse swig object");

--- a/tests/libdnf/transaction/CompsEnvironmentItemTest.cpp
+++ b/tests/libdnf/transaction/CompsEnvironmentItemTest.cpp
@@ -12,6 +12,8 @@
 
 CPPUNIT_TEST_SUITE_REGISTRATION(CompsEnvironmentItemTest);
 
+using namespace libdnf;
+
 void
 CompsEnvironmentItemTest::setUp()
 {

--- a/tests/libdnf/transaction/MergedTransactionTest.cpp
+++ b/tests/libdnf/transaction/MergedTransactionTest.cpp
@@ -12,6 +12,8 @@
 
 #include "MergedTransactionTest.hpp"
 
+using namespace libdnf;
+
 CPPUNIT_TEST_SUITE_REGISTRATION(MergedTransactionTest);
 
 void

--- a/tests/libdnf/transaction/RpmItemTest.cpp
+++ b/tests/libdnf/transaction/RpmItemTest.cpp
@@ -10,6 +10,8 @@
 
 #include "RpmItemTest.hpp"
 
+using namespace libdnf;
+
 CPPUNIT_TEST_SUITE_REGISTRATION(RpmItemTest);
 
 void

--- a/tests/libdnf/transaction/TransactionItemReasonTest.cpp
+++ b/tests/libdnf/transaction/TransactionItemReasonTest.cpp
@@ -14,6 +14,8 @@
 
 #include "TransactionItemReasonTest.hpp"
 
+using namespace libdnf;
+
 CPPUNIT_TEST_SUITE_REGISTRATION(TransactionItemReasonTest);
 
 void

--- a/tests/libdnf/transaction/TransactionTest.cpp
+++ b/tests/libdnf/transaction/TransactionTest.cpp
@@ -7,6 +7,7 @@
 
 #include "TransactionTest.hpp"
 
+using namespace libdnf;
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TransactionTest);
 

--- a/tests/libdnf/transaction/TransformerTest.cpp
+++ b/tests/libdnf/transaction/TransformerTest.cpp
@@ -14,6 +14,8 @@
 
 #include "TransformerTest.hpp"
 
+using namespace libdnf;
+
 CPPUNIT_TEST_SUITE_REGISTRATION(TransformerTest);
 
 TransformerMock::TransformerMock()

--- a/tests/libdnf/transaction/TransformerTest.hpp
+++ b/tests/libdnf/transaction/TransformerTest.hpp
@@ -6,12 +6,12 @@
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
 
-class TransformerMock : protected Transformer {
+class TransformerMock : protected libdnf::Transformer {
 public:
     TransformerMock();
-    using Transformer::Exception;
-    using Transformer::processGroupPersistor;
-    using Transformer::transformTrans;
+    using libdnf::Transformer::Exception;
+    using libdnf::Transformer::processGroupPersistor;
+    using libdnf::Transformer::transformTrans;
 };
 
 class TransformerTest : public CppUnit::TestCase {

--- a/tests/libdnf/transaction/WorkflowTest.cpp
+++ b/tests/libdnf/transaction/WorkflowTest.cpp
@@ -14,6 +14,8 @@
 
 #include "WorkflowTest.hpp"
 
+using namespace libdnf;
+
 CPPUNIT_TEST_SUITE_REGISTRATION(WorkflowTest);
 
 void


### PR DESCRIPTION
Namespace libdnf should be used consistently.
PR is against development `wip/swdb` branch.