### PR TITLE
Reset callback to NULL (RhBug:1637923)

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1906,6 +1906,7 @@ out:
     g_free(updatedata.last_mirror_url);
     dnf_state_release_locks(state);
     lr_handle_setopt(priv->repo_handle, NULL, LRO_PROGRESSCB, NULL);
+    lr_handle_setopt(priv->repo_handle, NULL, LRO_HMFCB, NULL);
     lr_handle_setopt(priv->repo_handle, NULL, LRO_PROGRESSDATA, 0xdeadbeef);
     return ret;
 }


### PR DESCRIPTION
It prevents crash of PackageKit
 #0 repo_mirrorlist_failure_cb at /usr/src/debug/libdnf-0.20.0-1.fc29.x86_64/libdnf/dnf-repo.cpp:1641
 #1 check_transfer_statuses at /usr/src/debug/librepo-1.9.1-1.fc29.x86_64/librepo/downloader.c:1718
 #2 lr_perform at /usr/src/debug/librepo-1.9.1-1.fc29.x86_64/librepo/downloader.c:1956
 #3 lr_download at /usr/src/debug/librepo-1.9.1-1.fc29.x86_64/librepo/downloader.c:2083
 #4 lr_download_target at /usr/src/debug/librepo-1.9.1-1.fc29.x86_64/librepo/downloader.c:2187
 #5 lr_yum_download_url at /usr/src/debug/librepo-1.9.1-1.fc29.x86_64/librepo/yum.c:491
 #6 lr_download_url at /usr/src/debug/librepo-1.9.1-1.fc29.x86_64/librepo/downloader.c:2197
 #7 dnf_repo_download_import_public_key at /usr/src/debug/libdnf-0.20.0-1.fc29.x86_64/libdnf/dnf-repo.cpp:1616
 #8 dnf_repo_update at /usr/src/debug/libdnf-0.20.0-1.fc29.x86_64/libdnf/dnf-repo.cpp:1758
 #9 dnf_sack_add_repo at /usr/src/debug/libdnf-0.20.0-1.fc29.x86_64/libdnf/dnf-sack.cpp:2086