### PR TITLE
Fix: libdnf own plugin directory (RhBug:1714265)

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -224,6 +224,8 @@ popd
 %license COPYING
 %doc README.md AUTHORS
 %{_libdir}/%{name}.so.*
+%dir %{_libdir}/libdnf/
+%dir %{_libdir}/libdnf/plugins/
 %{_libdir}/libdnf/plugins/README
 
 %files devel


### PR DESCRIPTION
Directories "%{_libdir}/libdnf" and "%{_libdir}/libdnf/plugins"
should be owned by libdnf.