### PR TITLE
Improvements for building module test data

### DIFF
--- a/data/tests/modules/specs/_create_modulemd.py
+++ b/data/tests/modules/specs/_create_modulemd.py
@@ -1,5 +1,16 @@
 #!/usr/bin/python
 
+"""
+Generate module metadata for modularity tests.
+
+Input:
+
+RPMs built under ../modules/$name-$stream-$version/$arch
+profiles defined in $name-$stream-$version/profiles.json
+Output:
+
+../modules/$name-$stream-$version/$arch/$name-$stream-$version.$arch.yaml
+"""
 
 import os
 import json
@@ -62,15 +73,15 @@ for module_id in os.listdir(MODULES_DIR):
         sset.add("LGPLv2")
         mmd.set_module_licenses(sset)
         mmd.set_summary("Fake module")
-        mmd.set_description(mmd.get_summary())
+        mmd.set_description(mmd.peek_summary())
         artifacts = Modulemd.SimpleSet()
         for rpm in rpms:
-            #mmd.add_module_component(rpm.rsplit("-", 2)[0], "")
             artifacts.add(rpm[:-4])
         mmd.set_rpm_artifacts(artifacts)
         for profile_name in profiles:
             profile = Modulemd.Profile()
             profile.set_name(profile_name)
+            profile.set_description("Description for profile %s." % profile_name)
             profile_rpms = Modulemd.SimpleSet()
             profile_rpms.set(profiles[profile_name]["rpms"])
             profile.set_rpms(profile_rpms)

--- a/data/tests/modules/specs/_createrepo_c_modularity_hack.py
+++ b/data/tests/modules/specs/_createrepo_c_modularity_hack.py
@@ -1,5 +1,10 @@
 #!/usr/bin/python
 
+"""
+Createrepo_c doesn't support indexing module metadata.
+This script indexes all yaml files found in a target directory,
+concatenates them and injects into repodata as "modules" mdtype.
+"""
 
 import os
 import argparse

--- a/data/tests/modules/specs/build.sh
+++ b/data/tests/modules/specs/build.sh
@@ -45,9 +45,9 @@ for module in $DIR/*-*-*; do
 done
 
 
-for spec in _non-modular/*.spec; do
+for spec in $DIR/_non-modular/*.spec; do
     echo
-    echo "Building NON-MODULAR $spec..."
+    echo "Building NON-MODULAR $(basename $spec)..."
     for target in $ARCHES; do
         rpmbuild --quiet --target=$target -ba --nodeps --define "_srcrpmdir $DIR/../modules/_non-modular/src" --define "_rpmdir $DIR/../modules/_non-modular/" $spec
     done
@@ -63,11 +63,11 @@ for target in $ARCHES; do
 done
 
 
-./_create_modulemd.py
+$DIR/_create_modulemd.py
 
 
 for target in $ARCHES; do
-  cp ../defaults/httpd.yaml ../modules/httpd-2.4-1/$target/
+    cp $DIR/../defaults/httpd.yaml $DIR/../modules/httpd-2.4-1/$target/
 done
 
 for module in $DIR/*-*-* $DIR/_non-modular; do
@@ -82,7 +82,7 @@ for module in $DIR/*-*-* $DIR/_non-modular; do
         createrepo_c $repo_path
         if [ "_non-modular" != "$module_name" ]
         then
-          ./_createrepo_c_modularity_hack.py $repo_path
+          $DIR/_createrepo_c_modularity_hack.py $repo_path
         fi
     done
 done
@@ -91,7 +91,7 @@ done
 for target in $ARCHES; do
     repo_path=$DIR/../modules/_all/$target
     createrepo_c $repo_path
-    ./_createrepo_c_modularity_hack.py $repo_path
+    $DIR/_createrepo_c_modularity_hack.py $repo_path
 done
 
 


### PR DESCRIPTION
* Incorporate improvements to `_create_modulemd.py` and `_createrepo_c_modularity_hack.py` from
  latest [`dnf/tests/modules/specs/`](https://github.com/rpm-software-management/dnf/tree/master/tests/modules/specs)
* Improve `_create_modulemd.py` to include per-profile description data in generated modulemd
* Improve `build.sh` so it can be run from other than just the current directory