### PR TITLE
Handle NoModuleException in dnf_context_reset_modules (RhBug:1767453)

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -2559,7 +2559,12 @@ dnf_context_reset_modules(DnfContext * context, DnfSack * sack, const char ** mo
         return TRUE;
     }
     for (const char ** names = module_names; *names != NULL; ++names) {
-        container->reset(*names);
+        try {
+            container->reset(*names);
+        } catch (libdnf::ModulePackageContainer::NoModuleException & exception) {
+            g_set_error(error, DNF_ERROR, DNF_ERROR_FAILED, "%s", exception.what());
+            return FALSE;
+        }
     }
     container->save();
     container->updateFailSafeData();


### PR DESCRIPTION
We need to do this in case modular repos are disabled or not
accessible; otherwise we can crash with an unhandled exception
here.

Signed-off-by: Adam Williamson <awilliam@redhat.com>