### PR TITLE
Use POOL_FLAG_WHATPROVIDESWITHDISABLED

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -1,4 +1,4 @@
-%global libsolv_version 0.7.4-1
+%global libsolv_version 0.7.7
 %global libmodulemd_version 1.6.1
 %global librepo_version 1.10.0
 %global dnf_conflict 4.2.11

--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -183,6 +183,7 @@ dnf_sack_init(DnfSack *sack)
 {
     DnfSackPrivate *priv = GET_PRIVATE(sack);
     priv->pool = pool_create();
+    pool_set_flag(priv->pool, POOL_FLAG_WHATPROVIDESWITHDISABLED, 1);
     priv->running_kernel_id = -1;
     priv->running_kernel_fn = running_kernel;
     priv->considered_uptodate = TRUE;


### PR DESCRIPTION
It resolves the problem with --best and search in provides.
The patch does not requires libsolv update, but to make it fully
functional it requires libsolv-0.7.7.

https://bugzilla.redhat.com/show_bug.cgi?id=1737469

Requires for 100% functionality:
https://github.com/openSUSE/libsolv/commit/954862319e32e97b20afd0f598cd461ece320e4f
https://github.com/openSUSE/libsolv/commit/bfdc347fdfc350a9b290543fac905cb21f9a71a8