### PR TITLE
Unlink libsolv repo when libdnf:Repo: detachLibsolvRepo

### DIFF
--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -1345,9 +1345,8 @@ void Repo::Impl::attachLibsolvRepo(LibsolvRepo * libsolvRepo)
 void Repo::Impl::detachLibsolvRepo()
 {
     libsolvRepo->appdata = nullptr;
-    if (--nrefs > 0)
-        this->libsolvRepo = nullptr;
-    else
+    this->libsolvRepo = nullptr;
+    if (--nrefs <= 0)
         delete owner;
 }
 


### PR DESCRIPTION
it should prevent from calling of libsolv repo after deallocation of
Sack and Pool.