### PR TITLE
Disable librhsm support by default

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -19,11 +19,7 @@
 %bcond_without python2
 %endif
 
-%if 0%{?rhel} && ! 0%{?centos}
-%bcond_without rhsm
-%else
 %bcond_with rhsm
-%endif
 
 %global _cmake_opts \\\
     -DENABLE_RHSM_SUPPORT=%{?with_rhsm:ON}%{!?with_rhsm:OFF} \\\


### PR DESCRIPTION
Currently, on any system where subscription-manager runs, librhsm is not doing anything useful.

When entitlement certificates are provided directly by subscription-manager, subscription-manager also updates `/etc/yum.repos.d/redhat.repo` accordingly. librhsm is also used to produce `redhat.repo` for use cases where entitlements are present without subscription-manager.

No such supported use cases exist yet.

Without librhsm, `redhat.repo` is the same as any other repo to libdnf, which is acceptable since it is managed via subscription-manager.

Furthermore, it is problematic to have two processes manage `redhat.repo`. subscription-manager attempts to respect manual edits to `redhat.repo` (with some caveats), and supports modifying some repo attributes on the entitlement server (Red Hat Customer Portal or Red Hat Satellite 6). librhsm doesn't have this functionality. So there are lots of confusing and buggy interactions on a system where both librhsm and subscription-manager are present. Therefore, it is RHEL's best interest to disable librhsm support by default.

For use cases where subscription-manager will never be used to manage entitlements on a system, libdnf can still be built with librhsm support by using `--with rhsm`.