### PR TITLE
Test if sack is present and run save module persistor (RhBug:1632518)

### DIFF
--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -1437,8 +1437,11 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
             goto out;
     }
 
-    if (auto moduleContainer = dnf_sack_get_module_container(dnf_context_get_sack(priv->context)))
-        moduleContainer->save();
+    if (DnfSack * sack = hy_goal_get_sack(goal)) {
+        if (auto moduleContainer = dnf_sack_get_module_container(sack)) {
+            moduleContainer->save();
+        }
+    }
 
     /* all sacks are invalid now */
     dnf_context_invalidate_full(priv->context,


### PR DESCRIPTION
It looks like that PackageKit is able to have a context without
initialized sack, therefore sack from Goal is used.

https://bugzilla.redhat.com/show_bug.cgi?id=1632518