### PR TITLE
libdnf.conf - added characters into URL regex (RhBug:1576749)

### DIFF
--- a/libdnf/conf/Const.hpp
+++ b/libdnf/conf/Const.hpp
@@ -26,8 +26,8 @@ namespace libdnf {
 constexpr const char * PERSISTDIR = "/var/lib/dnf";
 constexpr const char * SYSTEM_CACHEDIR = "/var/cache/dnf";
 
-constexpr const char * URL_REGEX = "(https?|ftp|file):\\/\\/[-a-zA-Z0-9_.\\/?=&#\\$;]+$";
-constexpr const char * PROXY_URL_REGEX = "^((https?|ftp|socks5h?|socks4a?):\\/\\/[-a-zA-Z0-9_.\\/?=&#\\$;]+)?$";
+constexpr const char * URL_REGEX = "(https?|ftp|file):\\/\\/[-a-zA-Z0-9_.\\/?=&#\\$;%@+~|!:,]+$";
+constexpr const char * PROXY_URL_REGEX = "^((https?|ftp|socks5h?|socks4a?):\\/\\/[-a-zA-Z0-9_.\\/?=&#\\$;%@+~|!:,]+)?$";
 
 constexpr const char * CONF_FILENAME = "/etc/dnf/dnf.conf";
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1576749