### PR TITLE
dnf-sack: remove memory leak

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -2073,7 +2073,7 @@ namespace {
 void enableModuleStreams(ModulePackageContainer &modulePackages, const char *install_root)
 {
     // TODO: remove hard-coded path
-    std::string dirPath = g_build_filename(install_root, "/etc/dnf/modules.d/", NULL);
+    g_autofree gchar *dirPath = g_build_filename(install_root, "/etc/dnf/modules.d/", NULL);
 
     libdnf::ConfigParser parser{};
     for (const auto &file : filesystem::getDirContent(dirPath)) {
@@ -2230,7 +2230,7 @@ void dnf_sack_filter_modules(DnfSack *sack, GPtrArray *repos, const char *instal
     const char * platformModule)
 {
     // TODO: remove hard-coded path
-    std::string defaultsDirPath = g_build_filename(install_root, "/etc/dnf/modules.defaults.d/", NULL);
+    g_autofree gchar *defaultsDirPath = g_build_filename(install_root, "/etc/dnf/modules.defaults.d/", NULL);
     DnfSackPrivate *priv = GET_PRIVATE(sack);
 
     ModulePackageContainer modulePackages{std::shared_ptr<Pool>(pool_create(), &pool_free), priv->arch};


### PR DESCRIPTION
g_build_filename returns an allocated string which needs to be properly
freed before std::string makes a deep copy of it.

Signed-off-by: Rafael Fonseca <rdossant@redhat.com>