### PR TITLE
DnfRepo: fix module_hotfixes keyfile priority level 

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -966,7 +966,7 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
         dnf_repo_set_cost(repo, cost);
 
     module_hotfixes = g_key_file_get_boolean(priv->keyfile, repoId, "module_hotfixes", NULL);
-    dnf_repo_set_module_hotfixes(repo, module_hotfixes);
+    priv->repo->getConfig()->module_hotfixes().set(libdnf::Option::Priority::REPOCONFIG, module_hotfixes);
 
     /* baseurl is optional; if missing, unset it */
     baseurls = g_key_file_get_string_list(priv->keyfile, repoId, "baseurl", NULL, NULL);


### PR DESCRIPTION
We were setting the runtime value of the knob instead of the repoconfig
value. This meant that a user wanting to override the config via
`dnf_repo_set_module_hotfixes` (which also sets the runtime value) would
have its changes clobbered.

This should fix Silverblue Rawhide rpm-ostree composes:
https://pagure.io/releng/failed-composes/issue/717
https://pagure.io/releng/failed-composes/issue/929

where we use a hack to allow rpm-ostree to install modular packages
until we fully support modules (which requires #874) and it was getting
reset because `dnf_repo_download_packages` wants to reset the repo
config from the keyfile. For more information, see discussions at:

#885