### PR TITLE
Disable librhsm if subscription-manager is present

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -1630,6 +1630,13 @@ dnf_context_setup_enrollments(DnfContext *context, GError **error)
         return TRUE;
 
 #ifdef RHSM_SUPPORT
+    /* If /var/lib/rhsm exists, then we can assume that
+     * subscription-manager is installed, and thus don't need to
+     * manage redhat.repo via librhsm.
+     */
+    if (access("/var/lib/rhsm", F_OK) == 0) {
+        return TRUE;
+    }
     g_autoptr(RHSMContext) rhsm_ctx = rhsm_context_new ();
     g_autofree gchar *repofname = g_build_filename (priv->repo_dir,
                                                     "redhat.repo",


### PR DESCRIPTION
(Mostly the same context as #636)

When entitlement certificates are provided directly by subscription-manager, subscription-manager also updates `/etc/yum.repos.d/redhat.repo` accordingly.  librhsm is also used to produce `redhat.repo` for use cases where entitlements are present without subscription-manager.

Without librhsm, `redhat.repo` is the same as any other repo to libdnf, which is acceptable when it is externally managed via subscription-manager.

Furthermore, it is problematic to have two processes manage `redhat.repo`. subscription-manager attempts to respect manual edits to `redhat.repo` (with some caveats), and supports modifying some
repo attributes on the entitlement server (Red Hat Customer Portal or Red Hat Satellite 6). librhsm doesn't have this functionality. So there are lots of confusing and buggy interactions on a system where
both librhsm and subscription-manager are managing `redhat.repo` simultaneously.

Note that this patch uses the presence of `/var/lib/rhsm` to determine whether subscription-manager is installed (we're not tied to this method if another method of detection is preferable).

This patch obsoletes #636.