### PR TITLE
ConfigParser: add write to ini file support

### DIFF
--- a/libdnf/conf/ConfigParser.hpp
+++ b/libdnf/conf/ConfigParser.hpp
@@ -73,6 +73,21 @@ public:
     * @param filePath Name (with path) of file to read
     */
     void read(const std::string & filePath);
+    /**
+    * @brief Writes all data (all sections) to INI file
+    *
+    * @param filePath Name (with path) of file to write
+    * @param append If true, existent file will be appended, otherwise overwritten
+    */
+    void write(const std::string & filePath, bool append) const;
+    /**
+    * @brief Writes one section data to INI file
+    *
+    * @param filePath Name (with path) of file to write
+    * @param append If true, existent file will be appended, otherwise overwritten
+    * @param section Section to write
+    */
+    void write(const std::string & filePath, bool append, const std::string & section) const;
     bool hasSection(const std::string & section) const;
     const std::string & getValue(const std::string & section, const std::string & key) const;
     std::string getSubstitutedValue(const std::string & section, const std::string & key) const;

--- a/libdnf/conf/ConfigParser.hpp
+++ b/libdnf/conf/ConfigParser.hpp
@@ -92,6 +92,7 @@ public:
     const std::string & getValue(const std::string & section, const std::string & key) const;
     std::string getSubstitutedValue(const std::string & section, const std::string & key) const;
     const std::map<std::string, std::map<std::string, std::string>> & getData() const noexcept;
+    std::map<std::string, std::map<std::string, std::string>> & getData() noexcept;
 
 private:
     std::map<std::string, std::string> substitutions;
@@ -120,6 +121,12 @@ inline bool ConfigParser::hasSection(const std::string & section) const
 
 inline const std::map<std::string,
     std::map<std::string, std::string>> & ConfigParser::getData() const noexcept
+{
+    return data;
+}
+
+inline std::map<std::string,
+    std::map<std::string, std::string>> & ConfigParser::getData() noexcept
 {
     return data;
 }


### PR DESCRIPTION
Supports saving of one section or all data to ini file.

Current state:
Original order is not preserved. Section are sorted by its name. And Key-Value pairs are sorted by key.