### PR TITLE
[context] Use installonly_limit from global config (RhBug:1256108)

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -942,7 +942,8 @@ dnf_context_get_installonly_pkgs(DnfContext *context)
 guint
 dnf_context_get_installonly_limit(DnfContext *context)
 {
-    return 3;
+    auto & mainConf = libdnf::getGlobalMainConfig();
+    return mainConf.installonly_limit().getValue();
 }
 
 /**


### PR DESCRIPTION
The patch uses the global configuration option "installonly_limit".
The option was ignored and hardcoded value 3 was used before the patch.