### PR TITLE
Fix memory corruption in dnf_context

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -128,6 +128,7 @@ dnf_sack_finalize(GObject *object)
         auto hrepo = static_cast<HyRepo>(repo->appdata);
         if (!hrepo)
             continue;
+        hrepo->libsolv_repo = NULL;
         hy_repo_free(hrepo);
     }
     g_free(priv->cache_dir);


### PR DESCRIPTION
This bug causes that microdnf sometimes fails with
"corrupted double-linked list (not small)" during finalization phase.