### PR TITLE
Fix memory leak of resultingModuleIndex and handle g_object refs

### DIFF
--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -106,6 +106,41 @@ ModulePackage::ModulePackage(DnfSack * moduleSack, LibsolvRepo * repo,
     dnf_sack_set_considered_to_update(moduleSack);
 }
 
+ModulePackage::ModulePackage(const ModulePackage & mpkg)
+        : mdStream(mpkg.mdStream)
+        , moduleSack(mpkg.moduleSack)
+        , repoID(mpkg.repoID)
+        , id(mpkg.id)
+{
+    if (mdStream != nullptr) {
+        g_object_ref(mdStream);
+    }
+}
+
+ModulePackage & ModulePackage::operator=(const ModulePackage & mpkg)
+{
+    if (this != &mpkg) {
+        if (mdStream != nullptr) {
+            g_object_unref(mdStream);
+        }
+        mdStream = mpkg.mdStream;
+        if (mdStream != nullptr) {
+            g_object_ref(mdStream);
+        }
+        moduleSack = mpkg.moduleSack;
+        repoID = mpkg.repoID;
+        id = mpkg.id;
+    }
+    return *this;
+}
+
+ModulePackage::~ModulePackage()
+{
+    if (mdStream != nullptr) {
+        g_object_unref(mdStream);
+    }
+}
+
 /**
  * @brief Create stream dependencies based on modulemd metadata.
  */

--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -83,9 +83,7 @@ static std::pair<std::string, std::string> parsePlatform(const std::string & pla
         return {};
     }
     return make_pair(platform.substr(0,index), platform.substr(index+1));
-    }
-
-ModulePackage::~ModulePackage() = default;
+}
 
 ModulePackage::ModulePackage(DnfSack * moduleSack, LibsolvRepo * repo,
     ModulemdModuleStream * mdStream, const std::string & repoID)
@@ -93,6 +91,9 @@ ModulePackage::ModulePackage(DnfSack * moduleSack, LibsolvRepo * repo,
         , moduleSack(moduleSack)
         , repoID(repoID)
 {
+    if (mdStream != nullptr) {
+        g_object_ref(mdStream);
+    }
     Pool * pool = dnf_sack_get_pool(moduleSack);
     id = repo_add_solvable(repo);
     Solvable *solvable = pool_id2solvable(pool, id);

--- a/libdnf/module/ModulePackage.hpp
+++ b/libdnf/module/ModulePackage.hpp
@@ -82,6 +82,9 @@ private:
     ModulePackage(DnfSack * moduleSack, LibsolvRepo * repo,
         ModulemdModuleStream * mdStream, const std::string & repoID);
 
+    ModulePackage(const ModulePackage & mpkg);
+    ModulePackage & operator=(const ModulePackage & mpkg);
+
     static Id createPlatformSolvable(DnfSack * moduleSack, const std::string &osReleasePath,
         const std::string install_root, const char *  platformModule);
     static Id createPlatformSolvable(DnfSack * sack, DnfSack * moduleSack,

--- a/libdnf/module/modulemd/ModuleDependencies.cpp
+++ b/libdnf/module/modulemd/ModuleDependencies.cpp
@@ -27,7 +27,36 @@ ModuleDependencies::ModuleDependencies() : dependencies(nullptr) {}
 
 ModuleDependencies::ModuleDependencies(ModulemdDependencies *dependencies)
         : dependencies(dependencies)
-{}
+{
+    g_object_ref(dependencies);
+}
+
+ModuleDependencies::ModuleDependencies(const ModuleDependencies & d)
+        : dependencies(d.dependencies)
+{
+    if (dependencies != nullptr) {
+        g_object_ref(d.dependencies);
+    }
+}
+
+ModuleDependencies & ModuleDependencies::operator=(const ModuleDependencies & d)
+{
+    if (this != &d) {
+        g_object_unref(dependencies);
+        dependencies = d.dependencies;
+        if (dependencies != nullptr) {
+            g_object_ref(dependencies);
+        }
+    }
+    return *this;
+}
+
+ModuleDependencies::~ModuleDependencies()
+{
+    if (dependencies != nullptr) {
+        g_object_unref(dependencies);
+    }
+}
 
 std::vector<std::map<std::string, std::vector<std::string>>> ModuleDependencies::getRequires() const
 {

--- a/libdnf/module/modulemd/ModuleDependencies.hpp
+++ b/libdnf/module/modulemd/ModuleDependencies.hpp
@@ -36,6 +36,9 @@ class ModuleDependencies
 public:
     explicit ModuleDependencies();
     explicit ModuleDependencies(ModulemdDependencies *dependencies);
+    ModuleDependencies(const ModuleDependencies & d);
+    ModuleDependencies & operator=(const ModuleDependencies & d);
+    ~ModuleDependencies();
 
     std::vector<std::map<std::string, std::vector<std::string> > > getRequires() const;
 

--- a/libdnf/module/modulemd/ModuleMetadata.cpp
+++ b/libdnf/module/modulemd/ModuleMetadata.cpp
@@ -30,6 +30,38 @@ namespace libdnf {
 
 ModuleMetadata::ModuleMetadata(): resultingModuleIndex(NULL), moduleMerger(NULL) {}
 
+ModuleMetadata::ModuleMetadata(const ModuleMetadata & m)
+        : resultingModuleIndex(m.resultingModuleIndex), moduleMerger(m.moduleMerger)
+{
+    if (resultingModuleIndex != nullptr) {
+        g_object_ref(resultingModuleIndex);
+    }
+    if (moduleMerger != nullptr) {
+        g_object_ref(moduleMerger);
+    }
+}
+
+ModuleMetadata & ModuleMetadata::operator=(const ModuleMetadata & m)
+{
+    if (this != &m) {
+        if (resultingModuleIndex != nullptr) {
+            g_object_unref(resultingModuleIndex);
+        }
+        if (moduleMerger != nullptr) {
+            g_object_unref(moduleMerger);
+        }
+        resultingModuleIndex = m.resultingModuleIndex;
+        moduleMerger = m.moduleMerger;
+        if (resultingModuleIndex != nullptr) {
+            g_object_ref(resultingModuleIndex);
+        }
+        if (moduleMerger != nullptr) {
+            g_object_ref(moduleMerger);
+        }
+    }
+    return *this;
+}
+
 ModuleMetadata::~ModuleMetadata()
 {
     if (resultingModuleIndex != nullptr) {

--- a/libdnf/module/modulemd/ModuleMetadata.cpp
+++ b/libdnf/module/modulemd/ModuleMetadata.cpp
@@ -30,6 +30,16 @@ namespace libdnf {
 
 ModuleMetadata::ModuleMetadata(): resultingModuleIndex(NULL), moduleMerger(NULL) {}
 
+ModuleMetadata::~ModuleMetadata()
+{
+    if (resultingModuleIndex != nullptr) {
+        g_object_unref(resultingModuleIndex);
+    }
+    if (moduleMerger != nullptr) {
+        g_object_unref(moduleMerger);
+    }
+}
+
 void ModuleMetadata::addMetadataFromString(const std::string & yaml, int priority)
 {
     GError *error = NULL;

--- a/libdnf/module/modulemd/ModuleMetadata.hpp
+++ b/libdnf/module/modulemd/ModuleMetadata.hpp
@@ -31,6 +31,8 @@ class ModuleMetadata
 {
 public:
     ModuleMetadata();
+    ModuleMetadata(const ModuleMetadata & m);
+    ModuleMetadata & operator=(const ModuleMetadata & m);
     ~ModuleMetadata();
     void addMetadataFromString(const std::string & yaml, int priority);
     void resolveAddedMetadata();

--- a/libdnf/module/modulemd/ModuleMetadata.hpp
+++ b/libdnf/module/modulemd/ModuleMetadata.hpp
@@ -31,6 +31,7 @@ class ModuleMetadata
 {
 public:
     ModuleMetadata();
+    ~ModuleMetadata();
     void addMetadataFromString(const std::string & yaml, int priority);
     void resolveAddedMetadata();
     std::vector<ModulePackage *> getAllModulePackages(DnfSack * moduleSack, LibsolvRepo * repo, const std::string & repoID);

--- a/libdnf/module/modulemd/ModuleProfile.cpp
+++ b/libdnf/module/modulemd/ModuleProfile.cpp
@@ -25,6 +25,34 @@ namespace libdnf {
 ModuleProfile::ModuleProfile(ModulemdProfile *profile)
         : profile(profile)
 {
+    g_object_ref(profile);
+}
+
+ModuleProfile::ModuleProfile(const ModuleProfile & p)
+        : profile(p.profile)
+{
+    if (profile != nullptr) {
+        g_object_ref(profile);
+    }
+}
+
+ModuleProfile & ModuleProfile::operator=(const ModuleProfile & p)
+{
+    if (this != &p) {
+        g_object_unref(profile);
+        profile = p.profile;
+        if (profile != nullptr) {
+            g_object_ref(profile);
+        }
+    }
+    return *this;
+}
+
+ModuleProfile::~ModuleProfile()
+{
+    if (profile != nullptr) {
+        g_object_unref(profile);
+    }
 }
 
 std::string ModuleProfile::getName() const

--- a/libdnf/module/modulemd/ModuleProfile.hpp
+++ b/libdnf/module/modulemd/ModuleProfile.hpp
@@ -34,7 +34,9 @@ class ModuleProfile
 {
 public:
     ModuleProfile() : profile(nullptr) {}
-    //~ModuleProfile() = default;
+    ModuleProfile(const ModuleProfile & p);
+    ModuleProfile & operator=(const ModuleProfile & p);
+    ~ModuleProfile();
     std::string getName() const;
     std::string getDescription() const;
     std::vector<std::string> getContent() const;


### PR DESCRIPTION
If we want to keep some modulemd objects (such as streams, profiles..)
even after unrefing `resultingModuleIndex` in `ModuleMetadata` destructor,
we have to increase references to them in their respective libdnf
counterparts, otherwise unreferencing `resultingModuleIndex` will 
unreference the whole tree of module metadata and it will all be freed.

This is to resolve: https://github.com/rpm-software-management/libdnf/issues/977