### PR TITLE
[utests] Fix: set lock directory path, don't use config from host

### DIFF
--- a/tests/libdnf/module/ContextTest.cpp
+++ b/tests/libdnf/module/ContextTest.cpp
@@ -14,6 +14,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(ContextTest);
 
 void ContextTest::setUp()
 {
+    dnf_context_set_config_file_path("");
     context = dnf_context_new();
 }
 

--- a/tests/libdnf/module/ContextTest.cpp
+++ b/tests/libdnf/module/ContextTest.cpp
@@ -32,6 +32,8 @@ void ContextTest::testLoadModules()
     dnf_context_set_arch(context, "x86_64");
     constexpr auto install_root = TESTDATADIR "/modules/";
     dnf_context_set_install_root(context, install_root);
+    g_autoptr(DnfLock) lock = dnf_lock_new();
+    dnf_lock_set_lock_dir(lock, "/tmp");
     constexpr auto repos_dir = TESTDATADIR "/modules/yum.repos.d/";
     dnf_context_set_repo_dir(context, repos_dir);
     dnf_context_set_solv_dir(context, "/tmp");

--- a/tests/libdnf/module/ModulePackageContainerTest.cpp
+++ b/tests/libdnf/module/ModulePackageContainerTest.cpp
@@ -11,6 +11,7 @@ void ModulePackageContainerTest::setUp()
 {
     g_autoptr(GError) error = nullptr;
 
+    dnf_context_set_config_file_path("");
     context = dnf_context_new();
     dnf_context_set_release_ver(context, "26");
     dnf_context_set_arch(context, "x86_64");

--- a/tests/libdnf/module/ModulePackageContainerTest.cpp
+++ b/tests/libdnf/module/ModulePackageContainerTest.cpp
@@ -16,6 +16,8 @@ void ModulePackageContainerTest::setUp()
     dnf_context_set_arch(context, "x86_64");
     dnf_context_set_platform_module(context, "platform:26");
     dnf_context_set_install_root(context, TESTDATADIR "/modules/");
+    g_autoptr(DnfLock) lock = dnf_lock_new();
+    dnf_lock_set_lock_dir(lock, "/tmp");
     dnf_context_set_repo_dir(context, TESTDATADIR "/modules/yum.repos.d/");
     dnf_context_set_solv_dir(context, "/tmp");
     dnf_context_setup(context, nullptr, &error);


### PR DESCRIPTION
Two unit tests use "context". These tests set up install root but didn't set the lock directory path.
This PR sets the lock directory path to "/tmp" directory.
It fixes error:
failed (error == NULL): failed to obtain lock 'metadata': Failed to create file ?/var/run/dnf-metadata.lock.3ETIE0?: Permission denied (DnfError, 26)

The tests was read/depended on the host main configuration file (/etc/dnf/dnf.conf). PR disables using of the main config file from host in tests (default values are used instead).