### PR TITLE
Add modules main configuration

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -504,6 +504,13 @@ class ConfigMain::Impl {
 
     OptionNumber<std::uint32_t> deltarpm_percentage{75};
     OptionBinding deltaRpmPercentageBinding{owner, deltarpm_percentage, "deltarpm_percentage"};
+
+    OptionPath modulesdir{CONF_MODULESDIR};
+    OptionBinding modulesdirBinding{owner, modulesdir, "modulesdir"};
+
+    OptionPath moduledefaultsdir{CONF_MODULEDEFAULTSDIR};
+    OptionBinding moduledefaultsdirBinding{owner, moduledefaultsdir, "moduledefaultsdir"};
+
 };
 
 ConfigMain::ConfigMain() { pImpl = std::unique_ptr<Impl>(new Impl(*this)); }
@@ -602,5 +609,9 @@ OptionString & ConfigMain::sslclientcert() { return pImpl->sslclientcert; }
 OptionString & ConfigMain::sslclientkey() { return pImpl->sslclientkey; }
 OptionBool & ConfigMain::deltarpm() { return pImpl->deltarpm; }
 OptionNumber<std::uint32_t> & ConfigMain::deltarpm_percentage() { return pImpl->deltarpm_percentage; }
+
+// Modules main config
+OptionPath & ConfigMain::modulesdir() { return pImpl->modulesdir; }
+OptionPath & ConfigMain::moduledefaultsdir() { return pImpl->moduledefaultsdir; }
 
 }

--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -146,6 +146,10 @@ public:
     OptionBool & deltarpm();
     OptionNumber<std::uint32_t> & deltarpm_percentage();
 
+    // Modules main config
+    OptionPath & modulesdir();
+    OptionPath & moduledefaultsdir();
+
 private:
     class Impl;
     std::unique_ptr<Impl> pImpl;

--- a/libdnf/conf/Const.hpp
+++ b/libdnf/conf/Const.hpp
@@ -31,6 +31,9 @@ constexpr const char * PROXY_URL_REGEX = "^((https?|ftp|socks5h?|socks4a?):\\/\\
 
 constexpr const char * CONF_FILENAME = "/etc/dnf/dnf.conf";
 
+constexpr const char * CONF_MODULESDIR = "/etc/dnf/modules.d";
+constexpr const char * CONF_MODULEDEFAULTSDIR = "/etc/dnf/modules.defaults.d";
+
 const std::vector<std::string> GROUP_PACKAGE_TYPES{"mandatory", "default", "conditional"};
 const std::vector<std::string> INSTALLONLYPKGS{"kernel", "kernel-PAE",
                  "installonlypkg(kernel)",


### PR DESCRIPTION
With this we'll be able to remove hard-coded paths from DNF.