### PR TITLE
Encode the path part of package download URL

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -1,6 +1,6 @@
 %global libsolv_version 0.7.7
 %global libmodulemd_version 2.5.0
-%global librepo_version 1.11.3
+%global librepo_version 1.12.0
 %global dnf_conflict 4.2.13
 %global swig_version 3.0.12
 %global libdnf_major_version 0

--- a/libdnf/conf/ConfigRepo.cpp
+++ b/libdnf/conf/ConfigRepo.cpp
@@ -84,7 +84,20 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & masterConfig)
     owner.optBinds().add("name", name);
     owner.optBinds().add("enabled", enabled);
     owner.optBinds().add("cachedir", basecachedir);
-    owner.optBinds().add("baseurl", baseurl);
+
+    owner.optBinds().add("baseurl", baseurl,
+        [&](Option::Priority priority, const std::string & value) {
+            auto tmpValue = baseurl.fromString(value);
+            for (auto & v : tmpValue) {
+                if (v.substr(0, 1) == "/") {
+                    // a local path, turn it into an URL
+                    v = "file://" + v;
+                }
+            }
+            baseurl.set(priority, tmpValue);
+        }, nullptr, false
+    );
+
     owner.optBinds().add("mirrorlist", mirrorlist);
     owner.optBinds().add("metalink", metalink);
     owner.optBinds().add("type", type);

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -54,6 +54,7 @@
 #include "dnf-types.h"
 #include "dnf-utils.h"
 #include "utils/File.hpp"
+#include "utils/url-encode.hpp"
 
 #include <set>
 #include <string>
@@ -2240,8 +2241,13 @@ dnf_repo_download_packages(DnfRepo *repo,
         checksum = dnf_package_get_chksum(pkg, &checksum_type);
         checksum_str = hy_chksum_str(checksum, checksum_type);
 
+        std::string encodedUrl = dnf_package_get_location(pkg);
+        if (encodedUrl.find("://") == std::string::npos) {
+            encodedUrl = libdnf::urlEncode(encodedUrl, "/");
+        }
+
         target = lr_packagetarget_new_v2(priv->repo_handle,
-                                         dnf_package_get_location(pkg),
+                                         encodedUrl.c_str(),
                                          directory_slash,
                                          dnf_repo_checksum_hy_to_lr(checksum_type),
                                          checksum_str,

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -1753,9 +1753,15 @@ void PackageTarget::Impl::init(LrHandle * handle, const char * relativeUrl, cons
     }
 
     GError * errP{nullptr};
-    lrPkgTarget.reset(lr_packagetarget_new_v3(handle, relativeUrl, dest, lrChksType, chksum,  expectedSize,
-                                              baseUrl, resume, progressCB, callbacks, endCB, mirrorFailureCB,
-                                              byteRangeStart, byteRangeEnd, &errP));
+
+    std::string encodedUrl = relativeUrl;
+    if (encodedUrl.find("://") == std::string::npos) {
+        encodedUrl = urlEncode(encodedUrl, "/");
+    }
+
+    lrPkgTarget.reset(lr_packagetarget_new_v3(handle, encodedUrl.c_str(), dest, lrChksType, chksum,
+                                              expectedSize, baseUrl, resume, progressCB, callbacks, endCB,
+                                              mirrorFailureCB, byteRangeStart, byteRangeEnd, &errP));
     std::unique_ptr<GError> err(errP);
 
     if (!lrPkgTarget) {

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -36,6 +36,7 @@
 #include "libdnf/utils/File.hpp"
 #include "libdnf/utils/utils.hpp"
 #include "libdnf/utils/os-release.hpp"
+#include "libdnf/utils/url-encode.hpp"
 
 #include "bgettext/bgettext-lib.h"
 #include "tinyformat/tinyformat.hpp"
@@ -254,50 +255,6 @@ int Repo::Impl::mirrorFailureCB(void * data, const char * msg, const char * url,
     return cbObject->handleMirrorFailure(msg, url, metadata);
 };
 
-
-/**
-* @brief Converts the given input string to a URL encoded string
-*
-* All input characters that are not a-z, A-Z, 0-9, '-', '.', '_' or '~' are converted
-* to their "URL escaped" version (%NN where NN is a two-digit hexadecimal number).
-*
-* @param src String to encode
-* @return URL encoded string
-*/
-static std::string urlEncode(const std::string & src)
-{
-    auto noEncode = [](char ch)
-    {
-        return isalnum(ch) || ch=='-' || ch == '.' || ch == '_' || ch == '~';
-    };
-
-    // compute length of encoded string
-    auto len = src.length();
-    for (auto ch : src) {
-        if (!noEncode(ch))
-            len += 2;
-    }
-
-    // encode the input string
-    std::string encoded;
-    encoded.reserve(len);
-    for (auto ch : src) {
-        if (noEncode(ch))
-            encoded.push_back(ch);
-        else {
-            encoded.push_back('%');
-            unsigned char hex;
-            hex = static_cast<unsigned char>(ch) >> 4;
-            hex += hex <= 9 ? '0' : 'a' - 10;
-            encoded.push_back(hex);
-            hex = static_cast<unsigned char>(ch) & 0x0F;
-            hex += hex <= 9 ? '0' : 'a' - 10;
-            encoded.push_back(hex);
-        }
-    }
-
-    return encoded;
-}
 
 /**
 * @brief Format user password string

--- a/libdnf/utils/CMakeLists.txt
+++ b/libdnf/utils/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(smartcols)
 set(UTILS_SOURCES
     ${UTILS_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/filesystem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/url-encode.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/File.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CompressedFile.cpp

--- a/libdnf/utils/url-encode.cpp
+++ b/libdnf/utils/url-encode.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "url-encode.hpp"
+
+
+namespace libdnf {
+
+std::string urlEncode(const std::string & src) {
+    auto noEncode = [](char ch)
+    {
+        return isalnum(ch) || ch=='-' || ch == '.' || ch == '_' || ch == '~';
+    };
+
+    // compute length of encoded string
+    auto len = src.length();
+    for (auto ch : src) {
+        if (!noEncode(ch))
+            len += 2;
+    }
+
+    // encode the input string
+    std::string encoded;
+    encoded.reserve(len);
+    for (auto ch : src) {
+        if (noEncode(ch))
+            encoded.push_back(ch);
+        else {
+            encoded.push_back('%');
+            unsigned char hex;
+            hex = static_cast<unsigned char>(ch) >> 4;
+            hex += hex <= 9 ? '0' : 'a' - 10;
+            encoded.push_back(hex);
+            hex = static_cast<unsigned char>(ch) & 0x0F;
+            hex += hex <= 9 ? '0' : 'a' - 10;
+            encoded.push_back(hex);
+        }
+    }
+
+    return encoded;
+}
+
+} // namespace libdnf

--- a/libdnf/utils/url-encode.cpp
+++ b/libdnf/utils/url-encode.cpp
@@ -23,10 +23,18 @@
 
 namespace libdnf {
 
-std::string urlEncode(const std::string & src) {
-    auto noEncode = [](char ch)
+std::string urlEncode(const std::string & src, const std::string & exclude) {
+    auto noEncode = [&exclude](char ch)
     {
-        return isalnum(ch) || ch=='-' || ch == '.' || ch == '_' || ch == '~';
+        if (isalnum(ch) || ch=='-' || ch == '.' || ch == '_' || ch == '~') {
+            return true;
+        }
+
+        if (exclude.find(ch) != std::string::npos) {
+            return true;
+        }
+
+        return false;
     };
 
     // compute length of encoded string

--- a/libdnf/utils/url-encode.hpp
+++ b/libdnf/utils/url-encode.hpp
@@ -33,9 +33,10 @@ namespace libdnf {
 * to their "URL escaped" version (%NN where NN is a two-digit hexadecimal number).
 *
 * @param src String to encode
+* @param exclude A list of characters that won't be encoded
 * @return URL encoded string
 */
-std::string urlEncode(const std::string & src);
+std::string urlEncode(const std::string & src, const std::string & exclude = "");
 
 } // namespace libdnf
 

--- a/libdnf/utils/url-encode.hpp
+++ b/libdnf/utils/url-encode.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef LIBDNF_UTILS_URLENCODE_HPP
+#define LIBDNF_UTILS_URLENCODE_HPP
+
+#include <string>
+
+
+namespace libdnf {
+
+/**
+* @brief Converts the given input string to a URL encoded string
+*
+* All input characters that are not a-z, A-Z, 0-9, '-', '.', '_' or '~' are converted
+* to their "URL escaped" version (%NN where NN is a two-digit hexadecimal number).
+*
+* @param src String to encode
+* @return URL encoded string
+*/
+std::string urlEncode(const std::string & src);
+
+} // namespace libdnf
+
+#endif


### PR DESCRIPTION
Encodes the path part of package download URL before passing it to librepo. Doesn't work if the package URL is a full URL coming from the repository metadata - that would need to be encoded in the metadata itself.

The first/main librepo pull request: https://github.com/rpm-software-management/librepo/pull/188
Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/819