### PR TITLE
[tests] Fix: always run test cases

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -202,11 +202,19 @@ pushd build-py2
 popd
 %endif # with python2
 %if %{with python3}
-# Run just the Python tests, not all of them, since
-# we have coverage of the core from the first build
+# If we didn't run the general tests yet, do it now.
+%if %{without python2}
+pushd build-py3
+  make ARGS="-V" test
+popd
+%else
+# Otherwise, run just the Python tests, not all of
+# them, since we have coverage of the core from the
+# first build
 pushd build-py3/python/hawkey/tests
   make ARGS="-V" test
 popd
+%endif
 %endif
 
 %install


### PR DESCRIPTION
Previously, python2 builds were always enabled and the general test cases
were run as part of (also) building the python2 buildings.

Recently, though, python2 builds have been disabled by default on newer
distros (due to deprecation), but that also means that the general test
cases are not run any longer.

Fix that by running the general test cases in python3 builds if python2
builds are disabled.

**Note:** this will lead to test case failures if valgrind tests are enabled, see #783 and #784 .