### PR TITLE
Repo download: use full error description into the exception text

### DIFF
--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -1274,8 +1274,7 @@ bool Repo::Impl::load()
         timestamp = -1;
         loadCache(true);
     } catch (const LrExceptionWithSourceUrl & e) {
-        logger->debug(tfm::format(_("Cannot download '%s': %s."), e.getSourceUrl(), e.what()));
-        auto msg = tfm::format(_("Failed to download metadata for repo '%s'"), id);
+        auto msg = tfm::format(_("Failed to download metadata for repo '%s': %s"), id, e.what());
         throw std::runtime_error(msg);
     }
     expired = false;


### PR DESCRIPTION
Use full description of the error when repository metadata download
fails. In particular when the repository is configured with
repo_gpgcheck = 1 and does actually not support GPG verification, the
user should be notified of the error, which is coming from librepo.

Also removing the debug log line, as it doesn't contain more information
than the error message (the actual URL is included in the error
message from librepo).

https://bugzilla.redhat.com/show_bug.cgi?id=1741442

---
For main discussion, please see https://github.com/rpm-software-management/librepo/pull/165