### PR TITLE
Use copy+delete fallback if moving of directory failed (RhBug:1700341)

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -36,6 +36,7 @@
 #include "conf/OptionBool.hpp"
 
 #include "hy-repo-private.hpp"
+#include "hy-iutil-private.hpp"
 
 #include <strings.h>
 #include <fcntl.h>
@@ -1825,14 +1826,13 @@ dnf_repo_update(DnfRepo *repo,
 
     /* move the packages directory from the old cache to the new cache */
     if (g_file_test(priv->packages, G_FILE_TEST_EXISTS)) {
-        rc = g_rename(priv->packages, priv->packages_tmp);
-        if (rc != 0) {
-            ret = FALSE;
+        ret = dnf_move_recursive(priv->packages, priv->packages_tmp, &error_local);
+        if (!ret) {
             g_set_error(error,
                         DNF_ERROR,
                         DNF_ERROR_CANNOT_FETCH_SOURCE,
-                        "cannot move %s to %s",
-                        priv->packages, priv->packages_tmp);
+                        "cannot move %s to %s: %s",
+                        priv->packages, priv->packages_tmp, error_local->message);
             goto out;
         }
     }
@@ -1843,14 +1843,13 @@ dnf_repo_update(DnfRepo *repo,
         goto out;
 
     /* rename .tmp actual name */
-    rc = g_rename(priv->location_tmp, priv->location);
-    if (rc != 0) {
-        ret = FALSE;
+    ret = dnf_move_recursive(priv->location_tmp, priv->location, &error_local);
+    if (!ret) {
         g_set_error(error,
                     DNF_ERROR,
                     DNF_ERROR_CANNOT_FETCH_SOURCE,
-                    "cannot move %s to %s",
-                    priv->location_tmp, priv->location);
+                    "cannot move %s to %s: %s",
+                    priv->location_tmp, priv->location, error_local->message);
         goto out;
     }
     ret = lr_handle_setopt(priv->repo_handle, error,

--- a/libdnf/hy-iutil-private.hpp
+++ b/libdnf/hy-iutil-private.hpp
@@ -41,6 +41,7 @@ char *abspath(const char *path);
 int is_readable_rpm(const char *fn);
 int mkcachedir(char *path);
 gboolean mv(const char *old_path, const char *new_path, GError **error);
+gboolean dnf_move_recursive(const gchar *src_dir, const gchar *dst_dir, GError **error);
 char *this_username(void);
 
 /* misc utils */

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -44,6 +44,7 @@
 #include "../hy-iutil.h"
 #include "../hy-repo-private.hpp"
 #include "../hy-util-private.hpp"
+#include "../hy-iutil-private.hpp"
 #include "../hy-types.h"
 #include "libdnf/conf/ConfigParser.hpp"
 #include "libdnf/utils/File.hpp"
@@ -1229,10 +1230,13 @@ void Repo::Impl::fetch(const std::string & destdir, std::unique_ptr<LrHandle> &&
                 }
             }
             auto tempElement = tmpdir + "/" + elName;
-            if (rename(tempElement.c_str(), targetElement.c_str()) == -1) {
-                const char * errTxt = strerror(errno);
-                throw std::runtime_error(tfm::format(
-                    _("Cannot rename directory \"%s\" to \"%s\": %s"), tempElement, targetElement, errTxt));
+            GError * error = NULL;
+            if (!dnf_move_recursive(tempElement.c_str(), targetElement.c_str(), &error)) {
+                std::string errTxt = tfm::format(
+                    _("Cannot rename directory \"%s\" to \"%s\": %s"),
+                    tempElement, targetElement, error->message);
+                g_error_free(error);
+                throw std::runtime_error(errTxt);
             }
         }
     }


### PR DESCRIPTION
The `rename()` was used for atomic move of directory tree. But `rename()` is not working between filesystems. The `rename()` also had problems with `overlayfs` (used in Podman).

The PR implements copy + delete fallback for `rename()`.

Solves: https://bugzilla.redhat.com/show_bug.cgi?id=1700341