### PR TITLE
Use single-quotes around string literals used in SQL statements

### DIFF
--- a/libdnf/transaction/sql/migrate_tables_1_2.sql
+++ b/libdnf/transaction/sql/migrate_tables_1_2.sql
@@ -1,9 +1,9 @@
 R"**(
 BEGIN TRANSACTION;
     ALTER TABLE trans
-        ADD comment TEXT DEFAULT "";
+        ADD comment TEXT DEFAULT '';
     UPDATE config
-        SET value = "1.2"
+        SET value = '1.2'
         WHERE key = 'version';
 COMMIT;
 )**"


### PR DESCRIPTION
If sqlite is built with -DSQLITE_DQS=0 in accordance with
https://sqlite.org/quirks.html#dblquote, migration to version 1.2 of the
history database would fail with:

  History database cannot be created: /var/lib/dnf/history.sqlite.
  Error: SQLite error on ":memory:": Executing an SQL statement failed:
  no such column: 1.2