### PR TITLE
Remove unneeded regex URL tests (RhBug:1598336)

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -403,7 +403,7 @@ class ConfigMain::Impl {
     OptionStringListAppend includepkgs{std::vector<std::string>{}};
     OptionBinding includePkgsBinding{owner, includepkgs, "includepkgs"};
 
-    OptionString proxy{"", PROXY_URL_REGEX, true};
+    OptionString proxy{""};
     OptionBinding proxyBinding{owner, proxy, "proxy"};
 
     OptionString proxy_username{nullptr};

--- a/libdnf/conf/ConfigRepo.cpp
+++ b/libdnf/conf/ConfigRepo.cpp
@@ -40,13 +40,13 @@ class ConfigRepo::Impl {
     OptionChild<OptionString> basecachedir{masterConfig.cachedir()};
     OptionBinding baseCacheDirBindings{owner, basecachedir, "cachedir"};
 
-    OptionStringList baseurl{std::vector<std::string>{}, URL_REGEX, true};
+    OptionStringList baseurl{std::vector<std::string>{}};
     OptionBinding baseUrlBinding{owner, baseurl, "baseurl"};
 
-    OptionString mirrorlist{nullptr, URL_REGEX, true};
+    OptionString mirrorlist{nullptr};
     OptionBinding mirrorListBinding{owner, mirrorlist, "mirrorlist"};
 
-    OptionString metalink{nullptr, URL_REGEX, true};
+    OptionString metalink{nullptr};
     OptionBinding metaLinkBinding{owner, metalink, "metalink"};
 
     OptionString type{""};
@@ -55,7 +55,7 @@ class ConfigRepo::Impl {
     OptionString mediaid{""};
     OptionBinding mediaIdBinding{owner, mediaid, "mediaid"};
 
-    OptionStringList gpgkey{std::vector<std::string>{}, URL_REGEX, true};
+    OptionStringList gpgkey{std::vector<std::string>{}};
     OptionBinding gpgKeyBinding{owner, gpgkey, "gpgkey"};
 
     OptionStringListAppend excludepkgs{std::vector<std::string>{}};

--- a/libdnf/conf/Const.hpp
+++ b/libdnf/conf/Const.hpp
@@ -26,9 +26,6 @@ namespace libdnf {
 constexpr const char * PERSISTDIR = "/var/lib/dnf";
 constexpr const char * SYSTEM_CACHEDIR = "/var/cache/dnf";
 
-constexpr const char * URL_REGEX = "(https?|ftp|file):\\/\\/[-a-zA-Z0-9_.\\/?=&#\\$;%@+~|!:,]+$";
-constexpr const char * PROXY_URL_REGEX = "^((https?|ftp|socks5h?|socks4a?):\\/\\/[-a-zA-Z0-9_.\\/?=&#\\$;%@+~|!:,]+)?$";
-
 constexpr const char * CONF_FILENAME = "/etc/dnf/dnf.conf";
 
 const std::vector<std::string> GROUP_PACKAGE_TYPES{"mandatory", "default", "conditional"};


### PR DESCRIPTION
The tests were more problematic than useful.
Especially in combination with some locales.