### PR TITLE
PackageTest: remove leak of GError

### DIFF
--- a/tests/libdnf/repo/PackageTest.cpp
+++ b/tests/libdnf/repo/PackageTest.cpp
@@ -8,7 +8,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(PackageTest);
 
 void PackageTest::setUp()
 {
-    GError *error = nullptr;
+    g_autoptr(GError) error = nullptr;
     sack = dnf_sack_new();
     repo = hy_repo_create("repo");
     repo_finalize_init(repo, repo_create(dnf_sack_get_pool(sack), "repo"));


### PR DESCRIPTION
With this patch we go from

==17911== LEAK SUMMARY:
==17911==    definitely lost: 64 bytes in 4 blocks
==17911==    indirectly lost: 72 bytes in 4 blocks

to

==18523== LEAK SUMMARY:
==18523==    definitely lost: 0 bytes in 0 blocks
==18523==    indirectly lost: 0 bytes in 0 blocks

Signed-off-by: Rafael Fonseca <rdossant@redhat.com>