### PR TITLE
[dnf5] iniparser: Fix parsing empty lines, add unit tests

### DIFF
--- a/include/libdnf/utils/iniparser.hpp
+++ b/include/libdnf/utils/iniparser.hpp
@@ -138,6 +138,7 @@ private:
     std::string value;
     std::string raw_item;
     std::string line;
+    bool line_ready;
 };
 
 inline const std::string & IniParser::get_section() const noexcept {

--- a/libdnf/utils/iniparser.cpp
+++ b/libdnf/utils/iniparser.cpp
@@ -68,12 +68,12 @@ IniParser::ItemType IniParser::next() {
             line.erase(0, 3);
         }
 
-        if (line.length() == 0 || line[0] == '#' || line[0] == ';') {  // do not support [rR][eE][mM] comment
+        if (line.empty() || line[0] == '#' || line[0] == ';') {  // do not support [rR][eE][mM] comment
             if (previous_line_with_key_val) {
                 trim_value();
                 return ItemType::KEY_VAL;
             }
-            if (line.length() == 0) {
+            if (line.empty()) {
                 if (is->eof()) {
                     return ItemType::END_OF_INPUT;
                 }

--- a/libdnf/utils/iniparser.cpp
+++ b/libdnf/utils/iniparser.cpp
@@ -81,7 +81,10 @@ IniParser::ItemType IniParser::next() {
                 raw_item = DELIMITER;
                 return ItemType::EMPTY_LINE;
             }
-            raw_item = line + DELIMITER;
+            raw_item = line;
+            if (!is->eof()) {
+                raw_item += DELIMITER;
+            }
             line_ready = false;
             return ItemType::COMMENT_LINE;
         }
@@ -89,11 +92,17 @@ IniParser::ItemType IniParser::next() {
         if (start == std::string::npos) {
             if (previous_line_with_key_val) {
                 value += DELIMITER;
-                raw_item += line + DELIMITER;
+                raw_item += line;
+                if (!is->eof()) {
+                    raw_item += DELIMITER;
+                }
                 line_ready = false;
                 continue;
             }
-            raw_item = line + DELIMITER;
+            raw_item = line;
+            if (!is->eof()) {
+                raw_item += DELIMITER;
+            }
             line_ready = false;
             return ItemType::EMPTY_LINE;
         }
@@ -122,7 +131,10 @@ IniParser::ItemType IniParser::next() {
                 }
             }
             this->section = line.substr(start, end_sect_pos - start);
-            raw_item = line + DELIMITER;
+            raw_item = line;
+            if (!is->eof()) {
+                raw_item += DELIMITER;
+            }
             line_ready = false;
             return ItemType::SECTION;
         }
@@ -136,7 +148,10 @@ IniParser::ItemType IniParser::next() {
                 throw IllegalContinuationLine(std::to_string(line_number));
             }
             value += DELIMITER + line.substr(start, end - start + 1);
-            raw_item += line + DELIMITER;
+            raw_item += line;
+            if (!is->eof()) {
+                raw_item += DELIMITER;
+            }
             line_ready = false;
         } else {
             if (line[start] == '=') {
@@ -155,7 +170,10 @@ IniParser::ItemType IniParser::next() {
                 value.clear();
             }
             previous_line_with_key_val = true;
-            raw_item = line + DELIMITER;
+            raw_item = line;
+            if (!is->eof()) {
+                raw_item += DELIMITER;
+            }
             line_ready = false;
         }
     }

--- a/test/libdnf/iniparser/test_iniparser.cpp
+++ b/test/libdnf/iniparser/test_iniparser.cpp
@@ -1,0 +1,154 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_iniparser.hpp"
+
+#include "libdnf/utils/iniparser.hpp"
+
+#include <memory>
+#include <sstream>
+
+CPPUNIT_TEST_SUITE_REGISTRATION(IniparserTest);
+
+
+void IniparserTest::setUp() {}
+
+
+void IniparserTest::tearDown() {}
+
+
+using ItemType = libdnf::IniParser::ItemType;
+struct Item {
+    ItemType type;
+    const char * section;
+    const char * key;
+    const char * value;
+    const char * raw;
+};
+
+void IniparserTest::test_iniparser() {
+
+    // Source data
+    const std::string ini_file_content =
+R"**([section1]
+key1 = value1
+key2 =value2
+
+key3= value3
+# Comment1
+key4=value4
+;Comment2
+key5    = value5
+key6 = two line
+ value1
+
+key7 = two line
+ value2
+key8 = value8
+
+[section2]  # Test section2
+
+key1 = value1
+)**";
+
+    // Expected results from parser
+    const Item expected_items[] = {
+        {ItemType::SECTION, "section1", "", "", "[section1]\n"},
+        {ItemType::KEY_VAL, "section1", "key1", "value1", "key1 = value1\n"},
+        {ItemType::KEY_VAL, "section1", "key2", "value2", "key2 =value2\n"},
+        {ItemType::EMPTY_LINE, "section1", "", "", "\n"},
+        {ItemType::KEY_VAL, "section1", "key3", "value3", "key3= value3\n"},
+        {ItemType::COMMENT_LINE, "section1", "", "", "# Comment1\n"},
+        {ItemType::KEY_VAL, "section1", "key4", "value4", "key4=value4\n"},
+        {ItemType::COMMENT_LINE, "section1", "", "", ";Comment2\n"},
+        {ItemType::KEY_VAL, "section1", "key5", "value5", "key5    = value5\n"},
+        {ItemType::KEY_VAL, "section1", "key6", "two line\nvalue1", "key6 = two line\n value1\n"},
+        {ItemType::EMPTY_LINE, "section1", "", "", "\n"},
+        {ItemType::KEY_VAL, "section1", "key7", "two line\nvalue2", "key7 = two line\n value2\n"},
+        {ItemType::KEY_VAL, "section1", "key8", "value8", "key8 = value8\n"},
+        {ItemType::EMPTY_LINE, "section1", "", "", "\n"},
+        {ItemType::SECTION, "section2", "", "", "[section2]  # Test section2\n"},
+        {ItemType::EMPTY_LINE, "section2", "", "", "" "\n"},
+        {ItemType::KEY_VAL, "section2", "key1", "value1", "key1 = value1\n"},
+        {ItemType::END_OF_INPUT, "section2", "", "", ""}
+    };
+
+    // Parse input
+    libdnf::IniParser parser(std::make_unique<std::istringstream>(ini_file_content));
+    for (std::size_t idx = 0; idx < sizeof(expected_items)/sizeof(expected_items[0]); ++idx) {
+        auto readedType = parser.next();
+        CPPUNIT_ASSERT_EQUAL(readedType, expected_items[idx].type);
+        CPPUNIT_ASSERT_EQUAL(parser.get_section(), std::string(expected_items[idx].section));
+        if (readedType == ItemType::KEY_VAL) {
+            CPPUNIT_ASSERT_EQUAL(parser.get_key(), std::string(expected_items[idx].key));
+            CPPUNIT_ASSERT_EQUAL(parser.get_value(), std::string(expected_items[idx].value));
+        }
+        CPPUNIT_ASSERT_EQUAL(parser.get_raw_item(), std::string(expected_items[idx].raw));
+    }
+}
+
+void IniparserTest::test_iniparser2() {
+
+    // Source data
+    const std::string ini_file_content =
+R"**(
+# Test comment1
+# Test comment2
+[section1]
+key1 = value1
+key2 = two line  
+    value2
+key3 = multi line
+    with
+    
+    value3
+key4 = value4
+[section2]; Test section2
+  
+key1 = value1)**";
+
+    // Expected results from parser
+    const Item expected_items[] = {
+        {ItemType::EMPTY_LINE, "", "", "", "\n"},
+        {ItemType::COMMENT_LINE, "", "", "", "# Test comment1\n"},
+        {ItemType::COMMENT_LINE, "", "", "", "# Test comment2\n"},
+        {ItemType::SECTION, "section1", "", "", "[section1]\n"},
+        {ItemType::KEY_VAL, "section1", "key1", "value1", "key1 = value1\n"},
+        {ItemType::KEY_VAL, "section1", "key2", "two line\nvalue2", "key2 = two line  \n    value2\n"},
+        {ItemType::KEY_VAL, "section1", "key3", "multi line\nwith\n\nvalue3", "key3 = multi line\n    with\n    \n    value3\n"},
+        {ItemType::KEY_VAL, "section1", "key4", "value4", "key4 = value4\n"},
+        {ItemType::SECTION, "section2", "", "", "[section2]; Test section2\n"},
+        {ItemType::EMPTY_LINE, "section2", "", "", "  \n"},
+        {ItemType::KEY_VAL, "section2", "key1", "value1", "key1 = value1"},
+        {ItemType::END_OF_INPUT, "section2", "", "", ""}
+    };
+
+    // Parse input
+    libdnf::IniParser parser(std::make_unique<std::istringstream>(ini_file_content));
+    for (std::size_t idx = 0; idx < sizeof(expected_items)/sizeof(expected_items[0]); ++idx) {
+        auto readedType = parser.next();
+        CPPUNIT_ASSERT_EQUAL(readedType, expected_items[idx].type);
+        CPPUNIT_ASSERT_EQUAL(parser.get_section(), std::string(expected_items[idx].section));
+        if (readedType == ItemType::KEY_VAL) {
+            CPPUNIT_ASSERT_EQUAL(parser.get_key(), std::string(expected_items[idx].key));
+            CPPUNIT_ASSERT_EQUAL(parser.get_value(), std::string(expected_items[idx].value));
+        }
+        CPPUNIT_ASSERT_EQUAL(parser.get_raw_item(), std::string(expected_items[idx].raw));
+    }
+}

--- a/test/libdnf/iniparser/test_iniparser.hpp
+++ b/test/libdnf/iniparser/test_iniparser.hpp
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2020 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_TEST_INIPARSER_HPP
+#define LIBDNF_TEST_INIPARSER_HPP
+
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class IniparserTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(IniparserTest);
+
+    #ifndef WITH_PERFORMANCE_TESTS
+    CPPUNIT_TEST(test_iniparser);
+    CPPUNIT_TEST(test_iniparser2);
+    #endif
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+    void tearDown() override;
+
+    static void test_iniparser();
+    static void test_iniparser2();
+
+private:
+};
+
+#endif


### PR DESCRIPTION
The PR:
- contains fix from libdnf 4 branch https://github.com/rpm-software-management/libdnf/pull/975
- adds fix for case without a trailing newline character in the source
- and adds unit tests for iniparser
    