### PR TITLE
[dnf5] Add LogRouter::swap_logger() method

### DIFF
--- a/include/libdnf/logger/log_router.hpp
+++ b/include/libdnf/logger/log_router.hpp
@@ -30,11 +30,21 @@ namespace libdnf {
 
 
 /// LogRouter is an implementation of logging class that forwards incoming logging messages to several other loggers.
+/// Loggers can be addressed via index. Index is serial number of the logger starting from zero.
 class LogRouter : public Logger {
 public:
+    /// Moves (registers) the "logger" into the log router. It gets next free index number.
     void add_logger(std::unique_ptr<Logger> && logger) { loggers.push_back(std::move(logger)); }
+
+    /// Returns pointer to the logger at the "index" position.
     Logger * get_logger(size_t index) { return loggers.at(index).get(); }
+
+    /// Removes logger at the "index" position from LogRouter.
+    /// The array of the loggers is squeezed. Index of the loggers behind removed logger is decreased by one.
     std::unique_ptr<Logger> release_logger(size_t index);
+
+    /// Swaps the logger at the "index" position with another "logger".
+    void swap_logger(std::unique_ptr<Logger> & logger, size_t index) { loggers.at(index).swap(logger); }
 
     void write(Level level, const std::string & message) noexcept override;
     void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept override;

--- a/include/libdnf/logger/log_router.hpp
+++ b/include/libdnf/logger/log_router.hpp
@@ -46,6 +46,9 @@ public:
     /// Swaps the logger at the "index" position with another "logger".
     void swap_logger(std::unique_ptr<Logger> & logger, size_t index) { loggers.at(index).swap(logger); }
 
+    /// Returns number of loggers registered in LogRouter.
+    size_t get_loggers_count() const noexcept { return loggers.size(); }
+
     void write(Level level, const std::string & message) noexcept override;
     void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept override;
 


### PR DESCRIPTION
`void swap_logger(std::unique_ptr<Logger> & logger, size_t index);`
Swaps the logger at the `index` position with another `logger`.

It is used, for example, to replace a temporary (memory buffer) logger with a final one.