### PR TITLE
Revert upgrade all change

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -599,24 +599,10 @@ Goal::install(HySelector sltr, bool optional)
 }
 
 void
-Goal::upgrade(bool obsoletes)
+Goal::upgrade()
 {
     pImpl->actions = static_cast<DnfGoalActions>(pImpl->actions | DNF_UPGRADE_ALL);
-    DnfSack * sack = pImpl->sack;
-    Query query(sack);
-    query.addFilter(HY_PKG_UPGRADES, HY_EQ, 1);
-    if (obsoletes) {
-        Query installed(sack);
-        installed.addFilter(HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-        Query queryObsoletes(sack);
-        queryObsoletes.queryDifference(installed);
-        installed.queryUnion(query);
-        queryObsoletes.addFilter(HY_PKG_OBSOLETES, HY_EQ, installed.runSet());
-        query.queryUnion(queryObsoletes);
-    }
-    Selector selector(sack);
-    selector.set(query.runSet());
-    sltrToJob(&selector, &pImpl->staging, SOLVER_UPDATE);
+    queue_push2(&pImpl->staging, SOLVER_UPDATE|SOLVER_SOLVABLE_ALL, 0);
 }
 
 void

--- a/libdnf/goal/Goal.hpp
+++ b/libdnf/goal/Goal.hpp
@@ -79,11 +79,8 @@ public:
 
     /**
     * @brief Add upgrade all packages request to job. It adds obsoletes automatically to transaction
-    * if no parametrer obsoletes provided or setted to true.
-    *
-    * @param obsoletes p_obsoletes: bool parameter to specify if obsoletes should be added to job
     */
-    void upgrade(bool obsoletes=true);
+    void upgrade();
     void upgrade(DnfPackage *new_pkg);
 
     /**


### PR DESCRIPTION
The change triggers problem with reinstalling installonly packages and reports
them as a packages with conflict. The original issue appears only with upgrade
and --best, therefore it is less visible.

Reverts 25479d2d8b2e090c9a1b0b25151f169cc57319cd