### PR TITLE
[dnf5] rpm::RepoSack: Creating repositories according to config files

### DIFF
--- a/include/libdnf/rpm/repo_sack.hpp
+++ b/include/libdnf/rpm/repo_sack.hpp
@@ -34,14 +34,39 @@ class Base;
 
 namespace libdnf::rpm {
 
-class RepoSack : public libdnf::sack::Sack<Repo, RepoQuery> {
+class RepoSack : public sack::Sack<Repo, RepoQuery> {
 public:
     explicit RepoSack(Base & base) : base(&base) {}
 
     /// Creates new repository and add it into RepoSack
     RepoWeakPtr new_repo(const std::string & id);
 
+    /// Creates new repositories according to the configuration in the file defined by path.
+    /// The created repositories are added into RepoSack.
+    void new_repos_from_file(const std::string & path);
+
+    // "config_file_path" contains the main configuration, but may also contain the rpm repository definition.
+    // It is analyzed by two parsers. The codes of parsers are similar. However, the repository configuration
+    // parser applies variables/substitutions.
+    /// Creates new repositories according to the configuration in the file defined by "config_file_path"
+    /// configuration option.
+    /// The created repositories are added into RepoSack.
+    void new_repos_from_file();
+
+    /// Creates new repositories according to the configuration in the files with ".repo" extension in the directories
+    /// defined by "reposdir" configuration option.
+    /// The created repositories are added into RepoSack.
+    /// The files in the directories are read in alphabetical order.
+    void new_repos_from_dirs();
+
 private:
+    //TODO(jrohel): Make public?
+    /// Creates new repositories according to the configuration in the files with ".repo" extension in the directory
+    /// defined by dir_path.
+    /// The created repositories are added into RepoSack.
+    /// The files in the directory are read in alphabetical order.
+    void new_repos_from_dir(const std::string & dir_path);
+
     Base * base;
 };
 

--- a/libdnf/rpm/repo_sack.cpp
+++ b/libdnf/rpm/repo_sack.cpp
@@ -20,6 +20,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/rpm/repo_sack.hpp"
 
 #include "libdnf/base/base.hpp"
+#include "libdnf/conf/config_parser.hpp"
+#include "libdnf/conf/option_bool.hpp"
+
+#include <fmt/format.h>
+
+#include <filesystem>
 
 namespace libdnf::rpm {
 
@@ -28,6 +34,128 @@ RepoWeakPtr RepoSack::new_repo(const std::string & id) {
     auto repo_config = std::make_unique<ConfigRepo>(base->get_config());
     auto repo = std::make_unique<Repo>(id, std::move(repo_config), *base, Repo::Type::AVAILABLE);
     return add_item_with_return(std::move(repo));
+}
+
+static void load_config_from_parser(
+    Config & conf, const ConfigParser & parser, const std::string & section, Base & base) {
+    auto & logger = base.get_logger();
+    const auto & cfg_parser_data = parser.get_data();
+    auto cfg_parser_data_iter = cfg_parser_data.find(section);
+    if (cfg_parser_data_iter != cfg_parser_data.end()) {
+        auto opt_binds = conf.opt_binds();
+        const auto & cfg_parser_sect = cfg_parser_data_iter->second;
+        for (const auto & opt : cfg_parser_sect) {
+            auto opt_binds_iter = opt_binds.find(opt.first);
+            if (opt_binds_iter != opt_binds.end()) {
+                try {
+                    auto value = opt.second;
+                    parser.substitute(value, base.get_variables());
+                    opt_binds_iter->second.new_string(Option::Priority::REPOCONFIG, value);
+                } catch (const Option::Exception & ex) {
+                    auto msg = fmt::format(
+                        R"**(Config error in section "{}" key "{}": {}: {})**",
+                        section,
+                        opt.first,
+                        ex.get_description(),
+                        ex.what());
+                    logger.warning(msg);
+                }
+            }
+        }
+    }
+}
+
+void RepoSack::new_repos_from_file(const std::string & path) {
+    auto & logger = base->get_logger();
+    ConfigParser parser;
+    parser.read(path);
+    const auto & cfg_parser_data = parser.get_data();
+    for (const auto & cfg_parser_data_iter : cfg_parser_data) {
+        const auto & section = cfg_parser_data_iter.first;
+        if (section == "main") {
+            continue;
+        }
+        auto repo_id = section;
+        parser.substitute(repo_id, base->get_variables());
+
+        logger.debug(fmt::format(
+            R"**(Start of loading configuration of repository "{}" from file "{}" section "{}")**",
+            repo_id,
+            path,
+            section));
+
+        auto bad_char_idx = Repo::verify_id(repo_id);
+        if (bad_char_idx >= 0) {
+            bool skip_if_unavailable;
+            auto key_val = cfg_parser_data_iter.second.find("skip_if_unavailable");
+            if (key_val != cfg_parser_data_iter.second.end()) {
+                auto value = key_val->second;
+                parser.substitute(value, base->get_variables());
+                skip_if_unavailable = OptionBool(false).from_string(key_val->second);
+            } else {
+                skip_if_unavailable = base->get_config().skip_if_unavailable().get_value();
+            }
+            if (skip_if_unavailable) {
+                auto msg = fmt::format(
+                    R"**(Skipping repository with bad id "{}" section "{}", char = {} at pos {})**",
+                    repo_id,
+                    section,
+                    repo_id[bad_char_idx],
+                    bad_char_idx + 1);
+                logger.warning(msg);
+                continue;
+            } else {
+                auto msg = fmt::format(
+                    R"**(Bad id for repo "{}" section "{}", char = {} at pos {})**",
+                    repo_id,
+                    section,
+                    repo_id[bad_char_idx],
+                    bad_char_idx + 1);
+                throw RuntimeError(msg);
+            }
+        }
+
+        auto repo = new_repo(repo_id);
+        auto repo_cfg = repo->get_config();
+        load_config_from_parser(*repo_cfg, parser, section, *base);
+        logger.trace(fmt::format(R"**(Loading configuration of repository "{}" from file "{}" done)**", repo_id, path));
+
+        if (repo_cfg->name().get_priority() == Option::Priority::DEFAULT) {
+            logger.warning(fmt::format(
+                "Repository \"{}\" is missing name in configuration file \"{}\", using id.", repo_id, path));
+            repo_cfg->name().set(Option::Priority::REPOCONFIG, repo_id);
+        }
+    }
+}
+
+void RepoSack::new_repos_from_file() {
+    new_repos_from_file(std::filesystem::path(base->get_config().config_file_path().get_value()));
+}
+
+void RepoSack::new_repos_from_dir(const std::string & dir_path) {
+    std::filesystem::directory_iterator di(dir_path);
+    std::vector<std::filesystem::path> paths;
+    for (auto & dentry : di) {
+        auto & path = dentry.path();
+        if (dentry.is_regular_file() && path.extension() == ".repo") {
+            paths.push_back(path);
+        }
+    }
+    std::sort(paths.begin(), paths.end());
+    for (auto & path : paths) {
+        new_repos_from_file(path);
+    }
+}
+
+void RepoSack::new_repos_from_dirs() {
+    auto & logger = base->get_logger();
+    for (auto & dir : base->get_config().reposdir().get_value()) {
+        try {
+            new_repos_from_dir(dir);
+        } catch (const std::filesystem::filesystem_error & ex) {
+            logger.info(ex.what());
+        }
+    }
 }
 
 }  // namespace libdnf::rpm


### PR DESCRIPTION
Supports loading of repositories configuration from file and from files with ".repo" extension in the directory.