### PR TITLE
context, sack: Support all rpmdb path variants

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -226,7 +226,14 @@ dnf_sack_new(void)
 static int
 current_rpmdb_checksum(Pool *pool, unsigned char csout[CHKSUM_BYTES])
 {
-    const char *rpmdb_prefix_paths[] = { "/var/lib/rpm/Packages",
+    const char *rpmdb_prefix_paths[] = { "/var/lib/rpm/rpmdb.sqlite",
+                                         "/usr/lib/sysimage/rpm/rpmdb.sqlite",
+                                         "/var/lib/rpm/Packages.db",
+                                         "/usr/lib/sysimage/rpm/Packages.db",
+                                         "/var/lib/rpm/Packages",
+                                         "/usr/lib/sysimage/rpm/Packages",
+                                         "/var/lib/rpm/data.mdb",
+                                         "/usr/lib/sysimage/rpm/data.mdb",
                                          "/usr/share/rpm/Packages" };
     unsigned int i;
     const char *fn;


### PR DESCRIPTION
We rely on identifying whether the rpmdb path has changed to
determine whether we need to re-cache data from there. Now
that RPM has multiple rpmdb options and there are two common
paths in use by RPM-based systems, we need to handle all of
these.

Fixes #362 