### PR TITLE
Require spaces around operator in provides (RhBug:1588443)

### DIFF
--- a/libdnf/repo/DependencySplitter.cpp
+++ b/libdnf/repo/DependencySplitter.cpp
@@ -25,7 +25,7 @@
 namespace libdnf {
 
 static const Regex RELDEP_REGEX = 
-    Regex("^([^ \t\r\n\v\f<=>!]*)\\s*(<=|>=|!=|<|>|=)?\\s*(.*)$", REG_EXTENDED);
+    Regex("^(\\S*)\\s*(<=|>=|<|>|=)?\\s*(.*)$", REG_EXTENDED);
 
 static bool
 getCmpFlags(int *cmp_type, std::string matchCmpType)


### PR DESCRIPTION
This basically reverts commit dd43131b.

The only documentation about dependencies format in rpm I was able to find is
here: http://rpm.org/user_doc/dependencies.html
In Requires section, there is written "Spaces are required around the numeric
operator to separate the operator from the package name."
Hope this is true also for Provides.

https://bugzilla.redhat.com/show_bug.cgi?id=1588443