### PR TITLE
Optimize swig exceptions handling

### DIFF
--- a/bindings/swig/conf.i
+++ b/bindings/swig/conf.i
@@ -22,16 +22,13 @@
 %exception {
     try {
         $action
-    }
-    catch (const std::exception & e)
-    {
-       SWIG_exception(SWIG_RuntimeError, (std::string("C++ std::exception: ") + e.what()).c_str());
-    }
-    catch (...)
-    {
+    } catch (const std::exception & e) {
+       SWIG_exception(SWIG_RuntimeError, e.what());
+    } catch (...) {
        SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
     }
 }
+
 
 // make SWIG look into following headers
 %include "libdnf/conf/Option.hpp"

--- a/bindings/swig/conf.i
+++ b/bindings/swig/conf.i
@@ -24,8 +24,6 @@
         $action
     } catch (const std::exception & e) {
        SWIG_exception(SWIG_RuntimeError, e.what());
-    } catch (...) {
-       SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
     }
 }
 

--- a/bindings/swig/module.i
+++ b/bindings/swig/module.i
@@ -16,14 +16,8 @@
 %exception {
     try {
         $action
-    }
-    catch (const std::exception & e)
-    {
+    } catch (const std::exception & e) {
        SWIG_exception(SWIG_RuntimeError, e.what());
-    }
-    catch (...)
-    {
-       SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
     }
 }
 

--- a/bindings/swig/repo.i
+++ b/bindings/swig/repo.i
@@ -29,9 +29,7 @@
 %exception {
     try {
         $action
-    }
-    catch (const std::exception & e)
-    {
+    } catch (const std::exception & e) {
        SWIG_exception(SWIG_RuntimeError, e.what());
     }
 }

--- a/bindings/swig/smartcols.i
+++ b/bindings/swig/smartcols.i
@@ -23,8 +23,6 @@
         $action
     } catch (const std::exception & e) {
        SWIG_exception(SWIG_RuntimeError, e.what());
-    } catch (...) {
-       SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
     }
 }
 

--- a/bindings/swig/smartcols.i
+++ b/bindings/swig/smartcols.i
@@ -19,13 +19,13 @@
 %shared_ptr(Table)
 
 %exception {
-try {
-    $action
-} catch (const std::exception & e) {
-    SWIG_exception(SWIG_RuntimeError, (std::string("C++ std::exception: ") + e.what()).c_str());
-} catch (...) {
-    SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
-}
+    try {
+        $action
+    } catch (const std::exception & e) {
+       SWIG_exception(SWIG_RuntimeError, e.what());
+    } catch (...) {
+       SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
+    }
 }
 
 %include "libdnf/utils/smartcols/Table.hpp"

--- a/bindings/swig/transaction.i
+++ b/bindings/swig/transaction.i
@@ -19,13 +19,9 @@
 %exception {
     try {
         $action
-    }
-    catch (const std::exception & e)
-    {
-       SWIG_exception(SWIG_RuntimeError, (std::string("C++ std::exception: ") + e.what()).c_str());
-    }
-    catch (...)
-    {
+    } catch (const std::exception & e) {
+       SWIG_exception(SWIG_RuntimeError, e.what());
+    } catch (...) {
        SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
     }
 }

--- a/bindings/swig/transaction.i
+++ b/bindings/swig/transaction.i
@@ -21,8 +21,6 @@
         $action
     } catch (const std::exception & e) {
        SWIG_exception(SWIG_RuntimeError, e.what());
-    } catch (...) {
-       SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
     }
 }
 

--- a/bindings/swig/utils.i
+++ b/bindings/swig/utils.i
@@ -20,13 +20,9 @@
 %exception {
     try {
         $action
-    }
-    catch (const std::exception & e)
-    {
-       SWIG_exception(SWIG_RuntimeError, (std::string("C++ std::exception: ") + e.what()).c_str());
-    }
-    catch (...)
-    {
+    } catch (const std::exception & e) {
+       SWIG_exception(SWIG_RuntimeError, e.what());
+    } catch (...) {
        SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
     }
 }

--- a/bindings/swig/utils.i
+++ b/bindings/swig/utils.i
@@ -22,8 +22,6 @@
         $action
     } catch (const std::exception & e) {
        SWIG_exception(SWIG_RuntimeError, e.what());
-    } catch (...) {
-       SWIG_exception(SWIG_UnknownError, "C++ anonymous exception");
     }
 }
 


### PR DESCRIPTION
* Don't catch anonymous exceptions
The libdnf does not use anonymous exceptions. So there is no need to catch them.

* Remove "C++ std::exception: " prefix