### PR TITLE
cmake: use -Werror=implicit-function-declaration only for C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,8 @@ find_program(VALGRIND_PROGRAM NAMES valgrind PATH /usr/bin /usr/local/bin)
 
 
 # compiler options
-add_compile_options(-Wcast-align -Wno-uninitialized -Wredundant-decls -Wwrite-strings -Wformat-nonliteral -Wmissing-format-attribute -Wsign-compare -Wtype-limits -Wuninitialized -Wall -Werror=implicit-function-declaration -Wl,--as-needed)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Wmissing-prototypes -Waggregate-return -Wshadow")
+add_compile_options(-Wcast-align -Wno-uninitialized -Wredundant-decls -Wwrite-strings -Wformat-nonliteral -Wmissing-format-attribute -Wsign-compare -Wtype-limits -Wuninitialized -Wall -Wl,--as-needed)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Wmissing-prototypes -Waggregate-return -Wshadow -Werror=implicit-function-declaration")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wmissing-declarations")
 
 # apple: turn rpath off


### PR DESCRIPTION
g++ prints a warning when compiling with
-Werror=implicit-function-declaration, as it is only valid for C.

Move the switch to only the C compiler flags.