### PR TITLE
[dnf5] fix: WeakPtrGuard::clear() Remove/unregister invalidated WeakPtrs

### DIFF
--- a/include/libdnf/utils/weak_ptr.hpp
+++ b/include/libdnf/utils/weak_ptr.hpp
@@ -66,6 +66,7 @@ public:
         for (auto it : registered_weak_ptrs) {
             it->invalidate_guard();
         }
+        registered_weak_ptrs.clear();
     }
 
 private:

--- a/test/libdnf/weak_ptr/test_weak_ptr.cpp
+++ b/test/libdnf/weak_ptr/test_weak_ptr.cpp
@@ -46,15 +46,21 @@ void WeakPtrTest::test_weak_ptr() {
             return ret;
         }
 
-    private:
         libdnf::WeakPtrGuard<std::string, false> data_guard;
+
+    private:
         std::vector<std::unique_ptr<std::string>>
             data;  // Owns the data set. Objects get deleted when the Sack is deleted.
     };
 
+    // add weak pointers, test WeakPtrGuard::empty(), and WeakPtrGuard::size()
     auto sack1 = std::make_unique<Sack>();
+    CPPUNIT_ASSERT(sack1->data_guard.empty());
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(0));
     auto item1_weak_ptr = sack1->add_item_with_return(std::make_unique<std::string>("sack1_item1"));
     auto item2_weak_ptr = sack1->add_item_with_return(std::make_unique<std::string>("sack1_item2"));
+    CPPUNIT_ASSERT(!sack1->data_guard.empty());
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(2));
 
     auto sack2 = std::make_unique<Sack>();
     auto item3_weak_ptr = sack2->add_item_with_return(std::make_unique<std::string>("sack2_item1"));
@@ -88,21 +94,25 @@ void WeakPtrTest::test_weak_ptr() {
 
     // test copy constructor
     auto item5_weak_ptr(item1_weak_ptr);
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(3));
     CPPUNIT_ASSERT(*item1_weak_ptr.get() == "sack1_item1");
     CPPUNIT_ASSERT(*item5_weak_ptr.get() == "sack1_item1");
 
     // there is no move constructor, copy constructor must be used
     auto item6_weak_ptr(std::move(item5_weak_ptr));
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(4));
     CPPUNIT_ASSERT(*item5_weak_ptr.get() == "sack1_item1");
     CPPUNIT_ASSERT(*item6_weak_ptr.get() == "sack1_item1");
 
     // test copy assignment operator =
     item3_weak_ptr = item1_weak_ptr;
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(5));
     CPPUNIT_ASSERT(*item1_weak_ptr.get() == "sack1_item1");
     CPPUNIT_ASSERT(*item3_weak_ptr.get() == "sack1_item1");
 
     // there is no move assignment operator =, copy assignment must be used
     item4_weak_ptr = std::move(item2_weak_ptr);
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(6));
     CPPUNIT_ASSERT(*item2_weak_ptr.get() == "sack1_item2");
     CPPUNIT_ASSERT(*item4_weak_ptr.get() == "sack1_item2");
 
@@ -115,6 +125,25 @@ void WeakPtrTest::test_weak_ptr() {
     CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item1_weak_ptr, false);
     CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item3_weak_ptr, false);
     CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item4_weak_ptr, true);
+
+    // test WeakPtrGuard::clear()
+    // It must deregister and invalidate all registered weak pointers.
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(6));
+    CPPUNIT_ASSERT(*item1_weak_ptr.get() == "sack1_item1");
+    CPPUNIT_ASSERT(*item2_weak_ptr.get() == "sack1_item2");
+    CPPUNIT_ASSERT(*item3_weak_ptr.get() == "sack1_item1");
+    CPPUNIT_ASSERT(*item4_weak_ptr.get() == "sack1_item2");
+    CPPUNIT_ASSERT(*item5_weak_ptr.get() == "sack1_item1");
+    CPPUNIT_ASSERT(*item6_weak_ptr.get() == "sack1_item1");
+    sack1->data_guard.clear();
+    CPPUNIT_ASSERT(sack1->data_guard.empty());
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(0));
+    CPPUNIT_ASSERT_THROW(*item1_weak_ptr.get() == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item2_weak_ptr.get() == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get() == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item4_weak_ptr.get() == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item5_weak_ptr.get() == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item6_weak_ptr.get() == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
 }
 
 
@@ -134,15 +163,21 @@ void WeakPtrTest::test_weak_ptr_is_owner() {
             return ret;
         }
 
-    private:
         libdnf::WeakPtrGuard<DependentItem, true> data_guard;
+
+    private:
         std::vector<std::unique_ptr<std::string>>
             data;  // Owns the data set. Objects get deleted when the Sack is deleted.
     };
 
+    // add weak pointers, test WeakPtrGuard::empty(), and WeakPtrGuard::size()
     auto sack1 = std::make_unique<Sack>();
+    CPPUNIT_ASSERT(sack1->data_guard.empty());
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(0));
     auto item1_weak_ptr = sack1->add_item_with_return(std::make_unique<std::string>("sack1_item1"));
     auto item2_weak_ptr = sack1->add_item_with_return(std::make_unique<std::string>("sack1_item2"));
+    CPPUNIT_ASSERT(!sack1->data_guard.empty());
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(2));
 
     auto sack2 = std::make_unique<Sack>();
     auto item3_weak_ptr = sack2->add_item_with_return(std::make_unique<std::string>("sack2_item1"));
@@ -176,21 +211,25 @@ void WeakPtrTest::test_weak_ptr_is_owner() {
 
     // test copy constructor
     auto item5_weak_ptr(item1_weak_ptr);
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(3));
     CPPUNIT_ASSERT(*item1_weak_ptr->remote_data == "sack1_item1");
     CPPUNIT_ASSERT(*item5_weak_ptr->remote_data == "sack1_item1");
 
     // there move constructor
     auto item6_weak_ptr(std::move(item5_weak_ptr));
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(3));
     CPPUNIT_ASSERT_THROW(*item5_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
     CPPUNIT_ASSERT(*item6_weak_ptr->remote_data == "sack1_item1");
 
     // test copy assignment operator =
     item3_weak_ptr = item1_weak_ptr;
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(4));
     CPPUNIT_ASSERT(*item1_weak_ptr->remote_data == "sack1_item1");
     CPPUNIT_ASSERT(*item3_weak_ptr->remote_data == "sack1_item1");
 
     // test move assignment operator =
     item4_weak_ptr = std::move(item2_weak_ptr);
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(4));
     CPPUNIT_ASSERT_THROW(*item2_weak_ptr->remote_data == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
     CPPUNIT_ASSERT(*item4_weak_ptr->remote_data == "sack1_item2");
 
@@ -211,4 +250,21 @@ void WeakPtrTest::test_weak_ptr_is_owner() {
     CPPUNIT_ASSERT_EQUAL(item1_weak_ptr->remote_data != item3_weak_ptr->remote_data, false);
     CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item4_weak_ptr, true);
     CPPUNIT_ASSERT_EQUAL(item1_weak_ptr->remote_data != item4_weak_ptr->remote_data, true);
+
+    CPPUNIT_ASSERT_EQUAL(item1_weak_ptr != item4_weak_ptr, true);
+
+    // test WeakPtrGuard::clear()
+    // It must deregister and invalidate all registered weak pointers.
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(4));
+    CPPUNIT_ASSERT(*item1_weak_ptr->remote_data == "sack1_item1");
+    CPPUNIT_ASSERT(*item3_weak_ptr->remote_data == "sack1_item1");
+    CPPUNIT_ASSERT(*item4_weak_ptr->remote_data == "sack1_item2");
+    CPPUNIT_ASSERT(*item6_weak_ptr->remote_data == "sack1_item1");
+    sack1->data_guard.clear();
+    CPPUNIT_ASSERT(sack1->data_guard.empty());
+    CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(0));
+    CPPUNIT_ASSERT_THROW(*item1_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item3_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item4_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item6_weak_ptr->remote_data == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
 }


### PR DESCRIPTION
The `WeakPtrGuard::clear()` invalidated all registered WeakPtrs, but forgot to unregister them from guard.

Added unit tests for `WeakPtrGuard::empty()`, `WeakPtrGuard::size()`, and `WeakPtrGuard::clear()`.