### PR TITLE
[user-agent] Add RHEL and CentOS to whitelist

### DIFF
--- a/libdnf/utils/os-release.cpp
+++ b/libdnf/utils/os-release.cpp
@@ -45,6 +45,8 @@ static const std::map<std::string, std::vector<std::string>> distros = {
     { "Fedora", { "cinnamon", "cloud", "container", "coreos", "generic", "iot",
                   "kde", "matecompiz", "server", "silverblue", "snappy", "soas",
                   "workstation", "xfce" } },
+    { "Red Hat Enterprise Linux", {} },
+    { "CentOS Linux", {} },
 };
 std::array<const std::string, 1> canons = { "Linux" };
 


### PR DESCRIPTION
This commit ensures we report RHEL and CentOS systems (and their
versions) in the User-Agent (previously, we would fall back to "libdnf"
for these).
    
Note that these distros have no variant concept so we will always fall
back to "generic" as the variant.

CI test: https://github.com/rpm-software-management/ci-dnf-stack/pull/702