### PR TITLE
[dnf5] Add missing fmt requirement to spec file

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -51,6 +51,7 @@ BuildRequires:  pkgconfig(check)
 %if ! %{with tests_disabled}
 BuildRequires:  pkgconfig(cppunit)
 %endif
+BuildRequires:  pkgconfig(fmt)
 BuildRequires:  pkgconfig(gpgme)
 BuildRequires:  pkgconfig(json-c)
 %if %{with comps}


### PR DESCRIPTION
This requirement is already checked in libdnf/CMakeLists.txt, the patch
only makes `dnf builddep libdnf.spec` functional.