### PR TITLE
Swdb: Better error handling

### DIFF
--- a/libdnf/transaction/CompsEnvironmentItem.cpp
+++ b/libdnf/transaction/CompsEnvironmentItem.cpp
@@ -187,8 +187,10 @@ CompsEnvironmentItem::getTransactionItemsByPattern(SQLite3Ptr conn, const std::s
 
     // HACK: create a private connection to avoid undefined behavior
     // after forking process in Anaconda
-    SQLite3 privateConn(conn->getPath());
-    SQLite3::Query query(privateConn, sql);
+    if (conn->getPath() != ":memory:") {
+        conn = std::make_shared<SQLite3>(conn->getPath());
+    }
+    SQLite3::Query query(*conn, sql);
     std::string pattern_sql = pattern;
     std::replace(pattern_sql.begin(), pattern_sql.end(), '*', '%');
     query.bindv(pattern, pattern, pattern);

--- a/libdnf/transaction/CompsGroupItem.cpp
+++ b/libdnf/transaction/CompsGroupItem.cpp
@@ -183,8 +183,10 @@ CompsGroupItem::getTransactionItemsByPattern(SQLite3Ptr conn, const std::string 
 
     // HACK: create a private connection to avoid undefined behavior
     // after forking process in Anaconda
-    SQLite3 privateConn(conn->getPath());
-    SQLite3::Query query(privateConn, sql);
+    if (conn->getPath() != ":memory:") {
+        conn = std::make_shared<SQLite3>(conn->getPath());
+    }
+    SQLite3::Query query(*conn, sql);
     std::string pattern_sql = pattern;
     std::replace(pattern_sql.begin(), pattern_sql.end(), '*', '%');
     query.bindv(pattern, pattern, pattern);

--- a/libdnf/transaction/Swdb.cpp
+++ b/libdnf/transaction/Swdb.cpp
@@ -58,6 +58,8 @@ Swdb::Swdb(const std::string &path)
   : conn(nullptr)
   , autoClose(true)
 {
+    auto logger(libdnf::Log::getLogger());
+
     if (path == ":memory:") {
         // connect to an in-memory database as requested
         conn = std::make_shared<SQLite3>(path);
@@ -71,7 +73,6 @@ Swdb::Swdb(const std::string &path)
                 conn->exec("BEGIN; UPDATE config SET value='test' WHERE key='test'; ROLLBACK;");
             } catch (SQLite3::Error & ex) {
                 // root must have the database writable -> log and re-throw the exception
-                auto logger(libdnf::Log::getLogger());
                 logger->error(tfm::format("History database is not writable: %s", ex.what()));
                 throw;
             }
@@ -85,7 +86,6 @@ Swdb::Swdb(const std::string &path)
                 // unpriviledged user may have insufficient permissions to open the database -> in-memory fallback
                 conn = std::make_shared<SQLite3>(":memory:");
                 Transformer::createDatabase(conn);
-                auto logger(libdnf::Log::getLogger());
                 logger->error(tfm::format("History database is not readable, using in-memory database instead: %s", ex.what()));
             }
         }
@@ -102,7 +102,6 @@ Swdb::Swdb(const std::string &path)
                 conn = std::make_shared<SQLite3>(path);
             } catch (SQLite3::Error & ex) {
                 // root must have the database writable -> log and re-throw the exception
-                auto logger(libdnf::Log::getLogger());
                 logger->error(tfm::format("History database cannot be created: %s", ex.what()));
                 throw;
             }
@@ -116,7 +115,6 @@ Swdb::Swdb(const std::string &path)
                 // unpriviledged user may have insufficient permissions to create the database -> in-memory fallback
                 conn = std::make_shared<SQLite3>(":memory:");
                 Transformer::createDatabase(conn);
-                auto logger(libdnf::Log::getLogger());
                 logger->error(tfm::format("History database cannot be created, using in-memory database instead: %s", ex.what()));
             }
         }

--- a/libdnf/utils/filesystem.cpp
+++ b/libdnf/utils/filesystem.cpp
@@ -21,8 +21,11 @@
  */
 
 #include <sys/stat.h>
+#include <cerrno>
+#include <cstring>
 
 #include "filesystem.hpp"
+#include "../error.hpp"
 
 namespace libdnf {
 
@@ -37,6 +40,21 @@ pathExists(const char *path)
     struct stat buffer {
     };
     return stat(path, &buffer) == 0;
+}
+
+bool
+pathExistsOrException(const std::string & path)
+{
+    struct stat buffer;
+    if (stat(path.c_str(), &buffer) == 0) {
+        return true;
+    }
+
+    if (errno != ENOENT) {
+        throw Error("Failed to access \"" + path + "\": " + strerror(errno));
+    }
+
+    return false;
 }
 
 /**

--- a/libdnf/utils/filesystem.hpp
+++ b/libdnf/utils/filesystem.hpp
@@ -30,6 +30,14 @@ namespace libdnf {
 bool
 pathExists(const char *path);
 
+/**
+ * Verifies if a path exists. In case of an error, throws an exception.
+ * \param path file or directory path
+ * \return true if path exists
+ */
+bool
+pathExistsOrException(const std::string & path);
+
 void
 makeDirPath(std::string filePath);
 

--- a/libdnf/utils/sqlite3/Sqlite3.cpp
+++ b/libdnf/utils/sqlite3/Sqlite3.cpp
@@ -27,7 +27,6 @@ SQLite3::open()
     if (db == nullptr) {
         auto result = sqlite3_open(path.c_str(), &db);
         if (result != SQLITE_OK) {
-            sqlite3_close(db);
             throw Error(*this, result, "Open failed");
         }
 

--- a/libdnf/utils/sqlite3/Sqlite3.hpp
+++ b/libdnf/utils/sqlite3/Sqlite3.hpp
@@ -79,7 +79,7 @@ public:
         {
             auto result = sqlite3_prepare_v2(db.db, sql, -1, &stmt, nullptr);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Statement failed");
+                throw SQLite3::Error(db, result, "Creating statement failed");
         };
 
         Statement(SQLite3 &db, const std::string &sql)
@@ -87,7 +87,7 @@ public:
         {
             auto result = sqlite3_prepare_v2(db.db, sql.c_str(), sql.length() + 1, &stmt, nullptr);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Statement failed");
+                throw SQLite3::Error(db, result, "Creating statement failed");
         };
 
         void bind(int pos, int val)


### PR DESCRIPTION
Don't close SQLite3 database if it wasn't opened (results in a misleading error message).

For unprivileged user, don't try to create the database - the assumption is the user never writes to the database and shouldn't have the permissions either.