### PR TITLE
Append option: only first empty value clears existing (RhBug:1788154)

### DIFF
--- a/libdnf/conf/Config-private.hpp
+++ b/libdnf/conf/Config-private.hpp
@@ -34,14 +34,18 @@ static void optionTListAppend(T & option, Option::Priority priority, const std::
     }
     auto addPriority = priority < option.getPriority() ? option.getPriority() : priority;
     auto val = option.fromString(value);
+    bool first = true;
     for (auto & item : val) {
         if (item.empty()) {
-            option.set(priority, item);
+            if (first) {
+                option.set(priority, item);
+            }
         } else {
             auto origValue = option.getValue();
             origValue.push_back(item);
             option.set(addPriority, origValue);
         }
+        first = false;
     }
 }
 


### PR DESCRIPTION
Before the patch: setting of  "a,b,,c" -> the result list contains only
"c". Empty item ",," removes all items that existed beforethey.

After the patch:  setting of  "a,b,,c" -> The "a", "b", "c" are appended
to the list. The empty item ",," is ignored.

The patch didn't change this:
The old list contents can be deleted with an empty value at
the beginning.
Setting of ", a, b, c" -> Old content of the list is cleared. The result
list contains "a", "b", "c".