### PR TITLE
[microdnf] CMakeList: Fix: Use of found source files

### DIFF
--- a/microdnf/CMakeLists.txt
+++ b/microdnf/CMakeLists.txt
@@ -2,8 +2,10 @@ if(NOT WITH_MICRODNF)
     return()
 endif()
 
-
+# use any sources found under the current directory
 file(GLOB_RECURSE MICRODNF_SOURCES *.cpp)
-add_executable(microdnf main.cpp ${DNFDAEMON_CLIENT_SOURCES})
+
+add_executable(microdnf ${MICRODNF_SOURCES})
+
 target_link_libraries(microdnf PUBLIC libdnf libdnf-cli)
 install(TARGETS microdnf RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Replaces variable `DNFDAEMON_CLIENT_SOURCES` by `MICRODNF_SOURCES` (fixes copy&paste error).