### PR TITLE
include <stdexcept> for runtime_error

### DIFF
--- a/libdnf/module/ModulePackageContainer.hpp
+++ b/libdnf/module/ModulePackageContainer.hpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <stdexcept>
 
 namespace libdnf {
 

--- a/libdnf/repo/solvable/Dependency.cpp
+++ b/libdnf/repo/solvable/Dependency.cpp
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdexcept>
 #include "Dependency.hpp"
 #include "libdnf/utils/utils.hpp"
 #include "libdnf/repo/DependencySplitter.hpp"


### PR DESCRIPTION
Fixes

error: class 'libdnf::ModulePackageContainer::Exception' does not have any field named 'runtime_error'
         explicit Exception(const std::string &what) : runtime_error(what) {}
                                                       ^~~~~~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>