### PR TITLE
Remove installed profile on module  enable or disable (RhBug:1653623)

### DIFF
--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -386,6 +386,10 @@ ModulePackageContainer::enable(const std::string &name, const std::string & stre
     if (pImpl->persistor->changeState(name, ModuleState::ENABLED)) {
         changed = true;
     }
+    if (changed) {
+        auto & profiles = pImpl->persistor->getEntry(name).second.profiles;
+        profiles.clear();
+    }
     return changed;
 }
 
@@ -402,6 +406,8 @@ void ModulePackageContainer::disable(const std::string & name)
 {
     pImpl->persistor->changeState(name, ModuleState::DISABLED);
     pImpl->persistor->changeStream(name, "");
+    auto & profiles = pImpl->persistor->getEntry(name).second.profiles;
+    profiles.clear();
 }
 
 void ModulePackageContainer::disable(const ModulePackagePtr &module)


### PR DESCRIPTION
If module enable or disable all information about installed profile will
be lost.

https://bugzilla.redhat.com/show_bug.cgi?id=1653623