### PR TITLE
Use arch from spec in hy_subject_get_best_selector (RhBug:1542307)

### DIFF
--- a/libdnf/hy-subject.c
+++ b/libdnf/hy-subject.c
@@ -382,6 +382,9 @@ nevra_to_selector(HyNevra nevra, DnfSack *sack)
                 hy_selector_set(selector, HY_PKG_EVR, HY_EQ, evrbuf->str);
             }
         }
+        const char * arch = hy_nevra_get_string(nevra, HY_NEVRA_ARCH);
+        if (arch)
+            hy_selector_set(selector, HY_PKG_ARCH, HY_EQ, arch);
     }
 
     if (hy_selector_has_matches(selector)) {


### PR DESCRIPTION
In case that subject contains arch it was simply ignored. The patch
should fix it.

https://bugzilla.redhat.com/show_bug.cgi?id=1542307