### PR TITLE
Add dnf_reldep_list_free for C clients

### DIFF
--- a/libdnf/dnf-reldep-list.cpp
+++ b/libdnf/dnf-reldep-list.cpp
@@ -36,6 +36,18 @@ dnf_reldep_list_new (DnfSack *sack)
 }
 
 /**
+ * dnf_reldep_list_free:
+ * @reldep_list: a #DnfReldepList
+ *
+ * Returns: Nothing
+ */
+void
+dnf_reldep_list_free (DnfReldepList *reldep_list)
+{
+    delete reldep_list;
+}
+
+/**
  * dnf_reldep_list_add:
  * @reldep_list: a #DnfReldepList
  * @reldep: a #DnfReldep

--- a/libdnf/dnf-reldep-list.h
+++ b/libdnf/dnf-reldep-list.h
@@ -27,6 +27,7 @@ extern "C" {
 #endif
 
 DnfReldepList *dnf_reldep_list_new(DnfSack *sack);
+void dnf_reldep_list_free(DnfReldepList *reldep_list);
 DnfReldep *dnf_reldep_list_index(DnfReldepList *reldep_list, gint index);
 gint dnf_reldep_list_count(DnfReldepList *reldep_list);
 void dnf_reldep_list_add(DnfReldepList *reldep_list, DnfReldep *reldep);


### PR DESCRIPTION
This is needed for rpm-ostree so that we can correctly free the
`DnfReldepList` object.

Let me know if there's a cleaner way to do this!