### PR TITLE
package: Add an assertion to pacify static analysis

### DIFF
--- a/libdnf/dnf-package.cpp
+++ b/libdnf/dnf-package.cpp
@@ -155,6 +155,7 @@ dnf_package_get_filename(DnfPackage *pkg)
                                basename,
                                NULL);
         }
+        g_assert (priv->filename); /* Pacify static analysis */
     }
 
     /* remove file:// from filename */


### PR DESCRIPTION
(RHEL internal) Coverity isn't seeing that in every path
the subsequent `g_str_has_prefix()` will be seeing a non-NULL
pointer.   Let's add an assertion which should quiet the
analysis, and helps ensure that if the code changes later we
get a clean assertion failure and not a `SEGV`.