### PR TITLE
Add a new filter _safe_to_remove for query

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -31,7 +31,7 @@
     %{nil}
 
 Name:           libdnf
-Version:        0.29.0
+Version:        0.30.0
 Release:        1%{?dist}
 Summary:        Library providing simplified C and Python API to libsolv
 License:        LGPLv2+

--- a/libdnf/hy-query-private.hpp
+++ b/libdnf/hy-query-private.hpp
@@ -39,8 +39,6 @@ enum _match_type {
     _HY_STR,
 };
 
-int hy_filter_unneeded(HyQuery query, const libdnf::Swdb &swdb, bool debug_solver);
-
 namespace libdnf {
 void hy_query_to_name_ordered_queue(HyQuery query, libdnf::IdQueue * samename);
 void hy_query_to_name_arch_ordered_queue(HyQuery query, libdnf::IdQueue * samename);

--- a/libdnf/hy-query.cpp
+++ b/libdnf/hy-query.cpp
@@ -315,12 +315,6 @@ hy_filter_duplicated(HyQuery query)
     query->filterDuplicated();
 }
 
-int
-hy_filter_unneeded(HyQuery query, const libdnf::Swdb & swdb, bool debug_solver)
-{
-    return query->filterUnneeded(swdb, debug_solver);
-}
-
 HySelector
 hy_query_to_selector(HyQuery query)
 {

--- a/libdnf/sack/query.hpp
+++ b/libdnf/sack/query.hpp
@@ -158,6 +158,7 @@ public:
     void filterRecent(const long unsigned int recent_limit);
     void filterDuplicated();
     int filterUnneeded(const Swdb &swdb, bool debug_solver);
+    int filterSafeToRemove(const Swdb &swdb, bool debug_solver);
     void getAdvisoryPkgs(int cmpType,  std::vector<AdvisoryPkg> & advisoryPkgs);
     void filterUserInstalled(const Swdb &swdb);
 private:


### PR DESCRIPTION
The filter is similar to unneeded. It can be used to ensure that
packages do not have any dependent packages.