### PR TITLE
Re-size includes map before re-computation (RhBug:1690915)

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -356,6 +356,7 @@ dnf_sack_recompute_considered(DnfSack *sack)
     if (priv->module_excludes)
         map_subtract(pool->considered, priv->module_excludes);
     if (priv->pkg_includes) {
+        map_grow(priv->pkg_includes, pool->nsolvables);
         Map pkg_includes_tmp;
         map_init_clone(&pkg_includes_tmp, priv->pkg_includes);
 


### PR DESCRIPTION
It resolves problems with incorrect reads.

https://bugzilla.redhat.com/show_bug.cgi?id=1690915