### PR TITLE
Tweak #includes for GCC 10 compatibility

### DIFF
--- a/libdnf/goal/Goal.hpp
+++ b/libdnf/goal/Goal.hpp
@@ -22,6 +22,7 @@
 #define __GOAL_HPP
 
 #include <memory>
+#include <stdexcept>
 
 #include "../dnf-types.h"
 #include "../hy-goal.h"

--- a/libdnf/repo/solvable/Dependency.cpp
+++ b/libdnf/repo/solvable/Dependency.cpp
@@ -28,6 +28,8 @@ extern "C" {
 #include <solv/util.h>
 }
 
+#include <stdexcept>
+
 namespace libdnf {
 
 static int transformToLibsolvComparisonType(int cmp_type)


### PR DESCRIPTION
@cgwalters says: Quoting the email Jeff sent to me:

Red Hat's compiler team continues to try and be proactive in identifying
issues that will arise as a result of the introduction of a new GCC
release into Fedora each spring.

You're being contacted because a package you maintain in Fedora is going
to fail to build with gcc-10 in the spring.  Yes, I know that's many
months away, but it's far easier to fix this stuff proactively now than
wait.

Fixing it now also means that your package will continue to be built
with testing versions of gcc-10 as we proceed through the development
process thus allowing additional issues to be caught early.

This is a relatively common failure we're seeing with gcc-10 and occurs
as a result of header file cleanups within libstdc++.  For example
various C++ runtime headers indirectly included <string> which in turn
included <local> and <cerrno>.  Those indirect inclusions have been
eliminated which in turn forces packages to include the C++ headers they
actually need.