### PR TITLE
[transaction] Fix transaction item lookup for obsoleted packages (RhBug: 1642796)

### DIFF
--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -713,6 +713,9 @@ dnf_transaction_ts_progress_cb(const void *arg,
         case RPMCALLBACK_UNINST_STOP:
 
             pkg = dnf_find_pkg_from_header(priv->remove, hdr);
+            if (pkg == NULL) {
+                pkg = dnf_find_pkg_from_header(priv->remove_helper, hdr);
+            }
             if (pkg == NULL && filename != NULL) {
                 pkg = dnf_find_pkg_from_filename_suffix(priv->remove, filename);
             }


### PR DESCRIPTION
If a package gets removed completely, it's available in priv->remove list.
If a package only gets upgraded/reinstalled/... it's treated as obsoleted
and is available in priv->remove_helper list. This patch takes remove_helper
in consideration when looking for package objects in transaction.