### PR TITLE
[context] Preserve additionalMetadata content (RhBug:1808677)

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1473,9 +1473,14 @@ dnf_repo_check_internal(DnfRepo *repo,
 
     /* init newRepo */
     auto newRepo = hy_repo_create(priv->repo->getId().c_str());
+    auto newRepoImpl = libdnf::repoGetImpl(newRepo);
+
+    // "additionalMetadata" are not part of the config. They are filled during runtime
+    // (eg. by plugins) and must be kept.
+    newRepoImpl->additionalMetadata = repoImpl->additionalMetadata;
+
     hy_repo_free(priv->repo);
     priv->repo = newRepo;
-    auto newRepoImpl = libdnf::repoGetImpl(newRepo);
     newRepoImpl->repomdFn = yum_repo->repomd;
     for (auto *elem = yum_repo->paths; elem; elem = g_slist_next(elem)) {
         if (elem->data) {


### PR DESCRIPTION
The dnf_repo_check_internal() can creates new libdnf::Repo. This patch
copies content of additionalMetadata from old repository object
to the new one.
The swidtags plugin adds new metadata type into additionalMetadata
(which is part of libdnf::Repo) in configuration hook. Without this
patch the added metadata types are not copied to the newly created
repository.