### PR TITLE
dnf-repo: stop using LRO_MIRRORLIST completely

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1357,7 +1357,9 @@ dnf_repo_check_internal(DnfRepo *repo,
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_YUMDLIST, download_list.data()))
         return FALSE;
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_MIRRORLIST, NULL))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_MIRRORLISTURL, NULL))
+        return FALSE;
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_METALINKURL, NULL))
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_GNUPGHOMEDIR, priv->keyring))
         return FALSE;


### PR DESCRIPTION
The option is deprecated, so librepo will unconditionally print a big
warning, even if we set it to `NULL`:

    (rpm-ostree compose tree:19527): librepo-WARNING **: 12:10:08.322:
    WARNING! Deprecated LRO_MIRRORLIST used

This was the last place we used it. Instead, replace it by clearing both
`LRO_MIRRORLISTURL` and `LRO_METALINKURL`, which is functionally
equivalent to what setting `LRO_MIRRORLIST` to `NULL` did.