### PR TITLE
[module] Remove useless usage of std::shared_ptr

### DIFF
--- a/bindings/swig/module.i
+++ b/bindings/swig/module.i
@@ -8,7 +8,6 @@
 %include <std_map.i>
 %include <std_pair.i>
 %include <std_set.i>
-%include <std_shared_ptr.i>
 %include <std_string.i>
 %include <std_vector.i>
 
@@ -21,10 +20,6 @@
     }
 }
 
-
-%shared_ptr(ModulePackage)
-typedef std::shared_ptr< ModulePackage > ModulePackagePtr;
-
 typedef int Id;
 
 %{
@@ -34,8 +29,8 @@ typedef int Id;
     #include "libdnf/module/modulemd/ModuleProfile.hpp"
 %}
 %template(SetString) std::set<std::string>;
-%template(VectorModulePackagePtr) std::vector<ModulePackagePtr>;
-%template(VectorVectorVectorModulePackagePtr) std::vector<std::vector<std::vector<ModulePackagePtr>>>;
+%template(VectorModulePackagePtr) std::vector<ModulePackage *>;
+%template(VectorVectorVectorModulePackagePtr) std::vector<std::vector<std::vector<ModulePackage *>>>;
 %template(VectorModuleProfile) std::vector<ModuleProfile>;
 %template(MapStringString) std::map<std::string, std::string>;
 %template(MapStringPairStringString) std::map<std::string, std::pair<std::string, std::string>>;

--- a/libdnf/dnf-sack-private.hpp
+++ b/libdnf/dnf-sack-private.hpp
@@ -75,7 +75,7 @@ std::pair<std::vector<std::vector<std::string>>, ModulePackageContainer::ModuleE
     DnfSack *sack, DnfModulePackageContainer * moduleContainer, const char ** hotfixRepos,
     const char *install_root, const char * platformModule, bool updateOnly, bool debugSolver);
 
-std::vector<std::shared_ptr<ModulePackage>> requiresModuleEnablement(DnfSack * sack, const libdnf::PackageSet * installSet);
+std::vector<ModulePackage *> requiresModuleEnablement(DnfSack * sack, const libdnf::PackageSet * installSet);
 
 /**
  * @brief Return fingerprint of installed RPMs.

--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -2296,7 +2296,7 @@ setModuleExcludes(DnfSack *sack, const char ** hotfixRepos,
 
 }
 
-std::vector<std::shared_ptr<ModulePackage>> requiresModuleEnablement(
+std::vector<ModulePackage *> requiresModuleEnablement(
     DnfSack * sack, const libdnf::PackageSet * installSet)
 {
     DnfSackPrivate *priv = GET_PRIVATE(sack);

--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -322,7 +322,7 @@ std::vector<ModuleDependencies> ModulePackage::getModuleDependencies() const
 /**
  * @brief Add conflict with a module stream represented as a ModulePackage.
  */
-void ModulePackage::addStreamConflict(const ModulePackagePtr &package)
+void ModulePackage::addStreamConflict(const ModulePackage * package)
 {
     Pool * pool = dnf_sack_get_pool(moduleSack);
     std::ostringstream ss;

--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -67,8 +67,8 @@ static void setSovable(Pool * pool, Solvable *solvable, std::string name,
 ModulePackage::~ModulePackage() = default;
 
 ModulePackage::ModulePackage(DnfSack * moduleSack, Repo * repo,
-    const std::shared_ptr<ModuleMetadata> &metadata,  const std::string & repoID)
-        : metadata(metadata)
+    ModuleMetadata && metadata,  const std::string & repoID)
+        : metadata(std::move(metadata))
         , moduleSack(moduleSack)
         , repoID(repoID)
 {
@@ -77,7 +77,7 @@ ModulePackage::ModulePackage(DnfSack * moduleSack, Repo * repo,
     Solvable *solvable = pool_id2solvable(pool, id);
 
     setSovable(pool, solvable, getName(), getStream(), getVersion(), getContext(),
-        metadata->getArchitecture());
+        metadata.getArchitecture());
     createDependencies(solvable);
     HyRepo hyRepo = static_cast<HyRepo>(repo->appdata);
     hyRepo->needs_internalizing = 1;
@@ -94,7 +94,7 @@ void ModulePackage::createDependencies(Solvable *solvable) const
     Pool * pool = dnf_sack_get_pool(moduleSack);
 
     for (const auto &dependency : getModuleDependencies()) {
-        for (const auto &requires : dependency->getRequires()) {
+        for (const auto &requires : dependency.getRequires()) {
             for (const auto &singleRequires : requires) {
                 auto moduleName = singleRequires.first;
                 std::vector<std::string> requiresStream;
@@ -143,12 +143,12 @@ void ModulePackage::createDependencies(Solvable *solvable) const
  */
 const char * ModulePackage::getNameCStr() const
 {
-    return metadata->getName();
+    return metadata.getName();
 }
 
 std::string ModulePackage::getName() const
 {
-    auto name = metadata->getName();
+    auto name = metadata.getName();
     return name ? name : "";
 }
 
@@ -188,12 +188,12 @@ const std::string & ModulePackage::getRepoID() const
  */
 const char * ModulePackage::getStreamCStr() const
 {
-    return metadata->getStream();
+    return metadata.getStream();
 }
 
 std::string ModulePackage::getStream() const
 {
-    auto stream = metadata->getStream();
+    auto stream = metadata.getStream();
     return stream ? stream : "";
 }
 
@@ -204,7 +204,7 @@ std::string ModulePackage::getStream() const
  */
 std::string ModulePackage::getVersion() const
 {
-    return std::to_string(metadata->getVersion());
+    return std::to_string(metadata.getVersion());
 }
 
 /**
@@ -214,7 +214,7 @@ std::string ModulePackage::getVersion() const
  */
 long long ModulePackage::getVersionNum() const
 {
-    return metadata->getVersion();
+    return metadata.getVersion();
 }
 
 /**
@@ -224,12 +224,12 @@ long long ModulePackage::getVersionNum() const
  */
 const char * ModulePackage::getContextCStr() const
 {
-    return metadata->getContext();
+    return metadata.getContext();
 }
 
 std::string ModulePackage::getContext() const
 {
-    auto context = metadata->getContext();
+    auto context = metadata.getContext();
     return context ? context : "";
 }
 
@@ -241,12 +241,12 @@ std::string ModulePackage::getContext() const
  */
 const char * ModulePackage::getArchCStr() const
 {
-    return metadata->getArchitecture();
+    return metadata.getArchitecture();
 }
 
 std::string ModulePackage::getArch() const
 {
-    auto arch = metadata->getArchitecture();
+    auto arch = metadata.getArchitecture();
     return arch ? arch : "";
 }
 
@@ -270,7 +270,7 @@ std::string ModulePackage::getFullIdentifier() const
  */
 std::string ModulePackage::getSummary() const
 {
-    return metadata->getSummary();
+    return metadata.getSummary();
 }
 
 /**
@@ -280,7 +280,7 @@ std::string ModulePackage::getSummary() const
  */
 std::string ModulePackage::getDescription() const
 {
-    return metadata->getDescription();
+    return metadata.getDescription();
 }
 
 /**
@@ -290,13 +290,13 @@ std::string ModulePackage::getDescription() const
  */
 std::vector<std::string> ModulePackage::getArtifacts() const
 {
-    return metadata->getArtifacts();
+    return metadata.getArtifacts();
 }
 
 std::vector<ModuleProfile>
 ModulePackage::getProfiles(const std::string &name) const
 {
-    return metadata->getProfiles(name);
+    return metadata.getProfiles(name);
 }
 
 /**
@@ -306,7 +306,7 @@ ModulePackage::getProfiles(const std::string &name) const
  */
 std::vector<ModuleProfile> ModulePackage::getProfiles() const
 {
-    return metadata->getProfiles();
+    return metadata.getProfiles();
 }
 
 /**
@@ -314,9 +314,9 @@ std::vector<ModuleProfile> ModulePackage::getProfiles() const
  *
  * @return std::vector<std::shared_ptr<ModuleDependencies>>
  */
-std::vector<std::shared_ptr<ModuleDependencies>> ModulePackage::getModuleDependencies() const
+std::vector<ModuleDependencies> ModulePackage::getModuleDependencies() const
 {
-    return metadata->getDependencies();
+    return metadata.getDependencies();
 }
 
 /**

--- a/libdnf/module/ModulePackage.hpp
+++ b/libdnf/module/ModulePackage.hpp
@@ -71,24 +71,24 @@ public:
     std::vector<ModuleProfile> getProfiles(const std::string &name) const;
     std::vector<ModuleProfile> getProfiles() const;
 
-    std::vector<std::shared_ptr<ModuleDependencies> > getModuleDependencies() const;
+    std::vector<ModuleDependencies> getModuleDependencies() const;
 
     void addStreamConflict(const ModulePackagePtr &package);
 
     Id getId() const { return id; };
-    std::string getYaml() const { return metadata->getYaml(); };
+    std::string getYaml() const { return metadata.getYaml(); };
 
 private:
     friend struct ModulePackageContainer;
 
     ModulePackage(DnfSack * moduleSack, Repo * repo,
-        const std::shared_ptr<ModuleMetadata> &metadata, const std::string & repoID);
+        ModuleMetadata && metadata, const std::string & repoID);
 
     static Id createPlatformSolvable(DnfSack * moduleSack, const std::string &osReleasePath,
         const std::string install_root, const char *  platformModule);
     void createDependencies(Solvable *solvable) const;
 
-    std::shared_ptr<ModuleMetadata> metadata;
+    ModuleMetadata metadata;
 
     // TODO: remove after inheriting from Package
     DnfSack * moduleSack;

--- a/libdnf/module/ModulePackage.hpp
+++ b/libdnf/module/ModulePackage.hpp
@@ -29,10 +29,6 @@
 #include "libdnf/repo/solvable/Package.hpp"
 #include "../goal/IdQueue.hpp"
 
-class ModulePackage;
-
-typedef std::shared_ptr< ModulePackage > ModulePackagePtr;
-
 struct ModulePackageContainer;
 
 class ModulePackage // TODO inherit in future; : public Package
@@ -73,7 +69,7 @@ public:
 
     std::vector<ModuleDependencies> getModuleDependencies() const;
 
-    void addStreamConflict(const ModulePackagePtr &package);
+    void addStreamConflict(const ModulePackage * package);
 
     Id getId() const { return id; };
     std::string getYaml() const { return metadata.getYaml(); };

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -244,9 +244,9 @@ ModulePackageContainer::add(const std::string &fileContent, const std::string & 
         if (strcmp(r->name, "available") == 0) {
             g_autofree gchar *path = g_build_filename(pImpl->installRoot.c_str(),
                                                       "/etc/dnf/modules.d", NULL);
-            for (auto data : metadata) {
-                ModulePackagePtr modulePackage(new ModulePackage(pImpl->moduleSack, r, data,
-                    repoID));
+            for (auto & data : metadata) {
+                ModulePackagePtr modulePackage(new ModulePackage(pImpl->moduleSack, r
+                    , std::move(data), repoID));
                 pImpl->modules.insert(std::make_pair(modulePackage->getId(), modulePackage));
                 pImpl->persistor->insert(modulePackage->getName(), path);
             }

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -101,7 +101,7 @@ public:
     Impl();
     ~Impl();
     std::pair<std::vector<std::vector<std::string>>, ModulePackageContainer::ModuleErrorType> moduleSolve(
-        const std::vector<ModulePackagePtr> & modules, bool debugSolver);
+        const std::vector<ModulePackage *> & modules, bool debugSolver);
     bool insert(const std::string &moduleName, const char *path);
 
 
@@ -109,7 +109,7 @@ private:
     friend struct ModulePackageContainer;
     class ModulePersistor;
     std::unique_ptr<ModulePersistor> persistor;
-    std::map<Id, ModulePackagePtr> modules;
+    std::map<Id, std::unique_ptr<ModulePackage>> modules;
     DnfSack * moduleSack;
     std::unique_ptr<libdnf::PackageSet> activatedModules;
     std::string installRoot;
@@ -245,10 +245,11 @@ ModulePackageContainer::add(const std::string &fileContent, const std::string & 
             g_autofree gchar *path = g_build_filename(pImpl->installRoot.c_str(),
                                                       "/etc/dnf/modules.d", NULL);
             for (auto & data : metadata) {
-                ModulePackagePtr modulePackage(new ModulePackage(pImpl->moduleSack, r
+                std::unique_ptr<ModulePackage> modulePackage(new ModulePackage(pImpl->moduleSack, r
                     , std::move(data), repoID));
-                pImpl->modules.insert(std::make_pair(modulePackage->getId(), modulePackage));
-                pImpl->persistor->insert(modulePackage->getName(), path);
+                auto modulePackagePtr = modulePackage.get();
+                pImpl->modules.insert(std::make_pair(modulePackage->getId(), std::move(modulePackage)));
+                pImpl->persistor->insert(modulePackagePtr->getName(), path);
             }
             return;
         }
@@ -272,7 +273,7 @@ void ModulePackageContainer::createConflictsBetweenStreams()
         for (const auto &innerIter : pImpl->modules) {
             if (modulePackage->getName() == innerIter.second->getName()
                 && modulePackage->getStream() != innerIter.second->getStream()) {
-                modulePackage->addStreamConflict(innerIter.second);
+                modulePackage->addStreamConflict(innerIter.second.get());
             }
         }
     }
@@ -283,24 +284,23 @@ bool ModulePackageContainer::empty() const noexcept
     return pImpl->modules.empty();
 }
 
-ModulePackagePtr ModulePackageContainer::getModulePackage(Id id)
+ModulePackage * ModulePackageContainer::getModulePackage(Id id)
 {
-    return pImpl->modules.at(id);
+    return pImpl->modules.at(id).get();
 }
 
-std::vector<ModulePackagePtr>
+std::vector<ModulePackage *>
 ModulePackageContainer::requiresModuleEnablement(const libdnf::PackageSet & packages)
 {
     auto activatedModules = pImpl->activatedModules.get();
     if (!activatedModules) {
         return {};
     }
-    std::vector<ModulePackagePtr> output;
+    std::vector<ModulePackage *> output;
     libdnf::Query baseQuery(packages.getSack());
     baseQuery.addFilter(HY_PKG, HY_EQ, &packages);
     baseQuery.apply();
     libdnf::Query testQuery(baseQuery);
-    auto modules = pImpl->modules;
     Id moduleId = -1;
     while ((moduleId = activatedModules->next(moduleId)) != -1) {
         auto module = getModulePackage(moduleId);
@@ -332,7 +332,7 @@ bool ModulePackageContainer::isEnabled(const std::string &name, const std::strin
         pImpl->persistor->getStream(name) == stream;
 }
 
-bool ModulePackageContainer::isEnabled(const ModulePackagePtr &module)
+bool ModulePackageContainer::isEnabled(const ModulePackage * module)
 {
     return isEnabled(module->getName(), module->getStream());
 }
@@ -347,7 +347,7 @@ bool ModulePackageContainer::isDisabled(const std::string &name)
     return pImpl->persistor->getState(name) == ModuleState::DISABLED;
 }
 
-bool ModulePackageContainer::isDisabled(const ModulePackagePtr &module)
+bool ModulePackageContainer::isDisabled(const ModulePackage * module)
 {
     return isDisabled(module->getName());
 }
@@ -390,7 +390,7 @@ ModulePackageContainer::enable(const std::string &name, const std::string & stre
 }
 
 bool
-ModulePackageContainer::enable(const ModulePackagePtr &module)
+ModulePackageContainer::enable(const ModulePackage * module)
 {
     return enable(module->getName(), module->getStream());
 }
@@ -406,7 +406,7 @@ void ModulePackageContainer::disable(const std::string & name)
     profiles.clear();
 }
 
-void ModulePackageContainer::disable(const ModulePackagePtr &module)
+void ModulePackageContainer::disable(const ModulePackage * module)
 {
     disable(module->getName());
 }
@@ -422,7 +422,7 @@ void ModulePackageContainer::reset(const std::string & name)
     profiles.clear();
 }
 
-void ModulePackageContainer::reset(const ModulePackagePtr &module)
+void ModulePackageContainer::reset(const ModulePackage * module)
 {
     reset(module->getName());
 }
@@ -457,14 +457,14 @@ void ModulePackageContainer::install(const std::string &name, const std::string 
     const std::string &profile)
 {
     for (const auto &iter : pImpl->modules) {
-        auto modulePackage = iter.second;
+        auto modulePackage = iter.second.get();
         if (modulePackage->getName() == name && modulePackage->getStream() == stream) {
             install(modulePackage, profile);
         }
     }
 }
 
-void ModulePackageContainer::install(const ModulePackagePtr &module, const std::string &profile)
+void ModulePackageContainer::install(const ModulePackage * module, const std::string &profile)
 {
     if (pImpl->persistor->getStream(module->getName()) == module->getStream())
         pImpl->persistor->addProfile(module->getName(), profile);
@@ -474,21 +474,21 @@ void ModulePackageContainer::uninstall(const std::string &name, const std::strin
     const std::string &profile)
 {
     for (const auto &iter : pImpl->modules) {
-        auto modulePackage = iter.second;
+        auto modulePackage = iter.second.get();
         if (modulePackage->getName() == name && modulePackage->getStream() == stream) {
             uninstall(modulePackage, profile);
         }
     }
 }
 
-void ModulePackageContainer::uninstall(const ModulePackagePtr &module, const std::string &profile)
+void ModulePackageContainer::uninstall(const ModulePackage * module, const std::string &profile)
 {
     if (pImpl->persistor->getStream(module->getName()) == module->getStream())
         pImpl->persistor->removeProfile(module->getName(), profile);
 }
 
 std::pair<std::vector<std::vector<std::string>>, ModulePackageContainer::ModuleErrorType>
-ModulePackageContainer::Impl::moduleSolve(const std::vector<ModulePackagePtr> & modules,
+ModulePackageContainer::Impl::moduleSolve(const std::vector<ModulePackage *> & modules,
     bool debugSolver)
 {
     if (modules.empty()) {
@@ -538,18 +538,18 @@ ModulePackageContainer::Impl::moduleSolve(const std::vector<ModulePackagePtr> & 
     return make_pair(problems, problemType);
 }
 
-std::vector<ModulePackagePtr>
+std::vector<ModulePackage *>
 ModulePackageContainer::query(libdnf::Nsvcap& moduleNevra)
 {
     return query(moduleNevra.getName(), moduleNevra.getStream(), moduleNevra.getVersion(),
                  moduleNevra.getContext(), moduleNevra.getArch());
 }
 
-std::vector<ModulePackagePtr>
+std::vector<ModulePackage *>
 ModulePackageContainer::query(std::string subject)
 {
     // Alternatively a search using module provides could be performed
-    std::vector<ModulePackagePtr> result;
+    std::vector<ModulePackage *> result;
     libdnf::Query query(pImpl->moduleSack, HY_IGNORE_EXCLUDES);
     // platform modules are installed and not in modules std::Map.
     query.addFilter(HY_PKG_REPONAME, HY_NEQ, HY_SYSTEM_REPO_NAME);
@@ -559,17 +559,17 @@ ModulePackageContainer::query(std::string subject)
     auto pset = query.runSet();
     Id moduleId = -1;
     while ((moduleId = pset->next(moduleId)) != -1) {
-        result.push_back(pImpl->modules.at(moduleId));
+        result.push_back(pImpl->modules.at(moduleId).get());
     }
     return result;
 }
 
-std::vector<ModulePackagePtr>
+std::vector<ModulePackage *>
 ModulePackageContainer::query(std::string name, std::string stream, std::string version,
     std::string context, std::string arch)
 {
     // Alternatively a search using module provides could be performed
-    std::vector<ModulePackagePtr> result;
+    std::vector<ModulePackage *> result;
     libdnf::Query query(pImpl->moduleSack, HY_IGNORE_EXCLUDES);
     // platform modules are installed and not in modules std::Map.
     query.addFilter(HY_PKG_REPONAME, HY_NEQ, HY_SYSTEM_REPO_NAME);
@@ -584,12 +584,12 @@ ModulePackageContainer::query(std::string name, std::string stream, std::string 
     auto pset = query.runSet();
     Id moduleId = -1;
     while ((moduleId = pset->next(moduleId)) != -1) {
-        result.push_back(pImpl->modules.at(moduleId));
+        result.push_back(pImpl->modules.at(moduleId).get());
     }
     return result;
 }
 
-void ModulePackageContainer::enableDependencyTree(std::vector<ModulePackagePtr> & modulePackages)
+void ModulePackageContainer::enableDependencyTree(std::vector<ModulePackage *> & modulePackages)
 {
     if (!pImpl->activatedModules) {
         return;
@@ -616,7 +616,7 @@ void ModulePackageContainer::enableDependencyTree(std::vector<ModulePackagePtr> 
     while (!toEnable.empty()) {
         Id moduleId = -1;
         while ((moduleId = toEnable.next(moduleId)) != -1) {
-            enable(pImpl->modules.at(moduleId));
+            enable(pImpl->modules.at(moduleId).get());
             enabled.set(moduleId);
             libdnf::Query query(pImpl->moduleSack);
             query.addFilter(HY_PKG, HY_EQ, pImpl->activatedModules.get());
@@ -657,8 +657,8 @@ std::set<std::string> ModulePackageContainer::getInstalledPkgNames()
         nameStream += ":";
         nameStream += stream;
         auto modules = query(nameStream);
-        std::shared_ptr<ModulePackage> latest;
-        for (auto & module: modules) {
+        const ModulePackage * latest = nullptr;
+        for (const ModulePackage * module: modules) {
             if (isModuleActive(module->getId())) {
                 if (!latest) {
                     latest = module;
@@ -670,7 +670,7 @@ std::set<std::string> ModulePackageContainer::getInstalledPkgNames()
             }
         }
         if (!latest) {
-            for (auto & module: modules) {
+            for (auto module: modules) {
                 if (!latest) {
                     latest = module;
                 } else {
@@ -774,7 +774,7 @@ ModulePackageContainer::getReport()
 }
 
 static bool
-modulePackageLatestPerRepoSorter(DnfSack * sack, const ModulePackagePtr & first, const ModulePackagePtr & second)
+modulePackageLatestPerRepoSorter(DnfSack * sack, const ModulePackage * first, const ModulePackage * second)
 {
     if (first->getRepoID() != second->getRepoID())
         return first->getRepoID() < second->getRepoID();
@@ -790,15 +790,15 @@ modulePackageLatestPerRepoSorter(DnfSack * sack, const ModulePackagePtr & first,
     return first->getVersionNum() > second->getVersionNum();
 }
 
-std::vector<std::vector<std::vector<ModulePackagePtr>>>
+std::vector<std::vector<std::vector<ModulePackage *>>>
 ModulePackageContainer::getLatestModulesPerRepo(ModuleState moduleFilter,
-    std::vector<ModulePackagePtr> modulePackages)
+    std::vector<ModulePackage *> modulePackages)
 {
     if (modulePackages.empty()) {
         return {};
     }
     if (moduleFilter == ModuleState::ENABLED) {
-        std::vector<ModulePackagePtr> enabled;
+        std::vector<ModulePackage *> enabled;
         for (auto package: modulePackages) {
             if (isEnabled(package)) {
                 enabled.push_back(package);
@@ -806,7 +806,7 @@ ModulePackageContainer::getLatestModulesPerRepo(ModuleState moduleFilter,
         }
         modulePackages = enabled;
     } else if (moduleFilter == ModuleState::DISABLED) {
-        std::vector<ModulePackagePtr> disabled;
+        std::vector<ModulePackage *> disabled;
         for (auto package: modulePackages) {
             if (isDisabled(package)) {
                 disabled.push_back(package);
@@ -814,7 +814,7 @@ ModulePackageContainer::getLatestModulesPerRepo(ModuleState moduleFilter,
         }
         modulePackages = disabled;
     } else if (moduleFilter == ModuleState::INSTALLED) {
-        std::vector<ModulePackagePtr> installed;
+        std::vector<ModulePackage *> installed;
         for (auto package: modulePackages) {
             if ((!getInstalledProfiles(package->getName()).empty()) && isEnabled(package)) {
                 installed.push_back(package);
@@ -826,14 +826,14 @@ ModulePackageContainer::getLatestModulesPerRepo(ModuleState moduleFilter,
         return {};
     }
     auto & packageFirst = modulePackages[0];
-    std::vector<std::vector<std::vector<ModulePackagePtr>>> output;
+    std::vector<std::vector<std::vector<ModulePackage *>>> output;
     auto sack = pImpl->moduleSack;
     std::sort(modulePackages.begin(), modulePackages.end(),
-              [sack](const ModulePackagePtr & first, const ModulePackagePtr & second)
+              [sack](const ModulePackage * first, const ModulePackage * second)
               {return modulePackageLatestPerRepoSorter(sack, first, second);});
     auto vectorSize = modulePackages.size();
     output.push_back(
-        std::vector<std::vector<ModulePackagePtr>>{std::vector<ModulePackagePtr> {packageFirst}});
+        std::vector<std::vector<ModulePackage *>>{std::vector<ModulePackage *> {packageFirst}});
     int repoIndex = 0;
     int nameStreamArchIndex = 0;
     auto repoID = packageFirst->getRepoID();
@@ -850,7 +850,7 @@ ModulePackageContainer::getLatestModulesPerRepo(ModuleState moduleFilter,
             stream = package->getStreamCStr();
             arch = package->getArchCStr();
             version = package->getVersionNum();
-            output.push_back(std::vector<std::vector<ModulePackagePtr>>{std::vector<ModulePackagePtr> {package}});
+            output.push_back(std::vector<std::vector<ModulePackage *>>{std::vector<ModulePackage *> {package}});
             ++repoIndex;
             nameStreamArchIndex = 0;
             continue;
@@ -862,7 +862,7 @@ ModulePackageContainer::getLatestModulesPerRepo(ModuleState moduleFilter,
             stream = package->getStreamCStr();
             arch = package->getArchCStr();
             version = package->getVersionNum();
-            output[repoIndex].push_back(std::vector<ModulePackagePtr> {package});
+            output[repoIndex].push_back(std::vector<ModulePackage *> {package});
             ++nameStreamArchIndex;
             continue;
         }
@@ -878,12 +878,12 @@ std::pair<std::vector<std::vector<std::string>>, ModulePackageContainer::ModuleE
 ModulePackageContainer::resolveActiveModulePackages(bool debugSolver)
 {
     dnf_sack_reset_excludes(pImpl->moduleSack);
-    std::vector<ModulePackagePtr> packages;
+    std::vector<ModulePackage *> packages;
 
     libdnf::PackageSet excludes(pImpl->moduleSack);
     // Use only Enabled or Default modules for transaction
     for (const auto &iter : pImpl->modules) {
-        auto module = iter.second;
+        auto module = iter.second.get();
         auto moduleState = pImpl->persistor->getState(module->getName());
         if (moduleState == ModuleState::DISABLED) {
             excludes.set(module->getId());
@@ -917,7 +917,7 @@ bool ModulePackageContainer::isModuleActive(Id id)
     return false;
 }
 
-bool ModulePackageContainer::isModuleActive(ModulePackagePtr modulePackage)
+bool ModulePackageContainer::isModuleActive(const ModulePackage * modulePackage)
 {
     if (pImpl->activatedModules) {
         return pImpl->activatedModules->has(modulePackage->getId());
@@ -925,13 +925,13 @@ bool ModulePackageContainer::isModuleActive(ModulePackagePtr modulePackage)
     return false;
 }
 
-std::vector<ModulePackagePtr> ModulePackageContainer::getModulePackages()
+std::vector<ModulePackage *> ModulePackageContainer::getModulePackages()
 {
-    std::vector<ModulePackagePtr> values;
-    auto modules = pImpl->modules;
+    std::vector<ModulePackage *> values;
+    const auto & modules = pImpl->modules;
     std::transform(
         std::begin(modules), std::end(modules), std::back_inserter(values),
-        [](const std::map<Id, ModulePackagePtr>::value_type &pair){ return pair.second; });
+        [](const std::map<Id, std::unique_ptr<ModulePackage>>::value_type & pair){ return pair.second.get(); });
 
     return values;
 }

--- a/libdnf/module/ModulePackageContainer.hpp
+++ b/libdnf/module/ModulePackageContainer.hpp
@@ -106,12 +106,12 @@ public:
     /**
     * @brief Can throw std::out_of_range exception
     */
-    ModulePackagePtr getModulePackage(Id id);
-    std::vector<ModulePackagePtr> getModulePackages();
-    std::vector<std::vector<std::vector<ModulePackagePtr>>> getLatestModulesPerRepo(
-        ModuleState moduleFilter, std::vector<ModulePackagePtr> modulePackages);
+    ModulePackage * getModulePackage(Id id);
+    std::vector<ModulePackage *> getModulePackages();
+    std::vector<std::vector<std::vector<ModulePackage *>>> getLatestModulesPerRepo(
+        ModuleState moduleFilter, std::vector<ModulePackage *> modulePackages);
 
-    std::vector<ModulePackagePtr> requiresModuleEnablement(const libdnf::PackageSet & packages);
+    std::vector<ModulePackage *> requiresModuleEnablement(const libdnf::PackageSet & packages);
 
     /**
     * @brief Enable module stream. Return true if requested change realy triggers a change in
@@ -131,27 +131,27 @@ public:
     *
     * @return bool
     */
-    bool enable(const ModulePackagePtr &module);
+    bool enable(const ModulePackage * module);
     /**
      * @brief unmark module 'name' from any streams
      */
     void disable(const std::string & name);
-    void disable(const ModulePackagePtr &module);
+    void disable(const ModulePackage * module);
     /**
      * @brief Reset module state so it's no longer enabled or disabled.
      */
     void reset(const std::string &name);
-    void reset(const ModulePackagePtr &module);
+    void reset(const ModulePackage * module);
     /**
      * @brief add profile to name:stream
      */
     void install(const std::string &name, const std::string &stream, const std::string &profile);
-    void install(const ModulePackagePtr &module, const std::string &profile);
+    void install(const ModulePackage * module, const std::string &profile);
     /**
      * @brief remove profile from name:stream
      */
     void uninstall(const std::string &name, const std::string &stream, const std::string &profile);
-    void uninstall(const ModulePackagePtr &module, const std::string &profile);
+    void uninstall(const ModulePackage * module, const std::string &profile);
     /**
      * @brief commit module changes to storage
      */
@@ -166,10 +166,10 @@ public:
     bool isChanged();
 
     bool isEnabled(const std::string &name, const std::string &stream);
-    bool isEnabled(const ModulePackagePtr &module);
+    bool isEnabled(const ModulePackage * module);
 
     bool isDisabled(const std::string &name);
-    bool isDisabled(const ModulePackagePtr &module);
+    bool isDisabled(const ModulePackage * module);
     ModuleState getModuleState(const std::string & name);
     std::set<std::string> getInstalledPkgNames();
 
@@ -223,20 +223,20 @@ public:
     * @brief Query modules according libdnf::Nsvcap. But the search ignores profiles
     *
     */
-    std::vector<ModulePackagePtr> query(libdnf::Nsvcap & moduleNevra);
+    std::vector<ModulePackage *> query(libdnf::Nsvcap & moduleNevra);
     /**
     * @brief Requiers subject in format <name>, <name>:<stream>, or <name>:<stream>:<version>
     *
     * @param subject p_subject:...
     * @return std::vector< std::shared_ptr< ModulePackage > >
     */
-    std::vector<ModulePackagePtr> query(std::string subject);
-    std::vector<ModulePackagePtr> query(std::string name, std::string stream,
+    std::vector<ModulePackage *> query(std::string subject);
+    std::vector<ModulePackage *> query(std::string name, std::string stream,
         std::string version, std::string context, std::string arch);
-    void enableDependencyTree(std::vector<ModulePackagePtr> & modulePackages);
+    void enableDependencyTree(std::vector<ModulePackage *> & modulePackages);
     std::pair<std::vector<std::vector<std::string>>, ModulePackageContainer::ModuleErrorType> resolveActiveModulePackages(bool debugSolver);
     bool isModuleActive(Id id);
-    bool isModuleActive(ModulePackagePtr modulePackage);
+    bool isModuleActive(const ModulePackage * modulePackage);
 
 private:
     class Impl;

--- a/libdnf/module/modulemd/ModuleDependencies.cpp
+++ b/libdnf/module/modulemd/ModuleDependencies.cpp
@@ -25,7 +25,7 @@ ModuleDependencies::ModuleDependencies(ModulemdDependencies *dependencies)
         : dependencies(dependencies)
 {}
 
-std::vector <std::map<std::string, std::vector<std::string>>> ModuleDependencies::getRequires()
+std::vector <std::map<std::string, std::vector<std::string>>> ModuleDependencies::getRequires() const
 {
     auto cRequires = modulemd_dependencies_peek_requires(dependencies);
     return getRequirements(cRequires);

--- a/libdnf/module/modulemd/ModuleDependencies.hpp
+++ b/libdnf/module/modulemd/ModuleDependencies.hpp
@@ -34,7 +34,7 @@ class ModuleDependencies
 public:
     explicit ModuleDependencies(ModulemdDependencies *dependencies);
 
-    std::vector<std::map<std::string, std::vector<std::string> > > getRequires();
+    std::vector<std::map<std::string, std::vector<std::string> > > getRequires() const;
 
 private:
     std::map<std::string, std::vector<std::string>> wrapModuleDependencies(const char *moduleName, ModulemdSimpleSet *streams) const;

--- a/libdnf/module/modulemd/ModuleMetadata.hpp
+++ b/libdnf/module/modulemd/ModuleMetadata.hpp
@@ -31,13 +31,23 @@
 
 class ModuleProfile;
 
+namespace std {
+
+template<>
+struct default_delete<ModulemdModule> {
+    void operator()(ModulemdModule * ptr) noexcept { g_object_unref(ptr); }
+};
+
+}
+
 class ModuleMetadata
 {
 public:
-    static std::vector<std::shared_ptr<ModuleMetadata> > metadataFromString(const std::string &fileContent);
+    static std::vector<ModuleMetadata> metadataFromString(const std::string &fileContent);
 
 public:
-    explicit ModuleMetadata(const std::shared_ptr<ModulemdModule> &modulemd);
+    explicit ModuleMetadata(std::unique_ptr<ModulemdModule> && modulemd);
+    ModuleMetadata(ModuleMetadata && src) = default;
     ~ModuleMetadata();
     const char * getName() const;
     const char * getStream() const;
@@ -46,15 +56,15 @@ public:
     const char * getArchitecture() const;
     std::string getDescription() const;
     std::string getSummary() const;
-    std::vector<std::shared_ptr<ModuleDependencies> > getDependencies() const;
+    std::vector<ModuleDependencies> getDependencies() const;
     std::vector<std::string> getArtifacts() const;
     std::vector<ModuleProfile> getProfiles(const std::string & profileName = "") const;
     std::string getYaml() const;
 
 private:
-    static std::vector<std::shared_ptr<ModuleMetadata> > wrapModulemdModule(GPtrArray *data);
+    static std::vector<ModuleMetadata> wrapModulemdModule(GPtrArray *data);
 
-    std::shared_ptr<ModulemdModule> modulemd;
+    std::unique_ptr<ModulemdModule> modulemd;
     static void reportFailures(const GPtrArray *failures);
 };
 

--- a/tests/libdnf/module/ContextTest.cpp
+++ b/tests/libdnf/module/ContextTest.cpp
@@ -68,13 +68,13 @@ void ContextTest::testLoadModules()
     auto modules = ModuleMetadata::metadataFromString(yamlContent);
     for (const auto &module : modules) {
         // default module:stream
-        if ((g_strcmp0(module->getName(), "httpd") == 0) &&
-            (g_strcmp0(module->getStream(), "2.4") == 0))
+        if ((g_strcmp0(module.getName(), "httpd") == 0) &&
+            (g_strcmp0(module.getStream(), "2.4") == 0))
             sackHas(sack, module);
 
         // disabled stream
-        if ((g_strcmp0(module->getName(), "httpd") == 0) &&
-            (g_strcmp0(module->getStream(), "2.2") == 0))
+        if ((g_strcmp0(module.getName(), "httpd") == 0) &&
+            (g_strcmp0(module.getStream(), "2.2") == 0))
             sackHasNot(sack, module);
     }
 
@@ -122,10 +122,10 @@ void ContextTest::testLoadModules()
     }
 }
 
-void ContextTest::sackHas(DnfSack *sack, const std::shared_ptr<ModuleMetadata> &module) const
+void ContextTest::sackHas(DnfSack * sack, const ModuleMetadata & module) const
 {
     libdnf::Query query{sack};
-    auto artifacts = module->getArtifacts();
+    auto artifacts = module.getArtifacts();
     for (auto artifact : artifacts) {
         artifact = artifact.replace(artifact.find("-0:"), 3, "-");
         query.addFilter(HY_PKG_NEVRA_STRICT, HY_EQ, artifact.c_str());
@@ -140,10 +140,10 @@ void ContextTest::sackHas(DnfSack *sack, const std::shared_ptr<ModuleMetadata> &
     }
 }
 
-void ContextTest::sackHasNot(DnfSack *sack, const std::shared_ptr<ModuleMetadata> &module) const
+void ContextTest::sackHasNot(DnfSack * sack, const ModuleMetadata & module) const
 {
     libdnf::Query query{sack};
-    auto artifacts = module->getArtifacts();
+    auto artifacts = module.getArtifacts();
     for (auto artifact : artifacts) {
         artifact = artifact.replace(artifact.find("-0:"), 3, "-");
         query.addFilter(HY_PKG_NEVRA_STRICT, HY_EQ, artifact.c_str());

--- a/tests/libdnf/module/ContextTest.hpp
+++ b/tests/libdnf/module/ContextTest.hpp
@@ -20,8 +20,8 @@ public:
 
 private:
     DnfContext *context;
-    void sackHas(DnfSack *sack, const std::shared_ptr<ModuleMetadata> &module) const;
-    void sackHasNot(DnfSack *sack, const std::shared_ptr<ModuleMetadata> &module) const;
+    void sackHas(DnfSack *sack, const ModuleMetadata & module) const;
+    void sackHasNot(DnfSack *sack, const ModuleMetadata & module) const;
 };
 
 #endif //LIBDNF_CONTEXTTEST_HPP


### PR DESCRIPTION
All usage of std::share_ptr was removed from modularity code.
We know who is owner of the data. We do not need sharing.

Moreover:
SWIG does not have support for wrapping of std::shared_ptr type to some languages now.
The std::shared_ptr costs some overhead.