### PR TITLE
Ensure that repodir exists before creating file there

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -1795,6 +1795,9 @@ dnf_context_setup_enrollments(DnfContext *context, GError **error)
     } while (false);
 
     if (!sameContent) {
+        if (g_mkdir_with_parents(priv->repo_dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1) {
+            return FALSE;
+        }
         if (!g_key_file_save_to_file(repofile, repofname, error))
             return FALSE;
     }

--- a/plugins/rhsm.cpp
+++ b/plugins/rhsm.cpp
@@ -140,6 +140,10 @@ static bool setupEnrollments(PluginHandle *handle)
         close(fd);
     }
     if (!sameContent) {
+        if (g_mkdir_with_parents(repoDir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1) {
+            logger->error(std::string(info.name) + ": " + __func__ + ": Error: Can't create directory " + repoDir);
+            return false;
+        }
         GError * error = nullptr;
         if (!g_key_file_save_to_file(repofile, repofname, &error)) {
             logger->error(std::string(info.name) + ": " + __func__ + ": Error: Can't save repo file: " + error->message);


### PR DESCRIPTION
Ensure that repositories configuration directory (e.g. /etc/yum.repos.d)
exists before actual attempt to create a file in it.