### PR TITLE
CMakeLists.txt: use LRO_ONETIMEFLAG only if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,11 @@ if(ENABLE_SOLV_URPMREORDER)
     add_definitions(-DLIBSOLV_FLAG_URPMREORDER=1)
 endif()
 
+# librepo
+if(NOT REPO_VERSION VERSION_LESS 1.11.0)
+    add_definitions(-DHAVE_LRO_ONETIMEFLAG)
+endif()
+
 
 # build binaries
 add_subdirectory(libdnf)

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -1128,7 +1128,9 @@ void Repo::Impl::addCountmeFlag(LrHandle *handle) {
 
         // Set the flag
         std::string flag = "countme=" + std::to_string(bucket);
+#if defined(HAVE_LRO_ONETIMEFLAG)
         handleSetOpt(handle, LRO_ONETIMEFLAG, flag.c_str());
+#endif
         logger->debug(tfm::format("countme: event triggered for %s: bucket %i", id, bucket));
 
         // Request a new budget


### PR DESCRIPTION
There is no librepo 1.11.0 out yet with that flag. Let's make it
conditional to make libdnf easier to hack on without building librepo
locally. This will also allow rpm-ostree to bump to the latest libdnf
version.