### PR TITLE
[tests] Fix: disable fatal warnings during test case runs

### DIFF
--- a/tests/libdnf/dnf-self-test.c
+++ b/tests/libdnf/dnf-self-test.c
@@ -1202,6 +1202,7 @@ main(int argc, char **argv)
 
     /* only critical and error are fatal */
     g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
+    g_log_set_always_fatal (G_LOG_FATAL_MASK);
 
     /* tests go here */
     g_test_add_func("/libdnf/repo_loader{gpg-asc}", dnf_repo_loader_gpg_asc_func);


### PR DESCRIPTION
g_test_init() makes warning and critical messages fatal by default.

That's not immediately a problem on systems using dnf as their main package
manager (or having dnf installed for some other reason), but Debian does not
have an (older) dnf version in the build environment.

This leads to libdnf spitting out warning messages in hy_repo_create() due to
the global dnf config file not existing - and eventually to failing the test
case due to the TRAP signal issued by glib.

Let's really ignore warning messages globally, as it probably was intended in
the first place.