### PR TITLE
Rename dnf_repo_is_repo to dnf_repo_is_source

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -524,18 +524,18 @@ dnf_repo_is_local(DnfRepo *repo)
 }
 
 /**
- * dnf_repo_is_repo:
+ * dnf_repo_is_source:
  * @repo: a #DnfRepo instance.
  *
- * Returns: %TRUE if the repo is a repo repo
+ * Returns: %TRUE if the repo is a source repo
  *
  * Since: 0.1.0
  **/
 gboolean
-dnf_repo_is_repo(DnfRepo *repo)
+dnf_repo_is_source(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    if (g_str_has_suffix(priv->id, "-repo"))
+    if (g_str_has_suffix(priv->id, "-source"))
         return TRUE;
     return FALSE;
 }

--- a/libdnf/dnf-repo.h
+++ b/libdnf/dnf-repo.h
@@ -128,7 +128,7 @@ HyRepo           dnf_repo_get_repo              (DnfRepo              *repo);
 #endif
 gboolean         dnf_repo_is_devel              (DnfRepo              *repo);
 gboolean         dnf_repo_is_local              (DnfRepo              *repo);
-gboolean         dnf_repo_is_repo             (DnfRepo              *repo);
+gboolean         dnf_repo_is_source             (DnfRepo              *repo);
 
 /* setters */
 void             dnf_repo_set_id                (DnfRepo              *repo,


### PR DESCRIPTION
This somehow got all mangled up in source->repo rename a while back. Fix
it so that it does what originally intended: checks if a repo has
-source suffix (e.g. "updates-testing-source").