### PR TITLE
Apply targeted upgrade only for selector with packages

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -767,7 +767,11 @@ void
 Goal::upgrade(HySelector sltr)
 {
     pImpl->actions = static_cast<DnfGoalActions>(pImpl->actions | DNF_UPGRADE);
-    sltrToJob(sltr, &pImpl->staging, SOLVER_UPDATE|SOLVER_TARGETED);
+    auto flags = SOLVER_UPDATE;
+    if (sltr->getPkgs()) {
+        flags |= SOLVER_TARGETED;
+    }
+    sltrToJob(sltr, &pImpl->staging, flags);
 }
 
 void


### PR DESCRIPTION
It resolves problem when selector with name filter is used. Then
targeted transaction ignores obsoletes.