### PR TITLE
Add support (to microdnf) for xml:base attribute from primary.xml (RhBug:1691315)

### DIFF
--- a/libdnf/dnf-package.cpp
+++ b/libdnf/dnf-package.cpp
@@ -130,6 +130,25 @@ dnf_package_get_filename(DnfPackage *pkg)
         }
     }
 
+    /* remove file:// from filename */
+    if (g_str_has_prefix(priv->filename, "file:///")){
+        gchar *tmp = priv->filename;
+        priv->filename = g_strdup(tmp + 7);
+        g_free(tmp);
+        goto out;
+    }
+
+    /* remove file: from filename */
+    if (strlen(priv->filename) >= 7){
+        if (g_str_has_prefix(priv->filename, "file:/")){
+            if (priv->filename[6] != '/'){
+                gchar *tmp = priv->filename;
+                priv->filename = g_strdup(tmp + 5);
+                g_free(tmp);
+            }
+        }
+    }
+out:
     return priv->filename;
 }
 

--- a/libdnf/dnf-package.cpp
+++ b/libdnf/dnf-package.cpp
@@ -113,7 +113,11 @@ dnf_package_get_filename(DnfPackage *pkg)
     /* default cache filename location */
     if (priv->filename == NULL && priv->repo != NULL) {
         if (dnf_repo_is_local(priv->repo)) {
-            priv->filename = g_build_filename(dnf_repo_get_location(priv->repo),
+            const gchar *url_location = dnf_package_get_baseurl(pkg);
+            if (!url_location){
+                url_location = dnf_repo_get_location(priv->repo);
+            }
+            priv->filename = g_build_filename(url_location,
                                               dnf_package_get_location(pkg),
                                               NULL);
         } else {


### PR DESCRIPTION
xml:base attribute has priority over repository location.

The second commit discards possible file:// protocol from filename, because it doesn't work with it, for example g_file_test(...) can't handle filename with file:// protocol.