### PR TITLE
[context] Fix: Don't disable nonexistent but required repositories

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1312,7 +1312,8 @@ dnf_repo_check_internal(DnfRepo *repo,
     /* has the media repo vanished? */
     if (priv->kind == DNF_REPO_KIND_MEDIA &&
         !g_file_test(priv->location, G_FILE_TEST_EXISTS)) {
-        priv->enabled = DNF_REPO_ENABLED_NONE;
+        if (!dnf_repo_get_required(repo))
+            priv->enabled = DNF_REPO_ENABLED_NONE;
         g_set_error(error,
                     DNF_ERROR,
                     DNF_ERROR_REPO_NOT_AVAILABLE,
@@ -1323,7 +1324,8 @@ dnf_repo_check_internal(DnfRepo *repo,
     /* has the local repo vanished? */
     if (priv->kind == DNF_REPO_KIND_LOCAL &&
         !g_file_test(priv->location, G_FILE_TEST_EXISTS)) {
-        priv->enabled = DNF_REPO_ENABLED_NONE;
+        if (!dnf_repo_get_required(repo))
+            priv->enabled = DNF_REPO_ENABLED_NONE;
         g_set_error(error,
                     DNF_ERROR,
                     DNF_ERROR_REPO_NOT_AVAILABLE,


### PR DESCRIPTION
The nonexistent local/media repositories were automatically disabled
during check (in function dnf_repo_check_internal). So application
(the Packagekit daemon) that reuses the deactivated repository object
then silently skip the repository as disabled.

We should not to disable repositories which are required
(skip_if_unavailable=0).

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1689331