### PR TITLE
Exclude module pkgs that have conflict

### DIFF
--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -518,6 +518,10 @@ ModulePackageContainer::Impl::moduleSolve(const std::vector<ModulePackagePtr> & 
         problems = goal.describeAllProblemRules(false);
         ret = goal.run(DNF_NONE);
         if (ret) {
+            // Conflicting modules has to be removed otherwice it could result than one of them will
+            // be active
+            auto conflictingPkgs = goal.listConflictPkgs(DNF_PACKAGE_STATE_AVAILABLE);
+            dnf_sack_add_excludes(moduleSack, conflictingPkgs.get());
             ret = goalWeak.run(DNF_NONE);
             if (ret) {
                 auto logger(libdnf::Log::getLogger());


### PR DESCRIPTION
It is important to prevent solver to use one of the conflicting modules,
because it could result in switching enabled module to required stream
by other modular package. The original behavior is also unpredictable,
and user have no full control on package content.

https://bugzilla.redhat.com/show_bug.cgi?id=1670496