### PR TITLE
DnfContext: fix `dnf_context_remove` filters

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -2060,9 +2060,7 @@ dnf_context_remove(DnfContext *context, const gchar *name, GError **error)
 
     /* find installed packages to remove */
     query = hy_query_create(priv->sack);
-    hy_query_filter_latest_per_arch(query, TRUE);
     hy_query_filter(query, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-    hy_query_filter(query, HY_PKG_ARCH, HY_NEQ, "src");
     hy_query_filter(query, HY_PKG_NAME, HY_EQ, name);
     pkglist = hy_query_run(query);
 


### PR DESCRIPTION
When removing packages, it doesn't make a lot of sense to use
`filter_latest_per_arch()`: we want to remove a package from the system,
regardless of how old it is.

This issue surfaced while working on rebasing rpm-ostree to use libdnf
git master. At some point between the current snapshot of libdnf we use
and master, the way queries are implemented changed such that the issue
here becomes obvious: the filter from `hy_query_filter_latest_per_arch`
is applied *before* the one from `REPONAME == @System`, which meant that
one couldn't remove a package from the system for which a new version
was available in the yum repos since the first filter would cause the
installed version to drop out of the `Map`.

Also remove the `ARCH != src` filter since it's impossible to install
src packages in the first place in a way that they'd be removable.