### PR TITLE
[microdnf] Initial work

### DIFF
--- a/microdnf/CMakeLists.txt
+++ b/microdnf/CMakeLists.txt
@@ -2,10 +2,12 @@ if(NOT WITH_MICRODNF)
     return()
 endif()
 
+find_package(Threads)
+
 # use any sources found under the current directory
 file(GLOB_RECURSE MICRODNF_SOURCES *.cpp)
 
 add_executable(microdnf ${MICRODNF_SOURCES})
 
-target_link_libraries(microdnf PUBLIC libdnf libdnf-cli)
+target_link_libraries(microdnf PUBLIC libdnf libdnf-cli Threads::Threads)
 install(TARGETS microdnf RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/microdnf/argument_parser.cpp
+++ b/microdnf/argument_parser.cpp
@@ -1,0 +1,296 @@
+/*
+Copyright (C) 2019-2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "argument_parser.hpp"
+
+#include <fmt/format.h>
+
+#include <cstring>
+
+namespace microdnf {
+
+ArgumentParser::Argument * ArgumentParser::Argument::get_conflict_argument() const {
+    if (conflict_args) {
+        for (auto arg : *conflict_args) {
+            if (arg != this && arg->get_parse_count() > 0) {
+                return arg;
+            }
+        }
+    }
+    return nullptr;
+}
+
+std::string ArgumentParser::Argument::get_conflict_arg_msg(Argument * conflict_arg) {
+    std::string msg;
+    if (auto named_arg = dynamic_cast<NamedArg *>(conflict_arg)) {
+        std::string conflict;
+        if (!named_arg->get_long_name().empty()) {
+            conflict = "\"--" + named_arg->get_long_name() + "\"";
+        }
+        if (!named_arg->get_long_name().empty() && named_arg->get_short_name() != '\0') {
+            conflict += "/";
+        }
+        if (named_arg->get_short_name() != '\0') {
+            conflict = std::string("\"-") + named_arg->get_short_name() + "\"";
+        }
+        msg = fmt::format("not allowed with argument {}", conflict);
+    } else if (dynamic_cast<Command *>(conflict_arg)) {
+        msg = fmt::format("not allowed with command {}", conflict_arg->name);
+    } else {
+        msg = fmt::format("not allowed with positional argument {}", conflict_arg->name);
+    }
+    return msg;
+}
+
+ArgumentParser::PositionalArg::PositionalArg(
+    const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values)
+    : Argument(name)
+    , nargs(static_cast<int>(values->size()))
+    , init_value(nullptr)
+    , values(values) {
+    if (!values || values->empty()) {
+        throw std::runtime_error("PositionalArg: Error: values constructor parameter can't be nullptr or empty vector");
+    }
+}
+
+ArgumentParser::PositionalArg::PositionalArg(
+    const std::string & name,
+    int nargs,
+    libdnf::Option * init_value,
+    std::vector<std::unique_ptr<libdnf::Option>> * values)
+    : Argument(name)
+    , nargs(nargs)
+    , init_value(init_value)
+    , values(values) {
+    if (!values) {
+        throw std::runtime_error("PositionalArg: Error: values constructor parameter can't be nullptr");
+    }
+}
+
+int ArgumentParser::PositionalArg::parse(const char * option, int argc, const char * const argv[]) {
+    if (auto arg = get_conflict_argument()) {
+        auto conflict = get_conflict_arg_msg(arg);
+        auto msg = fmt::format("positional argument \"{}\": {}", option, conflict);
+        throw std::runtime_error(msg);
+    }
+    if (argc < nargs) {
+        throw std::runtime_error("Not enough parameters");
+    }
+    size_t count = nargs > 0 ? nargs : (nargs == OPTIONAL ? 1 : argc);
+    if (store_value) {
+        for (size_t i = 0; i < count; ++i) {
+            if (values->size() <= i) {
+                values->push_back(std::unique_ptr<libdnf::Option>((*init_value).clone()));
+            }
+            (*values)[i]->set(libdnf::Option::Priority::COMMANDLINE, argv[i]);
+        }
+    }
+    ++parse_count;
+    if (parse_hook) {
+        parse_hook(this, argc, argv);
+    }
+    return static_cast<int>(count);
+}
+
+int ArgumentParser::NamedArg::parse_long(const char * option, int argc, const char * const argv[]) {
+    if (auto arg = get_conflict_argument()) {
+        auto conflict = get_conflict_arg_msg(arg);
+        auto msg = fmt::format("argument \"--{}\": {}", option, conflict);
+        throw std::runtime_error(msg);
+    }
+    const char * arg_value;
+    int consumed_args;
+    auto assign_ptr = strchr(option, '=');
+    if (has_arg) {
+        if (assign_ptr) {
+            arg_value = assign_ptr + 1;
+            consumed_args = 1;
+        } else {
+            if (argc < 2) {
+                throw std::runtime_error("Not enough arguments");
+            }
+            arg_value = argv[1];
+            consumed_args = 2;
+        }
+    } else {
+        if (assign_ptr) {
+            throw std::runtime_error(fmt::format("NamedArg: Error: Unexpected argument \"{}\"", assign_ptr + 1));
+        }
+        arg_value = const_val.c_str();
+        consumed_args = 1;
+    }
+    if (store_value && value) {
+        value->set(libdnf::Option::Priority::COMMANDLINE, arg_value);
+    }
+    ++parse_count;
+    if (parse_hook) {
+        parse_hook(this, option, arg_value);
+    }
+    return consumed_args;
+}
+
+
+int ArgumentParser::NamedArg::parse_short(const char * option, int argc, const char * const argv[]) {
+    if (auto arg = get_conflict_argument()) {
+        auto conflict = get_conflict_arg_msg(arg);
+        auto msg = fmt::format("argument \"-{}\": {:.1}", option, conflict);
+        throw std::runtime_error(msg);
+    }
+    const char * arg_value;
+    int consumed_args;
+    if (has_arg) {
+        if (option[1] != '\0') {
+            arg_value = option + 1;
+            consumed_args = 1;
+        } else {
+            if (argc < 2) {
+                throw std::runtime_error("Not enough arguments");
+            }
+            arg_value = argv[1];
+            consumed_args = 2;
+        }
+    } else {
+        arg_value = const_val.c_str();
+        consumed_args =
+            option[1] == '\0' ? 1 : 0;  // consume only if we are the last option in grop, example of 3 options: -cvf
+    }
+    if (store_value && value) {
+        value->set(libdnf::Option::Priority::COMMANDLINE, arg_value);
+    }
+    ++parse_count;
+    if (parse_hook) {
+        parse_hook(this, option, arg_value);
+    }
+    return consumed_args;
+}
+
+ArgumentParser::Command & ArgumentParser::Command::get_command(const std::string & name) const {
+    for (auto item : cmds) {
+        if (item->get_name() == name) {
+            return *item;
+        }
+    }
+    throw std::runtime_error("Commnand not found");
+}
+
+ArgumentParser::NamedArg & ArgumentParser::Command::get_named_arg(const std::string & name) const {
+    for (auto item : named_args) {
+        if (item->get_name() == name) {
+            return *item;
+        }
+    }
+    throw std::runtime_error("Named argument not found");
+}
+
+ArgumentParser::PositionalArg & ArgumentParser::Command::get_positional_arg(const std::string & name) const {
+    for (auto item : pos_args) {
+        if (item->get_name() == name) {
+            return *item;
+        }
+    }
+    throw std::runtime_error("Positional argument not found");
+}
+
+void ArgumentParser::Command::parse(const char * option, int argc, const char * const argv[]) {
+    size_t used_values = 0;
+    int short_option_idx = 0;
+    for (int i = 1; i < argc;) {
+        bool used = false;
+        auto tmp = argv[i];
+        if (*tmp == '-') {
+            bool long_option = *++tmp == '-';
+            if (long_option) {
+                ++tmp;
+            }
+            auto assign_ptr = strchr(tmp, '=');
+            for (auto opt : named_args) {
+                if (long_option) {
+                    if (!opt->get_long_name().empty() &&
+                        (assign_ptr ? std::string(tmp).compare(0, assign_ptr - tmp, opt->get_long_name()) == 0
+                                    : opt->get_long_name() == tmp)) {
+                        i += opt->parse_long(tmp, argc - i, &argv[i]);
+                        used = true;
+                        break;
+                    }
+                } else {
+                    if (opt->get_short_name() != '\0' && opt->get_short_name() == tmp[short_option_idx]) {
+                        auto used_args = opt->parse_short(tmp + short_option_idx, argc - i, &argv[i]);
+                        if (used_args > 0) {
+                            i += used_args;
+                            short_option_idx = 0;
+                        } else {
+                            ++short_option_idx;
+                        }
+                        used = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!used) {
+            for (auto & cmd : cmds) {
+                if (cmd->name == argv[i]) {
+                    if (auto arg = get_conflict_argument()) {
+                        auto conflict = get_conflict_arg_msg(arg);
+                        auto msg = fmt::format("command \"{}\": {}", option, conflict);
+                        throw std::runtime_error(msg);
+                    }
+                    cmd->parse(argv[i], argc - i, &argv[i]);
+                    i = argc;
+                    used = true;
+                    break;
+                }
+            }
+        }
+        if (!used && used_values < pos_args.size()) {
+            i += pos_args[used_values]->parse(argv[i], argc - i, &argv[i]);
+            ++used_values;
+        }
+        if (!used) {
+            ++i;
+        }
+    }
+    ++parse_count;
+    if (parse_hook) {
+        parse_hook(this, option, argc, argv);
+    }
+}
+
+
+void ArgumentParser::parse(int argc, const char * const argv[]) {
+    if (!root_command) {
+        throw std::runtime_error("ArgumentParser: Error: root command is not set");
+    }
+    root_command->parse(argv[0], argc, argv);
+}
+
+void ArgumentParser::reset_parse_count() {
+    for (auto & i : pos_args) {
+        i->reset_parse_count();
+    }
+    for (auto & i : named_args) {
+        i->reset_parse_count();
+    }
+    for (auto & i : cmds) {
+        i->reset_parse_count();
+    }
+}
+
+
+}  // namespace microdnf

--- a/microdnf/argument_parser.hpp
+++ b/microdnf/argument_parser.hpp
@@ -47,6 +47,7 @@ public:
         void reset_parse_count() noexcept { parse_count = 0; }
         Argument * get_conflict_argument() const;
         static std::string get_conflict_arg_msg(Argument * conflict_arg);
+        virtual void help() const noexcept {}
 
     protected:
         std::string name;
@@ -109,6 +110,8 @@ public:
         // returns number of consumed arguments
         int parse_short(const char * option, int argc, const char * const argv[]);
 
+        std::string arg_value_help;
+
     private:
         std::string long_name;
         char short_name{'\0'};
@@ -132,6 +135,7 @@ public:
         NamedArg & get_named_arg(const std::string & name) const;
         PositionalArg & get_positional_arg(const std::string & name) const;
         std::function<bool(Command * arg, const char * cmd, int argc, const char * const argv[])> parse_hook;
+        void help() const noexcept override;
 
         std::string commands_help_header;
         std::string named_args_help_header;

--- a/microdnf/argument_parser.hpp
+++ b/microdnf/argument_parser.hpp
@@ -1,0 +1,247 @@
+/*
+Copyright (C) 2019-2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_ARGUMENT_PARSER_HPP
+#define MICRODNF_ARGUMENT_PARSER_HPP
+
+#include <libdnf/conf/option.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace microdnf {
+
+class ArgumentParser {
+public:
+    class Argument {
+    public:
+        explicit Argument(std::string name) : name(std::move(name)) {}
+        virtual ~Argument() = default;
+        void set_description(const std::string & descr) { description = descr; }
+        void set_description(std::string && descr) noexcept { description = std::move(descr); }
+        void set_short_description(const std::string & descr) { short_description = descr; }
+        void set_short_description(std::string && descr) noexcept { short_description = std::move(descr); }
+        void set_conflict_arguments(std::vector<Argument *> * args) noexcept { conflict_args = args; }
+        const std::string & get_name() const noexcept { return name; }
+        const std::string & get_description() const { return description; }
+        const std::string & get_short_description() const { return short_description; }
+        int get_parse_count() const noexcept { return parse_count; }
+        void reset_parse_count() noexcept { parse_count = 0; }
+        Argument * get_conflict_argument() const;
+        static std::string get_conflict_arg_msg(Argument * conflict_arg);
+
+    protected:
+        std::string name;
+        std::string description;
+        std::string short_description;
+        std::vector<Argument *> * conflict_args{nullptr};
+        int parse_count{0};
+    };
+
+    class PositionalArg : public Argument {
+    public:
+        constexpr static int OPTIONAL{0};
+        constexpr static int UNLIMITED{-1};
+        constexpr static int UNLIMITED_BUT_ONE{-2};
+
+        PositionalArg(const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values);
+        PositionalArg(
+            const std::string & name,
+            int nargs,
+            libdnf::Option * init_value,
+            std::vector<std::unique_ptr<libdnf::Option>> * values);
+
+        void set_store_value(bool enable) noexcept { store_value = enable; }
+        bool get_store_value() const noexcept { return store_value; }
+        std::vector<std::unique_ptr<libdnf::Option>> * get_linked_values() noexcept { return values; }
+        std::function<bool(PositionalArg * arg, int argc, const char * const argv[])> parse_hook;
+
+        // returns number of consumed arguments
+        int parse(const char * option, int argc, const char * const argv[]);
+
+    private:
+        int nargs;
+        libdnf::Option * init_value;
+        std::vector<std::unique_ptr<libdnf::Option>> * values;
+        bool store_value{true};
+    };
+
+    class NamedArg : public Argument {
+    public:
+        explicit NamedArg(const std::string & name) : Argument(name) {}
+        void set_long_name(const std::string & long_name) { this->long_name = long_name; }
+        void set_long_name(std::string && long_name) noexcept { this->long_name = std::move(long_name); }
+        void set_short_name(char short_name) { this->short_name = short_name; }
+        void set_has_arg(bool has_arg) { this->has_arg = has_arg; }
+        void link_value(libdnf::Option * value) { this->value = value; }
+        void set_const_value(const std::string & const_value) { const_val = const_value; }
+        void set_const_value(std::string && const_value) noexcept { const_val = std::move(const_value); }
+        const std::string & get_long_name() const noexcept { return long_name; }
+        char get_short_name() const noexcept { return short_name; }
+        bool get_has_arg() { return has_arg; }
+        const std::string & get_const_value() const noexcept { return const_val; }
+        libdnf::Option * get_linked_value() noexcept { return value; }
+        const libdnf::Option * get_linked_value() const noexcept { return value; }
+        void set_store_value(bool enable) noexcept { store_value = enable; }
+        bool get_store_value() const noexcept { return store_value; }
+        std::function<bool(NamedArg * arg, const char * option, const char * value)> parse_hook;
+
+        // returns number of consumed arguments
+        int parse_long(const char * option, int argc, const char * const argv[]);
+        // returns number of consumed arguments
+        int parse_short(const char * option, int argc, const char * const argv[]);
+
+    private:
+        std::string long_name;
+        char short_name{'\0'};
+        bool has_arg{false};
+        std::string const_val;  // used if params == 0
+        libdnf::Option * value{nullptr};
+        bool store_value{true};
+    };
+
+    class Command : public Argument {
+    public:
+        explicit Command(const std::string & name) : Argument(name) {}
+        void parse(const char * option, int argc, const char * const argv[]);
+        void add_command(Command * arg) { cmds.push_back(arg); }
+        void add_named_arg(NamedArg * arg) { named_args.push_back(arg); }
+        void add_positional_arg(PositionalArg * arg) { pos_args.push_back(arg); }
+        const std::vector<Command *> & get_commands() const noexcept { return cmds; }
+        const std::vector<NamedArg *> & get_named_args() const noexcept { return named_args; }
+        const std::vector<PositionalArg *> & get_positional_args() const noexcept { return pos_args; }
+        Command & get_command(const std::string & name) const;
+        NamedArg & get_named_arg(const std::string & name) const;
+        PositionalArg & get_positional_arg(const std::string & name) const;
+        std::function<bool(Command * arg, const char * cmd, int argc, const char * const argv[])> parse_hook;
+
+        std::string commands_help_header;
+        std::string named_args_help_header;
+        std::string positional_args_help_header;
+
+    private:
+        std::vector<Command *> cmds;
+        std::vector<NamedArg *> named_args;
+        std::vector<PositionalArg *> pos_args;
+    };
+
+    Command * add_new_command(const std::string & name);
+    NamedArg * add_new_named_arg(const std::string & name);
+    PositionalArg * add_new_positional_arg(
+        const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values);
+    PositionalArg * add_new_positional_arg(
+        const std::string & name,
+        int nargs,
+        libdnf::Option * init_value,
+        std::vector<std::unique_ptr<libdnf::Option>> * values);
+    std::vector<Argument *> * add_conflict_args_group(std::unique_ptr<std::vector<Argument *>> && conflict_args_group);
+    libdnf::Option * add_init_value(std::unique_ptr<libdnf::Option> && src);
+    std::vector<std::unique_ptr<libdnf::Option>> * add_new_values();
+    std::vector<std::unique_ptr<libdnf::Option>> * add_values(
+        std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> && values);
+
+    void set_root_command(Command * command);
+    Command * get_root_command();
+    void parse(int argc, const char * const argv[]);
+    void reset_parse_count();
+
+private:
+    std::vector<std::unique_ptr<Command>> cmds;
+    std::vector<std::unique_ptr<NamedArg>> named_args;
+    std::vector<std::unique_ptr<PositionalArg>> pos_args;
+    std::vector<std::unique_ptr<std::vector<Argument *>>> conflict_args_groups;
+    std::vector<std::unique_ptr<libdnf::Option>> values_init;
+    std::vector<std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>>> values;
+    Command * root_command{nullptr};
+};
+
+inline ArgumentParser::Command * ArgumentParser::add_new_command(const std::string & name) {
+    std::unique_ptr<Command> arg(new Command(name));
+    auto ptr = arg.get();
+    cmds.push_back(std::move(arg));
+    return ptr;
+}
+
+inline ArgumentParser::NamedArg * ArgumentParser::add_new_named_arg(const std::string & name) {
+    std::unique_ptr<NamedArg> arg(new NamedArg(name));
+    auto ptr = arg.get();
+    named_args.push_back(std::move(arg));
+    return ptr;
+}
+
+inline ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
+    const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values) {
+    std::unique_ptr<PositionalArg> arg(new PositionalArg(name, values));
+    auto ptr = arg.get();
+    pos_args.push_back(std::move(arg));
+    return ptr;
+}
+
+inline ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
+    const std::string & name,
+    int nargs,
+    libdnf::Option * init_value,
+    std::vector<std::unique_ptr<libdnf::Option>> * values) {
+    std::unique_ptr<PositionalArg> arg(new PositionalArg(name, nargs, init_value, values));
+    auto ptr = arg.get();
+    pos_args.push_back(std::move(arg));
+    return ptr;
+}
+
+inline std::vector<ArgumentParser::Argument *> * ArgumentParser::add_conflict_args_group(
+    std::unique_ptr<std::vector<Argument *>> && conflict_args_group) {
+    auto ptr = conflict_args_group.get();
+    conflict_args_groups.push_back(std::move(conflict_args_group));
+    return ptr;
+}
+
+inline libdnf::Option * ArgumentParser::add_init_value(std::unique_ptr<libdnf::Option> && src) {
+    auto ptr = src.get();
+    values_init.push_back(std::move(src));
+    return ptr;
+}
+
+inline std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_new_values() {
+    std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> tmp(new std::vector<std::unique_ptr<libdnf::Option>>);
+    auto ptr = tmp.get();
+    values.push_back(std::move(tmp));
+    return ptr;
+}
+
+inline std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_values(
+    std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> && src) {
+    auto ptr = src.get();
+    values.push_back(std::move(src));
+    return ptr;
+}
+
+
+inline void ArgumentParser::set_root_command(Command * command) {
+    root_command = command;
+}
+
+inline ArgumentParser::Command * ArgumentParser::get_root_command() {
+    return root_command;
+}
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/commands/command.hpp
+++ b/microdnf/commands/command.hpp
@@ -1,0 +1,38 @@
+/*
+Copyright (C) 2019-2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_COMMAND_HPP
+#define MICRODNF_COMMANDS_COMMAND_HPP
+
+namespace microdnf {
+
+class Context;
+
+class Command {
+public:
+    virtual void set_argument_parser(Context &) {}
+    virtual void pre_configure(Context &) {}
+    virtual void configure(Context &) {}
+    virtual void run(Context &) {}
+    virtual ~Command() = default;
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -1,0 +1,96 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "download.hpp"
+
+#include "../../context.hpp"
+
+#include <libdnf/conf/option_string.hpp>
+#include <libdnf/rpm/package.hpp>
+#include <libdnf/rpm/package_set.hpp>
+#include <libdnf/rpm/solv_query.hpp>
+#include <libdnf/rpm/transaction.hpp>
+#include <libsmartcols/libsmartcols.h>
+
+#include <filesystem>
+#include <iostream>
+
+namespace fs = std::filesystem;
+
+namespace microdnf {
+
+void CmdDownload::set_argument_parser(Context & ctx) {
+    patterns_to_download_options = ctx.arg_parser.add_new_values();
+    auto keys = ctx.arg_parser.add_new_positional_arg(
+        "keys_to_match",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_to_download_options);
+    keys->set_short_description("List of keys to match");
+
+    auto download = ctx.arg_parser.add_new_command("download");
+    download->set_short_description("download packages to current directory");
+    download->set_description("");
+    download->named_args_help_header = "Optional arguments:";
+    download->positional_args_help_header = "Positional arguments:";
+    download->parse_hook = [this, &ctx](
+                               [[maybe_unused]] ArgumentParser::Argument * arg,
+                               [[maybe_unused]] const char * option,
+                               [[maybe_unused]] int argc,
+                               [[maybe_unused]] const char * const argv[]) {
+        ctx.select_command(this);
+        return true;
+    };
+
+    download->add_positional_arg(keys);
+
+    ctx.arg_parser.get_root_command()->add_command(download);
+}
+
+void CmdDownload::configure([[maybe_unused]] Context & ctx) {}
+
+void CmdDownload::run(Context & ctx) {
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+
+    // To search in available repositories (available packages)
+    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    for (auto & repo : enabled_repos.get_data()) {
+        ctx.load_rpm_repo(*repo.get());
+    }
+
+    for (auto & repo : enabled_repos.get_data()) {
+        solv_sack.load_repo(
+            *repo.get(),
+            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
+    }
+
+    libdnf::rpm::PackageSet result_pset(&solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    for (auto & pattern : *patterns_to_download_options) {
+        libdnf::rpm::SolvQuery solv_query(full_solv_query);
+        solv_query.resolve_pkg_spec(
+            dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value(), true, true, true, true, true, {});
+        result_pset |= solv_query.get_package_set();
+    }
+
+    download_packages(result_pset, ".");
+}
+
+}  // namespace microdnf

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -66,20 +66,15 @@ void CmdDownload::set_argument_parser(Context & ctx) {
 void CmdDownload::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdDownload::run(Context & ctx) {
-    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto & solv_sack = ctx.base.get_rpm_solv_sack();
 
     // To search in available repositories (available packages)
     auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
-    for (auto & repo : enabled_repos.get_data()) {
-        ctx.load_rpm_repo(*repo.get());
-    }
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
+    ctx.load_rpm_repos(enabled_repos, flags);
 
-    for (auto & repo : enabled_repos.get_data()) {
-        solv_sack.load_repo(
-            *repo.get(),
-            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
-    }
+    std::cout << std::endl;
 
     libdnf::rpm::PackageSet result_pset(&solv_sack);
     libdnf::rpm::SolvQuery full_solv_query(&solv_sack);

--- a/microdnf/commands/download/download.hpp
+++ b/microdnf/commands/download/download.hpp
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_DOWNLOAD_DOWNLOAD_HPP
+#define MICRODNF_COMMANDS_DOWNLOAD_DOWNLOAD_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_bool.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+class CmdDownload : public Command {
+public:
+    void set_argument_parser(Context & ctx) override;
+    void configure(Context & ctx) override;
+    void run(Context & ctx) override;
+
+private:
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_download_options{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -68,7 +68,6 @@ void CmdInstall::set_argument_parser(Context & ctx) {
 void CmdInstall::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdInstall::run(Context & ctx) {
-    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto & solv_sack = ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
@@ -77,15 +76,11 @@ void CmdInstall::run(Context & ctx) {
 
     // To search in available repositories (available packages)
     auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
-    for (auto & repo : enabled_repos.get_data()) {
-        ctx.load_rpm_repo(*repo.get());
-    }
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
+    ctx.load_rpm_repos(enabled_repos, flags);
 
-    for (auto & repo : enabled_repos.get_data()) {
-        solv_sack.load_repo(
-            *repo.get(),
-            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
-    }
+    std::cout << std::endl;
 
     libdnf::rpm::PackageSet result_pset(&solv_sack);
     libdnf::rpm::SolvQuery full_solv_query(&solv_sack);

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -67,15 +67,6 @@ void CmdInstall::set_argument_parser(Context & ctx) {
 
 void CmdInstall::configure([[maybe_unused]] Context & ctx) {}
 
-class TransCB : public libdnf::rpm::TransactionCB {
-    void install_start(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t total) override {
-        std::cout << "Start: " << header.get_full_nevra() << "Size: " << total << std::endl;
-    }
-    void install_progress(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t amount, uint64_t total) override {
-        std::cout << "Progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;
-    }
-};
-
 void CmdInstall::run(Context & ctx) {
     using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto & solv_sack = ctx.base.get_rpm_solv_sack();
@@ -106,18 +97,16 @@ void CmdInstall::run(Context & ctx) {
 
     download_packages(result_pset, nullptr);
 
-    std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
+    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
     auto ts = libdnf::rpm::Transaction(ctx.base);
     for (auto package : result_pset) {
-        auto item = std::make_unique<libdnf::rpm::TransactionItem>(package);
+        auto item = std::make_unique<RpmTransactionItem>(package, RpmTransactionItem::Actions::INSTALL);
         auto item_ptr = item.get();
         transaction_items.push_back(std::move(item));
         ts.install(*item_ptr);
     }
-    TransCB trans_cb;
-    ts.register_cb(&trans_cb);
-    ts.run();
-    ts.register_cb(nullptr);
+    std::cout << std::endl;
+    run_transaction(ts);
 }
 
 }  // namespace microdnf

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -1,0 +1,162 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "install.hpp"
+
+#include "../../context.hpp"
+
+#include <libdnf/conf/option_string.hpp>
+#include <libdnf/rpm/package.hpp>
+#include <libdnf/rpm/package_set.hpp>
+#include <libdnf/rpm/repo.hpp>
+#include <libdnf/rpm/solv_query.hpp>
+#include <libdnf/rpm/transaction.hpp>
+#include <libsmartcols/libsmartcols.h>
+
+#include <iostream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace microdnf {
+
+void CmdInstall::set_argument_parser(Context & ctx) {
+
+    patterns_to_install_options = ctx.arg_parser.add_new_values();
+    auto keys = ctx.arg_parser.add_new_positional_arg(
+        "keys_to_match",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_to_install_options);
+    keys->set_short_description("List of keys to match");
+
+    auto install = ctx.arg_parser.add_new_command("install");
+    install->set_short_description("install a package or packages on your system");
+    install->set_description("");
+    install->named_args_help_header = "Optional arguments:";
+    install->positional_args_help_header = "Positional arguments:";
+    install->parse_hook = [this, &ctx](
+                                [[maybe_unused]] ArgumentParser::Argument * arg,
+                                [[maybe_unused]] const char * option,
+                                [[maybe_unused]] int argc,
+                                [[maybe_unused]] const char * const argv[]) {
+        ctx.select_command(this);
+        return true;
+    };
+
+    install->add_positional_arg(keys);
+
+    ctx.arg_parser.get_root_command()->add_command(install);
+}
+
+void CmdInstall::configure([[maybe_unused]] Context & ctx) {}
+
+class TransCB : public libdnf::rpm::TransactionCB {
+    void install_start(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t total) override {
+        std::cout << "Start: " << header.get_full_nevra() << "Size: " << total << std::endl;
+    }
+    void install_progress(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t amount, uint64_t total) override {
+        std::cout << "Progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;
+    }
+};
+
+void CmdInstall::run(Context & ctx) {
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+
+    // To search in the system repository (installed packages)
+    // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
+    //solv_sack.create_system_repo(false);
+
+    // To search in available repositories (available packages)
+    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    for (auto & repo : enabled_repos.get_data()) {
+        ctx.load_rpm_repo(*repo.get());
+    }
+
+    for (auto & repo : enabled_repos.get_data()) {
+        solv_sack.load_repo(
+            *repo.get(),
+            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
+    }
+
+    libdnf::rpm::PackageSet result_pset(&solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    for (auto & pattern : *patterns_to_install_options) {
+        libdnf::rpm::SolvQuery solv_query(full_solv_query);
+        solv_query.resolve_pkg_spec(dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value(), true, true, true, true, true, {});
+        result_pset |= solv_query.get_package_set();
+    }
+
+    for (auto package : result_pset) {
+        std::cout << package.get_full_nevra() << '\n';
+        std::cout << package.get_url() << '\n';
+        std::cout << package.get_baseurl() << '\n';
+        std::cout << package.get_location() << '\n';
+        //auto repo = package.get_repo();
+        //fd = open();
+        //repo.download_url(url, fd);
+        //close(fd);
+    }
+
+    // download packages
+    std::vector<libdnf::rpm::PackageTarget *> targets;
+    try {
+        for (auto package : result_pset) {
+            auto repo = package.get_repo();
+            auto destination = fs::path(repo->get_cachedir()) / "packages";
+            auto checksum = package.get_checksum();
+            auto pkg_target = new libdnf::rpm::PackageTarget(repo, package.get_location().c_str(), destination.c_str(),
+                                    static_cast<int>(checksum.get_type()), checksum.get_checksum().c_str(),
+                                    static_cast<int64_t>(package.get_download_size()), package.get_baseurl().empty() ? nullptr : package.get_baseurl().c_str(), true,
+                                    0, 0, nullptr);
+            targets.push_back(pkg_target);
+        }
+        std::cout << "Start packages download" << std::endl;
+        try {
+            libdnf::rpm::PackageTarget::download_packages(targets, true);
+        } catch (const std::runtime_error & ex) {
+            std::cout << "Exception: " << ex.what() << std::endl;
+        }
+        std::cout << "Done packages download" << std::endl;
+    } catch (...) {
+        for (auto target : targets) {
+            delete target;
+        }
+        throw;
+    }
+    for (auto target : targets) {
+        delete target;
+    }
+
+    std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
+    auto ts = libdnf::rpm::Transaction(ctx.base);
+    for (auto package : result_pset) {
+        auto item = std::make_unique<libdnf::rpm::TransactionItem>(package);
+        auto item_ptr = item.get();
+        transaction_items.push_back(std::move(item));
+        ts.install(*item_ptr);
+    }
+    TransCB trans_cb;
+    ts.register_cb(&trans_cb);
+    ts.run();
+    ts.register_cb(nullptr);
+}
+
+}  // namespace microdnf

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -104,46 +104,7 @@ void CmdInstall::run(Context & ctx) {
         result_pset |= solv_query.get_package_set();
     }
 
-    for (auto package : result_pset) {
-        std::cout << package.get_full_nevra() << '\n';
-        std::cout << package.get_url() << '\n';
-        std::cout << package.get_baseurl() << '\n';
-        std::cout << package.get_location() << '\n';
-        //auto repo = package.get_repo();
-        //fd = open();
-        //repo.download_url(url, fd);
-        //close(fd);
-    }
-
-    // download packages
-    std::vector<libdnf::rpm::PackageTarget *> targets;
-    try {
-        for (auto package : result_pset) {
-            auto repo = package.get_repo();
-            auto destination = fs::path(repo->get_cachedir()) / "packages";
-            auto checksum = package.get_checksum();
-            auto pkg_target = new libdnf::rpm::PackageTarget(repo, package.get_location().c_str(), destination.c_str(),
-                                    static_cast<int>(checksum.get_type()), checksum.get_checksum().c_str(),
-                                    static_cast<int64_t>(package.get_download_size()), package.get_baseurl().empty() ? nullptr : package.get_baseurl().c_str(), true,
-                                    0, 0, nullptr);
-            targets.push_back(pkg_target);
-        }
-        std::cout << "Start packages download" << std::endl;
-        try {
-            libdnf::rpm::PackageTarget::download_packages(targets, true);
-        } catch (const std::runtime_error & ex) {
-            std::cout << "Exception: " << ex.what() << std::endl;
-        }
-        std::cout << "Done packages download" << std::endl;
-    } catch (...) {
-        for (auto target : targets) {
-            delete target;
-        }
-        throw;
-    }
-    for (auto target : targets) {
-        delete target;
-    }
+    download_packages(result_pset, nullptr);
 
     std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
     auto ts = libdnf::rpm::Transaction(ctx.base);

--- a/microdnf/commands/install/install.hpp
+++ b/microdnf/commands/install/install.hpp
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_INSTALL_INSTALL_HPP
+#define MICRODNF_COMMANDS_INSTALL_INSTALL_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_bool.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+class CmdInstall : public Command {
+public:
+    void set_argument_parser(Context & ctx) override;
+    void configure(Context & ctx) override;
+    void run(Context & ctx) override;
+
+private:
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_install_options{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -1,0 +1,160 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "reinstall.hpp"
+
+#include "../../context.hpp"
+
+#include <libdnf/conf/option_string.hpp>
+#include <libdnf/rpm/package.hpp>
+#include <libdnf/rpm/package_set.hpp>
+#include <libdnf/rpm/solv_query.hpp>
+#include <libdnf/rpm/transaction.hpp>
+#include <libsmartcols/libsmartcols.h>
+
+#include <iostream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace microdnf {
+
+void CmdReinstall::set_argument_parser(Context & ctx) {
+    patterns_to_reinstall_options = ctx.arg_parser.add_new_values();
+    auto keys = ctx.arg_parser.add_new_positional_arg(
+        "keys_to_match",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_to_reinstall_options);
+    keys->set_short_description("List of keys to match");
+
+    auto reinstall = ctx.arg_parser.add_new_command("reinstall");
+    reinstall->set_short_description("reinstall a package or packages");
+    reinstall->set_description("");
+    reinstall->named_args_help_header = "Optional arguments:";
+    reinstall->positional_args_help_header = "Positional arguments:";
+    reinstall->parse_hook = [this, &ctx](
+                                [[maybe_unused]] ArgumentParser::Argument * arg,
+                                [[maybe_unused]] const char * option,
+                                [[maybe_unused]] int argc,
+                                [[maybe_unused]] const char * const argv[]) {
+        ctx.select_command(this);
+        return true;
+    };
+
+    reinstall->add_positional_arg(keys);
+
+    ctx.arg_parser.get_root_command()->add_command(reinstall);
+}
+
+void CmdReinstall::configure([[maybe_unused]] Context & ctx) {}
+
+class TransCB : public libdnf::rpm::TransactionCB {
+    void install_start(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t total) override {
+        std::cout << "Start: " << header.get_full_nevra() << "Size: " << total << std::endl;
+    }
+    void install_progress(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t amount, uint64_t total) override {
+        std::cout << "Progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;
+    }
+};
+
+void CmdReinstall::run(Context & ctx) {
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+
+    // To search in the system repository (installed packages)
+    // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
+    //solv_sack.create_system_repo(false);
+
+    // To search in available repositories (available packages)
+    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    for (auto & repo : enabled_repos.get_data()) {
+        ctx.load_rpm_repo(*repo.get());
+    }
+
+    for (auto & repo : enabled_repos.get_data()) {
+        solv_sack.load_repo(
+            *repo.get(),
+            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
+    }
+
+    libdnf::rpm::PackageSet result_pset(&solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    for (auto & pattern : *patterns_to_reinstall_options) {
+        libdnf::rpm::SolvQuery solv_query(full_solv_query);
+        solv_query.resolve_pkg_spec(dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value(), true, true, true, true, true, {});
+        result_pset |= solv_query.get_package_set();
+    }
+
+    for (auto package : result_pset) {
+        std::cout << package.get_full_nevra() << '\n';
+        std::cout << package.get_url() << '\n';
+        std::cout << package.get_baseurl() << '\n';
+        std::cout << package.get_location() << '\n';
+        //auto repo = package.get_repo();
+        //fd = open();
+        //repo.download_url(url, fd);
+        //close(fd);
+    }
+
+    // download packages
+    std::vector<libdnf::rpm::PackageTarget *> targets;
+    try {
+        for (auto package : result_pset) {
+            auto repo = package.get_repo();
+            auto destination = fs::path(repo->get_cachedir()) / "packages";
+            auto checksum = package.get_checksum();
+            auto pkg_target = new libdnf::rpm::PackageTarget(repo, package.get_location().c_str(), destination.c_str(),
+                                    static_cast<int>(checksum.get_type()), checksum.get_checksum().c_str(),
+                                    static_cast<int64_t>(package.get_download_size()), package.get_baseurl().empty() ? nullptr : package.get_baseurl().c_str(), true,
+                                    0, 0, nullptr);
+            targets.push_back(pkg_target);
+        }
+        std::cout << "Start packages download" << std::endl;
+        try {
+            libdnf::rpm::PackageTarget::download_packages(targets, true);
+        } catch (const std::runtime_error & ex) {
+            std::cout << "Exception: " << ex.what() << std::endl;
+        }
+        std::cout << "Done packages download" << std::endl;
+    } catch (...) {
+        for (auto target : targets) {
+            delete target;
+        }
+        throw;
+    }
+    for (auto target : targets) {
+        delete target;
+    }
+
+    std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
+    auto ts = libdnf::rpm::Transaction(ctx.base);
+    for (auto package : result_pset) {
+        auto item = std::make_unique<libdnf::rpm::TransactionItem>(package);
+        auto item_ptr = item.get();
+        transaction_items.push_back(std::move(item));
+        ts.reinstall(*item_ptr);
+    }
+    TransCB trans_cb;
+    ts.register_cb(&trans_cb);
+    ts.run();
+    ts.register_cb(nullptr);
+}
+
+}  // namespace microdnf

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -66,7 +66,6 @@ void CmdReinstall::set_argument_parser(Context & ctx) {
 void CmdReinstall::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdReinstall::run(Context & ctx) {
-    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto & solv_sack = ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
@@ -75,15 +74,11 @@ void CmdReinstall::run(Context & ctx) {
 
     // To search in available repositories (available packages)
     auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
-    for (auto & repo : enabled_repos.get_data()) {
-        ctx.load_rpm_repo(*repo.get());
-    }
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
+    ctx.load_rpm_repos(enabled_repos, flags);
 
-    for (auto & repo : enabled_repos.get_data()) {
-        solv_sack.load_repo(
-            *repo.get(),
-            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
-    }
+    std::cout << std::endl;
 
     libdnf::rpm::PackageSet result_pset(&solv_sack);
     libdnf::rpm::SolvQuery full_solv_query(&solv_sack);

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -102,46 +102,7 @@ void CmdReinstall::run(Context & ctx) {
         result_pset |= solv_query.get_package_set();
     }
 
-    for (auto package : result_pset) {
-        std::cout << package.get_full_nevra() << '\n';
-        std::cout << package.get_url() << '\n';
-        std::cout << package.get_baseurl() << '\n';
-        std::cout << package.get_location() << '\n';
-        //auto repo = package.get_repo();
-        //fd = open();
-        //repo.download_url(url, fd);
-        //close(fd);
-    }
-
-    // download packages
-    std::vector<libdnf::rpm::PackageTarget *> targets;
-    try {
-        for (auto package : result_pset) {
-            auto repo = package.get_repo();
-            auto destination = fs::path(repo->get_cachedir()) / "packages";
-            auto checksum = package.get_checksum();
-            auto pkg_target = new libdnf::rpm::PackageTarget(repo, package.get_location().c_str(), destination.c_str(),
-                                    static_cast<int>(checksum.get_type()), checksum.get_checksum().c_str(),
-                                    static_cast<int64_t>(package.get_download_size()), package.get_baseurl().empty() ? nullptr : package.get_baseurl().c_str(), true,
-                                    0, 0, nullptr);
-            targets.push_back(pkg_target);
-        }
-        std::cout << "Start packages download" << std::endl;
-        try {
-            libdnf::rpm::PackageTarget::download_packages(targets, true);
-        } catch (const std::runtime_error & ex) {
-            std::cout << "Exception: " << ex.what() << std::endl;
-        }
-        std::cout << "Done packages download" << std::endl;
-    } catch (...) {
-        for (auto target : targets) {
-            delete target;
-        }
-        throw;
-    }
-    for (auto target : targets) {
-        delete target;
-    }
+    download_packages(result_pset, nullptr);
 
     std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
     auto ts = libdnf::rpm::Transaction(ctx.base);

--- a/microdnf/commands/reinstall/reinstall.hpp
+++ b/microdnf/commands/reinstall/reinstall.hpp
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_REINSTALL_REINSTALL_HPP
+#define MICRODNF_COMMANDS_REINSTALL_REINSTALL_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_bool.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+class CmdReinstall : public Command {
+public:
+    void set_argument_parser(Context & ctx) override;
+    void configure(Context & ctx) override;
+    void run(Context & ctx) override;
+
+private:
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_reinstall_options{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/commands/remove/remove.cpp
+++ b/microdnf/commands/remove/remove.cpp
@@ -1,0 +1,111 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "remove.hpp"
+
+#include "../../context.hpp"
+
+#include <libdnf/conf/option_string.hpp>
+#include <libdnf/rpm/package.hpp>
+#include <libdnf/rpm/package_set.hpp>
+#include <libdnf/rpm/solv_query.hpp>
+#include <libdnf/rpm/transaction.hpp>
+#include <libsmartcols/libsmartcols.h>
+
+#include <iostream>
+
+namespace microdnf {
+
+
+void CmdRemove::set_argument_parser(Context & ctx) {
+    patterns_to_remove_options = ctx.arg_parser.add_new_values();
+    auto keys = ctx.arg_parser.add_new_positional_arg(
+        "keys_to_match",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_to_remove_options);
+    keys->set_short_description("List of keys to match");
+
+    auto remove = ctx.arg_parser.add_new_command("remove");
+    remove->set_short_description("remove a package or packages from your system");
+    remove->set_description("");
+    remove->named_args_help_header = "Optional arguments:";
+    remove->positional_args_help_header = "Positional arguments:";
+    remove->parse_hook = [this, &ctx](
+                                [[maybe_unused]] ArgumentParser::Argument * arg,
+                                [[maybe_unused]] const char * option,
+                                [[maybe_unused]] int argc,
+                                [[maybe_unused]] const char * const argv[]) {
+        ctx.select_command(this);
+        return true;
+    };
+
+    remove->add_positional_arg(keys);
+
+    ctx.arg_parser.get_root_command()->add_command(remove);
+}
+
+void CmdRemove::configure([[maybe_unused]] Context & ctx) {}
+
+class TransCB : public libdnf::rpm::TransactionCB {
+    void install_start(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t total) override {
+        std::cout << "Start: " << header.get_full_nevra() << "Size: " << total << std::endl;
+    }
+    void install_progress(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t amount, uint64_t total) override {
+        std::cout << "Progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;
+    }
+};
+
+void CmdRemove::run(Context & ctx) {
+    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+
+    // To search in the system repository (installed packages)
+    // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
+    solv_sack.create_system_repo(false);
+
+    libdnf::rpm::PackageSet result_pset(&solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    for (auto & pattern : *patterns_to_remove_options) {
+        libdnf::rpm::SolvQuery solv_query(full_solv_query);
+        solv_query.resolve_pkg_spec(dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value(), true, true, true, true, true, {});
+        result_pset |= solv_query.get_package_set();
+    }
+
+    // print debug for development
+    for (auto package : result_pset) {
+        auto rpmdb_id = package.get_rpmdbid();
+        std::cout << "rpmdb_id: " << rpmdb_id << '\n';
+        std::cout << package.get_full_nevra() << '\n';
+    }
+
+    std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
+    auto ts = libdnf::rpm::Transaction(ctx.base);
+    for (auto package : result_pset) {
+        auto item = std::make_unique<libdnf::rpm::TransactionItem>(package);
+        auto item_ptr = item.get();
+        transaction_items.push_back(std::move(item));
+        ts.erase(*item_ptr);
+    }
+    TransCB trans_cb;
+    ts.register_cb(&trans_cb);
+    ts.run();
+    ts.register_cb(nullptr);
+}
+
+}  // namespace microdnf

--- a/microdnf/commands/remove/remove.hpp
+++ b/microdnf/commands/remove/remove.hpp
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_REMOVE_REMOVE_HPP
+#define MICRODNF_COMMANDS_REMOVE_REMOVE_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_bool.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+class CmdRemove : public Command {
+public:
+    void set_argument_parser(Context & ctx) override;
+    void configure(Context & ctx) override;
+    void run(Context & ctx) override;
+
+private:
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_remove_options{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/commands/repolist/repolist.cpp
+++ b/microdnf/commands/repolist/repolist.cpp
@@ -1,0 +1,185 @@
+/*
+Copyright (C) 2019-2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "repolist.hpp"
+
+#include "../../context.hpp"
+
+#include <libdnf/conf/option_string.hpp>
+#include <libsmartcols/libsmartcols.h>
+
+namespace microdnf {
+
+// repository list table columns
+enum { COL_REPO_ID, COL_REPO_NAME, COL_REPO_STATUS };
+
+static struct libscols_table * create_repolist_table(bool with_status) {
+    struct libscols_table * table = scols_new_table();
+    if (isatty(1)) {
+        scols_table_enable_colors(table, 1);
+        scols_table_enable_maxout(table, 1);
+    }
+    struct libscols_column * cl = scols_table_new_column(table, "repo id", 0.4, 0);
+    scols_column_set_cmpfunc(cl, scols_cmpstr_cells, NULL);
+    scols_table_new_column(table, "repo name", 0.5, SCOLS_FL_TRUNC);
+    if (with_status) {
+        scols_table_new_column(table, "status", 0.1, SCOLS_FL_RIGHT);
+    }
+    return table;
+}
+
+static void add_line_into_table(
+    struct libscols_table * table, bool with_status, const char * id, const char * descr, bool enabled) {
+    struct libscols_line * ln = scols_table_new_line(table, NULL);
+    scols_line_set_data(ln, COL_REPO_ID, id);
+    scols_line_set_data(ln, COL_REPO_NAME, descr);
+    if (with_status) {
+        scols_line_set_data(ln, COL_REPO_STATUS, enabled ? "enabled" : "disabled");
+        struct libscols_cell * cl = scols_line_get_cell(ln, COL_REPO_STATUS);
+        scols_cell_set_color(cl, enabled ? "green" : "red");
+    }
+}
+
+
+void CmdRepolist::set_argument_parser(Context & ctx) {
+    enable_disable_option = dynamic_cast<libdnf::OptionEnum<std::string> *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionEnum<std::string>>(
+            new libdnf::OptionEnum<std::string>("enabled", {"all", "enabled", "disabled"}))));
+
+    auto all = ctx.arg_parser.add_new_named_arg("all");
+    all->set_long_name("all");
+    all->set_short_description("show all repos");
+    all->set_const_value("all");
+    all->link_value(enable_disable_option);
+
+    auto enabled = ctx.arg_parser.add_new_named_arg("enabled");
+    enabled->set_long_name("enabled");
+    enabled->set_short_description("show enabled repos (default)");
+    enabled->set_const_value("enabled");
+    enabled->link_value(enable_disable_option);
+
+    auto disabled = ctx.arg_parser.add_new_named_arg("disabled");
+    disabled->set_long_name("disabled");
+    disabled->set_short_description("show disabled repos");
+    disabled->set_const_value("disabled");
+    disabled->link_value(enable_disable_option);
+
+    patterns_to_show_options = ctx.arg_parser.add_new_values();
+    auto repos = ctx.arg_parser.add_new_positional_arg(
+        "repos_to_show",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_to_show_options);
+    repos->set_short_description("List of repos to show");
+
+    auto conflict_args =
+        ctx.arg_parser.add_conflict_args_group(std::unique_ptr<std::vector<ArgumentParser::Argument *>>(
+            new std::vector<ArgumentParser::Argument *>{all, enabled, disabled}));
+
+    all->set_conflict_arguments(conflict_args);
+    enabled->set_conflict_arguments(conflict_args);
+    disabled->set_conflict_arguments(conflict_args);
+
+    auto repolist = ctx.arg_parser.add_new_command("repolist");
+    repolist->set_short_description("display the configured software repositories");
+    repolist->set_description("");
+    repolist->named_args_help_header = "Optional arguments:";
+    repolist->positional_args_help_header = "Positional arguments:";
+    repolist->parse_hook = [this, &ctx](
+                               [[maybe_unused]] ArgumentParser::Argument * arg,
+                               [[maybe_unused]] const char * option,
+                               [[maybe_unused]] int argc,
+                               [[maybe_unused]] const char * const argv[]) {
+        ctx.select_command(this);
+        return true;
+    };
+
+    repolist->add_named_arg(all);
+    repolist->add_named_arg(enabled);
+    repolist->add_named_arg(disabled);
+    repolist->add_positional_arg(repos);
+
+    ctx.arg_parser.get_root_command()->add_command(repolist);
+
+    auto repoinfo = ctx.arg_parser.add_new_command("repoinfo");
+    repoinfo->set_short_description("display the configured software repositories");
+    repoinfo->set_description("");
+    repoinfo->named_args_help_header = "Optional arguments:";
+    repoinfo->positional_args_help_header = "Positional arguments:";
+    repoinfo->parse_hook = [this, &ctx](
+                               [[maybe_unused]] ArgumentParser::Argument * arg,
+                               [[maybe_unused]] const char * option,
+                               [[maybe_unused]] int argc,
+                               [[maybe_unused]] const char * const argv[]) {
+        // TODO(jrohel): implement repoinfo
+        throw std::logic_error("Not implemented");
+        ctx.select_command(this);
+        return true;
+    };
+
+    repoinfo->add_named_arg(all);
+    repoinfo->add_named_arg(enabled);
+    repoinfo->add_named_arg(disabled);
+    repoinfo->add_positional_arg(repos);
+
+    ctx.arg_parser.get_root_command()->add_command(repoinfo);
+}
+
+void CmdRepolist::run(Context & ctx) {
+    std::vector<std::string> patterns_to_show;
+    if (patterns_to_show_options->size() > 0) {
+        patterns_to_show.reserve(patterns_to_show_options->size());
+        for (auto & pattern : *patterns_to_show_options) {
+            patterns_to_show.emplace_back(dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value());
+        }
+    }
+
+    auto query = ctx.base.get_rpm_repo_sack().new_query();
+    if (enable_disable_option->get_value() == "enabled") {
+        query.ifilter_enabled(true);
+    } else if (enable_disable_option->get_value() == "disabled") {
+        query.ifilter_enabled(false);
+    }
+
+    if (patterns_to_show.size() > 0) {
+        auto query_names = query;
+        query.ifilter_id(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query |= query_names.ifilter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+    }
+
+    bool with_status = enable_disable_option->get_value() == "all";
+
+    auto table = create_repolist_table(with_status);
+
+    for (auto & repo : query.get_data()) {
+        add_line_into_table(
+            table,
+            with_status,
+            repo->get_id().c_str(),
+            repo->get_config()->name().get_value().c_str(),
+            repo->is_enabled());
+    }
+
+    auto cl = scols_table_get_column(table, COL_REPO_ID);
+    scols_sort_table(table, cl);
+    scols_print_table(table);
+    scols_unref_table(table);
+}
+
+}  // namespace microdnf

--- a/microdnf/commands/repolist/repolist.hpp
+++ b/microdnf/commands/repolist/repolist.hpp
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2019-2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_REPOLIST_REPOLIST_HPP
+#define MICRODNF_COMMANDS_REPOLIST_REPOLIST_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_enum.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+class CmdRepolist : public Command {
+public:
+    void set_argument_parser(Context & ctx) override;
+    void run(Context & ctx) override;
+
+private:
+    libdnf::OptionEnum<std::string> * enable_disable_option{nullptr};
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_show_options{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -147,7 +147,6 @@ void CmdRepoquery::set_argument_parser(Context & ctx) {
 void CmdRepoquery::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdRepoquery::run(Context & ctx) {
-    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto & solv_sack = ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
@@ -159,15 +158,11 @@ void CmdRepoquery::run(Context & ctx) {
     // To search in available repositories (available packages)
     if (available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !installed_option->get_value()) {
         auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
-        for (auto & repo : enabled_repos.get_data()) {
-            ctx.load_rpm_repo(*repo.get());
-        }
-
-        for (auto & repo : enabled_repos.get_data()) {
-            solv_sack.load_repo(
-                *repo.get(),
-                LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
-        }
+        using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+        auto flags =
+            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
+        ctx.load_rpm_repos(enabled_repos, flags);
+        std::cout << std::endl;
     }
 
     libdnf::rpm::PackageSet result_pset(&solv_sack);

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -1,0 +1,197 @@
+/*
+Copyright (C) 2019-2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "repoquery.hpp"
+
+#include "../../context.hpp"
+
+#include <libdnf/conf/option_string.hpp>
+#include <libdnf/rpm/package.hpp>
+#include <libdnf/rpm/package_set.hpp>
+#include <libdnf/rpm/solv_query.hpp>
+#include <libsmartcols/libsmartcols.h>
+
+#include <iostream>
+
+namespace microdnf {
+
+static void package_info_add_line(struct libscols_table * table, const char * key, const char * value) {
+    struct libscols_line * ln = scols_table_new_line(table, nullptr);
+    scols_line_set_data(ln, 0, key);
+    scols_line_set_data(ln, 1, value);
+}
+
+static void print_package_info(libdnf::rpm::Package & package) {
+    struct libscols_table * table = scols_new_table();
+    scols_table_enable_noheadings(table, 1);
+    scols_table_set_column_separator(table, " : ");
+    scols_table_new_column(table, "key", 5, 0);
+    struct libscols_column * cl = scols_table_new_column(table, "value", 10, SCOLS_FL_WRAP);
+    scols_column_set_safechars(cl, "\n");
+    scols_column_set_wrapfunc(cl, scols_wrapnl_chunksize, scols_wrapnl_nextchunk, nullptr);
+
+    package_info_add_line(table, "Name", package.get_name().c_str());
+    auto epoch = package.get_epoch();
+    if (epoch != 0) {
+        auto str_epoch = std::to_string(epoch);
+        package_info_add_line(table, "Epoch", str_epoch.c_str());
+    }
+    package_info_add_line(table, "Version", package.get_version().c_str());
+    package_info_add_line(table, "Release", package.get_release().c_str());
+    package_info_add_line(table, "Architecture", package.get_arch().c_str());
+    auto size = package.get_size();
+    package_info_add_line(table, "Size", std::to_string(size).c_str());
+    package_info_add_line(table, "Source", package.get_sourcerpm().c_str());
+    // TODO(jrohel): support for reponame package_info_add_line(table, "Repository", package.get_reponame().c_str());
+    package_info_add_line(table, "Summary", package.get_summary().c_str());
+    package_info_add_line(table, "URL", package.get_url().c_str());
+    package_info_add_line(table, "License", package.get_license().c_str());
+    package_info_add_line(table, "Description", package.get_description().c_str());
+
+    scols_print_table(table);
+    scols_unref_table(table);
+}
+
+void CmdRepoquery::set_argument_parser(Context & ctx) {
+    available_option = dynamic_cast<libdnf::OptionBool *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(true))));
+
+    installed_option = dynamic_cast<libdnf::OptionBool *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(false))));
+
+    info_option = dynamic_cast<libdnf::OptionBool *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(false))));
+
+    nevra_option = dynamic_cast<libdnf::OptionBool *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(true))));
+
+    auto available = ctx.arg_parser.add_new_named_arg("available");
+    available->set_long_name("available");
+    available->set_short_description("display available packages (default)");
+    available->set_const_value("true");
+    available->link_value(available_option);
+
+    auto installed = ctx.arg_parser.add_new_named_arg("installed");
+    installed->set_long_name("installed");
+    installed->set_short_description("display installed packages");
+    installed->set_const_value("true");
+    installed->link_value(installed_option);
+
+    auto info = ctx.arg_parser.add_new_named_arg("info");
+    info->set_long_name("info");
+    info->set_short_description("show detailed information about the packages");
+    info->set_const_value("true");
+    info->link_value(info_option);
+
+    auto nevra = ctx.arg_parser.add_new_named_arg("nevra");
+    nevra->set_long_name("nevra");
+    nevra->set_short_description(
+        "use name-epoch:version-release.architecture format for displaying packages (default)");
+    nevra->set_const_value("true");
+    nevra->link_value(nevra_option);
+
+    patterns_to_show_options = ctx.arg_parser.add_new_values();
+    auto keys = ctx.arg_parser.add_new_positional_arg(
+        "keys_to_match",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_to_show_options);
+    keys->set_short_description("List of keys to match");
+
+    auto conflict_args =
+        ctx.arg_parser.add_conflict_args_group(std::unique_ptr<std::vector<ArgumentParser::Argument *>>(
+            new std::vector<ArgumentParser::Argument *>{info, nevra}));
+
+    info->set_conflict_arguments(conflict_args);
+    nevra->set_conflict_arguments(conflict_args);
+
+    auto repoquery = ctx.arg_parser.add_new_command("repoquery");
+    repoquery->set_short_description("search for packages matching keyword");
+    repoquery->set_description("");
+    repoquery->named_args_help_header = "Optional arguments:";
+    repoquery->positional_args_help_header = "Positional arguments:";
+    repoquery->parse_hook = [this, &ctx](
+                                [[maybe_unused]] ArgumentParser::Argument * arg,
+                                [[maybe_unused]] const char * option,
+                                [[maybe_unused]] int argc,
+                                [[maybe_unused]] const char * const argv[]) {
+        ctx.select_command(this);
+        return true;
+    };
+
+    repoquery->add_named_arg(available);
+    repoquery->add_named_arg(installed);
+    repoquery->add_named_arg(info);
+    repoquery->add_named_arg(nevra);
+    repoquery->add_positional_arg(keys);
+
+    ctx.arg_parser.get_root_command()->add_command(repoquery);
+}
+
+void CmdRepoquery::configure([[maybe_unused]] Context & ctx) {}
+
+void CmdRepoquery::run(Context & ctx) {
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+
+    // To search in the system repository (installed packages)
+    if (installed_option->get_value()) {
+        // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
+        solv_sack.create_system_repo(false);
+    }
+
+    // To search in available repositories (available packages)
+    if (available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !installed_option->get_value()) {
+        auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+        for (auto & repo : enabled_repos.get_data()) {
+            ctx.load_rpm_repo(*repo.get());
+        }
+
+        for (auto & repo : enabled_repos.get_data()) {
+            solv_sack.load_repo(
+                *repo.get(),
+                LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
+        }
+    }
+
+    std::vector<std::string> patterns_to_show;
+    if (patterns_to_show_options->size() > 0) {
+        patterns_to_show.reserve(patterns_to_show_options->size());
+        for (auto & pattern : *patterns_to_show_options) {
+            patterns_to_show.emplace_back(dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value());
+        }
+    }
+
+    libdnf::rpm::SolvQuery solv_query(&solv_sack);
+    solv_query.ifilter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+
+    auto package_set = solv_query.get_package_set();
+    if (info_option->get_value()) {
+        for (auto package : package_set) {
+            print_package_info(package);
+            std::cout << '\n';
+        }
+    } else {
+        for (auto package : package_set) {
+            std::cout << package.get_full_nevra() << '\n';
+        }
+    }
+}
+
+}  // namespace microdnf

--- a/microdnf/commands/repoquery/repoquery.hpp
+++ b/microdnf/commands/repoquery/repoquery.hpp
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2019-2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_REPOQUERY_REPOQUERY_HPP
+#define MICRODNF_COMMANDS_REPOQUERY_REPOQUERY_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_bool.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+class CmdRepoquery : public Command {
+public:
+    void set_argument_parser(Context & ctx) override;
+    void configure(Context & ctx) override;
+    void run(Context & ctx) override;
+
+private:
+    libdnf::OptionBool * available_option{nullptr};
+    libdnf::OptionBool * installed_option{nullptr};
+    libdnf::OptionBool * info_option{nullptr};
+    libdnf::OptionBool * nevra_option{nullptr};
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_show_options{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -1,0 +1,160 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "upgrade.hpp"
+
+#include "../../context.hpp"
+
+#include <libdnf/conf/option_string.hpp>
+#include <libdnf/rpm/package.hpp>
+#include <libdnf/rpm/package_set.hpp>
+#include <libdnf/rpm/solv_query.hpp>
+#include <libdnf/rpm/transaction.hpp>
+#include <libsmartcols/libsmartcols.h>
+
+#include <iostream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace microdnf {
+
+void CmdUpgrade::set_argument_parser(Context & ctx) {
+    patterns_to_upgrade_options = ctx.arg_parser.add_new_values();
+    auto keys = ctx.arg_parser.add_new_positional_arg(
+        "keys_to_match",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_to_upgrade_options);
+    keys->set_short_description("List of keys to match");
+
+    auto upgrade = ctx.arg_parser.add_new_command("upgrade");
+    upgrade->set_short_description("upgrade a package or packages on your system");
+    upgrade->set_description("");
+    upgrade->named_args_help_header = "Optional arguments:";
+    upgrade->positional_args_help_header = "Positional arguments:";
+    upgrade->parse_hook = [this, &ctx](
+                                [[maybe_unused]] ArgumentParser::Argument * arg,
+                                [[maybe_unused]] const char * option,
+                                [[maybe_unused]] int argc,
+                                [[maybe_unused]] const char * const argv[]) {
+        ctx.select_command(this);
+        return true;
+    };
+
+    upgrade->add_positional_arg(keys);
+
+    ctx.arg_parser.get_root_command()->add_command(upgrade);
+}
+
+void CmdUpgrade::configure([[maybe_unused]] Context & ctx) {}
+
+class TransCB : public libdnf::rpm::TransactionCB {
+    void install_start(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t total) override {
+        std::cout << "Start: " << header.get_full_nevra() << "Size: " << total << std::endl;
+    }
+    void install_progress(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t amount, uint64_t total) override {
+        std::cout << "Progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;
+    }
+};
+
+void CmdUpgrade::run(Context & ctx) {
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+
+    // To search in the system repository (installed packages)
+    // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
+    //solv_sack.create_system_repo(false);
+
+    // To search in available repositories (available packages)
+    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    for (auto & repo : enabled_repos.get_data()) {
+        ctx.load_rpm_repo(*repo.get());
+    }
+
+    for (auto & repo : enabled_repos.get_data()) {
+        solv_sack.load_repo(
+            *repo.get(),
+            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
+    }
+
+    libdnf::rpm::PackageSet result_pset(&solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    for (auto & pattern : *patterns_to_upgrade_options) {
+        libdnf::rpm::SolvQuery solv_query(full_solv_query);
+        solv_query.resolve_pkg_spec(dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value(), true, true, true, true, true, {});
+        result_pset |= solv_query.get_package_set();
+    }
+
+    for (auto package : result_pset) {
+        std::cout << package.get_full_nevra() << '\n';
+        std::cout << package.get_url() << '\n';
+        std::cout << package.get_baseurl() << '\n';
+        std::cout << package.get_location() << '\n';
+        //auto repo = package.get_repo();
+        //fd = open();
+        //repo.download_url(url, fd);
+        //close(fd);
+    }
+
+    // download packages
+    std::vector<libdnf::rpm::PackageTarget *> targets;
+    try {
+        for (auto package : result_pset) {
+            auto repo = package.get_repo();
+            auto destination = fs::path(repo->get_cachedir()) / "packages";
+            auto checksum = package.get_checksum();
+            auto pkg_target = new libdnf::rpm::PackageTarget(repo, package.get_location().c_str(), destination.c_str(),
+                                    static_cast<int>(checksum.get_type()), checksum.get_checksum().c_str(),
+                                    static_cast<int64_t>(package.get_download_size()), package.get_baseurl().empty() ? nullptr : package.get_baseurl().c_str(), true,
+                                    0, 0, nullptr);
+            targets.push_back(pkg_target);
+        }
+        std::cout << "Start packages download" << std::endl;
+        try {
+            libdnf::rpm::PackageTarget::download_packages(targets, true);
+        } catch (const std::runtime_error & ex) {
+            std::cout << "Exception: " << ex.what() << std::endl;
+        }
+        std::cout << "Done packages download" << std::endl;
+    } catch (...) {
+        for (auto target : targets) {
+            delete target;
+        }
+        throw;
+    }
+    for (auto target : targets) {
+        delete target;
+    }
+
+    std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
+    auto ts = libdnf::rpm::Transaction(ctx.base);
+    for (auto package : result_pset) {
+        auto item = std::make_unique<libdnf::rpm::TransactionItem>(package);
+        auto item_ptr = item.get();
+        transaction_items.push_back(std::move(item));
+        ts.upgrade(*item_ptr);
+    }
+    TransCB trans_cb;
+    ts.register_cb(&trans_cb);
+    ts.run();
+    ts.register_cb(nullptr);
+}
+
+}  // namespace microdnf

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -102,46 +102,7 @@ void CmdUpgrade::run(Context & ctx) {
         result_pset |= solv_query.get_package_set();
     }
 
-    for (auto package : result_pset) {
-        std::cout << package.get_full_nevra() << '\n';
-        std::cout << package.get_url() << '\n';
-        std::cout << package.get_baseurl() << '\n';
-        std::cout << package.get_location() << '\n';
-        //auto repo = package.get_repo();
-        //fd = open();
-        //repo.download_url(url, fd);
-        //close(fd);
-    }
-
-    // download packages
-    std::vector<libdnf::rpm::PackageTarget *> targets;
-    try {
-        for (auto package : result_pset) {
-            auto repo = package.get_repo();
-            auto destination = fs::path(repo->get_cachedir()) / "packages";
-            auto checksum = package.get_checksum();
-            auto pkg_target = new libdnf::rpm::PackageTarget(repo, package.get_location().c_str(), destination.c_str(),
-                                    static_cast<int>(checksum.get_type()), checksum.get_checksum().c_str(),
-                                    static_cast<int64_t>(package.get_download_size()), package.get_baseurl().empty() ? nullptr : package.get_baseurl().c_str(), true,
-                                    0, 0, nullptr);
-            targets.push_back(pkg_target);
-        }
-        std::cout << "Start packages download" << std::endl;
-        try {
-            libdnf::rpm::PackageTarget::download_packages(targets, true);
-        } catch (const std::runtime_error & ex) {
-            std::cout << "Exception: " << ex.what() << std::endl;
-        }
-        std::cout << "Done packages download" << std::endl;
-    } catch (...) {
-        for (auto target : targets) {
-            delete target;
-        }
-        throw;
-    }
-    for (auto target : targets) {
-        delete target;
-    }
+    download_packages(result_pset, nullptr);
 
     std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
     auto ts = libdnf::rpm::Transaction(ctx.base);

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -66,7 +66,6 @@ void CmdUpgrade::set_argument_parser(Context & ctx) {
 void CmdUpgrade::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdUpgrade::run(Context & ctx) {
-    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto & solv_sack = ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
@@ -75,15 +74,11 @@ void CmdUpgrade::run(Context & ctx) {
 
     // To search in available repositories (available packages)
     auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
-    for (auto & repo : enabled_repos.get_data()) {
-        ctx.load_rpm_repo(*repo.get());
-    }
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
+    ctx.load_rpm_repos(enabled_repos, flags);
 
-    for (auto & repo : enabled_repos.get_data()) {
-        solv_sack.load_repo(
-            *repo.get(),
-            LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER);
-    }
+    std::cout << std::endl;
 
     libdnf::rpm::PackageSet result_pset(&solv_sack);
     libdnf::rpm::SolvQuery full_solv_query(&solv_sack);

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -65,15 +65,6 @@ void CmdUpgrade::set_argument_parser(Context & ctx) {
 
 void CmdUpgrade::configure([[maybe_unused]] Context & ctx) {}
 
-class TransCB : public libdnf::rpm::TransactionCB {
-    void install_start(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t total) override {
-        std::cout << "Start: " << header.get_full_nevra() << "Size: " << total << std::endl;
-    }
-    void install_progress(const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & header, uint64_t amount, uint64_t total) override {
-        std::cout << "Progress: " << header.get_full_nevra() << " " << amount << '/' << total << std::endl;
-    }
-};
-
 void CmdUpgrade::run(Context & ctx) {
     using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto & solv_sack = ctx.base.get_rpm_solv_sack();
@@ -104,18 +95,16 @@ void CmdUpgrade::run(Context & ctx) {
 
     download_packages(result_pset, nullptr);
 
-    std::vector<std::unique_ptr<libdnf::rpm::TransactionItem>> transaction_items;
+    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
     auto ts = libdnf::rpm::Transaction(ctx.base);
     for (auto package : result_pset) {
-        auto item = std::make_unique<libdnf::rpm::TransactionItem>(package);
+        auto item = std::make_unique<RpmTransactionItem>(package, RpmTransactionItem::Actions::UPGRADE);
         auto item_ptr = item.get();
         transaction_items.push_back(std::move(item));
         ts.upgrade(*item_ptr);
     }
-    TransCB trans_cb;
-    ts.register_cb(&trans_cb);
-    ts.run();
-    ts.register_cb(nullptr);
+    std::cout << std::endl;
+    run_transaction(ts);
 }
 
 }  // namespace microdnf

--- a/microdnf/commands/upgrade/upgrade.hpp
+++ b/microdnf/commands/upgrade/upgrade.hpp
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_UPGRADE_UPGRADE_HPP
+#define MICRODNF_COMMANDS_UPGRADE_UPGRADE_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_bool.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+class CmdUpgrade : public Command {
+public:
+    void set_argument_parser(Context & ctx) override;
+    void configure(Context & ctx) override;
+    void run(Context & ctx) override;
+
+private:
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_upgrade_options{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -121,6 +121,9 @@ public:
                 break;
             case TransferStatus::ALREADYEXISTS:
                 //std::cout << "[SKIPPED] " << what << ": " << msg << std::endl;
+                // skipping the download -> downloading 0 bytes
+                progress_bar->set_ticks(0);
+                progress_bar->set_total_ticks(0);
                 progress_bar->add_message(libdnf::cli::progressbar::MessageType::SUCCESS, msg);
                 progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
                 break;
@@ -161,7 +164,8 @@ private:
         auto now = std::chrono::steady_clock::now();
         auto delta = now - prev_print_time;
         auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
-        if (ms > 400) {
+        if (ms > 100) {
+            // 100ms equals to 10 FPS and that seems to be smooth enough
             prev_print_time = now;
             return true;
         }
@@ -221,6 +225,9 @@ void download_packages(libdnf::rpm::PackageSet & package_set, const char * dest_
     } catch (const std::runtime_error & ex) {
         std::cout << "Exception: " << ex.what() << std::endl;
     }
+    // print a completed progress bar
+    multi_progress_bar.print();
+    // TODO(dmach): if a download gets interrupted, the "Total" bar should show reasonable data
 }
 
 }  // namespace microdnf

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -122,10 +122,12 @@ public:
             case TransferStatus::ALREADYEXISTS:
                 //std::cout << "[SKIPPED] " << what << ": " << msg << std::endl;
                 progress_bar->add_message(libdnf::cli::progressbar::MessageType::SUCCESS, msg);
+                progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::SUCCESS);
                 break;
             case TransferStatus::ERROR:
                 //std::cout << "[ERROR] " << what << ": " << msg << std::endl;
                 progress_bar->add_message(libdnf::cli::progressbar::MessageType::ERROR, msg);
+                progress_bar->set_state(libdnf::cli::progressbar::ProgressBarState::ERROR);
                 break;
         }
         multi_progress_bar->print();

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -1,0 +1,104 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "context.hpp"
+
+#include <iostream>
+#include <string>
+
+namespace microdnf {
+
+/// Asks user for confirmaton
+static bool userconfirm(libdnf::ConfigMain & config) {
+    std::string msg;
+    if (config.defaultyes().get_value()) {
+        msg = "Is this ok [Y/n]: ";
+    } else {
+        msg = "Is this ok [y/N]: ";
+    }
+    while (true) {
+        std::cout << msg;
+
+        std::string choice;
+        std::getline(std::cin, choice);
+
+        if (choice.empty()) {
+            return config.defaultyes().get_value();
+        }
+        if (choice == "y" || choice == "Y") {
+            return true;
+        }
+        if (choice == "n" || choice == "N") {
+            return false;
+        }
+    }
+}
+
+class MicrodnfRepoCB : public libdnf::rpm::RepoCB {
+public:
+    explicit MicrodnfRepoCB(libdnf::ConfigMain & config) : config(&config) {}
+
+    void start(const char * what) override { std::cout << "Start downloading: \"" << what << "\"" << std::endl; }
+
+    void end() override { std::cout << "End downloading" << std::endl; }
+
+    // TODO(jrohel): Progress bar
+    int progress([[maybe_unused]] double totalToDownload, [[maybe_unused]] double downloaded) override {
+        //std::cout << "Downloaded " << downloaded << "/" << totalToDownload << std::endl;
+        return 0;
+    }
+
+    bool repokey_import(
+        const std::string & id,
+        const std::string & user_id,
+        const std::string & fingerprint,
+        const std::string & url,
+        [[maybe_unused]] long int timestamp) override {
+        auto tmp_id = id.size() > 8 ? id.substr(id.size() - 8) : id;
+        std::cout << "Importing GPG key 0x" << id << ":\n";
+        std::cout << " Userid     : \"" << user_id << "\"\n";
+        std::cout << " Fingerprint: " << fingerprint << "\n";
+        std::cout << " From       : " << url << std::endl;
+
+        if (config->assumeyes().get_value()) {
+            return true;
+        }
+        if (config->assumeno().get_value()) {
+            return false;
+        }
+        return userconfirm(*config);
+    }
+
+private:
+    libdnf::ConfigMain * config;
+};
+
+void Context::load_rpm_repo(libdnf::rpm::Repo & repo) {
+    //repo->set_substitutions(variables);
+    auto & logger = base.get_logger();
+    repo.set_callbacks(std::make_unique<microdnf::MicrodnfRepoCB>(base.get_config()));
+    try {
+        repo.load();
+    } catch (const std::runtime_error & ex) {
+        logger.warning(ex.what());
+        std::cout << ex.what() << std::endl;
+    }
+}
+
+}  // namespace microdnf

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -26,6 +26,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/base/base.hpp>
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace microdnf {
@@ -40,11 +41,11 @@ public:
     /// Select commend to execute
     void select_command(Command * cmd) { selected_command = cmd; }
 
-    ArgumentParser arg_parser;
     libdnf::Base base;
-
+    std::vector<std::pair<std::string, std::string>> setopts;
     std::vector<std::unique_ptr<Command>> commands;
     Command * selected_command{nullptr};
+    ArgumentParser arg_parser;
 };
 
 }  // namespace microdnf

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -48,6 +48,9 @@ public:
     ArgumentParser arg_parser;
 };
 
+/// Downoad packages to destdir. If destdir == nullptr, packages are downloaded to the cache.
+void download_packages(libdnf::rpm::PackageSet & package_set, const char * dest_dir);
+
 }  // namespace microdnf
 
 #endif

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -36,8 +36,9 @@ constexpr const char * VERSION = "0.1.0";
 
 class Context {
 public:
-    /// Load rpm repository to rpm::RepoSack
-    void load_rpm_repo(libdnf::rpm::Repo & repo);
+    /// Updates the repositories metadata cache.
+    /// Loads the updated metadata into rpm::RepoSack and into rpm::SolvSack.
+    void load_rpm_repos(libdnf::rpm::RepoQuery & repos, libdnf::rpm::SolvSack::LoadRepoFlags flags);
 
     /// Select commend to execute
     void select_command(Command * cmd) { selected_command = cmd; }
@@ -47,6 +48,10 @@ public:
     std::vector<std::unique_ptr<Command>> commands;
     Command * selected_command{nullptr};
     ArgumentParser arg_parser;
+
+private:
+    /// Updates the repository metadata cache and load it into rpm::RepoSack.
+    void load_rpm_repo(libdnf::rpm::Repo & repo);
 };
 
 class RpmTransactionItem : public libdnf::rpm::TransactionItem {

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2019-2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_CONTEXT_HPP
+#define MICRODNF_CONTEXT_HPP
+
+#include "argument_parser.hpp"
+#include "commands/command.hpp"
+
+#include <libdnf/base/base.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+constexpr const char * VERSION = "0.1.0";
+
+class Context {
+public:
+    /// Select commend to execute
+    void select_command(Command * cmd) { selected_command = cmd; }
+
+    ArgumentParser arg_parser;
+    libdnf::Base base;
+
+    std::vector<std::unique_ptr<Command>> commands;
+    Command * selected_command{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -34,6 +34,9 @@ constexpr const char * VERSION = "0.1.0";
 
 class Context {
 public:
+    /// Load rpm repository to rpm::RepoSack
+    void load_rpm_repo(libdnf::rpm::Repo & repo);
+
     /// Select commend to execute
     void select_command(Command * cmd) { selected_command = cmd; }
 

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -24,6 +24,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/command.hpp"
 
 #include <libdnf/base/base.hpp>
+#include <libdnf/rpm/transaction.hpp>
 
 #include <memory>
 #include <utility>
@@ -48,8 +49,21 @@ public:
     ArgumentParser arg_parser;
 };
 
+class RpmTransactionItem : public libdnf::rpm::TransactionItem {
+public:
+    enum class Actions { INSTALL, ERASE, UPGRADE, DOWNGRADE, REINSTALL };
+
+    RpmTransactionItem(libdnf::rpm::Package pkg, Actions action) : TransactionItem(pkg), action(action) {}
+    Actions get_action() const noexcept { return action; }
+
+private:
+    Actions action;
+};
+
 /// Downoad packages to destdir. If destdir == nullptr, packages are downloaded to the cache.
 void download_packages(libdnf::rpm::PackageSet & package_set, const char * dest_dir);
+
+void run_transaction(libdnf::rpm::Transaction & transaction);
 
 }  // namespace microdnf
 

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -156,6 +156,13 @@ int main(int argc, char * argv[]) {
             auto cache_dir = microdnf::xdg::get_user_cache_dir() / "microdnf";
             base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cache_dir);
         }
+    } else {
+        auto tmp = fs::temp_directory_path() / "microdnf";
+        if (base.get_config().cachedir().get_priority() < libdnf::Option::Priority::COMMANDLINE) {
+            // Sets path to cache directory.
+            auto system_cache_dir = base.get_config().system_cachedir().get_value();
+            base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, system_cache_dir);
+        }
     }
 
     // Try to open the current directory to see if we have

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -18,6 +18,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "argument_parser.hpp"
+#include "commands/repolist/repolist.hpp"
 #include "context.hpp"
 #include "utils.hpp"
 
@@ -77,6 +78,7 @@ int main(int argc, char * argv[]) {
     log_router.info("Microdnf start");
 
     // Register commands
+    context.commands.push_back(std::make_unique<microdnf::CmdRepolist>());
 
     // Parse command line arguments
     microdnf::parse_args(context, argc, argv);

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -19,6 +19,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "argument_parser.hpp"
 #include "commands/install/install.hpp"
+#include "commands/download/download.hpp"
 #include "commands/reinstall/reinstall.hpp"
 #include "commands/remove/remove.hpp"
 #include "commands/repolist/repolist.hpp"
@@ -131,6 +132,7 @@ int main(int argc, char * argv[]) {
 
     // Register commands
     context.commands.push_back(std::make_unique<microdnf::CmdInstall>());
+    context.commands.push_back(std::make_unique<microdnf::CmdDownload>());
     context.commands.push_back(std::make_unique<microdnf::CmdReinstall>());
     context.commands.push_back(std::make_unique<microdnf::CmdRemove>());
     context.commands.push_back(std::make_unique<microdnf::CmdRepolist>());

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -19,6 +19,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "argument_parser.hpp"
 #include "commands/repolist/repolist.hpp"
+#include "commands/repoquery/repoquery.hpp"
 #include "context.hpp"
 #include "utils.hpp"
 
@@ -79,6 +80,7 @@ int main(int argc, char * argv[]) {
 
     // Register commands
     context.commands.push_back(std::make_unique<microdnf::CmdRepolist>());
+    context.commands.push_back(std::make_unique<microdnf::CmdRepoquery>());
 
     // Parse command line arguments
     microdnf::parse_args(context, argc, argv);

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -18,8 +18,12 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "argument_parser.hpp"
+#include "commands/install/install.hpp"
+#include "commands/reinstall/reinstall.hpp"
+#include "commands/remove/remove.hpp"
 #include "commands/repolist/repolist.hpp"
 #include "commands/repoquery/repoquery.hpp"
+#include "commands/upgrade/upgrade.hpp"
 #include "context.hpp"
 #include "utils.hpp"
 
@@ -126,8 +130,12 @@ int main(int argc, char * argv[]) {
     log_router.info("Microdnf start");
 
     // Register commands
+    context.commands.push_back(std::make_unique<microdnf::CmdInstall>());
+    context.commands.push_back(std::make_unique<microdnf::CmdReinstall>());
+    context.commands.push_back(std::make_unique<microdnf::CmdRemove>());
     context.commands.push_back(std::make_unique<microdnf::CmdRepolist>());
     context.commands.push_back(std::make_unique<microdnf::CmdRepoquery>());
+    context.commands.push_back(std::make_unique<microdnf::CmdUpgrade>());
 
     // Parse command line arguments
     bool help_printed = microdnf::parse_args(context, argc, argv);

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -50,6 +50,11 @@ int main() {
             base.get_config().logdir().set(libdnf::Option::Priority::RUNTIME, logdir);
             fs::create_directories(logdir);
         }
+        if (base.get_config().cachedir().get_priority() < libdnf::Option::Priority::COMMANDLINE) {
+            // Sets path to cache directory.
+            auto cache_dir = microdnf::xdg::get_user_cache_dir() / "microdnf";
+            base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cache_dir);
+        }
     }
 
     // Swap to destination logger (log to file) and write messages from memory buffer logger to it

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -17,7 +17,22 @@ You should have received a copy of the GNU General Public License
 along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include <libdnf/base/base.hpp>
+#include <libdnf/logger/memory_buffer_logger.hpp>
 
 int main() {
+    libdnf::Base base;
+
+    auto & log_router = base.get_logger();
+
+    // Add circular memory buffer logger
+    const std::size_t max_log_items_to_keep = 10000;
+    const std::size_t prealloc_log_items = 256;
+    log_router.add_logger(std::make_unique<libdnf::MemoryBufferLogger>(max_log_items_to_keep, prealloc_log_items));
+
+    log_router.info("Microdnf start");
+
+    log_router.info("Microdnf end");
+
     return 0;
 }

--- a/microdnf/utils.cpp
+++ b/microdnf/utils.cpp
@@ -1,0 +1,30 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "utils.hpp"
+
+#include <unistd.h>
+
+namespace microdnf {
+
+bool am_i_root() noexcept {
+    return geteuid() == 0;
+}
+
+}  // namespace microdnf

--- a/microdnf/utils.cpp
+++ b/microdnf/utils.cpp
@@ -20,9 +20,14 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils.hpp"
 
 #include <pwd.h>
+#include <rpm/rpmdb.h>
+#include <rpm/rpmlib.h>
+#include <rpm/rpmts.h>
 #include <unistd.h>
 
 #include <cstdlib>
+#include <cstring>
+#include <stdexcept>
 
 namespace microdnf {
 
@@ -71,5 +76,121 @@ std::filesystem::path get_user_runtime_dir() {
 }
 
 }  // namespace xdg
+
+// ================================================
+// Next utils probably will be move into library
+
+#define MAX_NATIVE_ARCHES 12
+
+// data taken from DNF
+static const struct {
+    const char * base;
+    const char * native[MAX_NATIVE_ARCHES];
+} ARCH_MAP[] = {{"aarch64", {"aarch64", nullptr}},
+                {"alpha",
+                 {"alpha",
+                  "alphaev4",
+                  "alphaev45",
+                  "alphaev5",
+                  "alphaev56",
+                  "alphaev6",
+                  "alphaev67",
+                  "alphaev68",
+                  "alphaev7",
+                  "alphapca56",
+                  nullptr}},
+                {"arm", {"armv5tejl", "armv5tel", "armv5tl", "armv6l", "armv7l", "armv8l", nullptr}},
+                {"armhfp", {"armv7hl", "armv7hnl", "armv8hl", "armv8hnl", "armv8hcnl", nullptr}},
+                {"i386", {"i386", "athlon", "geode", "i386", "i486", "i586", "i686", nullptr}},
+                {"ia64", {"ia64", nullptr}},
+                {"mips", {"mips", nullptr}},
+                {"mipsel", {"mipsel", nullptr}},
+                {"mips64", {"mips64", nullptr}},
+                {"mips64el", {"mips64el", nullptr}},
+                {"noarch", {"noarch", nullptr}},
+                {"ppc", {"ppc", nullptr}},
+                {"ppc64", {"ppc64", "ppc64iseries", "ppc64p7", "ppc64pseries", nullptr}},
+                {"ppc64le", {"ppc64le", nullptr}},
+                {"riscv32", {"riscv32", nullptr}},
+                {"riscv64", {"riscv64", nullptr}},
+                {"riscv128", {"riscv128", nullptr}},
+                {"s390", {"s390", nullptr}},
+                {"s390x", {"s390x", nullptr}},
+                {"sh3", {"sh3", nullptr}},
+                {"sh4", {"sh4", "sh4a", nullptr}},
+                {"sparc", {"sparc", "sparc64", "sparc64v", "sparcv8", "sparcv9", "sparcv9v", nullptr}},
+                {"x86_64", {"x86_64", "amd64", "ia32e", nullptr}},
+                {nullptr, {nullptr}}};
+
+const char * get_base_arch(const char * arch) {
+    for (int i = 0; ARCH_MAP[i].base; ++i) {
+        for (int j = 0; ARCH_MAP[i].native[j]; ++j) {
+            if (std::strcmp(ARCH_MAP[i].native[j], arch) == 0) {
+                return ARCH_MAP[i].base;
+            }
+        }
+    }
+    return nullptr;
+}
+
+static void init_lib_rpm() {
+    static bool lib_rpm_initiated{false};
+    if (!lib_rpm_initiated) {
+        if (rpmReadConfigFiles(nullptr, nullptr) != 0) {
+            throw std::runtime_error("failed to read rpm config files\n");
+        }
+        lib_rpm_initiated = true;
+    }
+}
+
+//#define RELEASEVER_PROV "system-release(releasever)"
+
+static constexpr const char * DISTROVERPKGS[] = {"system-release(releasever)",
+                                                 "system-release",
+                                                 "distribution-release(releasever)",
+                                                 "distribution-release",
+                                                 "redhat-release",
+                                                 "suse-release"};
+
+std::string detect_arch() {
+    init_lib_rpm();
+    const char * value;
+    rpmGetArchInfo(&value, nullptr);
+    return value;
+}
+
+std::string detect_release(const std::string & install_root_path) {
+    init_lib_rpm();
+    std::string release_ver;
+
+    bool found_in_rpmdb{false};
+    auto ts = rpmtsCreate();
+    rpmtsSetRootDir(ts, install_root_path.c_str());
+    for (auto distroverpkg : DISTROVERPKGS) {
+        auto mi = rpmtsInitIterator(ts, RPMTAG_PROVIDENAME, distroverpkg, 0);
+        while (auto hdr = rpmdbNextIterator(mi)) {
+            auto version = headerGetString(hdr, RPMTAG_VERSION);
+            rpmds ds = rpmdsNew(hdr, RPMTAG_PROVIDENAME, 0);
+            while (rpmdsNext(ds) >= 0) {
+                if (std::strcmp(rpmdsN(ds), distroverpkg) == 0 && rpmdsFlags(ds) == RPMSENSE_EQUAL) {
+                    version = rpmdsEVR(ds);
+                }
+            }
+            release_ver = version;
+            found_in_rpmdb = true;
+            rpmdsFree(ds);
+            break;
+        }
+        rpmdbFreeIterator(mi);
+        if (found_in_rpmdb) {
+            break;
+        }
+    }
+    rpmtsFree(ts);
+    if (found_in_rpmdb) {
+        return release_ver;
+    }
+    return "";
+}
 
 }  // namespace microdnf

--- a/microdnf/utils.cpp
+++ b/microdnf/utils.cpp
@@ -19,12 +19,57 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils.hpp"
 
+#include <pwd.h>
 #include <unistd.h>
+
+#include <cstdlib>
 
 namespace microdnf {
 
 bool am_i_root() noexcept {
     return geteuid() == 0;
 }
+
+namespace xdg {
+
+std::filesystem::path get_user_home_dir() {
+    if (char * dir = std::getenv("HOME")) {
+        return std::filesystem::path(dir);
+    }
+    if (struct passwd * pw = getpwuid(getuid())) {
+        return std::filesystem::path(pw->pw_dir);
+    }
+    throw std::runtime_error("get_home_dir(): Can't determine the user's home directory");
+}
+
+std::filesystem::path get_user_cache_dir() {
+    if (char * dir = std::getenv("XDG_CACHE_HOME")) {
+        return std::filesystem::path(dir);
+    }
+    return std::filesystem::path(get_user_home_dir()) / ".cache";
+}
+
+std::filesystem::path get_user_config_dir() {
+    if (char * dir = std::getenv("XDG_CONFIG_HOME")) {
+        return std::filesystem::path(dir);
+    }
+    return std::filesystem::path(get_user_home_dir()) / ".config";
+}
+
+std::filesystem::path get_user_data_dir() {
+    if (char * dir = std::getenv("XDG_DATA_HOME")) {
+        return std::filesystem::path(dir);
+    }
+    return std::filesystem::path(get_user_home_dir()) / ".local" / "share";
+}
+
+std::filesystem::path get_user_runtime_dir() {
+    if (char * dir = std::getenv("XDG_RUNTIME_HOME")) {
+        return std::filesystem::path(dir);
+    }
+    return get_user_cache_dir();
+}
+
+}  // namespace xdg
 
 }  // namespace microdnf

--- a/microdnf/utils.hpp
+++ b/microdnf/utils.hpp
@@ -47,6 +47,15 @@ std::filesystem::path get_user_runtime_dir();
 
 }  // namespace xdg
 
+/// find the base architecture
+const char * get_base_arch(const char * arch);
+
+/// detect hardware architecture
+std::string detect_arch();
+
+/// detect operation system release
+std::string detect_release(const std::string & install_root_path);
+
 }  // namespace microdnf
 
 #endif

--- a/microdnf/utils.hpp
+++ b/microdnf/utils.hpp
@@ -20,10 +20,32 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef MICRODNF_UTILS_HPP
 #define MICRODNF_UTILS_HPP
 
+#include <filesystem>
+#include <string>
+
 namespace microdnf {
 
 /// Returns "true" if program runs with effective user ID = 0
 bool am_i_root() noexcept;
+
+namespace xdg {
+
+/// Returns user home directory
+std::filesystem::path get_user_home_dir();
+
+/// Returns user cache directory
+std::filesystem::path get_user_cache_dir();
+
+/// Returns user configuration directory
+std::filesystem::path get_user_config_dir();
+
+/// Returns user data directory
+std::filesystem::path get_user_data_dir();
+
+/// Returns user runtime directory
+std::filesystem::path get_user_runtime_dir();
+
+}  // namespace xdg
 
 }  // namespace microdnf
 

--- a/microdnf/utils.hpp
+++ b/microdnf/utils.hpp
@@ -1,0 +1,30 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_UTILS_HPP
+#define MICRODNF_UTILS_HPP
+
+namespace microdnf {
+
+/// Returns "true" if program runs with effective user ID = 0
+bool am_i_root() noexcept;
+
+}  // namespace microdnf
+
+#endif


### PR DESCRIPTION
The PR is an attempt to implement microdnf based on the new libdnf.
The code is evolving rapidly and can change.

It implements basic skeleton, loads the configuration. It contains basic implementation of the `repolist`, `repoquery`, `install`, `upgrade`, `reinstall`, `remove`, `download` commands.
The PR also implements an argument parser (not all work is done) and more utilities. Some of them will be moved into libraries (libdnf, libdnf-cli).
The PR can contain not merged (work in progress) libdnf code.
The architecture and base architecture detection code may be replaced by an external library (as soon as it exists) in the future.

The PR is too big now. And the code is good enough for testing purposes.