### PR TITLE
Store information if platform module was generated

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -31,7 +31,7 @@
     %{nil}
 
 Name:           libdnf
-Version:        0.28.0
+Version:        0.29.0
 Release:        1%{?dist}
 Summary:        Library providing simplified C and Python API to libsolv
 License:        LGPLv2+

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -117,6 +117,7 @@ private:
     std::string installRoot;
     ModuleDefaultsContainer defaultConteiner;
     std::map<std::string, std::string> moduleDefaults;
+    bool platformAdded{false};
 };
 
 class ModulePackageContainer::Impl::ModulePersistor {
@@ -265,8 +266,10 @@ Id
 ModulePackageContainer::addPlatformPackage(const std::string& osReleasePath,
     const char* platformModule)
 {
-    return ModulePackage::createPlatformSolvable(pImpl->moduleSack, osReleasePath,
+    auto id = ModulePackage::createPlatformSolvable(pImpl->moduleSack, osReleasePath,
         pImpl->installRoot, platformModule);
+    pImpl->platformAdded = true;
+    return id;
 }
 
 void ModulePackageContainer::createConflictsBetweenStreams()
@@ -355,6 +358,11 @@ bool ModulePackageContainer::isDisabled(const std::string &name)
 bool ModulePackageContainer::isDisabled(const ModulePackage * module)
 {
     return isDisabled(module->getName());
+}
+
+bool ModulePackageContainer::isPlatformPresent() const noexcept
+{
+    return pImpl->platformAdded;
 }
 
 std::vector<std::string> ModulePackageContainer::getDefaultProfiles(std::string moduleName,

--- a/libdnf/module/ModulePackageContainer.hpp
+++ b/libdnf/module/ModulePackageContainer.hpp
@@ -172,6 +172,14 @@ public:
 
     bool isDisabled(const std::string &name);
     bool isDisabled(const ModulePackage * module);
+
+    /**
+     * @brief Report whether a platform module was added to ModulePackageContainer.
+     *
+     * @return bool true if the platform module was added
+     */
+    bool isPlatformPresent() const noexcept;
+
     ModuleState getModuleState(const std::string & name);
     std::set<std::string> getInstalledPkgNames();
 


### PR DESCRIPTION
This is important to provide a proper hint in DNF how to setup the
platform module manually.