### PR TITLE
Improve detection of Platform ID (RhBug:1688462)

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -2247,7 +2247,8 @@ void readModuleMetadataFromRepo(DnfSack * sack, libdnf::ModulePackageContainer *
         modulePackages->createConflictsBetweenStreams();
         // TODO remove hard-coded path
         try {
-            modulePackages->addPlatformPackage("/etc/os-release", platformModule);
+            std::vector<std::string> paths{"/etc/os-release", "/usr/lib/os-release"};
+            modulePackages->addPlatformPackage(sack, paths, platformModule);
         } catch (const std::exception & except) {
             auto logger(libdnf::Log::getLogger());
             logger->critical("Detection of Platform Module failed: " + std::string(except.what()));

--- a/libdnf/module/ModulePackage.hpp
+++ b/libdnf/module/ModulePackage.hpp
@@ -82,6 +82,9 @@ private:
 
     static Id createPlatformSolvable(DnfSack * moduleSack, const std::string &osReleasePath,
         const std::string install_root, const char *  platformModule);
+    static Id createPlatformSolvable(DnfSack * sack, DnfSack * moduleSack,
+        const std::vector<std::string> & osReleasePaths, const std::string install_root,
+        const char *  platformModule);
     void createDependencies(Solvable *solvable) const;
 
     ModuleMetadata metadata;

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -271,6 +271,15 @@ ModulePackageContainer::addPlatformPackage(const std::string& osReleasePath,
         pImpl->installRoot, platformModule);
 }
 
+Id
+ModulePackageContainer::addPlatformPackage(DnfSack * sack,
+    const std::vector<std::string> & osReleasePath,
+    const char* platformModule)
+{
+    return ModulePackage::createPlatformSolvable(sack, pImpl->moduleSack, osReleasePath,
+        pImpl->installRoot, platformModule);
+}
+
 void ModulePackageContainer::createConflictsBetweenStreams()
 {
     // TODO Use Query for filtering

--- a/libdnf/module/ModulePackageContainer.hpp
+++ b/libdnf/module/ModulePackageContainer.hpp
@@ -96,6 +96,8 @@ public:
     void addDefaultsFromDisk();
     void moduleDefaultsResolve();
     Id addPlatformPackage(const std::string &osReleasePath, const char *  platformModule);
+    Id addPlatformPackage(DnfSack * sack,
+        const std::vector<std::string> & osReleasePath, const char * platformModule);
     void createConflictsBetweenStreams();
 
     /**

--- a/libdnf/sack/query.hpp
+++ b/libdnf/sack/query.hpp
@@ -30,6 +30,8 @@
 #include "../dnf-types.h"
 #include "advisorypkg.hpp"
 
+#include <set>
+
 namespace libdnf {
 
 union _Match {
@@ -161,6 +163,16 @@ public:
     int filterSafeToRemove(const Swdb &swdb, bool debug_solver);
     void getAdvisoryPkgs(int cmpType,  std::vector<AdvisoryPkg> & advisoryPkgs);
     void filterUserInstalled(const Swdb &swdb);
+
+    /**
+     * @brief Apply query and return a set of strings representing information in provide that begin
+     * by patternProvide. For pattern "base-platform" and presence of provide
+     * "base-platform(platform:f26)", the function will return "platform:f26" in set.
+     *
+     * @param patternProvide p_patternProvide: No glob allowed!
+     * @return std::set< std::__cxx11::string >
+     */
+    std::set<std::string> getStringsFromProvide(const char * patternProvide);
 private:
     class Impl;
     std::unique_ptr<Impl> pImpl;


### PR DESCRIPTION
The detection should be performed according to points bellow:
1) Specified at commandline with --setopt
    Always prefer the user's explicit override

2) The virtual Provides from the latest `os-release` package in the
enabled repos.
    This will deal with upgrades and enabling the Rawhide repo from a
    stable release. The net result here will be that upgrading any
    module stream to one that requires a newer platform will update
    the os-release package to that new platform.

2.5) The virtual Provides from the latest `os-release` package that's
installed

3) /etc/os-release
    In the event that no enabled repos provide the virtual Provides,
    fall back to reading it from /etc/os-release

4) /usr/lib/os-release
    In the event that no enabled repos provide the virtual Provides and
    /etc/os-release doesn't exist (e.g. OSTree systems), fall back to
    reading it from /usr/lib/os-release

https://bugzilla.redhat.com/show_bug.cgi?id=1688462