### PR TITLE
ModulePersistor: don't add same profile again

### DIFF
--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -600,7 +600,7 @@ ModulePackageContainer::Impl::ModulePersistor::getProfiles(const std::string &na
 bool ModulePackageContainer::Impl::ModulePersistor::addProfile(const std::string &name, const std::string &profile)
 {
     auto &profiles = configs[name].second.profiles;
-    const auto &it = std::find(std::begin(profiles), std::end(profiles), name);
+    const auto &it = std::find(std::begin(profiles), std::end(profiles), profile);
     if (it != std::end(profiles))
         return false;
 


### PR DESCRIPTION
Fix a typo so that a profile isn't added multiple times to the
module configuration file.

Signed-off-by: Rafael Fonseca <rdossant@redhat.com>