### PR TITLE
Fix Python 3.8 deprecation warning (RhBug:1724244)

### DIFF
--- a/python/hawkey/package-py.cpp
+++ b/python/hawkey/package-py.cpp
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdio.h>
 
@@ -251,7 +252,7 @@ get_chksum(_PackageObject *self, void *closure)
 #if PY_MAJOR_VERSION < 3
     res = Py_BuildValue("is#", type, cs, checksum_length);
 #else
-    res = Py_BuildValue("iy#", type, cs, checksum_length);
+    res = Py_BuildValue("iy#", type, cs, (Py_ssize_t)checksum_length);
 #endif
 
     return res;

--- a/python/hawkey/packagedelta-py.cpp
+++ b/python/hawkey/packagedelta-py.cpp
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 // hawkey
@@ -92,7 +93,7 @@ get_chksum(_PackageDeltaObject *self, void *closure)
 #if PY_MAJOR_VERSION < 3
     res = Py_BuildValue("is#", type, cs, checksum_length);
 #else
-    res = Py_BuildValue("iy#", type, cs, checksum_length);
+    res = Py_BuildValue("iy#", type, cs, (Py_ssize_t)checksum_length);
 #endif
 
     return res;


### PR DESCRIPTION
This deprecation warning was introduced in Python 3.8 by
https://bugs.python.org/issue36381:

/usr/lib/python3.8/site-packages/dnf/package.py:57: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
  return super(Package, self).chksum

https://bugzilla.redhat.com/show_bug.cgi?id=1724244