### PR TITLE
gitignore: Ignore some files generated at cmake time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /libdnf/dnf-version.h
 build
 *.pyc
+data/tests/modules/yum.repos.d/test.repo
+libdnf/config.h


### PR DESCRIPTION
In rpm-ostree we do use a separate builddir, but these files
appear to be generated at `cmake` time.  (Which is probably
a bug there but I don't speak cmake enough to fix it)