### PR TITLE
fix failing python unit test

### DIFF
--- a/python/hawkey/tests/tests/test_query.py
+++ b/python/hawkey/tests/tests/test_query.py
@@ -298,7 +298,7 @@ class TestQueryAllRepos(base.TestCase):
 
     def test_rco_glob(self):
         q1 = hawkey.Query(self.sack).filter(requires__glob="*")
-        self.assertLength(q1, 9)
+        self.assertLength(q1, 10)
         q2 = hawkey.Query(self.sack).filter(requires="*")
         self.assertLength(q2, 0)
         q3 = hawkey.Query(self.sack).filter(conflicts__glob="cu*")


### PR DESCRIPTION
The problem was introduced by https://github.com/rpm-software-management/libdnf/pull/937
The PR added a new pkg with a require into the updates test repo
therefore their count increased.