### PR TITLE
dnf_keyring_add_public_keys(): Skip invalid key files (RhBug:1644040)

### DIFF
--- a/libdnf/dnf-keyring.cpp
+++ b/libdnf/dnf-keyring.cpp
@@ -200,8 +200,13 @@ dnf_keyring_add_public_keys(rpmKeyring keyring, GError **error)
         if (filename == NULL)
             break;
         path_tmp = g_build_filename(gpg_dir, filename, NULL);
-        ret = dnf_keyring_add_public_key(keyring, path_tmp, error);
-    } while (ret);
+        GError *localError = NULL;
+        ret = dnf_keyring_add_public_key(keyring, path_tmp, &localError);
+        if (!ret) {
+            g_warning("%s", localError->message);
+            g_error_free(localError);
+        }
+    } while (true);
     return TRUE;
 }
 


### PR DESCRIPTION
The dnf_keyring_add_public_keys function behaved badly before the patch.
It stopped on the first invalid key file and GError was setted,
but success return code was returned.
Invalid files with keys are skipped now and warning message is generated.

Note:
The dnf_keyring_add_public_keys function is not generally applicable
because the path to key files is hard coded to "/etc/pki/rpm-gpg".