### PR TITLE
Fix issue in call of a metadata object that was moved

### DIFF
--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -78,8 +78,7 @@ ModulePackage::ModulePackage(DnfSack * moduleSack, Repo * repo,
     id = repo_add_solvable(repo);
     Solvable *solvable = pool_id2solvable(pool, id);
 
-    setSovable(pool, solvable, getName(), getStream(), getVersion(), getContext(),
-        metadata.getArchitecture());
+    setSovable(pool, solvable, getName(), getStream(), getVersion(), getContext(), getArchCStr());
     createDependencies(solvable);
     HyRepo hyRepo = static_cast<HyRepo>(repo->appdata);
     hyRepo->needs_internalizing = 1;


### PR DESCRIPTION
The issue resulted in:
(process:13072): libmodulemd-CRITICAL **: 08:59:18.233:
modulemd_module_peek_arch: assertion 'MODULEMD_IS_MODULE (self)' failed