### PR TITLE
Add ConfigRepo.exclude alias into Python API

### DIFF
--- a/bindings/swig/conf.i
+++ b/bindings/swig/conf.i
@@ -213,4 +213,5 @@ public:
 %pythoncode %{
 # Compatible name aliases
 ConfigMain.exclude = ConfigMain.excludepkgs
+ConfigRepo.exclude = ConfigRepo.excludepkgs
 %}


### PR DESCRIPTION
The alias points to ConfigRepo.excludepkgs.
It is for compatibility.