### PR TITLE
[tinyformat] synch with upstream

### DIFF
--- a/libdnf/utils/tinyformat/README.md
+++ b/libdnf/utils/tinyformat/README.md
@@ -8,6 +8,7 @@ of the type of `s`, tinyformat might be for you.  Design goals include:
 
 * Type safety and extensibility for user defined types.
 * C99 `printf()` compatibility, to the extent possible using `std::ostream`
+* POSIX extension for positional arguments
 * Simplicity and minimalism.  A single header file to include and distribute
   with your projects.
 * Augment rather than replace the standard stream formatting mechanism
@@ -16,5 +17,3 @@ of the type of `s`, tinyformat might be for you.  Design goals include:
 Original project URL:
 https://github.com/c42f/tinyformat
 
-Added:
-* POSIX extension for positional arguments

--- a/libdnf/utils/tinyformat/tinyformat.hpp
+++ b/libdnf/utils/tinyformat/tinyformat.hpp
@@ -142,11 +142,16 @@ namespace tfm = tinyformat;
 //------------------------------------------------------------------------------
 // Implementation details.
 #include <algorithm>
-#include <cassert>
 #include <iostream>
 #include <sstream>
 
+#ifndef TINYFORMAT_ASSERT
+#   include <cassert>
+#   define TINYFORMAT_ASSERT(cond) assert(cond)
+#endif
+
 #ifndef TINYFORMAT_ERROR
+#   include <cassert>
 #   define TINYFORMAT_ERROR(reason) assert(0 && reason)
 #endif
 
@@ -157,13 +162,13 @@ namespace tfm = tinyformat;
 #endif
 
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20080201
-//  std::showpos is broken on old libstdc++ as provided with OSX.  See
+//  std::showpos is broken on old libstdc++ as provided with macOS.  See
 //  http://gcc.gnu.org/ml/libstdc++/2007-11/msg00075.html
 #   define TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
 #endif
 
 #ifdef __APPLE__
-// Workaround OSX linker warning: xcode uses different default symbol
+// Workaround macOS linker warning: Xcode uses different default symbol
 // visibilities for static libs vs executables (see issue #25)
 #   define TINYFORMAT_HIDDEN __attribute__((visibility("hidden")))
 #else
@@ -219,7 +224,7 @@ template<int n> struct is_wchar<wchar_t[n]> {};
 template<typename T, typename fmtT, bool convertible = is_convertible<T, fmtT>::value>
 struct formatValueAsType
 {
-    static void invoke(std::ostream& /*out*/, const T& /*value*/) { assert(0); }
+    static void invoke(std::ostream& /*out*/, const T& /*value*/) { TINYFORMAT_ASSERT(0); }
 };
 // Specialized version for types that can actually be converted to fmtT, as
 // indicated by the "convertible" template parameter.
@@ -241,8 +246,7 @@ struct formatZeroIntegerWorkaround<T,true>
 {
     static bool invoke(std::ostream& out, const T& value)
     {
-        if (static_cast<int>(value) == 0 && out.flags() & std::ios::showpos)
-        {
+        if (static_cast<int>(value) == 0 && out.flags() & std::ios::showpos) {
             out << "+0";
             return true;
         }
@@ -283,7 +287,7 @@ inline void formatTruncated(std::ostream& out, const T& value, int ntrunc)
 inline void formatTruncated(std::ostream& out, type* value, int ntrunc) \
 {                                                           \
     std::streamsize len = 0;                                \
-    while(len < ntrunc && value[len] != 0)                  \
+    while (len < ntrunc && value[len] != 0)                 \
         ++len;                                              \
     out.write(value, len);                                  \
 }
@@ -329,15 +333,14 @@ inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,
     // could otherwise lead to a crash when printing a dangling (const char*).
     const bool canConvertToChar = detail::is_convertible<T,char>::value;
     const bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
-    if(canConvertToChar && *(fmtEnd-1) == 'c')
+    if (canConvertToChar && *(fmtEnd-1) == 'c')
         detail::formatValueAsType<T, char>::invoke(out, value);
-    else if(canConvertToVoidPtr && *(fmtEnd-1) == 'p')
+    else if (canConvertToVoidPtr && *(fmtEnd-1) == 'p')
         detail::formatValueAsType<T, const void*>::invoke(out, value);
 #ifdef TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
-    else if(detail::formatZeroIntegerWorkaround<T>::invoke(out, value)) /**/;
+    else if (detail::formatZeroIntegerWorkaround<T>::invoke(out, value)) /**/;
 #endif
-    else if(ntrunc >= 0)
-    {
+    else if (ntrunc >= 0) {
         // Take care not to overread C strings in truncating conversions like
         // "%.4s" where at most 4 characters may be read.
         detail::formatTruncated(out, value, ntrunc);
@@ -352,8 +355,7 @@ inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,
 inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,  \
                         const char* fmtEnd, int /**/, charType value) \
 {                                                                     \
-    switch(*(fmtEnd-1))                                               \
-    {                                                                 \
+    switch (*(fmtEnd-1)) {                                            \
         case 'u': case 'd': case 'i': case 'o': case 'X': case 'x':   \
             out << static_cast<int>(value); break;                    \
         default:                                                      \
@@ -491,7 +493,7 @@ namespace detail {
 
 // Type-opaque holder for an argument to format(), with associated actions on
 // the type held as explicit function pointers.  This allows FormatArg's for
-// each argument to be allocated as a homogenous array inside FormatList
+// each argument to be allocated as a homogeneous array inside FormatList
 // whereas a naive implementation based on inheritance does not.
 class FormatArg
 {
@@ -512,15 +514,15 @@ class FormatArg
         void format(std::ostream& out, const char* fmtBegin,
                     const char* fmtEnd, int ntrunc) const
         {
-            assert(m_value);
-            assert(m_formatImpl);
+            TINYFORMAT_ASSERT(m_value);
+            TINYFORMAT_ASSERT(m_formatImpl);
             m_formatImpl(out, fmtBegin, fmtEnd, ntrunc, m_value);
         }
 
         int toInt() const
         {
-            assert(m_value);
-            assert(m_toIntImpl);
+            TINYFORMAT_ASSERT(m_value);
+            TINYFORMAT_ASSERT(m_toIntImpl);
             return m_toIntImpl(m_value);
         }
 
@@ -550,36 +552,68 @@ class FormatArg
 inline int parseIntAndAdvance(const char*& c)
 {
     int i = 0;
-    for(;*c >= '0' && *c <= '9'; ++c)
+    for (;*c >= '0' && *c <= '9'; ++c)
         i = 10*i + (*c - '0');
     return i;
 }
 
-// Print literal part of format string and return next format spec
-// position.
+// Parse width or precision `n` from format string pointer `c`, and advance it
+// to the next character. If an indirection is requested with `*`, the argument
+// is read from `args[argIndex]` and `argIndex` is incremented (or read
+// from `args[n]` in positional mode). Returns true if one or more
+// characters were read.
+inline bool parseWidthOrPrecision(int& n, const char*& c, bool positionalMode,
+                                  const detail::FormatArg* args,
+                                  int& argIndex, int numArgs)
+{
+    if (*c >= '0' && *c <= '9') {
+        n = parseIntAndAdvance(c);
+    }
+    else if (*c == '*') {
+        ++c;
+        n = 0;
+        if (positionalMode) {
+            int pos = parseIntAndAdvance(c) - 1;
+            if (*c != '$')
+                TINYFORMAT_ERROR("tinyformat: Non-positional argument used after a positional one");
+            if (pos >= 0 && pos < numArgs)
+                n = args[pos].toInt();
+            else
+                TINYFORMAT_ERROR("tinyformat: Positional argument out of range");
+            ++c;
+        }
+        else {
+            if (argIndex < numArgs)
+                n = args[argIndex++].toInt();
+            else
+                TINYFORMAT_ERROR("tinyformat: Not enough arguments to read variable width or precision");
+        }
+    }
+    else {
+        return false;
+    }
+    return true;
+}
+
+// Print literal part of format string and return next format spec position.
 //
-// Skips over any occurrences of '%%', printing a literal '%' to the
-// output.  The position of the first % character of the next
-// nontrivial format spec is returned, or the end of string.
+// Skips over any occurrences of '%%', printing a literal '%' to the output.
+// The position of the first % character of the next nontrivial format spec is
+// returned, or the end of string.
 inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
 {
     const char* c = fmt;
-    for(;; ++c)
-    {
-        switch(*c)
-        {
-            case '\0':
-                out.write(fmt, c - fmt);
+    for (;; ++c) {
+        if (*c == '\0') {
+            out.write(fmt, c - fmt);
+            return c;
+        }
+        else if (*c == '%') {
+            out.write(fmt, c - fmt);
+            if (*(c+1) != '%')
                 return c;
-            case '%':
-                out.write(fmt, c - fmt);
-                if(*(c+1) != '%')
-                    return c;
-                // for "%%", tack trailing % onto next literal section.
-                fmt = ++c;
-                break;
-            default:
-                break;
+            // for "%%", tack trailing % onto next literal section.
+            fmt = ++c;
         }
     }
 }
@@ -616,19 +650,15 @@ inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
 // Formatting options which can't be natively represented using the ostream
 // state are returned in spacePadPositive (for space padded positive numbers)
 // and ntrunc (for truncating conversions).  argIndex is incremented if
-// necessary to pull out variable width and precision .  The function returns a
+// necessary to pull out variable width and precision.  The function returns a
 // pointer to the character after the end of the current format spec.
 inline const char* streamStateFromFormat(std::ostream& out, bool& positionalMode,
                                          bool& spacePadPositive,
                                          int& ntrunc, const char* fmtStart,
-                                         const detail::FormatArg* formatters,
-                                         int& argIndex, int numFormatters)
+                                         const detail::FormatArg* args,
+                                         int& argIndex, int numArgs)
 {
-    if(*fmtStart != '%')
-    {
-        TINYFORMAT_ERROR("tinyformat: Not enough conversion specifiers in format string");
-        return fmtStart;
-    }
+    TINYFORMAT_ASSERT(*fmtStart == '%');
     // Reset stream state to defaults.
     out.width(0);
     out.precision(6);
@@ -644,63 +674,49 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& positionalMode
 
     // 1) Parse an argument index (if followed by '$') or a width possibly
     // preceded with '0' flag.
-    if(*c >= '0' && *c <= '9')
-    {
+    if (*c >= '0' && *c <= '9') {
         const char tmpc = *c;
         int value = parseIntAndAdvance(c);
-        if(*c == '$')
-        {  // value is an argument index
-            if(value > 0 && value <= numFormatters)
-            {
+        if (*c == '$') {
+            // value is an argument index
+            if (value > 0 && value <= numArgs)
                 argIndex = value - 1;
-            }
             else
-            {
                 TINYFORMAT_ERROR("tinyformat: Positional argument out of range");
-            }
             ++c;
             positionalMode = true;
         }
-        else if(positionalMode)
-        {
+        else if (positionalMode) {
             TINYFORMAT_ERROR("tinyformat: Non-positional argument used after a positional one");
         }
-        else
-        {
-            if(tmpc == '0')
-            {
+        else {
+            if (tmpc == '0') {
                 // Use internal padding so that numeric values are
                 // formatted correctly, eg -00010 rather than 000-10
                 out.fill('0');
                 out.setf(std::ios::internal, std::ios::adjustfield);
             }
-            if(value != 0)
-            {
+            if (value != 0) {
                 // Nonzero value means that we parsed width.
                 widthSet = true;
                 out.width(value);
             }
         }
     }
-    else if(positionalMode)
-    {
+    else if (positionalMode) {
         TINYFORMAT_ERROR("tinyformat: Non-positional argument used after a positional one");
     }
     // 2) Parse flags and width if we did not do it in previous step.
-    if(!widthSet)
-    {
+    if (!widthSet) {
         // Parse flags
-        for(;; ++c)
-        {
-            switch(*c)
-            {
+        for (;; ++c) {
+            switch (*c) {
                 case '#':
                     out.setf(std::ios::showpoint | std::ios::showbase);
                     continue;
                 case '0':
                     // overridden by left alignment ('-' flag)
-                    if(!(out.flags() & std::ios::left))
-                    {
+                    if (!(out.flags() & std::ios::left)) {
                         // Use internal padding so that numeric values are
                         // formatted correctly, eg -00010 rather than 000-10
                         out.fill('0');
@@ -713,7 +729,7 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& positionalMode
                     continue;
                 case ' ':
                     // overridden by show positive sign, '+' flag.
-                    if(!(out.flags() & std::ios::showpos))
+                    if (!(out.flags() & std::ios::showpos))
                         spacePadPositive = true;
                     continue;
                 case '+':
@@ -727,91 +743,41 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& positionalMode
             break;
         }
         // Parse width
-        if(*c >= '0' && *c <= '9')
-        {
-            widthSet = true;
-            out.width(parseIntAndAdvance(c));
-        }
-        else if(*c == '*')
-        {
-            widthSet = true;
-            int width = 0;
-            if(positionalMode)
-            {
-                ++c;
-                int pos = parseIntAndAdvance(c) - 1;
-                if(*c != '$')
-                    TINYFORMAT_ERROR("tinyformat: Non-positional argument used after a positional one");
-                if(pos >= 0 && pos < numFormatters)
-                    width = formatters[pos].toInt();
-                else
-                    TINYFORMAT_ERROR("tinyformat: Positional argument out of range");
-            }
-            else
-            {
-                if(argIndex < numFormatters)
-                    width = formatters[argIndex++].toInt();
-                else
-                    TINYFORMAT_ERROR("tinyformat: Not enough arguments to read variable width");
-            }
-            if(width < 0)
-            {
+        int width = 0;
+        widthSet = parseWidthOrPrecision(width, c, positionalMode,
+                                         args, argIndex, numArgs);
+        if (widthSet) {
+            if (width < 0) {
                 // negative widths correspond to '-' flag set
                 out.fill(' ');
                 out.setf(std::ios::left, std::ios::adjustfield);
                 width = -width;
             }
             out.width(width);
-            ++c;
         }
     }
     // 3) Parse precision
-    if(*c == '.')
-    {
+    if (*c == '.') {
         ++c;
         int precision = 0;
-        if(*c == '*')
-        {
-            ++c;
-            if(positionalMode)
-            {
-                int pos = parseIntAndAdvance(c) - 1;
-                if(*c != '$')
-                    TINYFORMAT_ERROR("tinyformat: Non-positional argument used after a positional one");
-                if(pos >= 0 && pos < numFormatters)
-                    precision = formatters[pos].toInt();
-                else
-                    TINYFORMAT_ERROR("tinyformat: Positional argument out of range");
-                ++c;
-            }
-            else
-            {
-                if(argIndex < numFormatters)
-                    precision = formatters[argIndex++].toInt();
-                else
-                    TINYFORMAT_ERROR("tinyformat: Not enough arguments to read variable precision");
-            }
-        }
-        else
-        {
-            if(*c >= '0' && *c <= '9')
-                precision = parseIntAndAdvance(c);
-            else if(*c == '-') // negative precisions ignored, treated as zero.
-                parseIntAndAdvance(++c);
-        }
-        out.precision(precision);
-        precisionSet = true;
+        parseWidthOrPrecision(precision, c, positionalMode,
+                              args, argIndex, numArgs);
+        // Presence of `.` indicates precision set, unless the inferred value
+        // was negative in which case the default is used.
+        precisionSet = precision >= 0;
+        if (precisionSet)
+            out.precision(precision);
     }
     // 4) Ignore any C99 length modifier
-    while(*c == 'l' || *c == 'h' || *c == 'L' ||
-          *c == 'j' || *c == 'z' || *c == 't')
+    while (*c == 'l' || *c == 'h' || *c == 'L' ||
+           *c == 'j' || *c == 'z' || *c == 't') {
         ++c;
+    }
     // 5) We're up to the conversion specifier character.
     // Set stream flags based on conversion specifier (thanks to the
     // boost::format class for forging the way here).
     bool intConversion = false;
-    switch(*c)
-    {
+    switch (*c) {
         case 'u': case 'd': case 'i':
             out.setf(std::ios::dec, std::ios::basefield);
             intConversion = true;
@@ -840,6 +806,18 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& positionalMode
         case 'f':
             out.setf(std::ios::fixed, std::ios::floatfield);
             break;
+        case 'A':
+            out.setf(std::ios::uppercase);
+            // Falls through
+        case 'a':
+#           ifdef _MSC_VER
+            // Workaround https://developercommunity.visualstudio.com/content/problem/520472/hexfloat-stream-output-does-not-ignore-precision-a.html
+            // by always setting maximum precision on MSVC to avoid precision
+            // loss for doubles.
+            out.precision(13);
+#           endif
+            out.setf(std::ios::fixed | std::ios::scientific, std::ios::floatfield);
+            break;
         case 'G':
             out.setf(std::ios::uppercase);
             // Falls through
@@ -848,17 +826,13 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& positionalMode
             // As in boost::format, let stream decide float format.
             out.flags(out.flags() & ~std::ios::floatfield);
             break;
-        case 'a': case 'A':
-            TINYFORMAT_ERROR("tinyformat: the %a and %A conversion specs "
-                             "are not supported");
-            break;
         case 'c':
             // Handled as special case inside formatValue()
             break;
         case 's':
-            if(precisionSet)
+            if (precisionSet)
                 ntrunc = static_cast<int>(out.precision());
-            // Make %s print booleans as "true" and "false"
+            // Make %s print Booleans as "true" and "false"
             out.setf(std::ios::boolalpha);
             break;
         case 'n':
@@ -872,8 +846,7 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& positionalMode
         default:
             break;
     }
-    if(intConversion && precisionSet && !widthSet)
-    {
+    if (intConversion && precisionSet && !widthSet) {
         // "precision" for integers gives the minimum number of digits (to be
         // padded with zeros on the left).  This isn't really supported by the
         // iostreams, but we can approximately simulate it with the width if
@@ -888,8 +861,8 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& positionalMode
 
 //------------------------------------------------------------------------------
 inline void formatImpl(std::ostream& out, const char* fmt,
-                       const detail::FormatArg* formatters,
-                       int numFormatters)
+                       const detail::FormatArg* args,
+                       int numArgs)
 {
     // Saved stream state
     std::streamsize origWidth = out.width();
@@ -897,29 +870,34 @@ inline void formatImpl(std::ostream& out, const char* fmt,
     std::ios::fmtflags origFlags = out.flags();
     char origFill = out.fill();
 
+    // "Positional mode" means all format specs should be of the form "%n$..."
+    // with `n` an integer. We detect this in `streamStateFromFormat`.
     bool positionalMode = false;
-    for(int argIndex = 0; positionalMode || argIndex < numFormatters; ++argIndex)
-    {
-        // Parse the format string
+    int argIndex = 0;
+    while (true) {
         fmt = printFormatStringLiteral(out, fmt);
-        if(positionalMode && *fmt == '\0')
+        if (*fmt == '\0') {
+            if (!positionalMode && argIndex < numArgs) {
+                TINYFORMAT_ERROR("tinyformat: Not enough conversion specifiers in format string");
+            }
             break;
+        }
         bool spacePadPositive = false;
         int ntrunc = -1;
         const char* fmtEnd = streamStateFromFormat(out, positionalMode, spacePadPositive, ntrunc, fmt,
-                                                   formatters, argIndex, numFormatters);
-        if (argIndex >= numFormatters)
-        {
-            // Check args remain after reading any variable width/precision
-            TINYFORMAT_ERROR("tinyformat: Not enough format arguments");
+                                                   args, argIndex, numArgs);
+        // NB: argIndex may be incremented by reading variable width/precision
+        // in `streamStateFromFormat`, so do the bounds check here.
+        if (argIndex >= numArgs) {
+            TINYFORMAT_ERROR("tinyformat: Too many conversion specifiers in format string");
             return;
         }
-        const FormatArg& arg = formatters[argIndex];
+        const FormatArg& arg = args[argIndex];
         // Format the arg into the stream.
-        if(!spacePadPositive)
+        if (!spacePadPositive) {
             arg.format(out, fmt, fmtEnd, ntrunc);
-        else
-        {
+        }
+        else {
             // The following is a special case with no direct correspondence
             // between stream formatting and the printf() behaviour.  Simulate
             // it crudely by formatting into a temporary string stream and
@@ -929,17 +907,16 @@ inline void formatImpl(std::ostream& out, const char* fmt,
             tmpStream.setf(std::ios::showpos);
             arg.format(tmpStream, fmt, fmtEnd, ntrunc);
             std::string result = tmpStream.str(); // allocates... yuck.
-            for(size_t i = 0, iend = result.size(); i < iend; ++i)
-                if(result[i] == '+') result[i] = ' ';
+            for (size_t i = 0, iend = result.size(); i < iend; ++i) {
+                if (result[i] == '+')
+                    result[i] = ' ';
+            }
             out << result;
         }
+        if (!positionalMode)
+            ++argIndex;
         fmt = fmtEnd;
     }
-
-    // Print remaining part of format string.
-    fmt = printFormatStringLiteral(out, fmt);
-    if(*fmt != '\0')
-        TINYFORMAT_ERROR("tinyformat: Too many conversion specifiers in format string");
 
     // Restore stream state
     out.width(origWidth);
@@ -960,14 +937,14 @@ inline void formatImpl(std::ostream& out, const char* fmt,
 class FormatList
 {
     public:
-        FormatList(detail::FormatArg* formatters, int N)
-            : m_formatters(formatters), m_N(N) { }
+        FormatList(detail::FormatArg* args, int N)
+            : m_args(args), m_N(N) { }
 
         friend void vformat(std::ostream& out, const char* fmt,
                             const FormatList& list);
 
     private:
-        const detail::FormatArg* m_formatters;
+        const detail::FormatArg* m_args;
         int m_N;
 };
 
@@ -990,23 +967,27 @@ class FormatListN : public FormatList
         { static_assert(sizeof...(args) == N, "Number of args must be N"); }
 #else // C++98 version
         void init(int) {}
-#       define TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR(n)       \
-                                                               \
-        template<TINYFORMAT_ARGTYPES(n)>                       \
-        FormatListN(TINYFORMAT_VARARGS(n))                     \
-            : FormatList(&m_formatterStore[0], n)              \
-        { assert(n == N); init(0, TINYFORMAT_PASSARGS(n)); }   \
-                                                               \
-        template<TINYFORMAT_ARGTYPES(n)>                       \
-        void init(int i, TINYFORMAT_VARARGS(n))                \
-        {                                                      \
-            m_formatterStore[i] = FormatArg(v1);               \
-            init(i+1 TINYFORMAT_PASSARGS_TAIL(n));             \
+#       define TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR(n)                \
+                                                                        \
+        template<TINYFORMAT_ARGTYPES(n)>                                \
+        FormatListN(TINYFORMAT_VARARGS(n))                              \
+            : FormatList(&m_formatterStore[0], n)                       \
+        { TINYFORMAT_ASSERT(n == N); init(0, TINYFORMAT_PASSARGS(n)); } \
+                                                                        \
+        template<TINYFORMAT_ARGTYPES(n)>                                \
+        void init(int i, TINYFORMAT_VARARGS(n))                         \
+        {                                                               \
+            m_formatterStore[i] = FormatArg(v1);                        \
+            init(i+1 TINYFORMAT_PASSARGS_TAIL(n));                      \
         }
 
         TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR)
 #       undef TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR
 #endif
+        FormatListN(const FormatListN& other)
+            : FormatList(&m_formatterStore[0], N)
+        { std::copy(&other.m_formatterStore[0], &other.m_formatterStore[N],
+                    &m_formatterStore[0]); }
 
     private:
         FormatArg m_formatterStore[N];
@@ -1061,7 +1042,7 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_MAKEFORMATLIST)
 /// list of format arguments is held in a single function argument.
 inline void vformat(std::ostream& out, const char* fmt, FormatListRef list)
 {
-    detail::formatImpl(out, fmt, list.m_formatters, list.m_N);
+    detail::formatImpl(out, fmt, list.m_args, list.m_N);
 }
 
 


### PR DESCRIPTION
In the beginning, I was looking for a safe replacement for `printf()` function. From the candidates I chose tinyformat - a small library in a single C++ header file. The only problem was a missing support for POSIX extension for positional arguments. So, I implemented the support to it and bundled the extended library (header file) into libdnf code.

My implementation (PR https://github.com/c42f/tinyformat/pull/45) of POSIX extension for positional arguments was merged into the upstream some time ago. So, upstream version of tinyformat can be used in the libdnf now.

This patch takes current version of tinyformat from the upstream.

Tinyformat project URL:
https://github.com/c42f/tinyformat