### PR TITLE
Remove unneeded "libdnf::" namespace prefix

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -191,7 +191,7 @@ libdnf_problemruleinfo2str(Solver *solv, SolverRuleinfo type, Id source, Id targ
 static void
 packageToJob(DnfPackage * package, Queue * job, int solver_action)
 {
-    libdnf::IdQueue pkgs;
+    IdQueue pkgs;
 
     Pool *pool = dnf_package_get_pool(package);
     DnfSack *sack = dnf_package_get_sack(package);
@@ -215,7 +215,7 @@ jobHas(Queue *job, Id what, Id id)
 }
 
 static int
-filterArchToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
+filterArchToJob(DnfSack *sack, const Filter *f, Queue *job)
 {
     if (!f)
         return 0;
@@ -246,7 +246,7 @@ filterArchToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
 }
 
 static int
-filterEvrToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
+filterEvrToJob(DnfSack *sack, const Filter *f, Queue *job)
 {
     if (!f)
         return 0;
@@ -274,7 +274,7 @@ filterEvrToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
 }
 
 static int
-filterFileToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
+filterFileToJob(DnfSack *sack, const Filter *f, Queue *job)
 {
     if (!f)
         return 0;
@@ -306,7 +306,7 @@ filterPkgToJob(Id what, Queue *job)
 }
 
 static int
-filterNameToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
+filterNameToJob(DnfSack *sack, const Filter *f, Queue *job)
 {
     if (!f)
         return 0;
@@ -344,7 +344,7 @@ filterNameToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
 }
 
 static int
-filterProvidesToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
+filterProvidesToJob(DnfSack *sack, const Filter *f, Queue *job)
 {
     if (!f)
         return 0;
@@ -381,7 +381,7 @@ filterProvidesToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
 }
 
 static int
-filterReponameToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
+filterReponameToJob(DnfSack *sack, const Filter *f, Queue *job)
 {
     Id i;
     Repo *repo;
@@ -397,7 +397,7 @@ filterReponameToJob(DnfSack *sack, const libdnf::Filter *f, Queue *job)
         return MULTIPLE_MATCH_OBJECTS;
     }
 
-    libdnf::IdQueue repo_sel;
+    IdQueue repo_sel;
     Pool *pool = dnf_sack_get_pool(sack);
     FOR_REPOS(i, repo)
         if (!strcmp(matches[0].str, repo->name)) {
@@ -425,12 +425,12 @@ sltrToJob(const HySelector sltr, Queue *job, int solver_action)
     int any_req_filter = sltr->getFilterName() || sltr->getFilterProvides()
         || sltr->getFilterFile() || sltr->getPkgs();
 
-    libdnf::IdQueue job_sltr;
+    IdQueue job_sltr;
 
     if (!any_req_filter) {
         if (any_opt_filter) {
             // no name or provides or file in the selector is an error
-            throw libdnf::Goal::Exception("Ill-formed Selector. No name or"
+            throw Goal::Exception("Ill-formed Selector. No name or"
                 "provides or file in the selector.", DNF_ERROR_BAD_SELECTOR);
         }
         goto finish;
@@ -465,7 +465,7 @@ sltrToJob(const HySelector sltr, Queue *job, int solver_action)
 
  finish:
     if (ret > 1) {
-        throw libdnf::Goal::Exception(TM_(ERROR_DICT[ret], 1), DNF_ERROR_BAD_SELECTOR);
+        throw Goal::Exception(TM_(ERROR_DICT[ret], 1), DNF_ERROR_BAD_SELECTOR);
     }
 }
 

--- a/libdnf/goal/Goal.hpp
+++ b/libdnf/goal/Goal.hpp
@@ -122,15 +122,15 @@ public:
     void writeDebugdata(const char *dir);
 
     /* result processing */
-    libdnf::PackageSet listErasures();
-    libdnf::PackageSet listInstalls();
-    libdnf::PackageSet listObsoleted();
-    libdnf::PackageSet listReinstalls();
-    libdnf::PackageSet listUnneeded();
-    libdnf::PackageSet listSuggested();
-    libdnf::PackageSet listUpgrades();
-    libdnf::PackageSet listDowngrades();
-    libdnf::PackageSet listObsoletedByPackage(DnfPackage * pkg);
+    PackageSet listErasures();
+    PackageSet listInstalls();
+    PackageSet listObsoleted();
+    PackageSet listReinstalls();
+    PackageSet listUnneeded();
+    PackageSet listSuggested();
+    PackageSet listUpgrades();
+    PackageSet listDowngrades();
+    PackageSet listObsoletedByPackage(DnfPackage * pkg);
 
 private:
     friend Query;

--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -337,7 +337,7 @@ void ModulePackage::addStreamConflict(const ModulePackage * package)
 
 static std::pair<std::string, std::string> getPlatformStream(const std::string &osReleasePath)
 {
-    auto file = libdnf::File::newFile(osReleasePath);
+    auto file = File::newFile(osReleasePath);
     file->open("r");
     std::string line;
     while (file->readLine(line)) {

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -536,7 +536,7 @@ std::string Repo::getMetadataContent(const std::string &metadataType)
     auto path = getMetadataPath(metadataType);
     if (path.empty()) return "";
 
-    auto mdfile = libdnf::File::newFile(path);
+    auto mdfile = File::newFile(path);
     mdfile->open("r");
     const auto &content = mdfile->getContent();
     mdfile->close();

--- a/libdnf/repo/solvable/Dependency.cpp
+++ b/libdnf/repo/solvable/Dependency.cpp
@@ -98,7 +98,7 @@ Dependency::getReldepId(DnfSack *sack, const char * reldepStr)
             throw std::runtime_error("Cannot parse a dependency string");
         return id;
     } else {
-        libdnf::DependencySplitter depSplitter;
+        DependencySplitter depSplitter;
         if(!depSplitter.parse(reldepStr))
             throw std::runtime_error("Cannot parse a dependency string");
         return getReldepId(sack, depSplitter.getNameCStr(), depSplitter.getEVRCStr(),

--- a/libdnf/repo/solvable/DependencyContainer.cpp
+++ b/libdnf/repo/solvable/DependencyContainer.cpp
@@ -87,7 +87,7 @@ void DependencyContainer::add(Id id)
 
 bool DependencyContainer::addReldepWithGlob(const char *reldepStr)
 {
-    libdnf::DependencySplitter depSplitter;
+    DependencySplitter depSplitter;
     if(!depSplitter.parse(reldepStr))
         return false;
     Dataiterator di;

--- a/libdnf/repo/solvable/Package.cpp
+++ b/libdnf/repo/solvable/Package.cpp
@@ -86,92 +86,92 @@ Id Package::getId() const
     return id;
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getConflicts() const
+std::shared_ptr<DependencyContainer> Package::getConflicts() const
 {
     return getDependencies(SOLVABLE_CONFLICTS);
 };
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getEnhances() const
+std::shared_ptr<DependencyContainer> Package::getEnhances() const
 {
     return getDependencies(SOLVABLE_ENHANCES);
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getObsoletes() const
+std::shared_ptr<DependencyContainer> Package::getObsoletes() const
 {
     return getDependencies(SOLVABLE_OBSOLETES);
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getProvides() const
+std::shared_ptr<DependencyContainer> Package::getProvides() const
 {
     return getDependencies(SOLVABLE_PROVIDES);
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getRecommends() const
+std::shared_ptr<DependencyContainer> Package::getRecommends() const
 {
     return getDependencies(SOLVABLE_RECOMMENDS);
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getRequires() const
+std::shared_ptr<DependencyContainer> Package::getRequires() const
 {
     return getDependencies(SOLVABLE_REQUIRES, 0);
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getRequiresPre() const
+std::shared_ptr<DependencyContainer> Package::getRequiresPre() const
 {
     return getDependencies(SOLVABLE_REQUIRES, 1);
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getSuggests() const
+std::shared_ptr<DependencyContainer> Package::getSuggests() const
 {
     return getDependencies(SOLVABLE_SUGGESTS);
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getSupplements() const
+std::shared_ptr<DependencyContainer> Package::getSupplements() const
 {
     return getDependencies(SOLVABLE_SUPPLEMENTS);
 }
 
-void Package::addConflicts(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addConflicts(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_CONFLICTS);
 }
 
-void Package::addEnhances(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addEnhances(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_ENHANCES);
 }
 
-void Package::addObsoletes(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addObsoletes(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_OBSOLETES);
 }
 
-void Package::addProvides(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addProvides(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_PROVIDES);
 }
 
-void Package::addRecommends(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addRecommends(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_RECOMMENDS);
 }
 
-void Package::addRequires(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addRequires(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_REQUIRES, 0);
 }
 
-void Package::addRequiresPre(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addRequiresPre(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_REQUIRES, 1);
 }
 
-void Package::addSuggests(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addSuggests(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_SUGGESTS);
 }
 
-void Package::addSupplements(std::shared_ptr<libdnf::Dependency> dependency)
+void Package::addSupplements(std::shared_ptr<Dependency> dependency)
 {
     addDependency(std::move(dependency), SOLVABLE_SUPPLEMENTS);
 }
@@ -191,10 +191,10 @@ void Package::fillSolvableData(const char *name, const char *version,
     solvable_set_str(solvable, SOLVABLE_ARCH, arch);
 }
 
-std::shared_ptr<libdnf::DependencyContainer> Package::getDependencies(Id type, Id marker) const
+std::shared_ptr<DependencyContainer> Package::getDependencies(Id type, Id marker) const
 {
     auto queue = getDependencyQueue(type, marker);
-    auto container = std::make_shared<libdnf::DependencyContainer>(sack, *queue);
+    auto container = std::make_shared<DependencyContainer>(sack, *queue);
 
     queue_free(queue);
     delete queue;
@@ -223,7 +223,7 @@ Queue *Package::getDependencyQueue(Id type, Id marker) const
     return queue;
 }
 
-void Package::addDependency(std::shared_ptr<libdnf::Dependency> dependency, int type, Id marker)
+void Package::addDependency(std::shared_ptr<Dependency> dependency, int type, Id marker)
 {
     Solvable *solvable = pool_id2solvable(dnf_sack_get_pool(sack), id);
     solvable_add_deparray(solvable, type, dependency->getId(), marker);

--- a/libdnf/repo/solvable/Package.hpp
+++ b/libdnf/repo/solvable/Package.hpp
@@ -20,15 +20,15 @@ public:
     Package(const Package &package);
     virtual ~Package();
 
-    std::shared_ptr<libdnf::DependencyContainer> getConflicts() const;
-    std::shared_ptr<libdnf::DependencyContainer> getEnhances() const;
-    std::shared_ptr<libdnf::DependencyContainer> getObsoletes() const;
-    std::shared_ptr<libdnf::DependencyContainer> getProvides() const;
-    std::shared_ptr<libdnf::DependencyContainer> getRecommends() const;
-    std::shared_ptr<libdnf::DependencyContainer> getRequires() const;
-    std::shared_ptr<libdnf::DependencyContainer> getRequiresPre() const;
-    std::shared_ptr<libdnf::DependencyContainer> getSuggests() const;
-    std::shared_ptr<libdnf::DependencyContainer> getSupplements() const;
+    std::shared_ptr<DependencyContainer> getConflicts() const;
+    std::shared_ptr<DependencyContainer> getEnhances() const;
+    std::shared_ptr<DependencyContainer> getObsoletes() const;
+    std::shared_ptr<DependencyContainer> getProvides() const;
+    std::shared_ptr<DependencyContainer> getRecommends() const;
+    std::shared_ptr<DependencyContainer> getRequires() const;
+    std::shared_ptr<DependencyContainer> getRequiresPre() const;
+    std::shared_ptr<DependencyContainer> getSuggests() const;
+    std::shared_ptr<DependencyContainer> getSupplements() const;
     Id getId() const;
 
     virtual const char *getName() const = 0;
@@ -39,15 +39,15 @@ protected:
     Package(DnfSack *sack, HyRepo repo, const char *name, const char *version, const char *arch, bool createSolvable = true);
     Package(DnfSack *sack, HyRepo repo, const std::string &name, const std::string &version, const std::string &arch, bool createSolvable = true);
 
-    void addConflicts(std::shared_ptr<libdnf::Dependency> dependency);
-    void addEnhances(std::shared_ptr<libdnf::Dependency> dependency);
-    void addObsoletes(std::shared_ptr<libdnf::Dependency> dependency);
-    void addProvides(std::shared_ptr<libdnf::Dependency> dependency);
-    void addRecommends(std::shared_ptr<libdnf::Dependency> dependency);
-    void addRequires(std::shared_ptr<libdnf::Dependency> dependency);
-    void addRequiresPre(std::shared_ptr<libdnf::Dependency> dependency);
-    void addSuggests(std::shared_ptr<libdnf::Dependency> dependency);
-    void addSupplements(std::shared_ptr<libdnf::Dependency> dependency);
+    void addConflicts(std::shared_ptr<Dependency> dependency);
+    void addEnhances(std::shared_ptr<Dependency> dependency);
+    void addObsoletes(std::shared_ptr<Dependency> dependency);
+    void addProvides(std::shared_ptr<Dependency> dependency);
+    void addRecommends(std::shared_ptr<Dependency> dependency);
+    void addRequires(std::shared_ptr<Dependency> dependency);
+    void addRequiresPre(std::shared_ptr<Dependency> dependency);
+    void addSuggests(std::shared_ptr<Dependency> dependency);
+    void addSupplements(std::shared_ptr<Dependency> dependency);
 
     const char *getSolvableName() const;
     const char *getSolvableEvr() const;
@@ -57,8 +57,8 @@ protected:
 private:
     void createSolvable(HyRepo repo);
     void fillSolvableData(const char *name, const char *version, const char *arch) const;
-    std::shared_ptr<libdnf::DependencyContainer> getDependencies(Id type, Id marker = -1) const;
-    void addDependency(std::shared_ptr<libdnf::Dependency> dependency, int type, Id marker = -1);
+    std::shared_ptr<DependencyContainer> getDependencies(Id type, Id marker = -1) const;
+    void addDependency(std::shared_ptr<Dependency> dependency, int type, Id marker = -1);
     Queue *getDependencyQueue(Id type, Id marker) const;
 
     DnfSack *sack;

--- a/libdnf/sack/query.cpp
+++ b/libdnf/sack/query.cpp
@@ -553,7 +553,7 @@ Filter::Filter(int keyname, int cmp_type, const DnfPackageSet *pset) : pImpl(new
     pImpl->cmpType = cmp_type;
     pImpl->matchType = _HY_PKG;
     _Match match_in;
-    match_in.pset = new libdnf::PackageSet(*pset);
+    match_in.pset = new PackageSet(*pset);
     pImpl->matches.push_back(match_in);
 }
 Filter::Filter(int keyname, int cmp_type, const Dependency * reldep) : pImpl(new Impl)
@@ -2005,13 +2005,13 @@ Query::filterDuplicated()
 }
 
 int
-Query::filterUnneeded(const libdnf::Swdb &swdb, bool debug_solver)
+Query::filterUnneeded(const Swdb &swdb, bool debug_solver)
 {
     apply();
     DnfSack * sack = pImpl->sack;
-    libdnf::Goal goal(sack);
+    Goal goal(sack);
     Pool *pool = dnf_sack_get_pool(sack);
-    libdnf::Query installed(sack);
+    Query installed(sack);
     installed.addFilter(HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
     auto userInstalled = installed.getResultPset();
 
@@ -2089,14 +2089,14 @@ Query::getAdvisoryPkgs(int cmpType, std::vector<AdvisoryPkg> & advisoryPkgs)
 }
 
 void
-Query::filterUserInstalled(const libdnf::Swdb &swdb)
+Query::filterUserInstalled(const Swdb &swdb)
 {
     addFilter(HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
     swdb.filterUserinstalled(*getResultPset());
 }
 
 void
-hy_query_to_name_ordered_queue(HyQuery query, libdnf::IdQueue * samename)
+hy_query_to_name_ordered_queue(HyQuery query, IdQueue * samename)
 {
     hy_query_apply(query);
     Pool *pool = dnf_sack_get_pool(query->getSack());
@@ -2106,12 +2106,12 @@ hy_query_to_name_ordered_queue(HyQuery query, libdnf::IdQueue * samename)
         if (MAPTST(result, i))
             samename->pushBack(i);
 
-    solv_sort(samename->data(), samename->size(), sizeof(Id), libdnf::filter_latest_sortcmp,
+    solv_sort(samename->data(), samename->size(), sizeof(Id), filter_latest_sortcmp,
         pool);
 }
 
 void
-hy_query_to_name_arch_ordered_queue(HyQuery query, libdnf::IdQueue * samename)
+hy_query_to_name_arch_ordered_queue(HyQuery query, IdQueue * samename)
 {
     hy_query_apply(query);
     Pool *pool = dnf_sack_get_pool(query->getSack());
@@ -2122,7 +2122,7 @@ hy_query_to_name_arch_ordered_queue(HyQuery query, libdnf::IdQueue * samename)
             samename->pushBack(i);
 
     solv_sort(samename->data(), samename->size(), sizeof(Id),
-        libdnf::filter_latest_sortcmp_byarch, pool);
+        filter_latest_sortcmp_byarch, pool);
 }
 
 }

--- a/libdnf/sack/query.hpp
+++ b/libdnf/sack/query.hpp
@@ -77,7 +77,7 @@ public:
     /**
     * @brief Applies query and returns pointer of PackageSet
     *
-    * @return libdnf::PackageSet*
+    * @return PackageSet*
     */
     PackageSet * getResultPset();
     DnfSack * getSack();
@@ -157,9 +157,9 @@ public:
     void filterExtras();
     void filterRecent(const long unsigned int recent_limit);
     void filterDuplicated();
-    int filterUnneeded(const libdnf::Swdb &swdb, bool debug_solver);
+    int filterUnneeded(const Swdb &swdb, bool debug_solver);
     void getAdvisoryPkgs(int cmpType,  std::vector<AdvisoryPkg> & advisoryPkgs);
-    void filterUserInstalled(const libdnf::Swdb &swdb);
+    void filterUserInstalled(const Swdb &swdb);
 private:
     class Impl;
     std::unique_ptr<Impl> pImpl;

--- a/libdnf/transaction/Swdb.cpp
+++ b/libdnf/transaction/Swdb.cpp
@@ -522,7 +522,7 @@ Swdb::createCompsGroupItem()
  * \return list of user installed package IDs
  */
 void
-Swdb::filterUserinstalled(libdnf::PackageSet & installed) const
+Swdb::filterUserinstalled(PackageSet & installed) const
 {
     Pool * pool = dnf_sack_get_pool(installed.getSack());
 

--- a/libdnf/transaction/Swdb.hpp
+++ b/libdnf/transaction/Swdb.hpp
@@ -116,7 +116,7 @@ public:
     /**
     * @brief Remove packages from PackageSet that were installed as Dependency or WEAK_DEPENDENCY
     */
-    void filterUserinstalled(libdnf::PackageSet & installed) const;
+    void filterUserinstalled(PackageSet & installed) const;
 
 protected:
     friend class Transformer;

--- a/libdnf/utils/CompressedFile.hpp
+++ b/libdnf/utils/CompressedFile.hpp
@@ -5,7 +5,7 @@
 
 namespace libdnf {
 
-class CompressedFile : public libdnf::File
+class CompressedFile : public File
 {
 public:
     explicit CompressedFile(const std::string &filePath);


### PR DESCRIPTION
Using "libdnf::" prefix is not needed in the "libdnf" namespace.