### PR TITLE
[docs] libdnf: build reproducibly

### DIFF
--- a/docs/libdnf/Doxyfile.in
+++ b/docs/libdnf/Doxyfile.in
@@ -150,7 +150,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand


### PR DESCRIPTION
Doxygen includes the full path to sources in its documentation by
default, which makes builds non-reproducible.

Instruct it to use the shortest possible path that makes file names
unique instead.