### PR TITLE
Add pythonx-libdnf requires for pythonx-hawkey (RhBug:1595487)

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -99,6 +99,7 @@ BuildRequires:  python-nose
 BuildRequires:  python2-nose
 %endif
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       python2-%{name} = %{version}-%{release}
 # Fix problem with hawkey - dnf version incompatibility
 # Can be deleted for distros where only python2-dnf >= 2.0.0
 Conflicts:      python2-dnf < %{dnf_conflict}
@@ -115,6 +116,7 @@ Summary:        Python 3 bindings for the hawkey library
 BuildRequires:  python3-devel
 BuildRequires:  python3-nose
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       python3-%{name} = %{version}-%{release}
 # Fix problem with hawkey - dnf version incompatibility
 # Can be deleted for distros where only python3-dnf >= 2.0.0
 Conflicts:      python3-dnf < %{dnf_conflict}


### PR DESCRIPTION
It is required for run, therefore it has to mentioned.

https://bugzilla.redhat.com/show_bug.cgi?id=1595487