### PR TITLE
[conf] Set useful default colors when color is enabled

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -240,18 +240,18 @@ class ConfigMain::Impl {
         }
     };
 
-    OptionString color_list_installed_older{"bold"};
+    OptionString color_list_installed_older{"yellow"};
     OptionString color_list_installed_newer{"bold,yellow"};
-    OptionString color_list_installed_reinstall{"normal"};
+    OptionString color_list_installed_reinstall{"dim,cyan"};
     OptionString color_list_installed_extra{"bold,red"};
     OptionString color_list_available_upgrade{"bold,blue"};
-    OptionString color_list_available_downgrade{"dim,cyan"};
+    OptionString color_list_available_downgrade{"dim,magenta"};
     OptionString color_list_available_reinstall{"bold,underline,green"};
-    OptionString color_list_available_install{"normal"};
-    OptionString color_update_installed{"normal"};
-    OptionString color_update_local{"bold"};
-    OptionString color_update_remote{"normal"};
-    OptionString color_search_match{"bold"};
+    OptionString color_list_available_install{"bold,cyan"};
+    OptionString color_update_installed{"dim,red"};
+    OptionString color_update_local{"dim,green"};
+    OptionString color_update_remote{"bold,green"};
+    OptionString color_search_match{"bold,magenta"};
     OptionBool history_record{true};
     OptionStringList history_record_packages{std::vector<std::string>{"dnf", "rpm"}};
     OptionString rpmverbosity{"info"};


### PR DESCRIPTION
DNF (and YUM before it) has supported colors for representing package transaction states for years, but it has largely remained not configured by default.

Adding some default color settings helps drastically improve the usability of the UI and gives DNF some nice personality.