### PR TITLE
Allow excluding packages with "excludepkgs" and globs

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1092,7 +1092,19 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_GPGCHECK, (long)gpgcheck_md))
         return FALSE;
 
-    tmp_strval = g_key_file_get_string(priv->keyfile, repoId, "exclude", NULL);
+    tmp_strval = g_key_file_get_string(priv->keyfile, repoId, "excludepkgs", NULL);
+    if (tmp_strval) {
+        gchar *tmp_strval2 = g_key_file_get_string(priv->keyfile, repoId, "exclude", NULL);
+        if (tmp_strval2) {
+            gchar *joined = g_strjoin(",", tmp_strval, tmp_strval2, NULL);
+            g_free(tmp_strval);
+            g_free(tmp_strval2);
+            tmp_strval = joined;
+        }
+    } else {
+        tmp_strval = g_key_file_get_string(priv->keyfile, repoId, "exclude", NULL);
+    }
+
     if (tmp_strval) {
         priv->exclude_packages = g_strsplit_set(tmp_strval, " ,", -1);
         g_free(g_steal_pointer (&tmp_strval));

--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -2097,7 +2097,7 @@ process_excludes(DnfSack *sack, DnfRepo *repo)
         query = hy_query_create(sack);
         hy_query_filter(query, HY_PKG_REPONAME, HY_EQ, dnf_repo_get_id(repo));
         hy_query_filter(query, HY_PKG_ARCH, HY_NEQ, "src");
-        hy_query_filter(query, HY_PKG_NAME, HY_EQ, name);
+        hy_query_filter(query, HY_PKG_NAME, HY_GLOB, name);
         pkgset = hy_query_run_set(query);
 
         if (dnf_packageset_count(pkgset) > 0)


### PR DESCRIPTION
Currently dnf_repo_set_keyfile_data only checks the "exclude" setting,
but DNF renamed that to "excludepkgs" years ago. This patch reads both
and combines them into a single set of excluded packages.

The second commit on this branch changes `HY_EQ` to `HY_GLOB` when filtering the package set by the excluded packages, so that `excludepkgs=foo*` works.

See https://github.com/rpm-software-management/libdnf/issues/303 for
some related discussion.