### PR TITLE
Make parsing of reldeps more strict (RhBug:1788107)

### DIFF
--- a/libdnf/repo/DependencySplitter.cpp
+++ b/libdnf/repo/DependencySplitter.cpp
@@ -25,7 +25,7 @@
 namespace libdnf {
 
 static const Regex RELDEP_REGEX = 
-    Regex("^(\\S*)\\s*(<=|>=|<|>|=)?\\s*(.*)$", REG_EXTENDED);
+    Regex("^(\\S*)\\s*(<=|>=|<|>|=)?\\s*(\\S*)$", REG_EXTENDED);
 
 static bool
 getCmpFlags(int *cmp_type, std::string matchCmpType)

--- a/python/hawkey/tests/tests/test_reldep.py
+++ b/python/hawkey/tests/tests/test_reldep.py
@@ -45,9 +45,6 @@ class Reldep(base.TestCase):
         reldep_str = "(foo if bar)"
         reldep = hawkey.Reldep(self.sack, reldep_str)
         self.assertEqual(reldep_str, str(reldep))
-        reldep_str = "take a space.txt"
-        reldep = hawkey.Reldep(self.sack, reldep_str)
-        self.assertEqual(reldep_str, str(reldep))
         reldep_str = "font(:lang=en)"
         reldep = hawkey.Reldep(self.sack, reldep_str)
         self.assertEqual(reldep_str, str(reldep))


### PR DESCRIPTION
The new code does not support parsing "take a space.txt" or
'python3-astroid <> 2.3.3-2.gitace7b29.fc31'.
In both example it is not valid reldep.

https://bugzilla.redhat.com/show_bug.cgi?id=1788107