### PR TITLE
Exit gpg-agent after repokey import (RhBug:1650266)

### DIFF
--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -861,10 +861,6 @@ void Repo::Impl::importRepoKeys()
             struct stat sb;
             if (stat(gpgDir.c_str(), &sb) != 0 || !S_ISDIR(sb.st_mode))
                 mkdir(gpgDir.c_str(), 0777);
-            auto confFd = open((gpgDir + "/gpg.conf").c_str(),
-                               O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-            if (confFd != -1)
-                close(confFd);
 
             gpgme_ctx_t ctx;
             gpgme_new(&ctx);


### PR DESCRIPTION
1. It tries to exit gpg-agent. Path to the communication socket is derived from gpgDir. The gpg-agent automaticaly removes all its socket before exit.
Newer gpg-agent creates sockets under [/var]/run/user/{pid}/... if directory exists. In this case gpg-agent will not be exited.
It solves the https://bugzilla.redhat.com/show_bug.cgi?id=1650266 issue of remaining sockets in the gpg home directory.

2. Sometimes empty gpg.conf file was created. It is not needed. Code unification. The file will be never created.

This PR replaces another solution https://github.com/rpm-software-management/libdnf/pull/731 that configures the gpg agent to run in server mode (without sockets). This PR use the same solution as librepo.