### PR TITLE
include missing <string> and errno.h headers

### DIFF
--- a/libdnf/conf/ConfigParser.hpp
+++ b/libdnf/conf/ConfigParser.hpp
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace libdnf {

--- a/libdnf/module/modulemd/ModuleProfile.hpp
+++ b/libdnf/module/modulemd/ModuleProfile.hpp
@@ -23,6 +23,7 @@
 
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <modulemd/modulemd.h>

--- a/libdnf/sack/changelog.hpp
+++ b/libdnf/sack/changelog.hpp
@@ -23,6 +23,7 @@
 #define __CHANGELOG_HPP
 
 #include <ctime>
+#include <string>
 
 namespace libdnf {
 

--- a/libdnf/utils/smartcols/Cell.hpp
+++ b/libdnf/utils/smartcols/Cell.hpp
@@ -22,6 +22,7 @@
 #define LIBDNF_CELL_HPP
 
 #include <libsmartcols/libsmartcols.h>
+#include <cerrno>
 #include <string>
 #include <stdexcept>
 


### PR DESCRIPTION
This is unearthed when compiling with clang/libc++

Signed-off-by: Khem Raj <raj.khem@gmail.com>