### PR TITLE
Support "_none_" value for repo option "proxy" (RhBug:1680272)

### DIFF
--- a/libdnf/conf/ConfigRepo.cpp
+++ b/libdnf/conf/ConfigRepo.cpp
@@ -107,7 +107,19 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & masterConfig)
     );
 
     owner.optBinds().add("fastestmirror", fastestmirror);
-    owner.optBinds().add("proxy", proxy);
+
+    owner.optBinds().add("proxy", proxy,
+        [&](Option::Priority priority, const std::string & value){
+            auto tmpValue(value);
+            for (auto & ch : tmpValue)
+                ch = std::tolower(ch);
+            if (tmpValue == "_none_")
+                proxy.set(priority, "");
+            else
+                proxy.set(priority, value);
+        }, nullptr, false
+    );
+
     owner.optBinds().add("proxy_username", proxy_username);
     owner.optBinds().add("proxy_password", proxy_password);
     owner.optBinds().add("proxy_auth_method", proxy_auth_method);

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1093,9 +1093,9 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
 
     /* proxy is optional */
     proxy = g_key_file_get_string(priv->keyfile, priv->id, "proxy", NULL);
-    if (proxy == NULL)
-        proxy = g_strdup(dnf_context_get_http_proxy(priv->context));
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_PROXY, proxy))
+    auto repoProxy = proxy ? (strcasecmp(proxy, "_none_") == 0 ? NULL : proxy)
+        : dnf_context_get_http_proxy(priv->context);
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_PROXY, repoProxy))
         return FALSE;
 
     /* both parts of the proxy auth are optional */


### PR DESCRIPTION
Value `_none_` is used to disable the global proxy setting
for the repository. The value `_none_` is case insensitive.

This is for YUM compatibility. The libdnf also support empty string for the same usage.