### PR TITLE
Allow disabling SWDB writing

### DIFF
--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -133,6 +133,7 @@ guint            dnf_context_get_cache_age              (DnfContext     *context
 guint            dnf_context_get_installonly_limit      (DnfContext     *context);
 const gchar     *dnf_context_get_http_proxy             (DnfContext     *context);
 gboolean         dnf_context_get_enable_filelists       (DnfContext     *context);
+gboolean         dnf_context_get_enable_swdb            (DnfContext     *context);
 GPtrArray       *dnf_context_get_repos                  (DnfContext     *context);
 #ifndef __GI_SCANNER__
 DnfRepoLoader   *dnf_context_get_repo_loader            (DnfContext     *context);
@@ -179,6 +180,8 @@ void             dnf_context_set_keep_cache             (DnfContext     *context
                                                          gboolean        keep_cache);
 void             dnf_context_set_enable_filelists       (DnfContext     *context,
                                                          gboolean        enable_filelists);
+void             dnf_context_set_enable_swdb            (DnfContext     *context,
+                                                         gboolean        enable_swdb);
 void             dnf_context_set_only_trusted           (DnfContext     *context,
                                                          gboolean        only_trusted);
 void             dnf_context_set_zchunk                 (DnfContext     *context,

--- a/libdnf/dnf-reldep-list.h
+++ b/libdnf/dnf-reldep-list.h
@@ -33,6 +33,8 @@ gint dnf_reldep_list_count(DnfReldepList *reldep_list);
 void dnf_reldep_list_add(DnfReldepList *reldep_list, DnfReldep *reldep);
 void dnf_reldep_list_extend(DnfReldepList *rl1, DnfReldepList *rl2);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(DnfReldepList, dnf_reldep_list_free)
+
 #ifdef __cplusplus
 }
 #endif

--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -1408,8 +1408,7 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
     // FIXME get commandline
     if (sack) {
         rpmdb_begin = dnf_sack_get_rpmdb_version(sack);
-    }
-    else {
+    } else {
         // if sack is not available, create a custom instance
         rpmdb_version_sack = dnf_sack_new();
         dnf_sack_load_system_repo(rpmdb_version_sack, nullptr, DNF_SACK_LOAD_FLAG_BUILD_CACHE, nullptr);

--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -1515,6 +1515,23 @@ out:
 DnfTransaction *
 dnf_transaction_new(DnfContext *context)
 {
+    return dnf_transaction_new_with_flags (context, DNF_TRANSACTION_FLAG_NONE);
+}
+
+/**
+ * dnf_transaction_new_with_flags:
+ * @context: a #DnfContext instance.
+ * @flags: the flags, e.g. %DNF_TRANSACTION_FLAG_ONLY_TRUSTED
+ *
+ * Creates a new #DnfTransaction with the given flags.
+ *
+ * Returns:(transfer full): a #DnfTransaction
+ *
+ * Since: 0.25.0
+ **/
+DnfTransaction *
+dnf_transaction_new_with_flags(DnfContext *context, guint64 flags)
+{
     auto transaction = DNF_TRANSACTION(g_object_new(DNF_TYPE_TRANSACTION, NULL));
     auto priv = GET_PRIVATE(transaction);
     priv->swdb = new libdnf::Swdb(libdnf::Swdb::defaultPath);
@@ -1523,6 +1540,7 @@ dnf_transaction_new(DnfContext *context)
     priv->ts = rpmtsCreate();
     rpmtsSetRootDir(priv->ts, dnf_context_get_install_root(context));
     priv->keyring = rpmtsGetKeyring(priv->ts, 1);
+    priv->flags = flags;
     return transaction;
 }
 

--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -1209,7 +1209,7 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
         }
 
         // add item to swdb transaction
-        _history_write_item(pkg, priv->swdb, swdbAction);
+        _history_write_item(pkg, swdb, swdbAction);
 
         /* this section done */
         ret = dnf_state_done(state_local, error);
@@ -1249,7 +1249,7 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
                 swdbAction = libdnf::TransactionItemAction::DOWNGRADED;
             }
         }
-        _history_write_item(pkg, priv->swdb, swdbAction);
+        _history_write_item(pkg, swdb, swdbAction);
     }
 
     /* add anything that gets obsoleted to a helper array which is used to
@@ -1301,7 +1301,7 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
             }
 
             // TODO SWDB add pkg_tmp replaced_by pkg
-            _history_write_item(pkg_tmp, priv->swdb, swdbAction);
+            _history_write_item(pkg_tmp, swdb, swdbAction);
         }
         g_ptr_array_unref(pkglist);
     }

--- a/libdnf/dnf-transaction.h
+++ b/libdnf/dnf-transaction.h
@@ -72,6 +72,8 @@ typedef enum {
 } DnfTransactionFlag;
 
 DnfTransaction  *dnf_transaction_new                    (DnfContext     *context);
+DnfTransaction  *dnf_transaction_new_with_flags         (DnfContext     *context,
+                                                         guint64         flags);
 
 /* getters */
 guint64          dnf_transaction_get_flags              (DnfTransaction *transaction);

--- a/libdnf/dnf-transaction.h
+++ b/libdnf/dnf-transaction.h
@@ -57,6 +57,7 @@ struct _DnfTransactionClass
  * @DNF_TRANSACTION_FLAG_ALLOW_DOWNGRADE:       Allow package downrades
  * @DNF_TRANSACTION_FLAG_NODOCS:                Don't install documentation
  * @DNF_TRANSACTION_FLAG_TEST:                  Only do a transaction test
+ * @DNF_TRANSACTION_FLAG_DISABLE_SWDB:          Don't write to SWDB
  *
  * The transaction flags.
  **/
@@ -67,6 +68,7 @@ typedef enum {
         DNF_TRANSACTION_FLAG_ALLOW_DOWNGRADE    = 1 << 2,
         DNF_TRANSACTION_FLAG_NODOCS             = 1 << 3,
         DNF_TRANSACTION_FLAG_TEST               = 1 << 4,
+        DNF_TRANSACTION_FLAG_DISABLE_SWDB       = 1 << 5,
         /*< private >*/
         DNF_TRANSACTION_FLAG_LAST
 } DnfTransactionFlag;

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -956,7 +956,7 @@ void Repo::Impl::importRepoKeys()
 std::unique_ptr<LrResult> Repo::Impl::lrHandlePerform(LrHandle * handle, const std::string & destDirectory,
     bool setGPGHomeEnv)
 {
-    bool isOrigGPGHomeEnvSet;
+    bool isOrigGPGHomeEnvSet = false;
     std::string origGPGHomeEnv;
     if (setGPGHomeEnv) {
             const char * orig = getenv(GPG_HOME_ENV);

--- a/libdnf/transaction/Swdb.cpp
+++ b/libdnf/transaction/Swdb.cpp
@@ -50,6 +50,26 @@ Swdb::Swdb(SQLite3Ptr conn, bool autoClose)
 {
 }
 
+Swdb::Swdb(const std::string &path)
+  : conn(nullptr)
+  , autoClose(true)
+{
+    // check if DB file is present
+    if (!pathExists(path.c_str())) {
+        // file not present
+
+        // extract persistdir from path - "/var/lib/dnf/"
+        auto found = path.find_last_of("/");
+
+        Transformer transformer(path.substr(0, found), path);
+        transformer.transform();
+
+        conn = std::make_shared< SQLite3 >(path);
+    } else {
+        conn = std::make_shared< SQLite3 >(path);
+    }
+}
+
 void
 Swdb::resetDatabase()
 {
@@ -494,26 +514,6 @@ CompsGroupItemPtr
 Swdb::createCompsGroupItem()
 {
     return std::make_shared< CompsGroupItem >(conn);
-}
-
-Swdb::Swdb(const std::string &path)
-  : conn(nullptr)
-  , autoClose(true)
-{
-    // check if DB file is present
-    if (!pathExists(path.c_str())) {
-        // file not present
-
-        // extract persistdir from path - "/var/lib/dnf/"
-        auto found = path.find_last_of("/");
-
-        Transformer transformer(path.substr(0, found), path);
-        transformer.transform();
-
-        conn = std::make_shared< SQLite3 >(path);
-    } else {
-        conn = std::make_shared< SQLite3 >(path);
-    }
 }
 
 /**

--- a/libdnf/transaction/Transformer.cpp
+++ b/libdnf/transaction/Transformer.cpp
@@ -82,7 +82,7 @@ static const std::map< std::string, TransactionItemReason > reasons = {
     {"group", TransactionItemReason::GROUP}};
 
 /**
- * Covert string reason into appropriate enumerated variant
+ * Convert string reason into appropriate enumerated variant
  */
 TransactionItemReason
 Transformer::getReason(const std::string &reason)

--- a/libdnf/utils/sqlite3/Sqlite3.cpp
+++ b/libdnf/utils/sqlite3/Sqlite3.cpp
@@ -57,7 +57,6 @@ SQLite3::close()
             sqlite3_finalize(res);
         }
         result = sqlite3_close(db);
-    } else {
     }
     if (result != SQLITE_OK) {
         throw LibException(result, "Close failed");


### PR DESCRIPTION
Only the last three commits are new here. The rest are from #660. I'll just copy the commit messages from the last two:

[transaction] Add DNF_TRANSACTION_FLAG_DISABLE_SWDB

Not all users of libdnf really need the functionality added by the SWDB
database. This is especially true for rpm-ostree-based variants of
Fedora and RHEL, which only use libdnf for composing on the server and
package layering on the client.

Some major differences that render the SWDB not useful for rpm-ostree:
- rpm-ostree already keeps track of requested packages in a separate
  database (really, text file).
- rpm-ostree always applies package installs from scratch on top of the
  base OSTree, so the concept of history is simply different (see e.g.
  projectatomic/rpm-ostree#1489).
- rpm-ostree updates are performed offline, i.e. not on the live system.
  As such, we don't need to track the state of the RPM transaction as it
  happens in a separate database. If librpm throws an error, we just
  throw out the whole offline rootfs.
- OSTree commits themselves already contain the list of packages that
  were installed in them, so that we can consult the commit metadata (or
  even the rpmdb directly) if we need to render the RPM diff on a system
  or OSTree branch.

[context] Disable SWDB in alternate install roots

This gets to the heart of the distinction. If one is using libdnf to
operate on the live system, then an SWDB tracking those mutations makes
sense. If not, then it's likely libdnf is only being used as a low-level
tool to generate some other artifacts. If we detect such cases,
automatically, disable writing an SWDB.

Closes: #645

Requires: #660