### PR TITLE
[history] Fix crash in TransactionItem::addReplacedBy().

### DIFF
--- a/libdnf/transaction/TransactionItem.hpp
+++ b/libdnf/transaction/TransactionItem.hpp
@@ -110,7 +110,7 @@ public:
     // int64_t getTransactionId() const noexcept { return trans.getId(); }
 
     const std::vector< TransactionItemPtr > &getReplacedBy() const noexcept { return replacedBy; }
-    void addReplacedBy(TransactionItemPtr value) { replacedBy.push_back(value); }
+    void addReplacedBy(TransactionItemPtr value) { if (value) replacedBy.push_back(value); }
 
     void save();
     void saveReplacedBy();


### PR DESCRIPTION
libdnf still incorrectly migrates some 'replaced-by' relations
from the old database because the algorithm for computing the
relations depends on item order, which can be almost random.