### PR TITLE
libdnf::CompressedFile::open: Throw exception if file cannot be opened

### DIFF
--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -70,6 +70,7 @@
 
 #include <atomic>
 #include <cctype>
+#include <cerrno>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -77,9 +78,9 @@
 #include <map>
 #include <set>
 #include <sstream>
+#include <system_error>
 #include <type_traits>
 
-#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -816,9 +817,8 @@ std::vector<Key> Repo::Impl::retrieve(const std::string & url)
     char tmpKeyFile[] = "/tmp/repokey.XXXXXX";
     auto fd = mkstemp(tmpKeyFile);
     if (fd == -1) {
-        char buf[1024];
-        (void)strerror_r(errno, buf, sizeof(buf));
-        auto msg = tfm::format("%s: mkstemp(): %s", __func__, buf);
+        auto msg = tfm::format("Error creating temporary file \"%s\": %s",
+            tmpKeyFile, std::system_category().message(errno));
         logger->debug(msg);
         throw LrException(LRE_GPGERROR, msg);
     }

--- a/libdnf/utils/CompressedFile.cpp
+++ b/libdnf/utils/CompressedFile.cpp
@@ -6,6 +6,9 @@ extern "C" {
 #   include <solv/solv_xfopen.h>
 };
 
+#include <cerrno>
+#include <system_error>
+
 namespace libdnf {
 
 CompressedFile::CompressedFile(const std::string &filePath)
@@ -15,7 +18,16 @@ CompressedFile::~CompressedFile() = default;
 
 void CompressedFile::open(const char *mode)
 {
+    // There are situations when solv_xfopen returns NULL but it does not set errno.
+    // In this case errno value is random, so we set a default value.
+    errno = 0;
     file = solv_xfopen(filePath.c_str(), mode);
+    if (!file) {
+        if (errno) {
+            throw OpenException(filePath, std::system_category().message(errno));
+        }
+        throw OpenException(filePath);
+    }
 }
 
 std::string CompressedFile::getContent()

--- a/libdnf/utils/File.cpp
+++ b/libdnf/utils/File.cpp
@@ -10,6 +10,9 @@
 #include <utility>
 #include <iostream>
 
+#include <cerrno>
+#include <system_error>
+
 extern "C" {
 #   include <solv/solv_xfopen.h>
 };
@@ -41,7 +44,7 @@ void File::open(const char *mode)
 {
     file = fopen(filePath.c_str(), mode);
     if (!file) {
-        throw OpenException(filePath);
+        throw OpenException(filePath, std::system_category().message(errno));
     }
 }
 

--- a/libdnf/utils/File.hpp
+++ b/libdnf/utils/File.hpp
@@ -17,7 +17,9 @@ public:
 
     struct OpenException : IOException
     {
-        explicit OpenException(const std::string &filePath) : IOException("Cannot open file: " + filePath) {}
+        explicit OpenException(const std::string &filePath) : IOException("Cannot open file \"" + filePath + "\".") {}
+        explicit OpenException(const std::string &filePath, const std::string &detail) :
+            IOException("Cannot open file \"" + filePath + "\". " + detail) {}
     };
 
     struct CloseException : IOException


### PR DESCRIPTION
The "open" method silently ignored errors. Now exception is thrown when error occurs - during open.
In addition, the exception contains a detail of the error (No such file or directory, Permission denied, ...).

