### PR TITLE
Zchunk fixes

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1439,14 +1439,33 @@ dnf_repo_check_internal(DnfRepo *repo,
         hy_repo_free(priv->repo);
     priv->repo = hy_repo_create(priv->id);
     hy_repo_set_string(priv->repo, HY_REPO_MD_FN, yum_repo->repomd);
-    tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "primary"));
-    hy_repo_set_string(priv->repo, HY_REPO_PRIMARY_FN, tmp);
-    tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "filelists"));
-    hy_repo_set_string(priv->repo, HY_REPO_FILELISTS_FN, tmp);
-    tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "updateinfo"));
-    hy_repo_set_string(priv->repo, HY_REPO_UPDATEINFO_FN, tmp);
-    tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "modules"));
-    hy_repo_set_string(priv->repo, MODULES_FN, tmp);
+    if (dnf_context_get_zchunk(priv->context)) {
+        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "primary_zck"));
+        if(!tmp)
+            tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "primary"));
+        hy_repo_set_string(priv->repo, HY_REPO_PRIMARY_FN, tmp);
+        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "filelists_zck"));
+        if(!tmp)
+            tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "filelists"));
+        hy_repo_set_string(priv->repo, HY_REPO_FILELISTS_FN, tmp);
+        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "updateinfo_zck"));
+        if(!tmp)
+            tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "updateinfo"));
+        hy_repo_set_string(priv->repo, HY_REPO_UPDATEINFO_FN, tmp);
+        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "modules_zck"));
+        if(!tmp)
+            tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "modules"));
+        hy_repo_set_string(priv->repo, MODULES_FN, tmp);
+    } else {
+        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "primary"));
+        hy_repo_set_string(priv->repo, HY_REPO_PRIMARY_FN, tmp);
+        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "filelists"));
+        hy_repo_set_string(priv->repo, HY_REPO_FILELISTS_FN, tmp);
+        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "updateinfo"));
+        hy_repo_set_string(priv->repo, HY_REPO_UPDATEINFO_FN, tmp);
+        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "modules"));
+        hy_repo_set_string(priv->repo, MODULES_FN, tmp);
+    }
 
     /* ensure we reset the values from the keyfile */
     if (!dnf_repo_set_keyfile_data(repo, error))

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -280,10 +280,25 @@ private:
             delete[] *item;
         delete[] ptr;
     }};
+    bool endsWith(std::string const &str, std::string const &ending) const;
 };
 
+bool Repo::Impl::endsWith(const std::string &str, const std::string &ending) const {
+    if (str.length() >= ending.length())
+        return (str.compare(str.length() - ending.length(), ending.length(), ending) == 0);
+    else
+        return false;
+}
+
 std::string Repo::Impl::getMetadataPath(const std::string &metadataType) const {
-    auto it = metadataPaths.find(metadataType);
+    std::string lookupMetadataType = metadataType;
+    if (conf->getMasterConfig().zchunk().getValue()) {
+        if(!endsWith(metadataType, "_zck"))
+            lookupMetadataType = metadataType + "_zck";
+    }
+    auto it = metadataPaths.find(lookupMetadataType);
+    if(it == metadataPaths.end() && lookupMetadataType != metadataType)
+        it = metadataPaths.find(metadataType);
     return (it != metadataPaths.end()) ? it->second : "";
 }
 

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -580,7 +580,7 @@ std::unique_ptr<LrHandle> Repo::Impl::lrHandleInitLocal()
     handleSetOpt(h.get(), LRO_LOCAL, 1L);
 #ifdef LRO_SUPPORTS_CACHEDIR
     /* If zchunk is enabled, set librepo cache dir */
-    if (!conf->getMasterConfig().zchunk().getValue())
+    if (conf->getMasterConfig().zchunk().getValue())
         handleSetOpt(h.get(), LRO_CACHEDIR, conf->basecachedir().getValue().c_str());
 #endif
     return h;
@@ -666,7 +666,7 @@ std::unique_ptr<LrHandle> Repo::Impl::lrHandleInitRemote(const char *destdir, bo
 
 #ifdef LRO_SUPPORTS_CACHEDIR
     /* If zchunk is enabled, set librepo cache dir */
-    if (!conf->getMasterConfig().zchunk().getValue())
+    if (conf->getMasterConfig().zchunk().getValue())
         handleSetOpt(h.get(), LRO_CACHEDIR, conf->basecachedir().getValue().c_str());
 #endif
 


### PR DESCRIPTION
These fix a couple of bugs in the zchunk code.  The first fixes a bug where zchunk had to be set to false to work with the new repo/Repo.cpp codepath.  The second fixes a segfault in both codepaths.  Tested with dnf, microdnf and PackageKit.