### PR TITLE
[docs] Fix: rename dnf-repos to dnf-repo-loader

### DIFF
--- a/docs/libdnf/libdnf-docs.sgml
+++ b/docs/libdnf/libdnf-docs.sgml
@@ -35,7 +35,7 @@
     </partintro>
     <xi:include href="xml/dnf-context.xml"/>
     <xi:include href="xml/dnf-lock.xml"/>
-    <xi:include href="xml/dnf-repos.xml"/>
+    <xi:include href="xml/dnf-repo-loader.xml"/>
     <xi:include href="xml/dnf-repo.xml"/>
     <xi:include href="xml/dnf-state.xml"/>
     <xi:include href="xml/dnf-transaction.xml"/>


### PR DESCRIPTION
dnf-repos was renamed to dnf-repo-loader in 2016, but the base gtk-doc sgml
file not updated.