### PR TITLE
Fix parsing empty lines in config files

### DIFF
--- a/libdnf/utils/iniparser/iniparser.hpp
+++ b/libdnf/utils/iniparser/iniparser.hpp
@@ -113,6 +113,7 @@ private:
     std::string value;
     std::string rawItem;
     std::string line;
+    bool lineReady;
 };
 
 inline const std::string & IniParser::getSection() const noexcept { return section; }


### PR DESCRIPTION
Using line.empty() to decide whether the next line should be read from
the file leads to actually skipping the empty lines. They are not
correctly returned by IniParser::next() method and so they are skipped
when file is saved back later on.
Using new lineReady flag eliminates the problem.

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/847