### PR TITLE
[dnf5] WeakPtr implementation

### DIFF
--- a/include/libdnf/utils/weak_ptr.hpp
+++ b/include/libdnf/utils/weak_ptr.hpp
@@ -1,0 +1,238 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_UTILS_WEAK_PTR_HPP
+#define LIBDNF_UTILS_WEAK_PTR_HPP
+
+#include "exception.hpp"
+
+#include <unordered_set>
+
+namespace libdnf {
+
+template <typename TPtr, bool ptr_owner>
+struct WeakPtr;
+
+
+/// WeakPtrGuard is a resource guard. WeakPtr instances register itself to the resource guard.
+/// And the resource guard invalidates the registered WeakPtrs when the resource is unusable
+/// (eg. its dependecny was released).
+template <typename TPtr, bool weak_ptr_is_owner>
+struct WeakPtrGuard {
+public:
+    using TWeakPtr = WeakPtr<TPtr, weak_ptr_is_owner>;
+
+    WeakPtrGuard() = default;
+    WeakPtrGuard(const WeakPtrGuard &) = delete;
+    WeakPtrGuard(WeakPtrGuard && src) noexcept : registered_weak_ptrs(std::move(src.registered_weak_ptrs)) {
+        for (auto it : registered_weak_ptrs) {
+            it->guard = this;
+        }
+    }
+    ~WeakPtrGuard() { clear(); }
+
+    WeakPtrGuard & operator=(const WeakPtrGuard & src) = delete;
+    WeakPtrGuard & operator=(WeakPtrGuard && src) noexcept {
+        registered_weak_ptrs = std::move(src.registered_weak_ptrs);
+        for (auto it : registered_weak_ptrs) {
+            it->guard = this;
+        }
+    }
+
+    /// Returns true if the guard is empty, false otherwise.
+    bool empty() const noexcept { return registered_weak_ptrs.empty(); }
+
+    /// Returns the number of registered weak pointers.
+    size_t size() const noexcept { return registered_weak_ptrs.size(); }
+
+    /// Deregisters and invalidates all registered weak pointers. After this call, size() returns zero.
+    void clear() noexcept {
+        for (auto it : registered_weak_ptrs) {
+            it->invalidate_guard();
+        }
+    }
+
+private:
+    friend TWeakPtr;
+    void register_ptr(TWeakPtr * weak_ptr) { registered_weak_ptrs.insert(weak_ptr); }
+    void unregister_ptr(TWeakPtr * weak_ptr) noexcept { registered_weak_ptrs.erase(weak_ptr); }
+    std::unordered_set<TWeakPtr *> registered_weak_ptrs;
+};
+
+
+/// WeakPtr is a "smart" pointer. It contains a pointer to resource and to guard of resource.
+/// WeakPtr pointer can be owner of the resource. However, the resource itself may depend on another resource.
+/// WeakPtr registers/unregisters itself at the guard of resource. And the resource guard invalidates
+/// the registered WeakPtrs when the resource is unusable (eg. its dependecny was released).
+// TODO(jrohel): We want thread-safety. Locking isn't for free. Idea is locking in more upper level. Future.
+template <typename TPtr, bool ptr_owner>
+struct WeakPtr {
+public:
+    using TWeakPtrGuard = WeakPtrGuard<TPtr, ptr_owner>;
+
+    /// Exception generated when the managed object is not valid.
+    class InvalidPtr : public RuntimeError {
+    public:
+        using RuntimeError::RuntimeError;
+        const char * get_domain_name() const noexcept override { return "libdnf::WeakPtr"; }
+        const char * get_name() const noexcept override { return "InvalidPtr"; }
+        const char * get_description() const noexcept override { return "Invalid pointer"; }
+    };
+
+    WeakPtr(TPtr * ptr, TWeakPtrGuard * guard) : ptr(ptr), guard(guard) {
+        if (!ptr) {
+            throw InvalidPtr("Creating null WeakPtr is not allowed");
+        }
+        if (!guard) {
+            throw InvalidPtr("Creating WeakPtr without guard is not allowed");
+        }
+        guard->register_ptr(this);
+    }
+
+    // TODO(jrohel): Want we to allow copying invalid WeakPtr?
+    WeakPtr(const WeakPtr & src) : guard(src.guard) {
+        if constexpr (ptr_owner) {
+            ptr = src.ptr ? new TPtr(*src.ptr) : nullptr;
+        } else {
+            ptr = src.ptr;
+        }
+        if (is_valid()) {
+            guard->register_ptr(this);
+        }
+    }
+
+    // TODO(jrohel): Want we to allow moving invalid WeakPtr?
+    template <typename T = TPtr, typename std::enable_if<sizeof(T) && ptr_owner, int>::type = 0>
+    WeakPtr(WeakPtr && src) : guard(src.guard) {
+        if (src.is_valid()) {
+            src.guard->unregister_ptr(&src);
+        }
+        src.guard = nullptr;
+        ptr = src.ptr;
+        src.ptr = nullptr;
+        if (is_valid()) {
+            guard->register_ptr(this);
+        }
+    }
+
+    ~WeakPtr() {
+        if (is_valid()) {
+            guard->unregister_ptr(this);
+        }
+        if constexpr (ptr_owner) {
+            delete ptr;
+        }
+    }
+
+    // TODO(jrohel): Want we to allow copying invalid WeakPtr?
+    WeakPtr & operator=(const WeakPtr & src) {
+        if (guard == src.guard) {
+            if constexpr (ptr_owner) {
+                delete ptr;
+                ptr = src.ptr ? new TPtr(*src.ptr) : nullptr;
+            } else {
+                ptr = src.ptr;
+            }
+        } else {
+            if (is_valid()) {
+                guard->unregister_ptr(this);
+            }
+            guard = src.guard;
+            if constexpr (ptr_owner) {
+                delete ptr;
+                ptr = src.ptr ? new TPtr(*src.ptr) : nullptr;
+            } else {
+                ptr = src.ptr;
+            }
+            if (is_valid()) {
+                guard->register_ptr(this);
+            }
+        }
+        return *this;
+    }
+
+    // TODO(jrohel): Want we to allow moving invalid WeakPtr?
+    template <typename T = TPtr, typename std::enable_if<sizeof(T) && ptr_owner, int>::type = 0>
+    WeakPtr & operator=(WeakPtr && src) {
+        if (guard == src.guard) {
+            if (src.is_valid()) {
+                src.guard->unregister_ptr(&src);
+            }
+            src.guard = nullptr;
+            ptr = src.ptr;
+            src.ptr = nullptr;
+        } else {
+            if (is_valid()) {
+                guard->unregister_ptr(this);
+            }
+            if (src.is_valid()) {
+                src.guard->unregister_ptr(&src);
+            }
+            guard = src.guard;
+            src.guard = nullptr;
+            ptr = src.ptr;
+            src.ptr = nullptr;
+            if (is_valid()) {
+                guard->register_ptr(this);
+            }
+        }
+        return *this;
+    }
+
+    /// Provides access to the managed object. Generates exception if object is not valid.
+    TPtr * operator->() const {
+        check();
+        return ptr;
+    }
+
+    /// Returns a pointer to the managed object. Generates exception if object is not valid.
+    TPtr * get() const {
+        check();
+        return ptr;
+    }
+
+    /// Checks if managed object is valid.
+    bool is_valid() const noexcept { return guard; }
+
+    /// Checks if the other WeakPtr instance has the same WeakPtrGuard.
+    bool has_same_guard(const WeakPtr & other) const noexcept { return guard == other.guard; }
+
+    bool operator==(const WeakPtr & other) const { return ptr == other.ptr; }
+    bool operator!=(const WeakPtr & other) const { return ptr != other.ptr; }
+    bool operator<(const WeakPtr & other) const { return ptr < other.ptr; }
+    bool operator>(const WeakPtr & other) const { return ptr > other.ptr; }
+    bool operator<=(const WeakPtr & other) const { return ptr <= other.ptr; }
+    bool operator>=(const WeakPtr & other) const { return ptr >= other.ptr; }
+
+private:
+    friend TWeakPtrGuard;
+    void invalidate_guard() noexcept { guard = nullptr; }
+    void check() const {
+        if (!is_valid()) {
+            throw InvalidPtr("Data guard is invalid");
+        }
+    }
+
+    TPtr * ptr;
+    TWeakPtrGuard * guard;
+};
+
+}  // namespace libdnf
+
+#endif

--- a/test/libdnf/weak_ptr/test_weak_ptr.cpp
+++ b/test/libdnf/weak_ptr/test_weak_ptr.cpp
@@ -1,0 +1,214 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_weak_ptr.hpp"
+
+#include "libdnf/utils/weak_ptr.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+CPPUNIT_TEST_SUITE_REGISTRATION(WeakPtrTest);
+
+
+void WeakPtrTest::setUp() {}
+
+
+void WeakPtrTest::tearDown() {}
+
+
+// In this test the WeakPtr instances point to data owned by Sack instance.
+void WeakPtrTest::test_weak_ptr() {
+    class Sack {
+    public:
+        using DataItemWeakPtr = libdnf::WeakPtr<std::string, false>;
+
+        DataItemWeakPtr add_item_with_return(std::unique_ptr<std::string> && item) {
+            auto ret = DataItemWeakPtr(item.get(), &data_guard);
+            data.push_back(std::move(item));
+            return ret;
+        }
+
+    private:
+        libdnf::WeakPtrGuard<std::string, false> data_guard;
+        std::vector<std::unique_ptr<std::string>>
+            data;  // Owns the data set. Objects get deleted when the Sack is deleted.
+    };
+
+    auto sack1 = std::make_unique<Sack>();
+    auto item1_weak_ptr = sack1->add_item_with_return(std::make_unique<std::string>("sack1_item1"));
+    auto item2_weak_ptr = sack1->add_item_with_return(std::make_unique<std::string>("sack1_item2"));
+
+    auto sack2 = std::make_unique<Sack>();
+    auto item3_weak_ptr = sack2->add_item_with_return(std::make_unique<std::string>("sack2_item1"));
+    auto item4_weak_ptr = sack2->add_item_with_return(std::make_unique<std::string>("sack2_item2"));
+
+    // test access to data managed by WeakPtr (by get() and operator ->)
+    CPPUNIT_ASSERT(*item1_weak_ptr.get() == "sack1_item1");
+    CPPUNIT_ASSERT(item2_weak_ptr->compare("sack1_item2") == 0);
+    CPPUNIT_ASSERT(*item3_weak_ptr.get() == "sack2_item1");
+    CPPUNIT_ASSERT(item4_weak_ptr->compare("sack2_item2") == 0);
+
+    // test hase_same_guard() method
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr.has_same_guard(item1_weak_ptr), true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr.has_same_guard(item2_weak_ptr), true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr.has_same_guard(item3_weak_ptr), false);
+
+    // delete sack2
+    sack2.reset();
+
+    // data from sack1 must be still accesible, but access to data from sack2 must throw exception
+    CPPUNIT_ASSERT(*item1_weak_ptr.get() == "sack1_item1");
+    CPPUNIT_ASSERT(item2_weak_ptr->compare("sack1_item2") == 0);
+    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get() == "sack2_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW((item4_weak_ptr->compare("sack2_item2") == 0), Sack::DataItemWeakPtr::InvalidPtr);
+
+    // test is_valid() method
+    CPPUNIT_ASSERT(item1_weak_ptr.is_valid());
+    CPPUNIT_ASSERT(item2_weak_ptr.is_valid());
+    CPPUNIT_ASSERT(!item3_weak_ptr.is_valid());
+    CPPUNIT_ASSERT(!item4_weak_ptr.is_valid());
+
+    // test copy constructor
+    auto item5_weak_ptr(item1_weak_ptr);
+    CPPUNIT_ASSERT(*item1_weak_ptr.get() == "sack1_item1");
+    CPPUNIT_ASSERT(*item5_weak_ptr.get() == "sack1_item1");
+
+    // there is no move constructor, copy constructor must be used
+    auto item6_weak_ptr(std::move(item5_weak_ptr));
+    CPPUNIT_ASSERT(*item5_weak_ptr.get() == "sack1_item1");
+    CPPUNIT_ASSERT(*item6_weak_ptr.get() == "sack1_item1");
+
+    // test copy assignment operator =
+    item3_weak_ptr = item1_weak_ptr;
+    CPPUNIT_ASSERT(*item1_weak_ptr.get() == "sack1_item1");
+    CPPUNIT_ASSERT(*item3_weak_ptr.get() == "sack1_item1");
+
+    // there is no move assignment operator =, copy assignment must be used
+    item4_weak_ptr = std::move(item2_weak_ptr);
+    CPPUNIT_ASSERT(*item2_weak_ptr.get() == "sack1_item2");
+    CPPUNIT_ASSERT(*item4_weak_ptr.get() == "sack1_item2");
+
+    // test operator ==
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr == item1_weak_ptr, true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr == item3_weak_ptr, true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr == item4_weak_ptr, false);
+
+    // test operator !=
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item1_weak_ptr, false);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item3_weak_ptr, false);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item4_weak_ptr, true);
+}
+
+
+// In this test the WeakPtr instances own DependentItem instances that point to data owned by Sack instance.
+void WeakPtrTest::test_weak_ptr_is_owner() {
+    struct DependentItem {
+        std::string * remote_data;
+    };
+
+    class Sack {
+    public:
+        using DataItemWeakPtr = libdnf::WeakPtr<DependentItem, true>;
+
+        DataItemWeakPtr add_item_with_return(std::unique_ptr<std::string> && item) {
+            auto ret = DataItemWeakPtr(new DependentItem{item.get()}, &data_guard);
+            data.push_back(std::move(item));
+            return ret;
+        }
+
+    private:
+        libdnf::WeakPtrGuard<DependentItem, true> data_guard;
+        std::vector<std::unique_ptr<std::string>>
+            data;  // Owns the data set. Objects get deleted when the Sack is deleted.
+    };
+
+    auto sack1 = std::make_unique<Sack>();
+    auto item1_weak_ptr = sack1->add_item_with_return(std::make_unique<std::string>("sack1_item1"));
+    auto item2_weak_ptr = sack1->add_item_with_return(std::make_unique<std::string>("sack1_item2"));
+
+    auto sack2 = std::make_unique<Sack>();
+    auto item3_weak_ptr = sack2->add_item_with_return(std::make_unique<std::string>("sack2_item1"));
+    auto item4_weak_ptr = sack2->add_item_with_return(std::make_unique<std::string>("sack2_item2"));
+
+    // test access to data managed by WeakPtr (by get() and operator ->)
+    CPPUNIT_ASSERT(*item1_weak_ptr.get()->remote_data == "sack1_item1");
+    CPPUNIT_ASSERT(*item2_weak_ptr->remote_data == "sack1_item2");
+    CPPUNIT_ASSERT(*item3_weak_ptr.get()->remote_data == "sack2_item1");
+    CPPUNIT_ASSERT(*item4_weak_ptr->remote_data == "sack2_item2");
+
+    // test hase_same_guard() method
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr.has_same_guard(item1_weak_ptr), true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr.has_same_guard(item2_weak_ptr), true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr.has_same_guard(item3_weak_ptr), false);
+
+    // delete sack2
+    sack2.reset();
+
+    // data from sack1 must be still accesible, but access to data from sack2 must throw exception
+    CPPUNIT_ASSERT(*item1_weak_ptr.get()->remote_data == "sack1_item1");
+    CPPUNIT_ASSERT(*item2_weak_ptr->remote_data == "sack1_item2");
+    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get()->remote_data == "sack2_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item4_weak_ptr->remote_data == "sack2_item2", Sack::DataItemWeakPtr::InvalidPtr);
+
+    // test is_valid() method
+    CPPUNIT_ASSERT(item1_weak_ptr.is_valid());
+    CPPUNIT_ASSERT(item2_weak_ptr.is_valid());
+    CPPUNIT_ASSERT(!item3_weak_ptr.is_valid());
+    CPPUNIT_ASSERT(!item4_weak_ptr.is_valid());
+
+    // test copy constructor
+    auto item5_weak_ptr(item1_weak_ptr);
+    CPPUNIT_ASSERT(*item1_weak_ptr->remote_data == "sack1_item1");
+    CPPUNIT_ASSERT(*item5_weak_ptr->remote_data == "sack1_item1");
+
+    // there move constructor
+    auto item6_weak_ptr(std::move(item5_weak_ptr));
+    CPPUNIT_ASSERT_THROW(*item5_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT(*item6_weak_ptr->remote_data == "sack1_item1");
+
+    // test copy assignment operator =
+    item3_weak_ptr = item1_weak_ptr;
+    CPPUNIT_ASSERT(*item1_weak_ptr->remote_data == "sack1_item1");
+    CPPUNIT_ASSERT(*item3_weak_ptr->remote_data == "sack1_item1");
+
+    // test move assignment operator =
+    item4_weak_ptr = std::move(item2_weak_ptr);
+    CPPUNIT_ASSERT_THROW(*item2_weak_ptr->remote_data == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT(*item4_weak_ptr->remote_data == "sack1_item2");
+
+    // test operator ==
+    // Each WeakPtr instance has its own data. However, the data may depend on the same remote data.
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr == item1_weak_ptr, true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr->remote_data == item1_weak_ptr->remote_data, true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr == item3_weak_ptr, false);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr->remote_data == item3_weak_ptr->remote_data, true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr == item4_weak_ptr, false);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr->remote_data == item4_weak_ptr->remote_data, false);
+
+    // test operator !=
+    // Each WeakPtr instance has its own data. However, the data may depend on the same remote data.
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item1_weak_ptr, false);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr->remote_data != item1_weak_ptr->remote_data, false);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item3_weak_ptr, true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr->remote_data != item3_weak_ptr->remote_data, false);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item4_weak_ptr, true);
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr->remote_data != item4_weak_ptr->remote_data, true);
+}

--- a/test/libdnf/weak_ptr/test_weak_ptr.hpp
+++ b/test/libdnf/weak_ptr/test_weak_ptr.hpp
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_TEST_WEAK_PTR_HPP
+#define LIBDNF_TEST_WEAK_PTR_HPP
+
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class WeakPtrTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(WeakPtrTest);
+    CPPUNIT_TEST(test_weak_ptr);
+    CPPUNIT_TEST(test_weak_ptr_is_owner);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+    void tearDown() override;
+
+    static void test_weak_ptr();
+    static void test_weak_ptr_is_owner();
+
+private:
+};
+
+#endif


### PR DESCRIPTION
WeakPtr is a "smart" pointer. It contains a pointer to resource and to
guard of resource. WeakPtr pointer can be owner of the resource. However,
the resource itself may depend on another resource.
WeakPtr registers/unregisters itself at the guard of resource. And
the resource guard invalidates the registered WeakPtrs when the resource
is unusable (eg. its dependecny was released).

PR depends on new exceptions "#925" and must be rebased when exceptions PR will be merged.