### PR TITLE
hy_detect_arch(): detect crypto only on arm version >= 8

### DIFF
--- a/libdnf/hy-util.cpp
+++ b/libdnf/hy-util.cpp
@@ -118,7 +118,8 @@ hy_detect_arch(char **arch)
             modifier++;
         if (getauxval(AT_HWCAP) & HWCAP_ARM_VFP)
             *modifier++ = 'h';
-        if (getauxval(AT_HWCAP2) & HWCAP2_AES)
+        // arm version >= 8 can have crypto extension
+        if ((atoi(un.machine+4) >= 8) && (getauxval(AT_HWCAP2) & HWCAP2_AES))
             *modifier++ = 'c';
         if (getauxval(AT_HWCAP) & HWCAP_ARM_NEON)
             *modifier++ = 'n';


### PR DESCRIPTION
Before patch:
It detected armv7 with crypto extension on some "qemu-arm"
configurations. New architecture string "armv7hcnl" was generated.

After patch:
It detect crypto extension only if arm version >= 8.

https://bugzilla.redhat.com/show_bug.cgi?id=1691430