### PR TITLE
Revert consequences of Fail-Safe mechanism

### DIFF
--- a/libdnf/dnf-rpmts.cpp
+++ b/libdnf/dnf-rpmts.cpp
@@ -69,11 +69,9 @@ test_fail_safe(Header * hdr, DnfPackage * pkg, GError **error)
             DnfSack * sack = dnf_package_get_sack(pkg);
             auto includes = dnf_sack_get_module_includes(sack);
             if (!includes || !includes->has(dnf_package_get_id(pkg))) {
-                g_set_error(error, DNF_ERROR, DNF_ERROR_INTERNAL_ERROR,
-                            _("No available modular metadata for modular package '%s'; "
-                              "cannot be installed on the system"),
-                            dnf_package_get_nevra(pkg));
-                ret = FALSE;
+                g_critical(_("No available modular metadata for modular package '%s'; "
+                             "cannot be installed on the system"),
+                           dnf_package_get_nevra(pkg));
             }
         }
     }


### PR DESCRIPTION
It looks like that infrastructure is not ready for Fail-Safe mechanism.
The patch should allows possibility for a release.

Requires: https://github.com/rpm-software-management/dnf/pull/1429