### PR TITLE
Add removeMetadataTypeFromDownload so it is possible to undo addMeta

### DIFF
--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -422,6 +422,11 @@ void Repo::addMetadataTypeToDownload(const std::string &metadataType)
     pImpl->additionalMetadata.insert(metadataType);
 }
 
+void Repo::removeMetadataTypeFromDownload(const std::string &metadataType)
+{
+    pImpl->additionalMetadata.erase(metadataType);
+}
+
 std::string Repo::getMetadataPath(const std::string &metadataType)
 {
     return pImpl->getMetadataPath(metadataType);

--- a/libdnf/repo/Repo.hpp
+++ b/libdnf/repo/Repo.hpp
@@ -183,6 +183,16 @@ public:
     void addMetadataTypeToDownload(const std::string &metadataType);
 
     /**
+    * @brief Stop asking for this additional repository metadata type
+    *
+    * given metadata_type is no longer downloaded by default
+    * when this repository is downloaded.
+    *
+    * @param metadataType metadata type (filelists, other, productid...)
+    */
+    void removeMetadataTypeFromDownload(const std::string &metadataType);
+
+    /**
     * @brief Return path to the particular downloaded repository metadata in cache
     *
     * @param metadataType metadata type (filelists, other, productid...)


### PR DESCRIPTION
I'm working with some optional metadata, so it is helpful if I can remove my metadata if it is missing from a repo.