### PR TITLE
Revert "SWIG: Set CMake policies to remove warnings"

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,8 +1,5 @@
 find_package(PythonInstDir)
 find_package(SWIG REQUIRED)
-
-cmake_policy(SET CMP0078 OLD)
-cmake_policy(SET CMP0086 OLD)
 include(UseSWIG)
 
 message(STATUS "Building for python${PYTHON_VERSION_MAJOR}")


### PR DESCRIPTION
This reverts commit afd511592195b867eab4e49801053dcc904d6dd0, for the
most part. The duplicate include(UseSWIG) is kept removed, but the
cmake_policies actually aren't backwards compatible with Cmake versions
that don't know them, so we can't use them like this.

Setting the policies behavior only removes some warnings, it's probably
better to remove them than to wrap them in Cmake version checks.