### PR TITLE
Test "environ" value to nullptr (RhBug:1761740)

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -629,6 +629,9 @@ void ConfigMain::addVarsFromDir(std::map<std::string, std::string> & varsMap, co
 
 void ConfigMain::addVarsFromEnv(std::map<std::string, std::string> & varsMap)
 {
+    if (!environ)
+        return;
+
     for (const char * const * varPtr = environ; *varPtr; ++varPtr) {
         auto var = *varPtr;
         if (auto eqlPtr = strchr(var, '=')) {


### PR DESCRIPTION
The packagekitd sets the "environ" value to nullptr. So, "environ" must be tested to nullptr before use.

Btw: That means environment values (DNF specific, proxy settings, ...) are not working with packagekitd by default. We found a workaround that there is "--keep-environment" argument in "packagekitd".
