### PR TITLE
[context] wildcard support in dnf_context_repo_set_data (RhBug:1781420)

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -52,6 +52,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #endif
+#include <fnmatch.h>
 #include <unistd.h>
 
 #include "log.hpp"
@@ -2273,20 +2274,19 @@ dnf_context_repo_set_data(DnfContext *context,
                           GError **error)
 {
     DnfContextPrivate *priv = GET_PRIVATE(context);
-    DnfRepo *repo = NULL;
-    guint i;
+    bool found = false;
 
-    /* find a repo with a matching ID */
-    for (i = 0; i < priv->repos->len; i++) {
-        auto repo_tmp = static_cast<DnfRepo *>(g_ptr_array_index(priv->repos, i));
-        if (g_strcmp0(dnf_repo_get_id(repo_tmp), repo_id) == 0) {
-            repo = repo_tmp;
-            break;
+    /* set repos with a matching ID */
+    for (guint i = 0; i < priv->repos->len; ++i) {
+        auto repo = static_cast<DnfRepo *>(g_ptr_array_index(priv->repos, i));
+        if (fnmatch(repo_id, dnf_repo_get_id(repo), 0) == 0) {
+            dnf_repo_set_enabled(repo, enabled);
+            found = true;
         }
     }
 
     /* nothing found */
-    if (repo == NULL) {
+    if (!found) {
         g_set_error(error,
                     DNF_ERROR,
                     DNF_ERROR_INTERNAL_ERROR,
@@ -2294,8 +2294,6 @@ dnf_context_repo_set_data(DnfContext *context,
         return FALSE;
     }
 
-    /* this is runtime only */
-    dnf_repo_set_enabled(repo, enabled);
     return TRUE;
 }
 
@@ -2305,7 +2303,8 @@ dnf_context_repo_set_data(DnfContext *context,
  * @repo_id: A repo_id, e.g. "fedora-rawhide"
  * @error: A #GError or %NULL
  *
- * Enables a specific repo.
+ * Enables a specific repo(s).
+ * Wildcard pattern is supported.
  *
  * This must be done before dnf_context_setup() is called.
  *
@@ -2329,7 +2328,8 @@ dnf_context_repo_enable(DnfContext *context,
  * @repo_id: A repo_id, e.g. "fedora-rawhide"
  * @error: A #GError or %NULL
  *
- * Disables a specific repo.
+ * Disables a specific repo(s).
+ * Wildcard pattern is supported.
  *
  * This must be done before dnf_context_setup() is called.
  *


### PR DESCRIPTION
Adds support for wildcard pattern in repo_id to these functions:
```
gboolean dnf_context_repo_enable(DnfContext *context, const gchar *repo_id, GError **error);
gboolean dnf_context_repo_disable(DnfContext *context, const gchar *repo_id, GError **error);
```
For example, it is used by microdnf for enable and disable repositories (arguments "--enablerepo=" and "--disablerepo=").