### PR TITLE
Change filling goal for upgrade all packages.

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -599,10 +599,24 @@ Goal::install(HySelector sltr, bool optional)
 }
 
 void
-Goal::upgrade()
+Goal::upgrade(bool obsoletes)
 {
     pImpl->actions = static_cast<DnfGoalActions>(pImpl->actions | DNF_UPGRADE_ALL);
-    queue_push2(&pImpl->staging, SOLVER_UPDATE|SOLVER_SOLVABLE_ALL, 0);
+    DnfSack * sack = pImpl->sack;
+    Query query(sack);
+    query.addFilter(HY_PKG_UPGRADES, HY_EQ, 1);
+    if (obsoletes) {
+        Query installed(sack);
+        installed.addFilter(HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
+        Query queryObsoletes(sack);
+        queryObsoletes.queryDifference(installed);
+        installed.queryUnion(query);
+        queryObsoletes.addFilter(HY_PKG_OBSOLETES, HY_EQ, installed.runSet());
+        query.queryUnion(queryObsoletes);
+    }
+    Selector selector(sack);
+    selector.set(query.runSet());
+    sltrToJob(&selector, &pImpl->staging, SOLVER_UPDATE);
 }
 
 void

--- a/libdnf/goal/Goal.hpp
+++ b/libdnf/goal/Goal.hpp
@@ -62,7 +62,7 @@ public:
 
     /**
     * @brief If selector ill formed, it rises std::runtime_error()
-    * 
+    *
     * @param sltr 
     * @param flags p_flags:...
     */
@@ -71,18 +71,26 @@ public:
 
     /**
     * @brief If selector ill formed, it rises std::runtime_error()
-    * 
+    *
     * @param sltr p_sltr:...
     * @param optional Set true for optional tasks, false for strict tasks
     */
     void install(HySelector sltr, bool optional);
-    void upgrade();
+
+    /**
+    * @brief Add upgrade all packages request to job. It adds obsoletes automatically to transaction
+    * if no parametrer obsoletes provided or setted to true.
+    *
+    * @param obsoletes p_obsoletes: bool parameter to specify if obsoletes should be added to job
+    */
+    void upgrade(bool obsoletes=true);
     void upgrade(DnfPackage *new_pkg);
 
     /**
     * @brief If selector ill formed, it rises std::runtime_error()
-    * 
-    * @param sltr p_sltr:...
+    *
+    * @param sltr p_sltr: It should contain only upgrades with obsoletes otherwise it can try to
+    * reinstall installonly packages.
     */
     void upgrade(HySelector sltr);
     void userInstalled(DnfPackage *pkg);


### PR DESCRIPTION
The change is requires, because if upgrade is performed with "--best" it also
crash due to excluded packages (same issue like with distupgrade).

This is a workaround how to create a upgrade of all packages, but ignore
excludes (don't recognize them as a best candidate).