### PR TITLE
Optimize DependencyContainer creation and fix a leak

### DIFF
--- a/libdnf/hy-package.cpp
+++ b/libdnf/hy-package.cpp
@@ -855,7 +855,9 @@ dnf_package_get_requires(DnfPackage *pkg)
 {
 
     DnfReldepList * l = reldeps_for(pkg, SOLVABLE_REQUIRES);
-    l->extend(reldeps_for(pkg, SOLVABLE_PREREQMARKER));
+    DnfReldepList * prereq_l = reldeps_for(pkg, SOLVABLE_PREREQMARKER);
+    l->extend(prereq_l);
+    delete prereq_l;
     return l;
 }
 

--- a/libdnf/hy-package.cpp
+++ b/libdnf/hy-package.cpp
@@ -159,9 +159,8 @@ reldeps_for(DnfPackage *pkg, Id type)
     queue_init(&q);
     solvable_lookup_deparray(s, solv_type, &q, marker);
 
-    reldeplist = new libdnf::DependencyContainer(dnf_package_get_sack(pkg), q);
+    reldeplist = new libdnf::DependencyContainer(dnf_package_get_sack(pkg), std::move(q));
 
-    queue_free(&q);
     return reldeplist;
 }
 

--- a/libdnf/repo/solvable/DependencyContainer.cpp
+++ b/libdnf/repo/solvable/DependencyContainer.cpp
@@ -42,11 +42,15 @@ DependencyContainer::DependencyContainer(DnfSack *sack)
     queue_init(&queue);
 }
 
-DependencyContainer::DependencyContainer(DnfSack *sack, Queue queue)
+DependencyContainer::DependencyContainer(DnfSack *sack, const Queue &queue)
         : sack(sack)
 {
     queue_init_clone(&this->queue, &queue);
 }
+
+DependencyContainer::DependencyContainer(DnfSack *sack, Queue &&queue)
+        : sack(sack), queue(queue)
+{}
 
 DependencyContainer::~DependencyContainer()
 {

--- a/libdnf/repo/solvable/DependencyContainer.hpp
+++ b/libdnf/repo/solvable/DependencyContainer.hpp
@@ -35,7 +35,8 @@ struct DependencyContainer
 public:
     DependencyContainer(const DependencyContainer &src);
     explicit DependencyContainer(DnfSack *sack);
-    DependencyContainer(DnfSack *sack, Queue queue);
+    DependencyContainer(DnfSack *sack, const Queue &queue);
+    DependencyContainer(DnfSack *sack, Queue &&queue);
     ~DependencyContainer();
 
     DependencyContainer &operator=(DependencyContainer &&src) noexcept;


### PR DESCRIPTION
The Queue gets copied multiple times when getting the dependencies, this removes at least one of the copies.

Also fixes a leak in `dnf_package_get_requires()`.