### PR TITLE
Fix problem with NULL conversion to std::string

### DIFF
--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -994,8 +994,9 @@ bool Repo::Impl::loadCache(bool throwExcept)
                 distro_tags.emplace_back(distroTag->cpeid, distroTag->tag);
         }
     }
-
-    revision = yum_repomd->revision;
+    if (auto cRevision = yum_repomd->revision) {
+        revision = cRevision;
+    }
     maxTimestamp = lr_yum_repomd_get_highest_timestamp(yum_repomd, NULL);
 
     // Load timestamp unless explicitly expired


### PR DESCRIPTION
In case that yum_repomd->revision was NULL it crashed.