### PR TITLE
Fix building for epel 7

### DIFF
--- a/libdnf/sack/query.cpp
+++ b/libdnf/sack/query.cpp
@@ -50,11 +50,14 @@ extern "C" {
 #include "libdnf/repo/solvable/DependencyContainer.hpp"
 
 
+namespace std {
+
 template<>
-struct std::default_delete<DnfPackage> {
+struct default_delete<DnfPackage> {
     void operator()(DnfPackage * ptr) noexcept { g_object_unref(ptr); }
 };
 
+}
 
 namespace libdnf {
 


### PR DESCRIPTION
This is error you get when building libdnf on epel7 (gcc 4.8.2):

/builddir/build/BUILD/libdnf-0.31.0/libdnf/sack/query.cpp:54:13: error: specialization of 'template<class _Tp> struct std::default_delete' in different namespace [-fpermissive]
 struct std::default_delete<DnfPackage> {
             ^
In file included from /usr/include/c++/4.8.2/memory:81:0,
                 from /builddir/build/BUILD/libdnf-0.31.0/libdnf/sack/advisory.hpp:25,
                 from /builddir/build/BUILD/libdnf-0.31.0/libdnf/utils/utils.hpp:10,
                 from /builddir/build/BUILD/libdnf-0.31.0/libdnf/sack/query.cpp:21:
/usr/include/c++/4.8.2/bits/unique_ptr.h:54:12: error:   from definition of 'template<class _Tp> struct std::default_delete' [-fpermissive]
     struct default_delete