### PR TITLE
[dnf5] Pass logger arg to MemoryBufferLogger::write_to_logger() as reference

### DIFF
--- a/include/libdnf/logger/memory_buffer_logger.hpp
+++ b/include/libdnf/logger/memory_buffer_logger.hpp
@@ -45,7 +45,7 @@ public:
     std::size_t get_items_count() const { return items.size(); }
     const Item & get_item(std::size_t item_idx) const;
     void clear() noexcept;
-    void write_to_logger(Logger * logger);
+    void write_to_logger(Logger & logger);
 
 private:
     mutable std::mutex items_mutex;

--- a/libdnf/logger/memory_buffer_logger.cpp
+++ b/libdnf/logger/memory_buffer_logger.cpp
@@ -57,15 +57,15 @@ const MemoryBufferLogger::Item & MemoryBufferLogger::get_item(std::size_t item_i
     return items[idx];
 }
 
-void MemoryBufferLogger::write_to_logger(Logger * logger) {
+void MemoryBufferLogger::write_to_logger(Logger & logger) {
     std::lock_guard<std::mutex> guard(items_mutex);
     for (size_t idx = first_item_idx; idx < items.size(); ++idx) {
         auto & msg = items[idx];
-        logger->write(msg.time, msg.pid, msg.level, msg.message);
+        logger.write(msg.time, msg.pid, msg.level, msg.message);
     }
     for (size_t idx = 0; idx < first_item_idx; ++idx) {
         auto & msg = items[idx];
-        logger->write(msg.time, msg.pid, msg.level, msg.message);
+        logger.write(msg.time, msg.pid, msg.level, msg.message);
     }
 }
 

--- a/test/libdnf/logger/test_loggers.cpp
+++ b/test/libdnf/logger/test_loggers.cpp
@@ -112,7 +112,7 @@ void LoggersTest::test_loggers() {
     // 4. Write messages from original (replaced) MemoryBufferLoger instance into LogRouter instance. They will be routed
     //    to both attached stream loggers.
     // ====================
-    dynamic_cast<libdnf::MemoryBufferLogger &>(*tmp_logger).write_to_logger(log_router.get());
+    dynamic_cast<libdnf::MemoryBufferLogger &>(*tmp_logger).write_to_logger(*log_router);
 
     // Messages from memory logger was written to log_router. Memory logger is not needed anymore.
     tmp_logger.reset();


### PR DESCRIPTION
Logger to be written to must be existing object (not null).
So, the reference make more sense than pointer.