### PR TITLE
Reset active modules when no module enabled or default

### DIFF
--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -606,6 +606,7 @@ ModulePackageContainer::Impl::moduleSolve(const std::vector<ModulePackage *> & m
     bool debugSolver)
 {
     if (modules.empty()) {
+        activatedModules.reset();
         return {};
     }
     dnf_sack_recompute_considered(moduleSack);


### PR DESCRIPTION
It resolves problem when all modules are still active after reset of all
modules.

CI-test: rpm-software-management/ci-dnf-stack#802