### PR TITLE
[WIP] Support for module intents

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -275,6 +275,7 @@ class ConfigMain::Impl {
     OptionBool downloadonly{false}; // runtime only option
     OptionBool ignorearch{false};
     OptionString module_platform_id{nullptr};
+    OptionString module_intent{nullptr};
 
     OptionString user_agent{getUserAgent()};
     OptionBool countme{false};
@@ -427,6 +428,7 @@ ConfigMain::Impl::Impl(Config & owner)
     owner.optBinds().add("comment", comment);
     owner.optBinds().add("ignorearch", ignorearch);
     owner.optBinds().add("module_platform_id", module_platform_id);
+    owner.optBinds().add("module_intent", module_intent);
     owner.optBinds().add("user_agent", user_agent);
     owner.optBinds().add("countme", countme);
 
@@ -558,6 +560,7 @@ OptionBool & ConfigMain::downloadonly() { return pImpl->downloadonly; }
 OptionBool & ConfigMain::ignorearch() { return pImpl->ignorearch; }
 
 OptionString & ConfigMain::module_platform_id() { return pImpl->module_platform_id; }
+OptionString & ConfigMain::module_intent() { return pImpl->module_intent; }
 OptionString & ConfigMain::user_agent() { return pImpl->user_agent; }
 OptionBool & ConfigMain::countme() { return pImpl->countme; }
 

--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -122,6 +122,7 @@ public:
     OptionBool & ignorearch();
 
     OptionString & module_platform_id();
+    OptionString & module_intent();
     OptionString & user_agent();
     OptionBool & countme();
 

--- a/libdnf/module/modulemd/ModuleMetadata.cpp
+++ b/libdnf/module/modulemd/ModuleMetadata.cpp
@@ -27,7 +27,7 @@
 
 namespace libdnf {
 
-ModuleMetadata::ModuleMetadata(): resultingModuleIndex(NULL), moduleMerger(NULL) {}
+ModuleMetadata::ModuleMetadata(): resultingModuleIndex(NULL), moduleMerger(NULL), intent(NULL) {}
 
 void ModuleMetadata::addMetadataFromString(const std::string & yaml, int priority)
 {
@@ -108,7 +108,7 @@ std::map<std::string, std::string> ModuleMetadata::getDefaultStreams()
     if (!resultingModuleIndex)
         return moduleDefaults;
 
-    GHashTable * table = modulemd_module_index_get_default_streams_as_hash_table(resultingModuleIndex, NULL);
+    GHashTable * table = modulemd_module_index_get_default_streams_as_hash_table(resultingModuleIndex, intent.c_str());
     GHashTableIter iterator;
     gpointer key, value;
     g_hash_table_iter_init(&iterator, table);
@@ -129,7 +129,7 @@ std::vector<std::string> ModuleMetadata::getDefaultProfiles(std::string moduleNa
     ModulemdModule * myModule = modulemd_module_index_get_module(resultingModuleIndex, moduleName.c_str());
     ModulemdDefaultsV1 * myDefaults = (ModulemdDefaultsV1 *) modulemd_module_get_defaults(myModule);
 
-    char ** list = modulemd_defaults_v1_get_default_profiles_for_stream_as_strv(myDefaults, moduleStream.c_str(), NULL);
+    char ** list = modulemd_defaults_v1_get_default_profiles_for_stream_as_strv(myDefaults, moduleStream.c_str(), intent.c_str());
 
     for (char **iter = list; iter && *iter; iter++) {
         output.emplace_back(*iter);
@@ -137,6 +137,11 @@ std::vector<std::string> ModuleMetadata::getDefaultProfiles(std::string moduleNa
 
     g_strfreev(list);
     return output;
+}
+
+void ModuleMetadata::setIntent(const std::string & intent)
+{
+    this->intent = intent;
 }
 
 void ModuleMetadata::reportFailures(const GPtrArray *failures)

--- a/libdnf/module/modulemd/ModuleMetadata.hpp
+++ b/libdnf/module/modulemd/ModuleMetadata.hpp
@@ -36,11 +36,13 @@ public:
     std::vector<ModulePackage *> getAllModulePackages(DnfSack * moduleSack, LibsolvRepo * repo, const std::string & repoID);
     std::map<std::string, std::string> getDefaultStreams();
     std::vector<std::string> getDefaultProfiles(std::string moduleName, std::string moduleStream);
+    void setIntent(const std::string & intent);
 
 private:
     static void reportFailures(const GPtrArray *failures);
     ModulemdModuleIndex * resultingModuleIndex;
     ModulemdModuleIndexMerger * moduleMerger;
+    std::string intent;
 };
 
 }


### PR DESCRIPTION
@j-mracek @kontura 

These two patches add support for module [intents](https://github.com/fedora-modularity/libmodulemd/blob/master/yaml_specs/modulemd_defaults_v1.yaml#L23)  in libdnf. The first patch modifies the calls to `get_default_streams()` and `get_default_profiles()` to pass it an optional "intent".

The purpose of intents is to allow us to specify different module defaults for different machine purposes. However, we also just realized that we can use the intents mechanism to allow us to create a way to opt-in to having module defaults in Fedora for testing without needing to have separate repositories for metadata.

The second patch adds a new dnf.conf config option `module_intent` that can optionally be specified by the user to indicate which set of defaults they should use. So, opting in to module defaults could be as simple as adding one line to dnf.conf once this lands.

My remaining problem is that I can't figure out how to access the ConfigMain object from the ModuleMetadata object. I could use some help with this.