### PR TITLE
Do not create @System.solv files (RhBug:1707995)

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -1471,7 +1471,7 @@ dnf_context_setup_sack_with_flags(DnfContext               *context,
     if (!skip_rpmdb && have_existing_install(context)) {
         if (!dnf_sack_load_system_repo(priv->sack,
                                        nullptr,
-                                       DNF_SACK_LOAD_FLAG_BUILD_CACHE,
+                                       DNF_SACK_LOAD_FLAG_NONE,
                                        error))
             return FALSE;
     }

--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -1412,7 +1412,7 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
     } else {
         // if sack is not available, create a custom instance
         rpmdb_version_sack = dnf_sack_new();
-        dnf_sack_load_system_repo(rpmdb_version_sack, nullptr, DNF_SACK_LOAD_FLAG_BUILD_CACHE, nullptr);
+        dnf_sack_load_system_repo(rpmdb_version_sack, nullptr, DNF_SACK_LOAD_FLAG_NONE, nullptr);
         rpmdb_begin = dnf_sack_get_rpmdb_version(rpmdb_version_sack);
         g_object_unref(rpmdb_version_sack);
     }
@@ -1457,7 +1457,7 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
     // finalize swdb transaction
     // always load a new sack with rpmdb state after the transaction
     rpmdb_version_sack = dnf_sack_new();
-    dnf_sack_load_system_repo(rpmdb_version_sack, nullptr, DNF_SACK_LOAD_FLAG_BUILD_CACHE, nullptr);
+    dnf_sack_load_system_repo(rpmdb_version_sack, nullptr, DNF_SACK_LOAD_FLAG_NONE, nullptr);
     rpmdb_end = dnf_sack_get_rpmdb_version(rpmdb_version_sack);
     g_object_unref(rpmdb_version_sack);
 


### PR DESCRIPTION
The patch will spare some place on the disk and prevents from using
outdated data, because sometime rpmdb could change but detection could
not cache it.

Additionally caching rpmDB provide minimal minimal boost in performance.

https://bugzilla.redhat.com/show_bug.cgi?id=1707995