### PR TITLE
[config] ignore trailing blank lines of multiline value (RhBug:1722493)

### DIFF
--- a/libdnf/utils/iniparser/iniparser.cpp
+++ b/libdnf/utils/iniparser/iniparser.cpp
@@ -81,6 +81,9 @@ IniParser::IniParser(std::unique_ptr<std::istream> && inputStream)
 }
 
 void IniParser::trimValue() noexcept {
+    auto end = value.find_last_not_of(DELIMITER);
+    if (end != value.npos)
+        value.resize(end + 1);
     if (value.length() > 1 &&
         value.front() == value.back() &&
         (value.front() == '\"' || value.front() == '\'')) {


### PR DESCRIPTION
Parser supports multiline values. Example:
key = value first line
  value second line

If a line starts with whitespace characters and it is not a section name,
it is treated as continuation of previous key=value line.

This commit ignores trailing blank lines. So newline characters
are trimmed out from the end of line.

Note:
It is not good idea to use multiline values in repo file because they are not supported in old libdnf "context" part. -> They are not working with microdnf, PackageKit, ...