### PR TITLE
Change order of vardirs

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -181,7 +181,8 @@ class ConfigMain::Impl {
     OptionString logdir{"/var/log"};
     OptionNumber<std::int32_t> log_size{1024 * 1024, strToBytes};
     OptionNumber<std::int32_t> log_rotate{4, 0};
-    OptionStringList varsdir{std::vector<std::string>{"/etc/dnf/vars", "/etc/yum/vars"}};
+    // More important varsdirs must be on the end of vector
+    OptionStringList varsdir{std::vector<std::string>{"/etc/yum/vars", "/etc/dnf/vars"}};
     OptionStringList reposdir{{"/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d"}};
     OptionBool debug_solver{false};
     OptionStringList installonlypkgs{INSTALLONLYPKGS};


### PR DESCRIPTION
It puts more important vardirs on the end of vector. This is logical
order for iteration when values from the first directory is overwritten
by values from the second one.