### PR TITLE
[transaction] Fix crash after using dnf.comps.CompsQuery and forking …

### DIFF
--- a/libdnf/transaction/CompsEnvironmentItem.cpp
+++ b/libdnf/transaction/CompsEnvironmentItem.cpp
@@ -185,7 +185,10 @@ CompsEnvironmentItem::getTransactionItemsByPattern(SQLite3Ptr conn, const std::s
 
     std::vector< TransactionItemPtr > result;
 
-    SQLite3::Query query(*conn, sql);
+    // HACK: create a private connection to avoid undefined behavior
+    // after forking process in Anaconda
+    SQLite3 privateConn(conn->getPath());
+    SQLite3::Query query(privateConn, sql);
     std::string pattern_sql = pattern;
     std::replace(pattern_sql.begin(), pattern_sql.end(), '*', '%');
     query.bindv(pattern, pattern, pattern);

--- a/libdnf/transaction/CompsGroupItem.cpp
+++ b/libdnf/transaction/CompsGroupItem.cpp
@@ -181,7 +181,10 @@ CompsGroupItem::getTransactionItemsByPattern(SQLite3Ptr conn, const std::string 
 
     std::vector< TransactionItemPtr > result;
 
-    SQLite3::Query query(*conn, sql);
+    // HACK: create a private connection to avoid undefined behavior
+    // after forking process in Anaconda
+    SQLite3 privateConn(conn->getPath());
+    SQLite3::Query query(privateConn, sql);
     std::string pattern_sql = pattern;
     std::replace(pattern_sql.begin(), pattern_sql.end(), '*', '%');
     query.bindv(pattern, pattern, pattern);


### PR DESCRIPTION
…the process in Anaconda.

dnf.base.Base.install_specs() uses CompsQuery.
CompsQuery opens a connection to the history database.
Anaconda runs do_transaction() as a background (forked) process.
The fork leads to undefined behavior and crash after an attempt
to work with the history database.