### PR TITLE
[config] Fix: toString() to not insert [] (RhBug:1584442)

### DIFF
--- a/libdnf/conf/OptionStringList.cpp
+++ b/libdnf/conf/OptionStringList.cpp
@@ -97,7 +97,6 @@ void OptionStringList::set(Priority priority, const std::string & value)
 std::string OptionStringList::toString(const ValueType & value) const
 {
     std::ostringstream oss;
-    oss << "[";
     bool next{false};
     for (auto & val : value) {
         if (next)
@@ -106,7 +105,6 @@ std::string OptionStringList::toString(const ValueType & value) const
             next = true;
         oss << val;
     }
-    oss << "]";
     return oss.str();
 }
 

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -1288,7 +1288,6 @@ bool ModulePackageContainer::Impl::ModulePersistor::update(const std::string & n
 
     OptionStringList slist{std::vector<std::string>()};
     auto profiles = slist.toString(getProfiles(name));
-    profiles = profiles.substr(1, profiles.size()-2);
     if (!parser.hasOption(name, "profiles") || parser.getValue(name, "profiles") != profiles) {
         parser.setValue(name, "profiles", std::move(profiles));
         changed = true;

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -1286,10 +1286,10 @@ bool ModulePackageContainer::Impl::ModulePersistor::update(const std::string & n
         changed = true;
     }
 
-    OptionStringList slist{std::vector<std::string>()};
-    auto profiles = slist.toString(getProfiles(name));
-    if (!parser.hasOption(name, "profiles") || parser.getValue(name, "profiles") != profiles) {
-        parser.setValue(name, "profiles", std::move(profiles));
+    OptionStringList profiles{getProfiles(name)};
+    if (!parser.hasOption(name, "profiles") ||
+        OptionStringList(parser.getValue(name, "profiles")).getValue() != profiles.getValue()) {
+        parser.setValue(name, "profiles", profiles.getValueString());
         changed = true;
     }
 


### PR DESCRIPTION
OptionStringList::toString() returned a string starting with
"[" and ended with "]" that represents list of strings (Python
compatibility like print([<values>])). But opposite method
OptionStringList::fromString() assumes input without "[" and "]".
The dnf.conf and .repo files do not support value surrounded
by "[" and "]" therefore this commit removes these characters.

Fix https://bugzilla.redhat.com/show_bug.cgi?id=1584442