### PR TITLE
[dnf5] Implement rpm::RepoQuery and rpm::RepoSack

### DIFF
--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_BASE_BASE_HPP
 #define LIBDNF_BASE_BASE_HPP
 
+#include <libdnf/conf/config_main.hpp>
 #include <libdnf/logger/log_router.hpp>
 
 namespace libdnf {
@@ -30,9 +31,11 @@ namespace libdnf {
 /// :class:`.Base` instances are stateful objects owning various data.
 class Base {
 public:
+    ConfigMain & get_config() { return config; }
     LogRouter & get_logger() { return log_router; }
 
 private:
+    ConfigMain config;
     LogRouter log_router;
 };
 

--- a/include/libdnf/rpm/repo_query.hpp
+++ b/include/libdnf/rpm/repo_query.hpp
@@ -1,0 +1,73 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_RPM_REPO_QUERY_HPP
+#define LIBDNF_RPM_REPO_QUERY_HPP
+
+#include "libdnf/common/sack/query.hpp"
+#include "libdnf/rpm/repo.hpp"
+#include "libdnf/utils/weak_ptr.hpp"
+
+namespace libdnf::rpm {
+
+/// Weak pointer to rpm repository. RepoWeakPtr does not own the repository (ptr_owner = false).
+/// Repositories are owned by RepoSack.
+using RepoWeakPtr = libdnf::WeakPtr<Repo, false>;
+
+class RepoQuery : public libdnf::sack::Query<RepoWeakPtr> {
+public:
+    using Query<RepoWeakPtr>::Query;
+
+    RepoQuery & ifilter_enabled(bool enabled);
+    RepoQuery & ifilter_expired(bool expired);
+    RepoQuery & ifilter_id(sack::QueryCmp cmp, const std::string & pattern);
+    RepoQuery & ifilter_local(bool local);
+
+private:
+    struct F {
+        static bool enabled(const RepoWeakPtr & obj) { return obj->is_enabled(); }
+        static bool expired(const RepoWeakPtr & obj) { return obj->is_expired(); }
+        static bool local(const RepoWeakPtr & obj) { return obj->is_local(); }
+        static std::string id(const RepoWeakPtr & obj) { return obj->get_id(); }
+    };
+};
+
+inline RepoQuery & RepoQuery::ifilter_enabled(bool enabled) {
+    ifilter(F::enabled, sack::QueryCmp::EQ, enabled);
+    return *this;
+}
+
+inline RepoQuery & RepoQuery::ifilter_expired(bool expired) {
+    ifilter(F::expired, sack::QueryCmp::EQ, expired);
+    return *this;
+}
+
+inline RepoQuery & RepoQuery::ifilter_id(sack::QueryCmp cmp, const std::string & pattern) {
+    ifilter(F::id, cmp, pattern);
+    return *this;
+}
+
+inline RepoQuery & RepoQuery::ifilter_local(bool local) {
+    ifilter(F::local, sack::QueryCmp::EQ, local);
+    return *this;
+}
+
+}  // namespace libdnf::rpm
+
+#endif

--- a/include/libdnf/rpm/repo_sack.hpp
+++ b/include/libdnf/rpm/repo_sack.hpp
@@ -1,0 +1,50 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_RPM_REPO_SACK_HPP
+#define LIBDNF_RPM_REPO_SACK_HPP
+
+#include "repo.hpp"
+#include "repo_query.hpp"
+
+#include "libdnf/common/sack/sack.hpp"
+#include "libdnf/logger/logger.hpp"
+
+namespace libdnf {
+
+class Base;
+
+}  // namespace libdnf
+
+namespace libdnf::rpm {
+
+class RepoSack : public libdnf::sack::Sack<Repo, RepoQuery> {
+public:
+    explicit RepoSack(Base & base) : base(&base) {}
+
+    /// Creates new repository and add it into RepoSack
+    RepoWeakPtr new_repo(const std::string & id, Repo::Type type = Repo::Type::AVAILABLE);
+
+private:
+    Base * base;
+};
+
+}  // namespace libdnf::rpm
+
+#endif

--- a/libdnf/rpm/repo_sack.cpp
+++ b/libdnf/rpm/repo_sack.cpp
@@ -1,0 +1,33 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/rpm/repo_sack.hpp"
+
+#include "libdnf/base/base.hpp"
+
+namespace libdnf::rpm {
+
+RepoWeakPtr RepoSack::new_repo(const std::string & id, Repo::Type type) {
+    // TODO(jrohel): Test repo exists
+    auto repo_config = std::make_unique<ConfigRepo>(base->get_config());
+    auto repo = std::make_unique<Repo>(id, std::move(repo_config), *base, type);
+    return add_item_with_return(std::move(repo));
+}
+
+}  // namespace libdnf::rpm

--- a/test/libdnf/rpm/test_repo_query.cpp
+++ b/test/libdnf/rpm/test_repo_query.cpp
@@ -1,0 +1,70 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_repo_query.hpp"
+
+#include "libdnf/base/base.hpp"
+#include "libdnf/rpm/repo_sack.hpp"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(RepoQueryTest);
+
+
+void RepoQueryTest::setUp() {}
+
+
+void RepoQueryTest::tearDown() {}
+
+
+void RepoQueryTest::test_query_basics() {
+    libdnf::Base base;
+    libdnf::rpm::RepoSack repo_sack(base);
+
+    // Creates new repositories in the repo_sack
+    auto repo1 = repo_sack.new_repo("repo1");
+    auto repo2 = repo_sack.new_repo("repo2");
+    auto repo1_updates = repo_sack.new_repo("repo1_updates");
+    auto repo2_updates = repo_sack.new_repo("repo2_updates");
+
+    // Tunes configuration of repositories
+    repo1->enable();
+    repo2->disable();
+    repo1_updates->disable();
+    repo2_updates->enable();
+    repo1->get_config()->baseurl().set(libdnf::Option::Priority::RUNTIME, "file:///path/to/repo1");
+    repo2->get_config()->baseurl().set(libdnf::Option::Priority::RUNTIME, "https://host/path/to/repo2");
+    repo1_updates->get_config()->baseurl().set(libdnf::Option::Priority::RUNTIME, "https://host/path/to/repo1_updates");
+    repo2_updates->get_config()->baseurl().set(libdnf::Option::Priority::RUNTIME, "https://host/path/to/repo2_updates");
+
+    // Creates new query on the repo_sack
+    auto repo_query = repo_sack.new_query();
+    CPPUNIT_ASSERT_EQUAL(repo_query.size(), static_cast<size_t>(4));
+    CPPUNIT_ASSERT((repo_query == libdnf::Set{repo1, repo2, repo1_updates, repo2_updates}));
+
+    // Tests ifilter_enabled method
+    repo_query.ifilter_enabled(true);
+    CPPUNIT_ASSERT((repo_query == libdnf::Set{repo1, repo2_updates}));
+
+    // Tests ifilter_id method
+    auto repo_query1 = repo_sack.new_query().ifilter_id(libdnf::sack::QueryCmp::GLOB, "*updates");
+    CPPUNIT_ASSERT((repo_query1 == libdnf::Set{repo1_updates, repo2_updates}));
+
+    // Tests ifilter_local method
+    repo_query1 = repo_sack.new_query().ifilter_local(false);
+    CPPUNIT_ASSERT((repo_query1 == libdnf::Set{repo2, repo1_updates, repo2_updates}));
+}

--- a/test/libdnf/rpm/test_repo_query.hpp
+++ b/test/libdnf/rpm/test_repo_query.hpp
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_TEST_REPO_QUERY_HPP
+#define LIBDNF_TEST_REPO_QUERY_HPP
+
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class RepoQueryTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(RepoQueryTest);
+    CPPUNIT_TEST(test_query_basics);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+    void tearDown() override;
+
+    static void test_query_basics();
+};
+
+#endif


### PR DESCRIPTION
The rpm::RepoSack is a container for rpm repositories.
The rpm::RepoQuery implements queries on the rpm::RepoSack.

Depends on: https://github.com/rpm-software-management/libdnf/pull/949