### PR TITLE
tests: Link executable with -fPIC

### DIFF
--- a/tests/hawkey/CMakeLists.txt
+++ b/tests/hawkey/CMakeLists.txt
@@ -23,6 +23,8 @@ ADD_LIBRARY(testshared STATIC testshared.cpp)
 SET_TARGET_PROPERTIES(testshared PROPERTIES COMPILE_FLAGS -fPIC)
 
 ADD_EXECUTABLE(test_hawkey_main ${hawkeytest_SRCS})
+# The binary links in testshared which was built with -fPIC
+SET_TARGET_PROPERTIES(test_hawkey_main PROPERTIES COMPILE_FLAGS -fPIC)
 TARGET_LINK_LIBRARIES(test_hawkey_main
     libdnf
     ${CHECK_LIBRARIES}


### PR DESCRIPTION
I'm trying to reproduce a build failure for rpm-ostree
with Fedora's `LDFLAGS` which look like e.g.:
`export LDFLAGS='-Wl,-z,relro`
But I ended up hitting this issue (not the one I was looking for).
I didn't fully verify this but I believe the problem here is
we're building the `testshared.cpp` twice, and it needs to be
consistently `PIC`.