### PR TITLE
[user-agent] Drop the whitelist

### DIFF
--- a/libdnf/utils/os-release.hpp
+++ b/libdnf/utils/os-release.hpp
@@ -50,11 +50,8 @@ getOsReleaseData();
  *   libdnf (NAME VERSION_ID; VARIANT_ID; OS.BASEARCH)
  *
  * where NAME, VERSION_ID and VARIANT_ID are OS identifiers read from the
- * passed os-release data, and OS and BASEARCH (if found) are the canonical OS
- * name and base architecture, respectively, detected using RPM.
- *
- * Note that the OS part (enclosed in parentheses) will only be included for
- * whitelisted values.
+ * passed os-release data, and OS and BASEARCH are the canonical OS name and
+ * base architecture, respectively, detected using RPM.
  *
  * @param  osReleaseData a map containing os-release data (will be loaded from
  *                       disk if not specified)


### PR DESCRIPTION
 - Stop checking os-release(5) data against a hard-coded whitelist and
   just use them as they are, to avoid a maintenance burden in the
   future (see [1] for details)

 - Clean up the getUserAgent() function a bit

Note that, by removing the whitelist, there's a risk of leaking a
"unique" value from the os-release file now, but a rather small one.

[1] https://github.com/rpm-software-management/libdnf/pull/851