### PR TITLE
[dnf5] Use rpm::SolvSackWeakPtr

### DIFF
--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -274,11 +274,11 @@ protected:
 
 private:
     friend PackageSetIterator;
-    SolvSack * sack;
+    SolvSackWeakPtr sack;
     PackageId id;
 };
 
-inline Package::Package(SolvSack * sack, PackageId id) : sack(sack), id(id) {}
+inline Package::Package(SolvSack * sack, PackageId id) : sack(sack->get_weak_ptr()), id(id) {}
 
 inline bool Package::operator==(const Package & other) const noexcept {
     return id == other.id && sack == other.sack;

--- a/include/libdnf/rpm/reldep.hpp
+++ b/include/libdnf/rpm/reldep.hpp
@@ -45,18 +45,17 @@ public:
     Reldep(SolvSack * sack, const std::string & reldep_string);
 
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(const Dependency & dependency);
-    Reldep(const Reldep & reldep);
-
-    Reldep(const Reldep && reldep) noexcept;
+    Reldep(const Reldep & reldep) = default;
+    Reldep(Reldep && reldep) = delete;
 
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:~Dependency();
     /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_free(DnfReldep *reldep)
-    ~Reldep();
+    ~Reldep() = default;
 
     bool operator==(const Reldep & other) const noexcept;
     bool operator!=(const Reldep & other) const noexcept;
     Reldep & operator=(const Reldep & other) noexcept = default;
-    Reldep & operator=(Reldep && other) noexcept;
+    Reldep & operator=(Reldep && other) = delete;
 
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getName()
     const char * get_name() const;
@@ -120,12 +119,6 @@ inline bool Reldep::operator==(const Reldep & other) const noexcept {
 
 inline bool Reldep::operator!=(const Reldep & other) const noexcept {
     return id != other.id || sack != other.sack;
-}
-
-inline Reldep & Reldep::operator=(Reldep && other) noexcept {
-    id = other.id;
-    sack = other.sack;
-    return *this;
 }
 
 }  // namespace libdnf::rpm

--- a/include/libdnf/rpm/reldep.hpp
+++ b/include/libdnf/rpm/reldep.hpp
@@ -54,7 +54,7 @@ public:
 
     bool operator==(const Reldep & other) const noexcept;
     bool operator!=(const Reldep & other) const noexcept;
-    Reldep & operator=(const Reldep & other) noexcept = default;
+    Reldep & operator=(const Reldep & other) = default;
     Reldep & operator=(Reldep && other) = delete;
 
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getName()
@@ -109,7 +109,7 @@ private:
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getReldepId(DnfSack *sack, const char * reldepStr)
     static ReldepId get_reldep_id(SolvSack * sack, const std::string & reldep_str);
 
-    SolvSack * sack;
+    SolvSackWeakPtr sack;
     ReldepId id;
 };
 

--- a/include/libdnf/rpm/solv_sack.hpp
+++ b/include/libdnf/rpm/solv_sack.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_RPM_SACK_HPP
 
 #include "libdnf/utils/exception.hpp"
+#include "libdnf/utils/weak_ptr.hpp"
 
 #include <memory>
 
@@ -70,6 +71,10 @@ class Reldep;
 class ReldepList;
 class Repo;
 
+class SolvSack;
+
+using SolvSackWeakPtr = WeakPtr<SolvSack, false>;
+
 class SolvSack {
 public:
     class Exception : public RuntimeError {
@@ -113,6 +118,9 @@ public:
 
     /// Creates system repository and loads it into SolvSack. Only one system repository can be in SolvSack.
     void create_system_repo(bool build_cache);
+
+    /// Create WeakPtr to SolvSack
+    SolvSackWeakPtr get_weak_ptr();
 
 private:
     friend Package;

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -169,77 +169,77 @@ std::vector<std::string> Package::get_files() {
 
 ReldepList Package::get_provides() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_provides(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_requires() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_provides(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_requires_pre() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_requires_pre(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_conflicts() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_conflicts(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_obsoletes() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_obsoletes(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_recommends() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_recommends(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_suggests() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_suggests(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_enhances() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_enhances(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_supplements() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_supplements(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_prereq_ignoreinst() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_prereq_ignoreinst(pool, id, list.pImpl->queue);
     return list;
 }
 
 ReldepList Package::get_regular_requires() const {
     Pool * pool = sack->pImpl->pool;
-    ReldepList list(sack);
+    ReldepList list(sack.get());
     solv::get_regular_requires(pool, id, list.pImpl->queue);
     return list;
 }

--- a/libdnf/rpm/package_set_impl.hpp
+++ b/libdnf/rpm/package_set_impl.hpp
@@ -49,20 +49,22 @@ public:
     /// Copy constructor: clone from an existing PackageSet::Impl
     Impl(const Impl & other);
 
-    SolvSack * get_sack() const noexcept { return sack; }
+    SolvSack * get_sack() const { return sack.get(); }
 
 private:
     friend PackageSet;
-    SolvSack * sack;
+    SolvSackWeakPtr sack;
 };
 
 
 inline PackageSet::Impl::Impl(SolvSack * sack)
     : libdnf::rpm::solv::SolvMap::SolvMap(sack->pImpl->pool->nsolvables)
-    , sack(sack) {}
+    , sack(sack->get_weak_ptr()) {}
 
 
-inline PackageSet::Impl::Impl(SolvSack * sack, Map * map) : libdnf::rpm::solv::SolvMap::SolvMap(map), sack(sack) {}
+inline PackageSet::Impl::Impl(SolvSack * sack, Map * map)
+    : libdnf::rpm::solv::SolvMap::SolvMap(map)
+    , sack(sack->get_weak_ptr()) {}
 
 
 inline PackageSet::Impl::Impl(const PackageSet & other) : Impl(*other.pImpl) {}
@@ -70,7 +72,7 @@ inline PackageSet::Impl::Impl(const PackageSet & other) : Impl(*other.pImpl) {}
 
 inline PackageSet::Impl::Impl(const PackageSet::Impl & other)
     : libdnf::rpm::solv::SolvMap::SolvMap(other.get_map())
-    , sack{other.get_sack()} {}
+    , sack(other.get_sack()->get_weak_ptr()) {}
 
 
 }  // namespace libdnf::rpm

--- a/libdnf/rpm/reldep.cpp
+++ b/libdnf/rpm/reldep.cpp
@@ -34,13 +34,14 @@ extern "C" {
 namespace libdnf::rpm {
 
 
-Reldep::Reldep(SolvSack * sack, ReldepId dependency_id) : sack(sack), id(dependency_id) {}
+Reldep::Reldep(SolvSack * sack, ReldepId dependency_id) : sack(sack->get_weak_ptr()), id(dependency_id) {}
 
-Reldep::Reldep(SolvSack * sack, const char * name, const char * version, CmpType cmp_type) : sack(sack) {
+Reldep::Reldep(SolvSack * sack, const char * name, const char * version, CmpType cmp_type)
+    : sack(sack->get_weak_ptr()) {
     id = get_reldep_id(sack, name, version, cmp_type);
 }
 
-Reldep::Reldep(SolvSack * sack, const std::string & reldep_string) : sack(sack) {
+Reldep::Reldep(SolvSack * sack, const std::string & reldep_string) : sack(sack->get_weak_ptr()) {
     id = get_reldep_id(sack, reldep_string);
 }
 

--- a/libdnf/rpm/reldep_list.cpp
+++ b/libdnf/rpm/reldep_list.cpp
@@ -88,13 +88,15 @@ bool ReldepList::add_reldep_with_glob(const std::string & reldep_str) {
     solv::ReldepParser dep_splitter;
     if (!dep_splitter.parse(reldep_str))
         return false;
-    Dataiterator di;
-    Pool * pool = pImpl->sack->pImpl->pool;
 
+    auto * sack = pImpl->sack.get();
+    Pool * pool = sack->pImpl->pool;
+
+    Dataiterator di;
     dataiterator_init(&di, pool, 0, 0, 0, dep_splitter.get_name_cstr(), SEARCH_STRING | SEARCH_GLOB);
     while (dataiterator_step(&di)) {
-        ReldepId id =
-            Reldep::get_reldep_id(pImpl->sack, di.kv.str, dep_splitter.get_evr_cstr(), dep_splitter.get_cmp_type());
+        ReldepId id = Reldep::get_reldep_id(
+            sack, di.kv.str, dep_splitter.get_evr_cstr(), dep_splitter.get_cmp_type());
         add(id);
     }
     dataiterator_free(&di);
@@ -103,7 +105,7 @@ bool ReldepList::add_reldep_with_glob(const std::string & reldep_str) {
 
 bool ReldepList::add_reldep(const std::string & reldep_str) {
     try {
-        ReldepId id = Reldep::get_reldep_id(pImpl->sack, reldep_str);
+        ReldepId id = Reldep::get_reldep_id(pImpl->sack.get(), reldep_str);
         add(id);
         return true;
         // TODO(jmracek) Make catch error more specific
@@ -118,7 +120,7 @@ void ReldepList::append(ReldepList & source) {
 
 Reldep ReldepList::get(int index) const noexcept {
     ReldepId id(pImpl->queue[index]);
-    return Reldep(pImpl->sack, id);
+    return Reldep(pImpl->sack.get(), id);
 }
 
 int ReldepList::size() const noexcept {

--- a/libdnf/rpm/reldep_list_impl.hpp
+++ b/libdnf/rpm/reldep_list_impl.hpp
@@ -29,26 +29,18 @@ namespace libdnf::rpm {
 
 class ReldepList::Impl {
 public:
-    Impl(const ReldepList::Impl & src);
-    Impl(SolvSack * sack);
-    Impl(SolvSack * sack, libdnf::rpm::solv::IdQueue queue_src);
-    ~Impl();
+    Impl(const ReldepList::Impl & src) = default;
+    Impl(SolvSack * sack) : sack(sack->get_weak_ptr()) {}
+    Impl(SolvSack * sack, libdnf::rpm::solv::IdQueue queue_src) : sack(sack->get_weak_ptr()), queue(queue_src) {}
+    ~Impl() = default;
 
 
 private:
     friend class ReldepList;
     friend Package;
-    SolvSack * sack;
+    SolvSackWeakPtr sack;
     libdnf::rpm::solv::IdQueue queue;
 };
-
-inline ReldepList::Impl::Impl(const ReldepList::Impl & src) : sack(src.sack), queue(src.queue) {}
-
-inline ReldepList::Impl::Impl(SolvSack * sack) : sack(sack) {}
-
-inline ReldepList::Impl::Impl(SolvSack * sack, libdnf::rpm::solv::IdQueue queue_src) : sack(sack), queue(queue_src) {}
-
-inline ReldepList::Impl::~Impl() {}
 
 }  // namespace libdnf::rpm
 

--- a/libdnf/rpm/solv_sack.cpp
+++ b/libdnf/rpm/solv_sack.cpp
@@ -481,6 +481,9 @@ void SolvSack::create_system_repo([[maybe_unused]] bool build_cache) {
     pImpl->load_system_repo(*pImpl->system_repo);
 }
 
+SolvSackWeakPtr SolvSack::get_weak_ptr() {
+    return SolvSackWeakPtr(this, &pImpl->data_guard);
+}
 
 // TODO(jrohel): we want to change directory for solv(x) cache (into repo metadata directory?)
 std::string SolvSack::Impl::give_repo_solv_cache_fn(const std::string & repoid, const char * ext) {

--- a/libdnf/rpm/solv_sack_impl.hpp
+++ b/libdnf/rpm/solv_sack_impl.hpp
@@ -85,6 +85,8 @@ private:
     Pool * pool;
     std::unique_ptr<Repo> system_repo;
 
+    WeakPtrGuard<SolvSack, false> data_guard;
+
     friend SolvSack;
     friend Package;
     friend PackageSet;


### PR DESCRIPTION
There are objects that depends on (points to) `rpm::SolvSack`. These objects are valid as long as `rpm::SolvSack` is valid. The raw pointer to `rpm::SolvSack` was replaced in these object by `rpm::SolvSackWeakPtr` to detect validity.

PR declares the `rpm::SolvSackWeakPtr`.
The `rpm::SolvSack` provides a method `get_weak_ptr()`. The method returns new `rpm::SolvSackWeakPtr` instance to `rpm::SolvSack`. All returned weak pointers are registered in the `rpm::SolvSack` and will be invalidated when the `rpm::SolvSack` data are invalidated.

The `rpm::SolvSackWeakPtr` was added into these classes:
`rpm::Package`, `rpm::ReldepList`, `rpm::Reldep`, `rpm::PackageSet`


