### PR TITLE
WIP [plugins] Pass transaction information to pluginHook()

### DIFF
--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -1089,6 +1089,11 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
     rpmtransFlags rpmts_flags = RPMTRANS_FLAG_NONE;
     DnfTransactionPrivate *priv = GET_PRIVATE(transaction);
     libdnf::Swdb *swdb = priv->swdb;
+    PluginHookContextTransactionData data = {
+        .transaction = transaction,
+        .goal = goal,
+        .state = state
+    };
 
     /* take lock */
     ret = dnf_state_take_lock(state, DNF_LOCK_TYPE_RPMDB, DNF_LOCK_MODE_PROCESS, error);
@@ -1378,7 +1383,7 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
         goto out;
     }
 
-    if (!dnf_context_plugin_hook(priv->context, PLUGIN_HOOK_ID_CONTEXT_PRE_TRANSACTION, nullptr, nullptr))
+    if (!dnf_context_plugin_hook(priv->context, PLUGIN_HOOK_ID_CONTEXT_PRE_TRANSACTION, &data, nullptr))
         goto out;
 
     // FIXME get commandline and rpmdb version
@@ -1424,7 +1429,7 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
     // FIXME get rpmdb version
     swdb->endTransaction(_get_current_time(), "", libdnf::TransactionState::DONE);
 
-    if (!dnf_context_plugin_hook(priv->context, PLUGIN_HOOK_ID_CONTEXT_TRANSACTION, nullptr, nullptr))
+    if (!dnf_context_plugin_hook(priv->context, PLUGIN_HOOK_ID_CONTEXT_TRANSACTION, &data, nullptr))
         goto out;
 
     /* this section done */

--- a/libdnf/plugin/plugin.h
+++ b/libdnf/plugin/plugin.h
@@ -21,6 +21,9 @@
 #ifndef _LIBDNF_PLUGIN_H
 #define _LIBDNF_PLUGIN_H
 
+#include "../dnf-types.h"
+#include "../hy-types.h"
+
 typedef struct {
     const char * name;
     const char * version;
@@ -43,6 +46,18 @@ typedef struct {
     char * path;
     char * message;
 } PluginHookError;
+
+/**
+* @brief Information about running transaction
+*
+* The structure is passed to pluginHook() as hookData, when id of hook
+* is PLUGIN_HOOK_ID_CONTEXT_PRE_TRANSACTION or PLUGIN_HOOK_ID_CONTEXT_TRANSACTION.
+*/
+typedef struct {
+    DnfTransaction * transaction;
+    HyGoal goal;
+    DnfState * state;
+} PluginHookContextTransactionData;
 
 typedef struct _PluginHandle PluginHandle;
 


### PR DESCRIPTION
The pluginHook() function will get information about transaction in hookData agrument, when it is called with id PLUGIN_HOOK_ID_CONTEXT_PRE_TRANSACTION or
PLUGIN_HOOK_ID_CONTEXT_TRANSACTION.

A PluginHookContextTransactionData structure was defined for the passed data.