### PR TITLE
Add error propagation because packageset_to_pylist can return NULL (RhBug:1610456)

### DIFF
--- a/python/hawkey/query-py.cpp
+++ b/python/hawkey/query-py.cpp
@@ -826,6 +826,8 @@ query_iter(PyObject *self)
 {
     const DnfPackageSet * pset = ((_QueryObject *) self)->query->runSet();
     UniquePtrPyObject list(packageset_to_pylist(pset, ((_QueryObject *) self)->sack));
+    if (!list)
+        return NULL;
     PyObject *iter = PyObject_GetIter(list.get());
     Py_INCREF(iter);
     return iter;


### PR DESCRIPTION
When SIGINT happens in packageset_to_pylist additional calls into
the Python/C API return NULL/-1 we have to check for that here
in order to avoid segfault.