### PR TITLE
Set skip_if_unavailable to true for all media repos (RhBug:1716067)

### DIFF
--- a/libdnf/dnf-repo-loader.cpp
+++ b/libdnf/dnf-repo-loader.cpp
@@ -165,6 +165,7 @@ dnf_repo_loader_add_media(DnfRepoLoader *self,
     dnf_repo_set_enabled(repo, DNF_REPO_ENABLED_PACKAGES);
     dnf_repo_set_gpgcheck(repo, TRUE);
     dnf_repo_set_kind(repo, DNF_REPO_KIND_MEDIA);
+    dnf_repo_set_skip_if_unavailable(repo, TRUE);
     dnf_repo_set_cost(repo, 100);
     dnf_repo_set_keyfile(repo, treeinfo);
     if (idx == 0) {

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -749,6 +749,22 @@ dnf_repo_set_gpgcheck(DnfRepo *repo, gboolean gpgcheck_pkgs)
 }
 
 /**
+ * dnf_repo_set_skip_if_unavailiable:
+ * @repo: a #DnfRepo instance.
+ * @skip_if_unavailable: whether the repo should be skipped if unavailable
+ *
+ * Sets the repo skip_if_unavailable status
+ *
+ * Since: 0.7.3
+ **/
+void
+dnf_repo_set_skip_if_unavailable(DnfRepo *repo, gboolean skip_if_unavailable)
+{
+    DnfRepoPrivate *priv = GET_PRIVATE(repo);
+    priv->repo->getConfig()->skip_if_unavailable().set(libdnf::Option::Priority::RUNTIME, skip_if_unavailable);
+}
+
+/**
  * dnf_repo_set_gpgcheck_md:
  * @repo: a #DnfRepo instance.
  * @gpgcheck_md: if the repo metadata should be signed

--- a/libdnf/dnf-repo.h
+++ b/libdnf/dnf-repo.h
@@ -155,6 +155,8 @@ void             dnf_repo_set_kind              (DnfRepo              *repo,
                                                  DnfRepoKind           kind);
 void             dnf_repo_set_gpgcheck          (DnfRepo              *repo,
                                                  gboolean              gpgcheck_pkgs);
+void             dnf_repo_set_skip_if_unavailable(DnfRepo             *repo,
+                                                 gboolean              skip_if_unavailable);
 void             dnf_repo_set_gpgcheck_md       (DnfRepo              *repo,
                                                  gboolean              gpgcheck_md);
 void             dnf_repo_set_keyfile           (DnfRepo              *repo,


### PR DESCRIPTION
After the change of skip_if_unavailable default to false libdnf users
(e.g. packagekit or microdnf) cannot work while some installation media,
such as rhel-8.0-x86_64-dvd.iso, is mounted. Libdnf by itself doesn't
know how to use media repos but it also cannot skip them, resulting in an
error.

This is a workaround to ensure media repos can always be skipped.

https://bugzilla.redhat.com/show_bug.cgi?id=1716067