### PR TITLE
[context] Fix: skip_if_unavailable=true for local repositories

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -2122,9 +2122,12 @@ dnf_sack_add_repo(DnfSack *sack,
                               &error_local);
         if (!ret) {
             if (!dnf_repo_get_required(repo) &&
-                g_error_matches(error_local,
-                                DNF_ERROR,
-                                DNF_ERROR_CANNOT_FETCH_SOURCE)) {
+                (g_error_matches(error_local,
+                                 DNF_ERROR,
+                                 DNF_ERROR_CANNOT_FETCH_SOURCE) ||
+                 g_error_matches(error_local,
+                                 DNF_ERROR,
+                                 DNF_ERROR_REPO_NOT_AVAILABLE))) {
                 g_warning("Skipping refresh of %s: %s",
                           dnf_repo_get_id(repo),
                           error_local->message);


### PR DESCRIPTION
The libdnf context didn't honor skip_if_unavailable=True for local
repositories. So, context users (microdnf) ended with error instead
of skipping such unrefreshable repositories.

https://bugzilla.redhat.com/show_bug.cgi?id=1716313