### PR TITLE
[context] Support for DNF main config file

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -319,7 +319,7 @@ guint
 dnf_repo_get_n_solvables (DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    return hy_repo_get_n_solvables (priv->repo);
+    return libdnf::repoGetImpl(priv->repo)->libsolvRepo->nsolvables;
 }
 
 /**

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -58,16 +58,11 @@
 typedef struct
 {
     DnfRepoEnabled   enabled;
-    gboolean         required;
-    gboolean         gpgcheck_md;
-    gboolean         gpgcheck_pkgs;
     gchar          **gpgkeys;
     gchar          **exclude_packages;
-    guint            cost;
     gboolean         module_hotfixes;
     guint            metadata_expire;       /*seconds*/
     gchar           *filename;      /* /etc/yum.repos.d/updates.repo */
-    gchar           *id;
     gchar           *location;      /* /var/cache/PackageKit/metadata/fedora */
     gchar           *location_tmp;  /* /var/cache/PackageKit/metadata/fedora.tmp */
     gchar           *packages;      /* /var/cache/PackageKit/metadata/fedora/packages */
@@ -80,11 +75,10 @@ typedef struct
     GKeyFile        *keyfile;
     DnfContext      *context;               /* weak reference */
     DnfRepoKind      kind;
-    HyRepo           repo;
+    libdnf::Repo    *repo;
     LrHandle        *repo_handle;
     LrResult        *repo_result;
     LrUrlVars       *urlvars;
-    std::set<std::string> * additionalMetadata;
 } DnfRepoPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(DnfRepo, dnf_repo, G_TYPE_OBJECT)
@@ -99,8 +93,6 @@ dnf_repo_finalize(GObject *object)
     DnfRepo *repo = DNF_REPO(object);
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
 
-    delete priv->additionalMetadata;
-    g_free(priv->id);
     g_free(priv->filename);
     g_strfreev(priv->gpgkeys);
     g_strfreev(priv->exclude_packages);
@@ -133,13 +125,9 @@ static void
 dnf_repo_init(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    priv->cost = 1000;
+    priv->repo = hy_repo_create("<preinit>");
     priv->repo_handle = lr_handle_init();
     priv->repo_result = lr_result_init();
-    priv->required = TRUE;  /* This is the original default which we're
-                             * keeping for compatibility with YUM.
-                             */
-    priv->additionalMetadata = new std::set<std::string>;
 }
 
 /**
@@ -166,7 +154,7 @@ const gchar *
 dnf_repo_get_id(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    return priv->id;
+    return libdnf::repoGetImpl(priv->repo)->id.c_str();
 }
 
 /**
@@ -351,7 +339,7 @@ gboolean
 dnf_repo_get_required(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    return priv->required;
+    return !priv->repo->getConfig()->skip_if_unavailable().getValue();
 }
 
 /**
@@ -368,7 +356,7 @@ guint
 dnf_repo_get_cost(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    return priv->cost;
+    return repoGetImpl(priv->repo)->conf->cost().getValue();
 }
 
 /**
@@ -434,7 +422,7 @@ gboolean
 dnf_repo_get_gpgcheck(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    return priv->gpgcheck_pkgs;
+    return priv->repo->getConfig()->gpgcheck().getValue();
 }
 
 /**
@@ -451,7 +439,7 @@ gboolean
 dnf_repo_get_gpgcheck_md(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    return priv->gpgcheck_md;
+    return priv->repo->getConfig()->repo_gpgcheck().getValue();
 }
 
 /**
@@ -499,11 +487,12 @@ gboolean
 dnf_repo_is_devel(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    if (g_str_has_suffix(priv->id, "-debuginfo"))
+    auto repoId = priv->repo->getId().c_str();
+    if (g_str_has_suffix(repoId, "-debuginfo"))
         return TRUE;
-    if (g_str_has_suffix(priv->id, "-debug"))
+    if (g_str_has_suffix(repoId, "-debug"))
         return TRUE;
-    if (g_str_has_suffix(priv->id, "-development"))
+    if (g_str_has_suffix(repoId, "-development"))
         return TRUE;
     return FALSE;
 }
@@ -541,7 +530,7 @@ gboolean
 dnf_repo_is_source(DnfRepo *repo)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    if (g_str_has_suffix(priv->id, "-source"))
+    if (g_str_has_suffix(priv->repo->getId().c_str(), "-source"))
         return TRUE;
     return FALSE;
 }
@@ -559,8 +548,8 @@ void
 dnf_repo_set_id(DnfRepo *repo, const gchar *id)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    g_free(priv->id);
-    priv->id = g_strdup(id);
+    libdnf::repoGetImpl(priv->repo)->id = id;
+    libdnf::repoGetImpl(priv->repo)->conf->name().set(libdnf::Option::Priority::RUNTIME, id);
 }
 
 /**
@@ -692,8 +681,7 @@ void
 dnf_repo_set_required(DnfRepo *repo, gboolean required)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-
-    priv->required = required;
+    priv->repo->getConfig()->skip_if_unavailable().set(libdnf::Option::Priority::RUNTIME, !required);
 }
 
 /**
@@ -709,7 +697,7 @@ void
 dnf_repo_set_cost(DnfRepo *repo, guint cost)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    priv->cost = cost;
+    repoGetImpl(priv->repo)->conf->cost().set(libdnf::Option::Priority::RUNTIME, cost);
 }
 
 /**
@@ -757,7 +745,7 @@ void
 dnf_repo_set_gpgcheck(DnfRepo *repo, gboolean gpgcheck_pkgs)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    priv->gpgcheck_pkgs = gpgcheck_pkgs;
+    priv->repo->getConfig()->gpgcheck().set(libdnf::Option::Priority::RUNTIME, gpgcheck_pkgs);
 }
 
 /**
@@ -773,7 +761,7 @@ void
 dnf_repo_set_gpgcheck_md(DnfRepo *repo, gboolean gpgcheck_md)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    priv->gpgcheck_md = gpgcheck_md;
+    priv->repo->getConfig()->repo_gpgcheck().set(libdnf::Option::Priority::RUNTIME, gpgcheck_md);
 }
 
 /**
@@ -956,31 +944,30 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
     g_autofree gchar *usr_pwd_proxy = NULL;
     g_auto(GStrv) baseurls;
 
-    g_debug("setting keyfile data for %s", priv->id);
+    auto repoId = priv->repo->getId().c_str();
+    g_debug("setting keyfile data for %s", repoId);
 
     /* skip_if_unavailable is optional */
-    if (g_key_file_has_key(priv->keyfile, priv->id, "skip_if_unavailable", NULL)) {
-        if (dnf_repo_get_boolean(priv->keyfile, priv->id, "skip_if_unavailable", NULL))
-            priv->required = FALSE;
-        else
-            priv->required = TRUE;
+    if (g_key_file_has_key(priv->keyfile, repoId, "skip_if_unavailable", NULL)) {
+        bool skip = dnf_repo_get_boolean(priv->keyfile, repoId, "skip_if_unavailable", NULL);
+        priv->repo->getConfig()->skip_if_unavailable().set(libdnf::Option::Priority::REPOCONFIG, skip);
     }
 
     /* cost is optional */
-    cost = g_key_file_get_integer(priv->keyfile, priv->id, "cost", NULL);
+    cost = g_key_file_get_integer(priv->keyfile, repoId, "cost", NULL);
     if (cost != 0)
         dnf_repo_set_cost(repo, cost);
 
-    module_hotfixes = g_key_file_get_boolean(priv->keyfile, priv->id, "module_hotfixes", NULL);
+    module_hotfixes = g_key_file_get_boolean(priv->keyfile, repoId, "module_hotfixes", NULL);
     dnf_repo_set_module_hotfixes(repo, module_hotfixes);
 
     /* baseurl is optional; if missing, unset it */
-    baseurls = g_key_file_get_string_list(priv->keyfile, priv->id, "baseurl", NULL, NULL);
+    baseurls = g_key_file_get_string_list(priv->keyfile, repoId, "baseurl", NULL, NULL);
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_URLS, baseurls))
         return FALSE;
 
     /* metadata_expire is optional, if shown, we parse the string to add the time */
-    metadata_expire_str = g_key_file_get_string(priv->keyfile, priv->id, "metadata_expire", NULL);
+    metadata_expire_str = g_key_file_get_string(priv->keyfile, repoId, "metadata_expire", NULL);
     if (metadata_expire_str) {
         guint metadata_expire;
         if (!dnf_repo_parse_time_from_str(metadata_expire_str, &metadata_expire, error))
@@ -992,7 +979,7 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
     }
 
     /* the "mirrorlist" entry could be either a real mirrorlist, or a metalink entry */
-    mirrorlist = g_key_file_get_string(priv->keyfile, priv->id, "mirrorlist", NULL);
+    mirrorlist = g_key_file_get_string(priv->keyfile, repoId, "mirrorlist", NULL);
     if (mirrorlist) {
         if (strstr(mirrorlist, "metalink"))
             metalinkurl = static_cast<gchar *>(g_steal_pointer(&mirrorlist));
@@ -1001,9 +988,9 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
     }
 
     /* let "metalink" entry override metalink-as-mirrorlist entry */
-    if (g_key_file_has_key(priv->keyfile, priv->id, "metalink", NULL)) {
+    if (g_key_file_has_key(priv->keyfile, repoId, "metalink", NULL)) {
         g_free(metalinkurl);
-        metalinkurl = g_key_file_get_string(priv->keyfile, priv->id, "metalink", NULL);
+        metalinkurl = g_key_file_get_string(priv->keyfile, repoId, "metalink", NULL);
     }
 
     /* now set the final values (or unset them) */
@@ -1031,7 +1018,7 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
     if (priv->location == NULL) {
         g_autofree gchar *tmp = NULL;
         /* make each repo's cache directory name has releasever and basearch as its suffix */
-        g_autofree gchar *file_name  = g_strjoin("-", priv->id,
+        g_autofree gchar *file_name  = g_strjoin("-", repoId,
                                                  dnf_context_get_release_ver(priv->context),
                                                  dnf_context_get_base_arch(priv->context), NULL);
 
@@ -1052,7 +1039,7 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
 
     /* gpgkey is optional for gpgcheck=1, but required for repo_gpgcheck=1 */
     g_strfreev(priv->gpgkeys);
-    tmp_strval = g_key_file_get_string(priv->keyfile, priv->id, "gpgkey", NULL);
+    tmp_strval = g_key_file_get_string(priv->keyfile, repoId, "gpgkey", NULL);
     if (tmp_strval) {
         priv->gpgkeys = g_strsplit_set(tmp_strval, " ,", -1);
         g_free(g_steal_pointer (&tmp_strval));
@@ -1066,12 +1053,16 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
      * repo files as required.  To claim compatibility with yum repository files, I think
      * we need to basically hard code the yum.conf defaults here.
      */
-    if (!g_key_file_has_key(priv->keyfile, priv->id, "gpgcheck", NULL))
-        priv->gpgcheck_pkgs = TRUE;
-    else
-        priv->gpgcheck_pkgs = dnf_repo_get_boolean(priv->keyfile, priv->id, "gpgcheck", NULL);
-    priv->gpgcheck_md = dnf_repo_get_boolean(priv->keyfile, priv->id, "repo_gpgcheck", NULL);
-    if (priv->gpgcheck_md && priv->gpgkeys == NULL) {
+    if (!g_key_file_has_key(priv->keyfile, repoId, "gpgcheck", NULL))
+        priv->repo->getConfig()->gpgcheck().set(libdnf::Option::Priority::DEFAULT, true);
+    else {
+        auto gpgcheck_pkgs = dnf_repo_get_boolean(priv->keyfile, repoId, "gpgcheck", NULL);
+        priv->repo->getConfig()->gpgcheck().set(libdnf::Option::Priority::REPOCONFIG, gpgcheck_pkgs);
+    }
+
+    auto gpgcheck_md = dnf_repo_get_boolean(priv->keyfile, repoId, "repo_gpgcheck", NULL);
+    priv->repo->getConfig()->repo_gpgcheck().set(libdnf::Option::Priority::REPOCONFIG, gpgcheck_md);
+    if (gpgcheck_md && priv->gpgkeys == NULL) {
         g_set_error_literal(error,
                             DNF_ERROR,
                             DNF_ERROR_FILE_INVALID,
@@ -1080,32 +1071,32 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
     }
 
     /* XXX: setopt() expects a long, so we need a long on the stack */
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_GPGCHECK, (long)priv->gpgcheck_md))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_GPGCHECK, (long)gpgcheck_md))
         return FALSE;
 
-    tmp_strval = g_key_file_get_string(priv->keyfile, priv->id, "exclude", NULL);
+    tmp_strval = g_key_file_get_string(priv->keyfile, repoId, "exclude", NULL);
     if (tmp_strval) {
         priv->exclude_packages = g_strsplit_set(tmp_strval, " ,", -1);
         g_free(g_steal_pointer (&tmp_strval));
     }
 
     /* proxy is optional */
-    proxy = g_key_file_get_string(priv->keyfile, priv->id, "proxy", NULL);
+    proxy = g_key_file_get_string(priv->keyfile, repoId, "proxy", NULL);
     auto repoProxy = proxy ? (strcasecmp(proxy, "_none_") == 0 ? NULL : proxy)
         : dnf_context_get_http_proxy(priv->context);
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_PROXY, repoProxy))
         return FALSE;
 
     /* both parts of the proxy auth are optional */
-    usr = g_key_file_get_string(priv->keyfile, priv->id, "proxy_username", NULL);
-    pwd = g_key_file_get_string(priv->keyfile, priv->id, "proxy_password", NULL);
+    usr = g_key_file_get_string(priv->keyfile, repoId, "proxy_username", NULL);
+    pwd = g_key_file_get_string(priv->keyfile, repoId, "proxy_password", NULL);
     usr_pwd_proxy = dnf_repo_get_username_password_string(usr, pwd);
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_PROXYUSERPWD, usr_pwd_proxy))
         return FALSE;
 
     /* both parts of the HTTP auth are optional */
-    usr = g_key_file_get_string(priv->keyfile, priv->id, "username", NULL);
-    pwd = g_key_file_get_string(priv->keyfile, priv->id, "password", NULL);
+    usr = g_key_file_get_string(priv->keyfile, repoId, "username", NULL);
+    pwd = g_key_file_get_string(priv->keyfile, repoId, "password", NULL);
     usr_pwd = dnf_repo_get_username_password_string(usr, pwd);
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_USERPWD, usr_pwd))
         return FALSE;
@@ -1171,8 +1162,9 @@ dnf_repo_setup(DnfRepo *repo, GError **error)
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_GNUPGHOMEDIR, priv->keyring))
         return FALSE;
 
-    if (g_key_file_has_key(priv->keyfile, priv->id, "sslverify", NULL))
-        sslverify = dnf_repo_get_boolean(priv->keyfile, priv->id, "sslverify", NULL);
+    auto repoId = priv->repo->getId().c_str();
+    if (g_key_file_has_key(priv->keyfile, repoId, "sslverify", NULL))
+        sslverify = dnf_repo_get_boolean(priv->keyfile, repoId, "sslverify", NULL);
 
     /* XXX: setopt() expects a long, so we need a long on the stack */
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYPEER, (long)sslverify))
@@ -1180,19 +1172,19 @@ dnf_repo_setup(DnfRepo *repo, GError **error)
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYHOST, (long)sslverify))
         return FALSE;
 
-    sslcacert = g_key_file_get_string(priv->keyfile, priv->id, "sslcacert", NULL);
+    sslcacert = g_key_file_get_string(priv->keyfile, repoId, "sslcacert", NULL);
     if (sslcacert != NULL) {
         if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLCACERT, sslcacert))
             return FALSE;
     }
 
-    sslclientcert = g_key_file_get_string(priv->keyfile, priv->id, "sslclientcert", NULL);
+    sslclientcert = g_key_file_get_string(priv->keyfile, repoId, "sslclientcert", NULL);
     if (sslclientcert != NULL) {
         if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLCLIENTCERT, sslclientcert))
             return FALSE;
     }
 
-    sslclientkey = g_key_file_get_string(priv->keyfile, priv->id, "sslclientkey", NULL);
+    sslclientkey = g_key_file_get_string(priv->keyfile, repoId, "sslclientkey", NULL);
     if (sslclientkey != NULL) {
         if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLCLIENTKEY, sslclientkey))
             return FALSE;
@@ -1207,16 +1199,16 @@ dnf_repo_setup(DnfRepo *repo, GError **error)
 #endif
 
     /* enabled is optional */
-    if (g_key_file_has_key(priv->keyfile, priv->id, "enabled", NULL)) {
-        if (dnf_repo_get_boolean(priv->keyfile, priv->id, "enabled", NULL))
+    if (g_key_file_has_key(priv->keyfile, repoId, "enabled", NULL)) {
+        if (dnf_repo_get_boolean(priv->keyfile, repoId, "enabled", NULL))
             enabled |= DNF_REPO_ENABLED_PACKAGES;
     } else {
         enabled |= DNF_REPO_ENABLED_PACKAGES;
     }
 
     /* enabled_metadata is optional */
-    if (g_key_file_has_key(priv->keyfile, priv->id, "enabled_metadata", NULL)) {
-        if (dnf_repo_get_boolean(priv->keyfile, priv->id, "enabled_metadata", NULL))
+    if (g_key_file_has_key(priv->keyfile, repoId, "enabled_metadata", NULL)) {
+        if (dnf_repo_get_boolean(priv->keyfile, repoId, "enabled_metadata", NULL))
             enabled |= DNF_REPO_ENABLED_METADATA;
     } else {
         g_autofree gchar *basename = g_path_get_basename(priv->filename);
@@ -1311,6 +1303,7 @@ dnf_repo_check_internal(DnfRepo *repo,
                         GError **error)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
+    auto repoImpl = libdnf::repoGetImpl(priv->repo);
 
     std::vector<const char *> download_list = {"primary", "group", "updateinfo", "appstream",
         "appstream-icons", "modules"};
@@ -1319,7 +1312,7 @@ dnf_repo_check_internal(DnfRepo *repo,
      */
     if (dnf_context_get_enable_filelists(priv->context))
         download_list.push_back("filelists");
-    for (const auto & item : *(priv->additionalMetadata)) {
+    for (const auto & item : repoImpl->additionalMetadata) {
         download_list.push_back(item.c_str());
     }
     download_list.push_back(NULL);
@@ -1376,7 +1369,7 @@ dnf_repo_check_internal(DnfRepo *repo,
                     DNF_ERROR,
                     DNF_ERROR_REPO_NOT_AVAILABLE,
                     "repodata %s was not complete: %s",
-                    priv->id, error_local->message);
+                    priv->repo->getId().c_str(), error_local->message);
         return FALSE;
     }
 
@@ -1422,20 +1415,34 @@ dnf_repo_check_internal(DnfRepo *repo,
         }
     }
 
-    /* create a HyRepo */
-    if (priv->repo)
-        hy_repo_free(priv->repo);
-    priv->repo = hy_repo_create(priv->id);
-    auto repoImpl = libdnf::repoGetImpl(priv->repo);
+    /* init  */
+    repoImpl->libsolvRepo = nullptr;
+    repoImpl->needs_internalizing = false;
+    repoImpl->nrefs = 1;
+    repoImpl->state_main = _HY_NEW;
+    repoImpl->state_filelists = _HY_NEW;
+    repoImpl->state_presto = _HY_NEW;
+    repoImpl->state_updateinfo = _HY_NEW;
+    repoImpl->state_other = _HY_NEW;
+    repoImpl->filenames_repodata = 0;
+    repoImpl->presto_repodata = 0;
+    repoImpl->updateinfo_repodata = 0;
+    repoImpl->other_repodata = 0;
+    repoImpl->load_flags = 0;
+    /* the following three elements are needed for repo rewriting */
+    repoImpl->main_nsolvables = 0;
+    repoImpl->main_nrepodata = 0;
+    repoImpl->main_end = 0;
+    priv->repo->setUseIncludes(false);
 
     repoImpl->repomdFn = yum_repo->repomd;
+    repoImpl->metadataPaths.clear();
     for (auto *elem = yum_repo->paths; elem; elem = g_slist_next(elem)) {
         if (elem->data) {
             auto yumrepopath = static_cast<LrYumRepoPath *>(elem->data);
             repoImpl->metadataPaths[yumrepopath->type] = yumrepopath->path;
         }
     }
-
     /* ensure we reset the values from the keyfile */
     if (!dnf_repo_set_keyfile_data(repo, error))
         return FALSE;
@@ -1680,7 +1687,7 @@ dnf_repo_update(DnfRepo *repo,
                     DNF_ERROR,
                     DNF_ERROR_INTERNAL_ERROR,
                     "location_tmp not set for %s",
-                    priv->id);
+                    priv->repo->getId().c_str());
         return FALSE;
     }
 
@@ -1723,7 +1730,7 @@ dnf_repo_update(DnfRepo *repo,
     }
 
     if (priv->gpgkeys &&
-        (priv->gpgcheck_md || priv->gpgcheck_pkgs)) {
+        (priv->repo->getConfig()->repo_gpgcheck().getValue() || priv->repo->getConfig()->gpgcheck().getValue())) {
         for (char **iter = priv->gpgkeys; iter && *iter; iter++) {
             const char *gpgkey = *iter;
             g_autofree char *gpgkey_name = g_path_get_basename(gpgkey);
@@ -1748,7 +1755,7 @@ dnf_repo_update(DnfRepo *repo,
         }
     }
 
-    g_debug("Attempting to update %s", priv->id);
+    g_debug("Attempting to update %s", priv->repo->getId().c_str());
     ret = lr_handle_setopt(priv->repo_handle, error,
                            LRO_LOCAL, 0L);
     if (!ret)
@@ -1924,7 +1931,7 @@ dnf_repo_set_data(DnfRepo *repo,
                   GError **error)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
-    g_key_file_set_string(priv->keyfile, priv->id, parameter, value);
+    g_key_file_set_string(priv->keyfile, priv->repo->getId().c_str(), parameter, value);
     return TRUE;
 }
 
@@ -2150,7 +2157,7 @@ dnf_repo_download_packages(DnfRepo *repo,
                     DNF_ERROR,
                     DNF_ERROR_INTERNAL_ERROR,
                     "Refusing to download from local repository \"%s\"",
-                    priv->id);
+                    priv->repo->getId().c_str());
         goto out;
     }
 
@@ -2282,7 +2289,7 @@ void
 dnf_repo_add_metadata_type_to_download(DnfRepo * repo, const gchar * metadataType)
 {
     auto priv = GET_PRIVATE(repo);
-    priv->additionalMetadata->insert(metadataType);
+    libdnf::repoGetImpl(priv->repo)->additionalMetadata.insert(metadataType);
 }
 
 /**

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -34,6 +34,8 @@
  */
 
 
+#include "hy-repo-private.hpp"
+
 #include <strings.h>
 #include <fcntl.h>
 #include <glib/gstdio.h>
@@ -76,7 +78,6 @@ typedef struct
     gint64           timestamp_modified;    /* µs */
     GError          *last_check_error;
     GKeyFile        *keyfile;
-    GHashTable      *filenames_md;          /* md filename (e.g. "primary") -> file path */
     DnfContext      *context;               /* weak reference */
     DnfRepoKind      kind;
     HyRepo           repo;
@@ -109,7 +110,6 @@ dnf_repo_finalize(GObject *object)
     g_free(priv->packages_tmp);
     g_free(priv->keyring);
     g_free(priv->keyring_tmp);
-    g_hash_table_unref(priv->filenames_md);
     g_clear_error(&priv->last_check_error);
     if (priv->repo_result != NULL)
         lr_result_free(priv->repo_result);
@@ -136,8 +136,6 @@ dnf_repo_init(DnfRepo *repo)
     priv->cost = 1000;
     priv->repo_handle = lr_handle_init();
     priv->repo_result = lr_result_init();
-    priv->filenames_md = g_hash_table_new_full(g_str_hash, g_str_equal,
-                                               g_free, g_free);
     priv->required = TRUE;  /* This is the original default which we're
                              * keeping for compatibility with YUM.
                              */
@@ -1325,7 +1323,6 @@ dnf_repo_check_internal(DnfRepo *repo,
         download_list.push_back(item.c_str());
     }
     download_list.push_back(NULL);
-    const gchar *tmp;
     gboolean ret;
     LrYumRepo *yum_repo;
     const gchar *urls[] = { "", NULL };
@@ -1425,46 +1422,18 @@ dnf_repo_check_internal(DnfRepo *repo,
         }
     }
 
-    g_hash_table_remove_all(priv->filenames_md);
+    /* create a HyRepo */
+    if (priv->repo)
+        hy_repo_free(priv->repo);
+    priv->repo = hy_repo_create(priv->id);
+    auto repoImpl = libdnf::repoGetImpl(priv->repo);
+
+    repoImpl->repomdFn = yum_repo->repomd;
     for (auto *elem = yum_repo->paths; elem; elem = g_slist_next(elem)) {
         if (elem->data) {
             auto yumrepopath = static_cast<LrYumRepoPath *>(elem->data);
-            g_hash_table_insert(priv->filenames_md, g_strdup(yumrepopath->type),
-                                g_strdup(yumrepopath->path));
+            repoImpl->metadataPaths[yumrepopath->type] = yumrepopath->path;
         }
-    }
-
-    /* create a HyRepo */
-    if (priv->repo != NULL)
-        hy_repo_free(priv->repo);
-    priv->repo = hy_repo_create(priv->id);
-    hy_repo_set_string(priv->repo, HY_REPO_MD_FN, yum_repo->repomd);
-    if (dnf_context_get_zchunk(priv->context)) {
-        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "primary_zck"));
-        if(!tmp)
-            tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "primary"));
-        hy_repo_set_string(priv->repo, HY_REPO_PRIMARY_FN, tmp);
-        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "filelists_zck"));
-        if(!tmp)
-            tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "filelists"));
-        hy_repo_set_string(priv->repo, HY_REPO_FILELISTS_FN, tmp);
-        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "updateinfo_zck"));
-        if(!tmp)
-            tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "updateinfo"));
-        hy_repo_set_string(priv->repo, HY_REPO_UPDATEINFO_FN, tmp);
-        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "modules_zck"));
-        if(!tmp)
-            tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "modules"));
-        hy_repo_set_string(priv->repo, MODULES_FN, tmp);
-    } else {
-        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "primary"));
-        hy_repo_set_string(priv->repo, HY_REPO_PRIMARY_FN, tmp);
-        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "filelists"));
-        hy_repo_set_string(priv->repo, HY_REPO_FILELISTS_FN, tmp);
-        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "updateinfo"));
-        hy_repo_set_string(priv->repo, HY_REPO_UPDATEINFO_FN, tmp);
-        tmp = static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, "modules"));
-        hy_repo_set_string(priv->repo, MODULES_FN, tmp);
     }
 
     /* ensure we reset the values from the keyfile */
@@ -1521,7 +1490,12 @@ dnf_repo_get_filename_md(DnfRepo *repo, const gchar *md_kind)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
     g_return_val_if_fail(md_kind != NULL, NULL);
-    return static_cast<const gchar *>(g_hash_table_lookup(priv->filenames_md, md_kind));
+    if (priv->repo) {
+        auto repoImpl = libdnf::repoGetImpl(priv->repo);
+        auto & filename = repoImpl->getMetadataPath(md_kind);
+        return filename.empty() ? nullptr : filename.c_str();
+    } else
+        return nullptr;
 }
 
 /**

--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -364,7 +364,7 @@ dnf_sack_recompute_considered(DnfSack *sack)
         Repo *repo;
         FOR_REPOS(repoid, repo) {
             auto hyrepo = static_cast<HyRepo>(repo->appdata);
-            if (!hy_repo_get_use_includes(hyrepo)) {
+            if (!hyrepo->getUseIncludes()) {
                 Id solvableid;
                 Solvable *solvable;
                 FOR_REPO_SOLVABLES(repo, solvableid, solvable)
@@ -380,23 +380,24 @@ dnf_sack_recompute_considered(DnfSack *sack)
 
 static gboolean
 load_ext(DnfSack *sack, HyRepo hrepo, _hy_repo_repodata which_repodata,
-         const char *suffix, int which_filename,
+         const char *suffix, const char * which_filename,
          int (*cb)(Repo *, FILE *), GError **error)
 {
     DnfSackPrivate *priv = GET_PRIVATE(sack);
     int ret = 0;
-    Repo *repo = libdnf::repoGetImpl(hrepo)->libsolvRepo;
+    auto repoImpl = libdnf::repoGetImpl(hrepo);
+    Repo *repo = repoImpl->libsolvRepo;
     const char *name = repo->name;
-    const char *fn = hy_repo_get_string(hrepo, which_filename);
+    auto fn = hrepo->getMetadataPath(which_filename);
     FILE *fp;
     gboolean done = FALSE;
 
     /* nothing set */
-    if (fn == NULL) {
+    if (fn.empty()) {
         g_set_error (error,
                      DNF_ERROR,
                      DNF_ERROR_NO_CAPABILITY,
-                     _("no %1$d string for %2$s"),
+                     _("no %1$s string for %2$s"),
                      which_filename, name);
         return FALSE;
     }
@@ -432,15 +433,15 @@ load_ext(DnfSack *sack, HyRepo hrepo, _hy_repo_repodata which_repodata,
     if (done)
         return TRUE;
 
-    fp = solv_xfopen(fn, "r");
+    fp = solv_xfopen(fn.c_str(), "r");
     if (fp == NULL) {
         g_set_error (error,
                      DNF_ERROR,
                      DNF_ERROR_FILE_INVALID,
-                     _("failed to open: %s"), fn);
+                     _("failed to open: %s"), fn.c_str());
         return FALSE;
     }
-    g_debug("%s: loading: %s", __func__, fn);
+    g_debug("%s: loading: %s", __func__, fn.c_str());
 
     int previous_last = repo->nrepodata - 1;
     ret = cb(repo, fp);
@@ -681,9 +682,9 @@ load_yum_repo(DnfSack *sack, HyRepo hrepo, GError **error)
     DnfSackPrivate *priv = GET_PRIVATE(sack);
     gboolean retval = TRUE;
     Pool *pool = priv->pool;
-    const char *name = hy_repo_get_string(hrepo, HY_REPO_NAME);
+    const char *name = hrepo->getId().c_str();
     Repo *repo = repo_create(pool, name);
-    const char *fn_repomd = hy_repo_get_string(hrepo, HY_REPO_MD_FN);
+    const char *fn_repomd = repoImpl->repomdFn.c_str();
     char *fn_cache = dnf_sack_give_cache_fn(sack, name, NULL);
 
     FILE *fp_primary = NULL;
@@ -722,8 +723,7 @@ load_yum_repo(DnfSack *sack, HyRepo hrepo, GError **error)
         }
         repoImpl->state_main = _HY_LOADED_CACHE;
     } else {
-        fp_primary = solv_xfopen(hy_repo_get_string(hrepo, HY_REPO_PRIMARY_FN),
-                                 "r");
+        fp_primary = solv_xfopen(hrepo->getMetadataPath(MD_TYPE_PRIMARY).c_str(), "r");
         assert(fp_primary);
 
         g_debug("fetching %s", name);
@@ -1541,9 +1541,9 @@ dnf_sack_set_use_includes(DnfSack *sack, const char *reponame, gboolean enabled)
         HyRepo hyrepo = hrepo_by_name(sack, reponame);
         if (!hyrepo)
             return FALSE;
-        if (hy_repo_get_use_includes(hyrepo) != enabled)
+        if (hyrepo->getUseIncludes() != enabled)
         {
-            hy_repo_set_use_includes(hyrepo, enabled);
+            hyrepo->setUseIncludes(enabled);
             priv->considered_uptodate = FALSE;
         }
     } else {
@@ -1551,9 +1551,9 @@ dnf_sack_set_use_includes(DnfSack *sack, const char *reponame, gboolean enabled)
         Repo *repo;
         FOR_REPOS(repoid, repo) {
             auto hyrepo = static_cast<HyRepo>(pool->repos[repoid]->appdata);
-            if (hy_repo_get_use_includes(hyrepo) != enabled)
+            if (hyrepo->getUseIncludes() != enabled)
             {
-                hy_repo_set_use_includes(hyrepo, enabled);
+                hyrepo->setUseIncludes(enabled);
                 priv->considered_uptodate = FALSE;
             }
         }
@@ -1610,7 +1610,7 @@ dnf_sack_get_use_includes(DnfSack *sack, const char *reponame, gboolean *enabled
     HyRepo hyrepo = hrepo_by_name(sack, reponame);
     if (!hyrepo)
         return FALSE;
-    *enabled = hy_repo_get_use_includes(hyrepo);
+    *enabled = hyrepo->getUseIncludes();
     return TRUE;
 }
 
@@ -1683,9 +1683,11 @@ dnf_sack_load_system_repo(DnfSack *sack, HyRepo a_hrepo, int flags, GError **err
     const int build_cache = flags & DNF_SACK_LOAD_FLAG_BUILD_CACHE;
 
     g_free(cache_fn);
-    if (hrepo)
-        hy_repo_set_string(hrepo, HY_REPO_NAME, HY_SYSTEM_REPO_NAME);
-    else
+    if (hrepo) {
+        auto repoImpl = libdnf::repoGetImpl(hrepo);
+        repoImpl->id = HY_SYSTEM_REPO_NAME;
+        repoImpl->conf->name().set(libdnf::Option::Priority::RUNTIME, HY_SYSTEM_REPO_NAME);
+    } else
         hrepo = hy_repo_create(HY_SYSTEM_REPO_NAME);
     auto repoImpl = libdnf::repoGetImpl(hrepo);
 
@@ -1781,7 +1783,7 @@ dnf_sack_load_repo(DnfSack *sack, HyRepo repo, int flags, GError **error)
     repoImpl->main_end = repoImpl->libsolvRepo->end;
     if (flags & DNF_SACK_LOAD_FLAG_USE_FILELISTS) {
         retval = load_ext(sack, repo, _HY_REPODATA_FILENAMES,
-                          HY_EXT_FILENAMES, HY_REPO_FILELISTS_FN,
+                          HY_EXT_FILENAMES, MD_TYPE_FILELISTS,
                           load_filelists_cb, &error_local);
         /* allow missing files */
         if (!retval) {
@@ -1804,7 +1806,7 @@ dnf_sack_load_repo(DnfSack *sack, HyRepo repo, int flags, GError **error)
     }
     if (flags & DNF_SACK_LOAD_FLAG_USE_OTHER) {
         retval = load_ext(sack, repo, _HY_REPODATA_OTHER,
-                          HY_EXT_OTHER, HY_REPO_OTHER_FN,
+                          HY_EXT_OTHER, MD_TYPE_OTHER,
                           load_other_cb, &error_local);
         /* allow missing files */
         if (!retval) {
@@ -1827,7 +1829,7 @@ dnf_sack_load_repo(DnfSack *sack, HyRepo repo, int flags, GError **error)
     }
     if (flags & DNF_SACK_LOAD_FLAG_USE_PRESTO) {
         retval = load_ext(sack, repo, _HY_REPODATA_PRESTO,
-                          HY_EXT_PRESTO, HY_REPO_PRESTO_FN,
+                          HY_EXT_PRESTO, MD_TYPE_PRESTODELTA,
                           load_presto_cb, &error_local);
         if (!retval) {
             if (g_error_matches (error_local,
@@ -1848,7 +1850,7 @@ dnf_sack_load_repo(DnfSack *sack, HyRepo repo, int flags, GError **error)
        extension, but contains a new set of packages */
     if (flags & DNF_SACK_LOAD_FLAG_USE_UPDATEINFO) {
         retval = load_ext(sack, repo, _HY_REPODATA_UPDATEINFO,
-                          HY_EXT_UPDATEINFO, HY_REPO_UPDATEINFO_FN,
+                          HY_EXT_UPDATEINFO, MD_TYPE_UPDATEINFO,
                           load_updateinfo_cb, &error_local);
         /* allow missing files */
         if (!retval) {

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -275,12 +275,12 @@ ModulePackageContainer::add(DnfSack * sack)
 
     FOR_REPOS(id, r) {
         HyRepo hyRepo = static_cast<HyRepo>(r->appdata);
-        auto modules_fn = hy_repo_get_string(hyRepo, MODULES_FN);
-        if (!modules_fn) {
+        auto modules_fn = hyRepo->getMetadataPath(MD_TYPE_MODULES);
+        if (modules_fn.empty()) {
             continue;
         }
         std::string yamlContent = getFileContent(modules_fn);
-        auto repoName = hy_repo_get_string(hyRepo, HY_REPO_NAME);
+        auto repoName = hyRepo->getId();
         add(yamlContent, repoName);
         // update defaults from repo
         try {

--- a/libdnf/repo/Repo-private.hpp
+++ b/libdnf/repo/Repo-private.hpp
@@ -48,6 +48,17 @@
 #include <string.h>
 #include <time.h>
 
+#define MD_TYPE_PRIMARY "primary"
+#define MD_TYPE_FILELISTS "filelists"
+#define MD_TYPE_PRESTODELTA "prestodelta"
+#define MD_TYPE_GROUP_GZ "group_gz"
+#define MD_TYPE_GROUP "group"
+#define MD_TYPE_UPDATEINFO "updateinfo"
+#define MD_TYPE_MODULES "modules"
+/* "other" in this context is not a generic "any other metadata", but real metadata type named "other"
+ * containing changelogs for packages */
+#define MD_TYPE_OTHER "other"
+
 enum _hy_repo_state {
     _HY_NEW,
     _HY_LOADED_FETCH,
@@ -165,7 +176,6 @@ public:
     int main_nsolvables{0};
     int main_nrepodata{0};
     int main_end{0};
-    bool use_includes{false};
 
 private:
     Repo * owner;

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -25,17 +25,6 @@
 #define RECOGNIZED_CHKSUMS {"sha512", "sha256"}
 #define USER_AGENT "libdnf"
 
-#define MD_TYPE_PRIMARY "primary"
-#define MD_TYPE_FILELISTS "filelists"
-#define MD_TYPE_PRESTODELTA "prestodelta"
-#define MD_TYPE_GROUP_GZ "group_gz"
-#define MD_TYPE_GROUP "group"
-#define MD_TYPE_UPDATEINFO "updateinfo"
-#define MD_TYPE_MODULES "modules"
-/* "other" in this context is not a generic "any other metadata", but real metadata type named "other"
- * containing changelogs for packages */
-#define MD_TYPE_OTHER "other"
-
 #include "../log.hpp"
 #include "Repo-private.hpp"
 #include "../dnf-utils.h"
@@ -1890,7 +1879,8 @@ hy_repo_create(const char *name)
     assert(name);
     std::unique_ptr<libdnf::ConfigRepo> cfgRepo(new libdnf::ConfigRepo(cfgMain));
     auto repo = new libdnf::Repo(name, std::move(cfgRepo), libdnf::Repo::Type::COMMANDLINE);
-    hy_repo_set_string(repo, HY_REPO_NAME, name);
+    auto repoImpl = libdnf::repoGetImpl(repo);
+    repoImpl->conf->name().set(libdnf::Option::Priority::RUNTIME, name);
     return repo;
 }
 
@@ -1909,7 +1899,7 @@ hy_repo_get_priority(HyRepo repo)
 gboolean
 hy_repo_get_use_includes(HyRepo repo)
 {
-  return libdnf::repoGetImpl(repo)->use_includes;
+  return repo->getUseIncludes();
 }
 
 guint
@@ -1939,7 +1929,7 @@ hy_repo_set_priority(HyRepo repo, int value)
 void
 hy_repo_set_use_includes(HyRepo repo, gboolean enabled)
 {
-    libdnf::repoGetImpl(repo)->use_includes = enabled;
+    repo->setUseIncludes(enabled);
 }
 
 void

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -1881,6 +1881,9 @@ hy_repo_create(const char *name)
 {
     assert(name);
     if (!cfgMainLoaded.test_and_set()) {
+        // The gpgcheck was enabled by default in context part of libdnf. We stay "compatible".
+        cfgMain.gpgcheck().set(libdnf::Option::Priority::DEFAULT, true);
+
         libdnf::ConfigParser parser;
         const std::string cfgPath{cfgMain.config_file_path().getValue()};
         try {

--- a/tests/hawkey/test_goal.cpp
+++ b/tests/hawkey/test_goal.cpp
@@ -219,10 +219,11 @@ END_TEST
 
 START_TEST(test_goal_install_selector_err)
 {
-    int rc;
-    g_autoptr(GError) error = NULL;
     // Test that using the hy_goal_*_selector() methods returns an error for
     // selectors invalid in this context.
+
+    int rc;
+    g_autoptr(GError) error = NULL;
 
     HySelector sltr;
     HyGoal goal = hy_goal_create(test_globals.sack);
@@ -240,7 +241,7 @@ START_TEST(test_goal_install_selector_err)
     hy_selector_free(sltr);
 
     sltr = hy_selector_create(test_globals.sack);
-    fail_unless(hy_selector_set(sltr, HY_REPO_NAME, HY_EQ, HY_SYSTEM_REPO_NAME));
+    fail_unless(hy_selector_set(sltr, HY_PKG, HY_EQ, HY_SYSTEM_REPO_NAME));
     hy_selector_free(sltr);
 
     hy_goal_free(goal);


### PR DESCRIPTION
The main (global) config file `/etc/dnf/dnf.conf` was ignored by context part of libdnf. So option from this file was not used in `microdnf`, `PackageKit`, ... 
The PR adds support for it. The config file is loaded during first `hy_repo_create` call. If it fails, warnings are written and program continues.

The same config parser as in DNF is used but only subset of readed options are used by libdnf context part. It depends on moving of DnfRepo members into libdnf::repo.
The PR moves:
skip_if_unavailable, gpgcheck, repo_gpgcheck
