### PR TITLE
Use #ifdef __cplusplus everywhere

### DIFF
--- a/libdnf/dnf-reldep-list.h
+++ b/libdnf/dnf-reldep-list.h
@@ -22,7 +22,7 @@
 #include "dnf-reldep.h"
 #include "dnf-types.h"
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -32,7 +32,7 @@ gint dnf_reldep_list_count(DnfReldepList *reldep_list);
 void dnf_reldep_list_add(DnfReldepList *reldep_list, DnfReldep *reldep);
 void dnf_reldep_list_extend(DnfReldepList *rl1, DnfReldepList *rl2);
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/libdnf/dnf-reldep.h
+++ b/libdnf/dnf-reldep.h
@@ -24,7 +24,7 @@
 #include "dnf-enums.h"
 #include "dnf-types.h"
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -33,7 +33,7 @@ const char *dnf_reldep_to_string(DnfReldep *reldep);
 Id dnf_reldep_get_id(DnfReldep *reldep);
 void dnf_reldep_free(DnfReldep *reldep);
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
These were the only two spots where we weren't consistently using
`#ifdef __cplusplus`. This was breaking compilations with
`-Werror=undef` turned on.