### PR TITLE
libdnf: Ensure libdl is linked into libdnf

### DIFF
--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -56,6 +56,7 @@ SET(LIBDNF_SRCS ${LIBDNF_SRCS} ${PLUGIN_SOURCES})
 
 ADD_LIBRARY(libdnf SHARED ${LIBDNF_SRCS})
 TARGET_LINK_LIBRARIES(libdnf
+                      ${CMAKE_DL_LIBS}
                       ${REPO_LIBRARIES}
                       ${GLIB_LIBRARIES}
                       ${GLIB_GOBJECT_LIBRARIES}


### PR DESCRIPTION
Without this, libdnf fails to link with `-Wl,--no-undefined` because those symbols are not automatically linked. This fixes building libdnf on Mageia.