### PR TITLE
fix RULE_YUMOBS message

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -84,7 +84,7 @@ static const std::map<int, const char *> PKG_PROBLEMS_DICT = {
     {RULE_PKG_IMPLICIT_OBSOLETES, _("package %s implicitly obsoletes %s provided by %s")},
     {RULE_PKG_REQUIRES, _("package %s requires %s, but none of the providers can be installed")},
     {RULE_PKG_SELF_CONFLICT, _("package %s conflicts with %s provided by itself")},
-    {RULE_YUMOBS, _("both package %s and %s obsolete ")}
+    {RULE_YUMOBS, _("both package %s and %s obsolete %s")}
 };
 
 static const std::map<int, const char *> MODULE_PROBLEMS_DICT = {


### PR DESCRIPTION
python3: /builddir/build/BUILD/libdnf-0.22.0/libdnf/transaction/private/../../utils/tinyformat/tinyformat.hpp:629: const char* tinyformat::detail::streamStateFromFormat(std::ostream&, bool&, bool&, int&, const char*, const tinyformat::detail::FormatArg*, int&, int): Assertion `0 && "tinyformat: Not enough conversion specifiers in format string"' failed.
Aborted (core dumped)

libdnf doesn't give any useful message, but manually comparing messages
and arguments helped to find this.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1642126
Reported-by: Stephen Gallagher <sgallagh@redhat.com>
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>