### PR TITLE
Various leak fixes and and adding free functions to returned GPtrArrays

### DIFF
--- a/libdnf/dnf-advisory.cpp
+++ b/libdnf/dnf-advisory.cpp
@@ -32,6 +32,7 @@
 
 
 #include "dnf-advisory-private.hpp"
+#include "dnf-advisorypkg.h"
 #include "dnf-advisoryref.h"
 #include "sack/advisory.hpp"
 #include "sack/advisoryref.hpp"
@@ -211,7 +212,7 @@ dnf_advisory_get_packages(DnfAdvisory *advisory)
     std::vector<libdnf::AdvisoryPkg> pkgsvector;
     advisory->getPackages(pkgsvector);
 
-    GPtrArray *pkglist =  g_ptr_array_new();
+    GPtrArray *pkglist = g_ptr_array_new_with_free_func((GDestroyNotify) dnf_advisorypkg_free);
     for (auto& advisorypkg : pkgsvector) {
         g_ptr_array_add(pkglist, new libdnf::AdvisoryPkg(std::move(advisorypkg)));
     }

--- a/libdnf/dnf-advisory.cpp
+++ b/libdnf/dnf-advisory.cpp
@@ -32,6 +32,7 @@
 
 
 #include "dnf-advisory-private.hpp"
+#include "dnf-advisoryref.h"
 #include "sack/advisory.hpp"
 #include "sack/advisoryref.hpp"
 #include "sack/advisorypkg.hpp"
@@ -233,7 +234,7 @@ dnf_advisory_get_references(DnfAdvisory *advisory)
     std::vector<libdnf::AdvisoryRef> refsvector;
     advisory->getReferences(refsvector);
 
-    GPtrArray *reflist =  g_ptr_array_new();
+    GPtrArray *reflist = g_ptr_array_new_with_free_func((GDestroyNotify) dnf_advisoryref_free);
     for (const auto& advisoryref : refsvector) {
         g_ptr_array_add(reflist, new libdnf::AdvisoryRef(advisoryref));
     }

--- a/libdnf/hy-package.cpp
+++ b/libdnf/hy-package.cpp
@@ -997,7 +997,7 @@ dnf_package_get_advisories(DnfPackage *pkg, int cmp_type)
     DnfAdvisory *advisory;
     Pool *pool = dnf_package_get_pool(pkg);
     DnfSack *sack = dnf_package_get_sack(pkg);
-    GPtrArray *advisorylist = g_ptr_array_new();
+    GPtrArray *advisorylist = g_ptr_array_new_with_free_func((GDestroyNotify) dnf_advisory_free);
     Solvable *s = get_solvable(pkg);
 
     dataiterator_init(&di, pool, 0, 0, UPDATE_COLLECTION_NAME,

--- a/python/hawkey/iutil-py.cpp
+++ b/python/hawkey/iutil-py.cpp
@@ -79,7 +79,7 @@ advisorylist_to_pylist(const GPtrArray *advisorylist, PyObject *sack)
 
     for (unsigned int i = 0; i < advisorylist->len; ++i) {
         auto cadvisory =
-            static_cast<DnfAdvisory *>(g_ptr_array_index(advisorylist, i));
+            static_cast<DnfAdvisory *>(g_steal_pointer(&g_ptr_array_index(advisorylist, i)));
         UniquePtrPyObject advisory(advisoryToPyObject(cadvisory, sack));
 
         if (!advisory)

--- a/tests/hawkey/test_advisory.cpp
+++ b/tests/hawkey/test_advisory.cpp
@@ -41,7 +41,7 @@ advisory_fixture(void)
     pkg = by_name(test_globals.sack, "tour");
     advisories = dnf_package_get_advisories(pkg, HY_GT);
 
-    advisory = static_cast<DnfAdvisory *>(g_ptr_array_index(advisories, 0));
+    advisory = static_cast<DnfAdvisory *>(g_steal_pointer(&g_ptr_array_index(advisories, 0)));
 
     g_ptr_array_unref(advisories);
     g_object_unref(pkg);

--- a/tests/hawkey/test_advisorypkg.cpp
+++ b/tests/hawkey/test_advisorypkg.cpp
@@ -43,7 +43,7 @@ advisorypkg_fixture(void)
     advisories = dnf_package_get_advisories(pkg, HY_GT);
     advisory = static_cast<DnfAdvisory *>(g_ptr_array_index(advisories, 0));
     pkglist = dnf_advisory_get_packages(advisory);
-    advisorypkg = static_cast<DnfAdvisoryPkg *>(g_ptr_array_index(pkglist, 0));
+    advisorypkg = static_cast<DnfAdvisoryPkg *>(g_steal_pointer(&g_ptr_array_index(pkglist, 0)));
 
     g_ptr_array_unref(pkglist);
     g_ptr_array_unref(advisories);

--- a/tests/hawkey/test_advisoryref.cpp
+++ b/tests/hawkey/test_advisoryref.cpp
@@ -42,7 +42,7 @@ advisoryref_fixture(void)
     advisories = dnf_package_get_advisories(pkg, HY_GT);
     auto advisory = static_cast<DnfAdvisory *>(g_ptr_array_index(advisories, 0));
     reflist = dnf_advisory_get_references(advisory);
-    reference = static_cast<DnfAdvisoryRef *>(g_ptr_array_index(reflist, 0));
+    reference = static_cast<DnfAdvisoryRef *>(g_steal_pointer(&g_ptr_array_index(reflist, 0)));
 
     g_ptr_array_unref(reflist);
     g_ptr_array_unref(advisories);

--- a/tests/hawkey/test_query.cpp
+++ b/tests/hawkey/test_query.cpp
@@ -458,6 +458,8 @@ START_TEST(test_query_conflicts)
     fail_unless(reldep != NULL);
     hy_query_filter_reldep(q, HY_PKG_CONFLICTS, reldep);
     fail_unless(query_count_results(q) == 1);
+
+    delete reldep;
     hy_query_free(q);
 }
 END_TEST
@@ -680,6 +682,7 @@ START_TEST(test_query_reldep)
     fail_if(hy_query_filter_reldep(q, HY_PKG_PROVIDES, reldep));
     fail_unless(query_count_results(q) == 3);
 
+    delete reldep;
     delete reldeplist;
     g_object_unref(flying);
     hy_query_free(q);
@@ -696,6 +699,7 @@ START_TEST(test_query_reldep_arbitrary)
     hy_query_filter_reldep(query, HY_PKG_PROVIDES, reldep);
     fail_unless(query_count_results(query) == 3);
 
+    delete reldep;
     hy_query_free(query);
 }
 END_TEST

--- a/tests/hawkey/test_reldep.cpp
+++ b/tests/hawkey/test_reldep.cpp
@@ -42,6 +42,7 @@ START_TEST(test_reldeplist_add)
     for (int i = 0; i < count; ++i) {
         DnfReldep *reldep = dnf_reldep_list_index (obsoletes.get(), i);
         dnf_reldep_list_add (reldeplist.get(), reldep);
+        delete reldep;
     }
 
     g_object_unref (flying);


### PR DESCRIPTION
In https://github.com/rpm-software-management/libdnf/issues/588 I complained that the C++ rewrite made the C API more difficult to use now that the returned arrays no longer take ownership of its elements. Here are some fixes to clean this up a bit.

After these fixes, there's just one valgrind failure left in the tests -- would be awesome if people who commit to libdnf could keep 'make test' working in the future.