### PR TITLE
[repo] Replace the 'Failed to synchronize cache' message (RhBug:1712055)

### DIFF
--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -1183,7 +1183,7 @@ bool Repo::Impl::load()
         loadCache(true);
     } catch (const LrExceptionWithSourceUrl & e) {
         logger->debug(tfm::format(_("Cannot download '%s': %s."), e.getSourceUrl(), e.what()));
-        auto msg = tfm::format(_("Failed to synchronize cache for repo '%s'"), id);
+        auto msg = tfm::format(_("Failed to download metadata for repo '%s'"), id);
         throw std::runtime_error(msg);
     }
     expired = false;


### PR DESCRIPTION
The message was misleading and indicated that there's
a problem with cache rather than with downloading repodata.
