### PR TITLE
Fix: including modulemd headers

### DIFF
--- a/libdnf/module/modulemd/ModuleDependencies.cpp
+++ b/libdnf/module/modulemd/ModuleDependencies.cpp
@@ -1,5 +1,3 @@
-#include <modulemd/modulemd-simpleset.h>
-
 #include "libdnf/utils/utils.hpp"
 #include "ModuleDependencies.hpp"
 

--- a/libdnf/module/modulemd/ModuleMetadata.cpp
+++ b/libdnf/module/modulemd/ModuleMetadata.cpp
@@ -1,4 +1,3 @@
-#include <modulemd/modulemd-simpleset.h>
 #include <utility>
 #include <iostream>
 

--- a/libdnf/module/modulemd/ModuleMetadata.hpp
+++ b/libdnf/module/modulemd/ModuleMetadata.hpp
@@ -9,8 +9,6 @@
 #include "profile/ModuleProfile.hpp"
 #include "ModuleDependencies.hpp"
 
-#include <modulemd/modulemd.h>
-
 class ModuleMetadata
 {
 public:

--- a/libdnf/module/modulemd/profile/ModuleProfile.cpp
+++ b/libdnf/module/modulemd/profile/ModuleProfile.cpp
@@ -1,5 +1,4 @@
 #include <regex>
-#include <modulemd/modulemd-simpleset.h>
 
 #include "ModuleProfile.hpp"
 

--- a/libdnf/module/modulemd/profile/ModuleProfile.hpp
+++ b/libdnf/module/modulemd/profile/ModuleProfile.hpp
@@ -1,4 +1,3 @@
-
 #ifndef LIBDNF_MODULEPROFILE_HPP
 #define LIBDNF_MODULEPROFILE_HPP
 
@@ -6,7 +5,7 @@
 #include "Profile.hpp"
 
 #include <memory>
-#include <modulemd/modulemd-profile.h>
+#include <modulemd/modulemd.h>
 
 class ModuleProfile : public Profile
 {

--- a/libdnf/module/modulemd/profile/ProfileMaker.hpp
+++ b/libdnf/module/modulemd/profile/ProfileMaker.hpp
@@ -6,7 +6,7 @@
 
 #include "Profile.hpp"
 
-#include <modulemd/modulemd-module.h>
+#include <modulemd/modulemd.h>
 
 class ProfileMaker
 {

--- a/tests/libdnf/module/ContextTest.cpp
+++ b/tests/libdnf/module/ContextTest.cpp
@@ -1,4 +1,3 @@
-#include <modulemd/modulemd-simpleset.h>
 #include "ContextTest.hpp"
 
 CPPUNIT_TEST_SUITE_REGISTRATION(ContextTest);


### PR DESCRIPTION
Fix: Importing of  libmodulemd header files

This is needed for libmodulemd 1.6.1.
The code must import <modulemd/modulemd.h>. Importing the individual objects is not working with libmodule 1.6.1.