### PR TITLE
Mark job goal.upgrade with sltr as targeted

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -1,7 +1,7 @@
 %global libsolv_version 0.7.4-1
 %global libmodulemd_version 1.6.1
 %global librepo_version 1.10.0
-%global dnf_conflict 4.2.5
+%global dnf_conflict 4.2.11
 %global swig_version 3.0.12
 
 %bcond_with valgrind
@@ -37,7 +37,7 @@
     %{nil}
 
 Name:           libdnf
-Version:        0.35.4
+Version:        0.35.5
 Release:        1%{?dist}
 Summary:        Library providing simplified C and Python API to libsolv
 License:        LGPLv2+

--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -767,7 +767,7 @@ void
 Goal::upgrade(HySelector sltr)
 {
     pImpl->actions = static_cast<DnfGoalActions>(pImpl->actions | DNF_UPGRADE);
-    sltrToJob(sltr, &pImpl->staging, SOLVER_UPDATE);
+    sltrToJob(sltr, &pImpl->staging, SOLVER_UPDATE|SOLVER_TARGETED);
 }
 
 void

--- a/libdnf/goal/Goal.hpp
+++ b/libdnf/goal/Goal.hpp
@@ -86,8 +86,10 @@ public:
     /**
     * @brief If selector ill formed, it rises std::runtime_error()
     *
-    * @param sltr p_sltr: It should contain only upgrades with obsoletes otherwise it can try to
-    * reinstall installonly packages.
+    * @param sltr p_sltr: It contains upgrade-to packages and obsoletes. The presence of installed
+    * packages prevents reinstalling packages with the same NEVRA but changed contant. To honor repo
+    * priority all relevant packages must be present. To upgrade package foo from priority repo, all
+    * installed and available packages of the foo must be in selector plus obsoletes of foo.
     */
     void upgrade(HySelector sltr);
     void userInstalled(DnfPackage *pkg);


### PR DESCRIPTION
It allows to keep installed packages in upgrade set.

It also prevents from reinstalling of modified packages with same NEVRA.