### PR TITLE
[swdb] Revert journal_mode to TRUNCATE (RhBug:1640235)

### DIFF
--- a/libdnf/utils/sqlite3/Sqlite3.cpp
+++ b/libdnf/utils/sqlite3/Sqlite3.cpp
@@ -32,7 +32,7 @@ SQLite3::open()
         }
         // sqlite doesn't behave correctly in chroots without following line:
         // turn foreign key checking on
-        exec("PRAGMA locking_mode = NORMAL; PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;");
+        exec("PRAGMA locking_mode = NORMAL; PRAGMA journal_mode = TRUNCATE; PRAGMA foreign_keys = ON;");
         sqlite3_busy_timeout(db, 10000);
     }
 }


### PR DESCRIPTION
WAL is impossible to use as a non root user for read only.

https://bugzilla.redhat.com/show_bug.cgi?id=1640235