### PR TITLE
Use handleSetOpt to pass gnupg homedir to librepo

### DIFF
--- a/libdnf/repo/Repo-private.hpp
+++ b/libdnf/repo/Repo-private.hpp
@@ -169,7 +169,7 @@ public:
 private:
     Repo * owner;
     std::unique_ptr<LrResult> lrHandlePerform(LrHandle * handle, const std::string & destDirectory,
-        bool setGPGHomeEnv);
+        bool setGPGHomeDir);
     bool isMetalinkInSync();
     bool isRepomdInSync();
     void resetMetadataExpired();


### PR DESCRIPTION
The PR calls handleSetOpt (which calls lr_handle_setopt) to pass gnupg
home directory to librepo instead of using "GNUPGHOME" environment variable.

The new solution is simpler. In addition, using environment variable
for passing value was dangerous, because a Any other thread/process/application
could change the value.