### PR TITLE
[context] Read of variables (urlvars) from directories

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -43,7 +43,7 @@
     %{nil}
 
 Name:           libdnf
-Version:        0.35.5
+Version:        0.35.6
 Release:        1%{?dist}
 Summary:        Library providing simplified C and Python API to libsolv
 License:        LGPLv2+

--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -182,8 +182,7 @@ class ConfigMain::Impl {
     OptionString logdir{"/var/log"};
     OptionNumber<std::int32_t> log_size{1024 * 1024, strToBytes};
     OptionNumber<std::int32_t> log_rotate{4, 0};
-    // More important varsdirs must be on the end of vector
-    OptionStringList varsdir{std::vector<std::string>{"/etc/yum/vars", "/etc/dnf/vars"}};
+    OptionStringList varsdir{VARS_DIRS};
     OptionStringList reposdir{{"/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d"}};
     OptionBool debug_solver{false};
     OptionStringList installonlypkgs{INSTALLONLYPKGS};

--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -168,6 +168,16 @@ public:
     */
     static void addVarsFromDir(std::map<std::string, std::string> & varsMap, const std::string & dirPath);
 
+    /**
+    * @brief Adds variables from environment
+    *
+    * Environment variables DNF[0-9] and DNF_VAR_[A-Za-z0-9_]+ are used if exists.
+    * DNF_VAR_ prefix is cut off.
+    *
+    * @param varsMap Storage where the variables are added.
+    */
+    static void addVarsFromEnv(std::map<std::string, std::string> & varsMap);
+
 private:
     class Impl;
     std::unique_ptr<Impl> pImpl;

--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -157,6 +157,17 @@ public:
     OptionNumber<std::uint32_t> & deltarpm_percentage();
     OptionBool & skip_if_unavailable();
 
+    /**
+    * @brief Adds variables from directory
+    *
+    * Additional variables are added from directory. Each file represents one variable.
+    * The variable name is equal to filename and the value is defined by first line of the file.
+    *
+    * @param varsMap Storage where the variables are added.
+    * @param dirPath Path to directory.
+    */
+    static void addVarsFromDir(std::map<std::string, std::string> & varsMap, const std::string & dirPath);
+
 private:
     class Impl;
     std::unique_ptr<Impl> pImpl;

--- a/libdnf/conf/Const.hpp
+++ b/libdnf/conf/Const.hpp
@@ -31,6 +31,9 @@ constexpr const char * SYSTEM_CACHEDIR = "/var/cache/dnf";
 
 constexpr const char * CONF_FILENAME = "/etc/dnf/dnf.conf";
 
+// More important varsdirs must be on the end of vector
+const std::vector<std::string> VARS_DIRS{"/etc/yum/vars", "/etc/dnf/vars"};
+
 const std::vector<std::string> GROUP_PACKAGE_TYPES{"mandatory", "default", "conditional"};
 const std::vector<std::string> INSTALLONLYPKGS{"kernel", "kernel-PAE",
                  "installonlypkg(kernel)",

--- a/libdnf/conf/Const.hpp
+++ b/libdnf/conf/Const.hpp
@@ -21,6 +21,9 @@
 #ifndef _LIBDNF_CONFIG_CONST_HPP
 #define _LIBDNF_CONFIG_CONST_HPP
 
+#include <string>
+#include <vector>
+
 namespace libdnf {
 
 constexpr const char * PERSISTDIR = "/var/lib/dnf";

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "config.h"
+#include "conf/Const.hpp"
 
 #include <memory>
 #include <string>
@@ -240,8 +241,12 @@ static void
 dnf_context_init(DnfContext *context)
 {
     DnfContextPrivate *priv = GET_PRIVATE(context);
-    const gchar *vars_dir[] = {"/etc/dnf/vars", "/etc/yum/vars", NULL};
-    priv->vars_dir = g_strdupv(const_cast<gchar **>(vars_dir));
+
+    priv->vars_dir = g_new(gchar*, libdnf::VARS_DIRS.size() + 1);
+    for (size_t i = 0; i < libdnf::VARS_DIRS.size(); ++i)
+        priv->vars_dir[i] = g_strdup(libdnf::VARS_DIRS[i].c_str());
+    priv->vars_dir[libdnf::VARS_DIRS.size()] = NULL;
+
     priv->install_root = g_strdup("/");
     priv->check_disk_space = TRUE;
     priv->check_transaction = TRUE;

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -2533,6 +2533,7 @@ dnf_context_load_vars(DnfContext * context)
     priv->vars->clear();
     for (auto dir = priv->vars_dir; *dir; ++dir)
         ConfigMain::addVarsFromDir(*priv->vars, std::string(priv->install_root) + *dir);
+    ConfigMain::addVarsFromEnv(*priv->vars);
     priv->varsCached = true;
 }
 

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -32,9 +32,9 @@
 
 #include "config.h"
 #include "conf/Const.hpp"
+#include "dnf-context.hpp"
 
 #include <memory>
-#include <string>
 #include <vector>
 #include <gio/gio.h>
 #include <rpm/rpmlib.h>
@@ -162,6 +162,8 @@ typedef struct
     DnfState        *state;        /* used for setup() and run() */
     HyGoal           goal;
     DnfSack         *sack;
+    std::map<std::string, std::string> *vars;
+    bool             varsCached;
     libdnf::Plugins *plugins;
 } DnfContextPrivate;
 
@@ -194,6 +196,7 @@ dnf_context_finalize(GObject *object)
 
     priv->plugins->free();
     delete priv->plugins;
+    delete priv->vars;
 
     g_free(priv->repo_dir);
     g_strfreev(priv->vars_dir);
@@ -259,6 +262,8 @@ dnf_context_init(DnfContext *context)
     priv->override_macros = g_hash_table_new_full(g_str_hash, g_str_equal,
                                                   g_free, g_free);
     priv->user_agent = g_strdup("libdnf/" PACKAGE_VERSION);
+
+    priv->vars = new std::map<std::string, std::string>;
 
     priv->plugins = new libdnf::Plugins;
     if (!pluginsDir.empty()) {
@@ -952,6 +957,7 @@ dnf_context_set_vars_dir(DnfContext *context, const gchar * const *vars_dir)
     DnfContextPrivate *priv = GET_PRIVATE(context);
     g_strfreev(priv->vars_dir);
     priv->vars_dir = g_strdupv(const_cast<gchar **>(vars_dir));
+    priv->varsCached = false;
 }
 
 /**
@@ -2504,4 +2510,30 @@ pluginGetContext(DnfPluginInitData * data)
         return nullptr;
     }
     return (static_cast<PluginHookContextInitData *>(data)->context);
+}
+
+namespace libdnf {
+
+std::map<std::string, std::string> &
+dnf_context_get_vars(DnfContext * context)
+{
+    return *GET_PRIVATE(context)->vars;
+}
+
+bool
+dnf_context_get_vars_cached(DnfContext * context)
+{
+    return GET_PRIVATE(context)->varsCached;
+}
+
+void
+dnf_context_load_vars(DnfContext * context)
+{
+    auto priv = GET_PRIVATE(context);
+    priv->vars->clear();
+    for (auto dir = priv->vars_dir; *dir; ++dir)
+        ConfigMain::addVarsFromDir(*priv->vars, std::string(priv->install_root) + *dir);
+    priv->varsCached = true;
+}
+
 }

--- a/libdnf/dnf-context.hpp
+++ b/libdnf/dnf-context.hpp
@@ -23,9 +23,20 @@
 
 #include "dnf-context.h"
 
+#include <map>
+#include <string>
+
 inline DnfContextInvalidateFlags operator|(DnfContextInvalidateFlags a, DnfContextInvalidateFlags b)
 {
     return static_cast<DnfContextInvalidateFlags>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+namespace libdnf {
+
+std::map<std::string, std::string> & dnf_context_get_vars(DnfContext * context);
+bool dnf_context_get_vars_cached(DnfContext * context);
+void dnf_context_load_vars(DnfContext * context);
+
 }
 
 #endif /* __DNF_CONTEXT_HPP */


### PR DESCRIPTION
DNF reads variables (urlvars from direcectories (by default from `/etc/dnf/vars` and `/etc/yum/vars`).
The PR adds this functionality into context part of libdnf. So, microdnf, PackageKit, ... will automatically use this variables too.

It can solve  https://github.com/hughsie/PackageKit/issues/339