### PR TITLE
Enable module dependencies (RhBug:1762314)

### DIFF
--- a/python/hawkey/sack-py.cpp
+++ b/python/hawkey/sack-py.cpp
@@ -658,9 +658,7 @@ set_modules_enabled_by_pkgset(_SackObject *self, PyObject *args, PyObject *kwds)
         PyObject_GetAttrString(pyModuleContainer, "this"));
     auto moduleContainer = swigContainer->ptr;
     auto modules = moduleContainer->requiresModuleEnablement(*pset.get());
-    for (auto module: modules) {
-        moduleContainer->enable(module->getName(), module->getStream());
-    }
+    moduleContainer->enableDependencyTree(modules);
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
It will enable whole module dependency trees when sack function
set_modules_enabled_by_pkgset() is used.

https://bugzilla.redhat.com/show_bug.cgi?id=1762314

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/658