### PR TITLE
Accept '==' as an operator in reldeps (RhBug:1847946)

### DIFF
--- a/python/hawkey/tests/tests/test_reldep.py
+++ b/python/hawkey/tests/tests/test_reldep.py
@@ -61,6 +61,11 @@ class Reldep(base.TestCase):
         reldep = hawkey.Reldep(self.sack, "P-lib = 3-3")
         q = hawkey.Query(self.sack).filter(provides=reldep)
         self.assertLength(q, 1)
+        # '==' operator is deprecated and the support will be dropped in future
+        # versions (see bug 1847946)
+        reldep = hawkey.Reldep(self.sack, "P-lib == 3-3")
+        q = hawkey.Query(self.sack).filter(provides=reldep)
+        self.assertLength(q, 1)
         reldep = hawkey.Reldep(self.sack, "P-lib >= 3")
         q = hawkey.Query(self.sack).filter(provides=reldep)
         self.assertLength(q, 1)


### PR DESCRIPTION
Although rpm doesn't support this and using '==' can result in an
unexpected behavior, libdnf accepted '==' by mistake for some time and
other tools (namely Ansible Tower) already rely on it.

This brings back the '==' support with a deprecation warning.

https://bugzilla.redhat.com/show_bug.cgi?id=1847946