### PR TITLE
Use more descriptive message when fail to retrieve GPG key (RhBug:160…

### DIFF
--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -822,7 +822,13 @@ std::vector<Key> Repo::Impl::retrieve(const std::string & url)
         close(fd);
     });
 
-    downloadUrl(url.c_str(), fd);
+    try {
+        downloadUrl(url.c_str(), fd);
+    }
+    catch (const LrExceptionWithSourceUrl & e) {
+        auto msg = tfm::format(_("Failed to retrieve GPG key for repo '%s': %s"), id, e.what());
+        throw std::runtime_error(msg);
+    }
     lseek(fd, SEEK_SET, 0);
     auto keyInfos = rawkey2infos(fd);
     for (auto & key : keyInfos)


### PR DESCRIPTION
…5117)

https://bugzilla.redhat.com/show_bug.cgi?id=1605117
This patch replaces generic message "Failed to synchronize cache for
repo '%s': %s" with more specific "Failed to retrieve GPG key for repo
'%s': %s" in case GPG key retrieval fails.