### PR TITLE
build-sys: Add -DWITH_HTML:BOOL=0 option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ INCLUDE_DIRECTORIES (${CMAKE_SOURCE_DIR} libdnf/utils/)
 
 OPTION(WITH_GTKDOC "Enables libdnf GTK-Doc HTML documentation" ON)
 OPTION(WITH_MAN "Enables hawkey man page generation" ON)
+OPTION(WITH_HTML "Enables hawkey HTML generation" ON)
 
 OPTION (ENABLE_SOLV_URPMREORDER "Build with support for URPM-like solution reordering?" OFF)
 option (ENABLE_RHSM_SUPPORT "Build with Red Hat Subscription Manager support?" OFF)

--- a/docs/hawkey/CMakeLists.txt
+++ b/docs/hawkey/CMakeLists.txt
@@ -7,10 +7,12 @@ else()
     SET(SPHINX_BUILD_NAME "sphinx-build-3")
 endif()
 
-ADD_CUSTOM_TARGET (doc-html
-		  PYTHONPATH=${CMAKE_BINARY_DIR}/src/python ${SPHINX_BUILD_NAME} -b html
-		  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/html
-		  COMMENT "Building html documentation")
+IF(WITH_HTML)
+  ADD_CUSTOM_TARGET (doc-html
+        PYTHONPATH=${CMAKE_BINARY_DIR}/src/python ${SPHINX_BUILD_NAME} -b html
+        ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/html
+        COMMENT "Building html documentation")
+ENDIF()
 IF(WITH_MAN)
 	ADD_CUSTOM_TARGET (doc-man ALL
 			  PYTHONPATH=${CMAKE_BINARY_DIR}/src/python ${SPHINX_BUILD_NAME} -b man


### PR DESCRIPTION
For rpm-ostree we embed libdnf, but have no interest in building
its documentation; it slows the build and imposes a python-sphinx
build dependency.