### PR TITLE
Add a debug argument to Librepolog::addHandler

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -31,7 +31,7 @@
     %{nil}
 
 Name:           libdnf
-Version:        0.31.0
+Version:        0.32.0
 Release:        1%{?dist}
 Summary:        Library providing simplified C and Python API to libsolv
 License:        LGPLv2+

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -1724,7 +1724,7 @@ static void librepoLogCB(G_GNUC_UNUSED const gchar *log_domain, GLogLevelFlags l
     }
 }
 
-long LibrepoLog::addHandler(const std::string & filePath)
+long LibrepoLog::addHandler(const std::string & filePath, bool debug)
 {
     static long uid = 0;
 
@@ -1739,7 +1739,14 @@ long LibrepoLog::addHandler(const std::string & filePath)
     data->fd = fd;
 
     // Set handler
-    data->handlerId = g_log_set_handler(LR_LOGDOMAIN, G_LOG_LEVEL_MASK, librepoLogCB, data.get());
+    GLogLevelFlags log_mask = debug ? G_LOG_LEVEL_MASK : static_cast<GLogLevelFlags>(
+        G_LOG_LEVEL_INFO |
+        G_LOG_LEVEL_MESSAGE |
+        G_LOG_LEVEL_WARNING |
+        G_LOG_LEVEL_CRITICAL |
+        G_LOG_LEVEL_ERROR);
+
+    data->handlerId = g_log_set_handler(LR_LOGDOMAIN, log_mask, librepoLogCB, data.get());
     data->used = true;
 
     // Save user data (in a thread safe way)

--- a/libdnf/repo/Repo.hpp
+++ b/libdnf/repo/Repo.hpp
@@ -338,7 +338,7 @@ private:
 
 struct LibrepoLog {
 public:
-    static long addHandler(const std::string & filePath);
+    static long addHandler(const std::string & filePath, bool debug = false);
     static void removeHandler(long uid);
     static void removeAllHandlers();
 };

--- a/python/hawkey/sack-py.hpp
+++ b/python/hawkey/sack-py.hpp
@@ -35,7 +35,7 @@ DnfSack *sackFromPyObject(PyObject *o);
 int sack_converter(PyObject *o, DnfSack **sack_ptr);
 
 PyObject *new_package(PyObject *sack, Id id);
-gboolean set_logfile(const gchar *path, FILE *log_out);
+gboolean set_logfile(const gchar *path, FILE *log_out, bool debug = false);
 const char *log_level_name(int level);
 
 #endif // SACK_PY_H


### PR DESCRIPTION
When set to false (default), only logs messages from INFO up, when true,
logs all the messages, including DEBUG.

The argument having a default means the change is compatible with older
consumers of the API, but the bahaviour will be changed, the debug
messages will not be logged anymore.

https://bugzilla.redhat.com/show_bug.cgi?id=1678598