### PR TITLE
[transaction] Handle merging multilib packages correctly.

### DIFF
--- a/libdnf/transaction/MergedTransaction.cpp
+++ b/libdnf/transaction/MergedTransaction.cpp
@@ -217,7 +217,7 @@ getItemIdentifier(ItemPtr item)
     std::string name;
     if (itemType == ItemType::RPM) {
         auto rpm = std::dynamic_pointer_cast< RPMItem >(item);
-        name = rpm->getName();
+        name = rpm->getName() + "." + rpm->getArch();
     } else if (itemType == ItemType::GROUP) {
         auto group = std::dynamic_pointer_cast< CompsGroupItem >(item);
         name = group->getGroupId();

--- a/tests/libdnf/transaction/MergedTransactionTest.cpp
+++ b/tests/libdnf/transaction/MergedTransactionTest.cpp
@@ -737,6 +737,65 @@ MergedTransactionTest::test_install_downgrade()
     CPPUNIT_ASSERT_EQUAL(TransactionItemReason::USER, item->getReason());
 }
 
+void
+MergedTransactionTest::test_multilib_identity()
+{
+    auto trans = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans->addItem(
+        nevraToRPMItem(conn, "gtk3-3.24.8-1.fc30.i686"),
+        "repo2",
+        TransactionItemAction::DOWNGRADE,
+        TransactionItemReason::USER
+    );
+    trans->addItem(
+        nevraToRPMItem(conn, "gtk3-3.24.10-1.fc31.i686"),
+        "repo2",
+        TransactionItemAction::DOWNGRADED,
+        TransactionItemReason::USER
+    );
+    trans->addItem(
+        nevraToRPMItem(conn, "gtk3-3.24.8-1.fc30.x86_64"),
+        "repo2",
+        TransactionItemAction::DOWNGRADE,
+        TransactionItemReason::USER
+    );
+    trans->addItem(
+        nevraToRPMItem(conn, "gtk3-3.24.10-1.fc31.x86_64"),
+        "repo2",
+        TransactionItemAction::DOWNGRADED,
+        TransactionItemReason::USER
+    );
+
+    MergedTransaction merged(trans);
+
+    auto items = merged.getItems();
+    CPPUNIT_ASSERT_EQUAL(4, (int)items.size());
+
+    auto item0 = items.at(0);
+    CPPUNIT_ASSERT_EQUAL(std::string("gtk3-3.24.10-1.fc31.i686"), item0->getItem()->toStr());
+    CPPUNIT_ASSERT_EQUAL(std::string("repo2"), item0->getRepoid());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemAction::DOWNGRADED, item0->getAction());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemReason::USER, item0->getReason());
+
+    auto item1 = items.at(1);
+    CPPUNIT_ASSERT_EQUAL(std::string("gtk3-3.24.8-1.fc30.i686"), item1->getItem()->toStr());
+    CPPUNIT_ASSERT_EQUAL(std::string("repo2"), item1->getRepoid());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemAction::DOWNGRADE, item1->getAction());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemReason::USER, item1->getReason());
+
+    auto item2 = items.at(2);
+    CPPUNIT_ASSERT_EQUAL(std::string("gtk3-3.24.10-1.fc31.x86_64"), item2->getItem()->toStr());
+    CPPUNIT_ASSERT_EQUAL(std::string("repo2"), item2->getRepoid());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemAction::DOWNGRADED, item2->getAction());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemReason::USER, item2->getReason());
+
+    auto item3 = items.at(3);
+    CPPUNIT_ASSERT_EQUAL(std::string("gtk3-3.24.8-1.fc30.x86_64"), item3->getItem()->toStr());
+    CPPUNIT_ASSERT_EQUAL(std::string("repo2"), item3->getRepoid());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemAction::DOWNGRADE, item3->getAction());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemReason::USER, item3->getReason());
+}
+
 /*
     def test_add_obsoleted_removed(self):
         """Test add with an obsoleted NEVRA which was removed before."""

--- a/tests/libdnf/transaction/MergedTransactionTest.hpp
+++ b/tests/libdnf/transaction/MergedTransactionTest.hpp
@@ -28,6 +28,8 @@ class MergedTransactionTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_downgrade);
     CPPUNIT_TEST(test_install_downgrade);
 
+    CPPUNIT_TEST(test_multilib_identity);
+
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -56,6 +58,7 @@ public:
     void test_downgrade();
     void test_install_downgrade();
 
+    void test_multilib_identity();
 private:
     std::shared_ptr< SQLite3 > conn;
 };


### PR DESCRIPTION
Use Name.Arch (instead of Name) as a key for pairing the RPMs.
RhBug:1728637