### PR TITLE
Change filling of goal for upgrade of all packages.

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -599,21 +599,12 @@ Goal::install(HySelector sltr, bool optional)
 }
 
 void
-Goal::upgrade(bool obsoletes)
+Goal::upgrade()
 {
     pImpl->actions = static_cast<DnfGoalActions>(pImpl->actions | DNF_UPGRADE_ALL);
     DnfSack * sack = pImpl->sack;
     Query query(sack);
-    query.addFilter(HY_PKG_UPGRADES, HY_EQ, 1);
-    if (obsoletes) {
-        Query installed(sack);
-        installed.addFilter(HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-        Query queryObsoletes(sack);
-        queryObsoletes.queryDifference(installed);
-        installed.queryUnion(query);
-        queryObsoletes.addFilter(HY_PKG_OBSOLETES, HY_EQ, installed.runSet());
-        query.queryUnion(queryObsoletes);
-    }
+    query.addFilter(HY_PKG_REPONAME, HY_NEQ, HY_SYSTEM_REPO_NAME);
     Selector selector(sack);
     selector.set(query.runSet());
     sltrToJob(&selector, &pImpl->staging, SOLVER_UPDATE);

--- a/libdnf/goal/Goal.hpp
+++ b/libdnf/goal/Goal.hpp
@@ -79,11 +79,8 @@ public:
 
     /**
     * @brief Add upgrade all packages request to job. It adds obsoletes automatically to transaction
-    * if no parametrer obsoletes provided or setted to true.
-    *
-    * @param obsoletes p_obsoletes: bool parameter to specify if obsoletes should be added to job
     */
-    void upgrade(bool obsoletes=true);
+    void upgrade();
     void upgrade(DnfPackage *new_pkg);
 
     /**


### PR DESCRIPTION
The change is required, because if upgrade is performed with "--best" it also
crash due to excluded packages (same issue like with distupgrade).

I am sorry I incorrectly approve https://github.com/rpm-software-management/libdnf/pull/522, where solution is too complicated.

The solution do not cover - reinstalling installonly packages and using obsoletes