### PR TITLE
[dnf5] Fix rpm::PackageSetIterator class and rpm::solv::SolvMapIterator::begin()

### DIFF
--- a/include/libdnf/rpm/package_set_iterator.hpp
+++ b/include/libdnf/rpm/package_set_iterator.hpp
@@ -60,9 +60,6 @@ public:
 private:
     class Impl;
     std::unique_ptr<Impl> pImpl;
-
-    // value of the iterator
-    Package current_value;
 };
 
 

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -43,7 +43,6 @@ PackageSetIterator::~PackageSetIterator() {}
 
 void PackageSetIterator::begin() {
     pImpl->begin();
-    ++(*pImpl);
     current_value.id = PackageId(*(*pImpl));
 }
 

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -34,8 +34,8 @@ PackageSetIterator::PackageSetIterator(const PackageSet & package_set)
 
 
 PackageSetIterator::PackageSetIterator(const PackageSetIterator & other)
-    : pImpl{new Impl(other.pImpl->package_set)}
-    , current_value{other.pImpl->package_set.get_sack(), PackageId(*(*pImpl))} {}
+    : pImpl{new Impl(*other.pImpl)}
+    , current_value{other.current_value} {}
 
 
 PackageSetIterator::~PackageSetIterator() {}

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -28,57 +28,48 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::rpm {
 
 
-PackageSetIterator::PackageSetIterator(const PackageSet & package_set)
-    : pImpl{new Impl(package_set)}
-    , current_value{package_set.get_sack(), PackageId(*(*pImpl))} {}
+PackageSetIterator::PackageSetIterator(const PackageSet & package_set) : pImpl{new Impl(package_set)} {}
 
-
-PackageSetIterator::PackageSetIterator(const PackageSetIterator & other)
-    : pImpl{new Impl(*other.pImpl)}
-    , current_value{other.current_value} {}
-
+PackageSetIterator::PackageSetIterator(const PackageSetIterator & other) : pImpl{new Impl(*other.pImpl)} {}
 
 PackageSetIterator::~PackageSetIterator() {}
 
-
 void PackageSetIterator::begin() {
     pImpl->begin();
-    current_value.id = PackageId(*(*pImpl));
+    pImpl->current_value.id = PackageId(*(*pImpl));
 }
 
 
 void PackageSetIterator::end() {
     pImpl->end();
-    current_value.id = PackageId(*(*pImpl));
+    pImpl->current_value.id = PackageId(*(*pImpl));
 }
 
 
 Package PackageSetIterator::operator*() {
-    return current_value;
+    return pImpl->current_value;
 }
 
 
 PackageSetIterator & PackageSetIterator::operator++() {
     ++(*pImpl);
-    current_value.id = static_cast<PackageId>(*(*pImpl));
     return *this;
 }
 
 
 PackageSetIterator PackageSetIterator::operator++(int) {
     ++(*pImpl);
-    current_value.id = static_cast<PackageId>(*(*pImpl));
     return *this;
 }
 
 
 bool PackageSetIterator::operator==(const PackageSetIterator & other) const {
-    return current_value == other.current_value;
+    return pImpl->current_value == other.pImpl->current_value;
 }
 
 
 bool PackageSetIterator::operator!=(const PackageSetIterator & other) const {
-    return current_value != other.current_value;
+    return pImpl->current_value != other.pImpl->current_value;
 }
 
 

--- a/libdnf/rpm/package_set_iterator_impl.hpp
+++ b/libdnf/rpm/package_set_iterator_impl.hpp
@@ -34,7 +34,7 @@ namespace libdnf::rpm {
 class PackageSetIterator::Impl : public libdnf::rpm::solv::SolvMap::iterator {
 public:
     Impl(const PackageSet & package_set);
-    Impl(const PackageSetIterator::Impl & package_set_iterator_impl);
+    Impl(const PackageSetIterator::Impl & package_set_iterator_impl) = default;
 
     PackageSetIterator::Impl & operator++();
 
@@ -49,11 +49,6 @@ inline PackageSetIterator::Impl::Impl(const PackageSet & package_set)
     : libdnf::rpm::solv::SolvMap::iterator(package_set.pImpl->get_map())
     , package_set{package_set}
     , current_value{package_set.get_sack(), PackageId(-1)} {}
-
-
-inline PackageSetIterator::Impl::Impl(const PackageSetIterator::Impl & package_set_iterator_impl)
-    : PackageSetIterator::Impl::Impl(package_set_iterator_impl.package_set) {}
-
 
 inline PackageSetIterator::Impl & PackageSetIterator::Impl::operator++() {
     // construct and store package based on Id obtained from the underlying iterator

--- a/libdnf/rpm/solv/map_iterator.hpp
+++ b/libdnf/rpm/solv/map_iterator.hpp
@@ -39,7 +39,7 @@ class SolvMap;
 class SolvMapIterator {
 public:
     explicit SolvMapIterator(const Map * map);
-    SolvMapIterator(const SolvMapIterator & other);
+    SolvMapIterator(const SolvMapIterator & other) = default;
 
     using iterator_category = std::forward_iterator_tag;
     using difference_type = PackageId;
@@ -85,9 +85,6 @@ inline SolvMapIterator::SolvMapIterator(const Map * map) : map{map} {
     current_value.id = BEGIN;
     ++(*this);
 }
-
-
-inline SolvMapIterator::SolvMapIterator(const SolvMapIterator & other) : SolvMapIterator(other.map) {}
 
 
 inline SolvMapIterator & SolvMapIterator::operator++() {

--- a/libdnf/rpm/solv/map_iterator.hpp
+++ b/libdnf/rpm/solv/map_iterator.hpp
@@ -55,7 +55,7 @@ public:
     bool operator==(const SolvMapIterator & other) const { return current_value == other.current_value; }
     bool operator!=(const SolvMapIterator & other) const { return current_value != other.current_value; }
 
-    void begin() { current_value.id = BEGIN; }
+    void begin();
     void end() { current_value.id = END; }
 
 protected:
@@ -75,7 +75,7 @@ private:
     const unsigned char * map_end;
 
     // value of the iterator
-    PackageId current_value = PackageId(BEGIN);
+    PackageId current_value;
 };
 
 
@@ -86,6 +86,10 @@ inline SolvMapIterator::SolvMapIterator(const Map * map) : map{map} {
     ++(*this);
 }
 
+inline void SolvMapIterator::begin() {
+    current_value.id = BEGIN;
+    ++*this;
+}
 
 inline SolvMapIterator & SolvMapIterator::operator++() {
     if (current_value.id >= 0) {


### PR DESCRIPTION
- fixes copy constructors
- rpm::solv::SolvMapIterator::begin() points to the first element or end()
- removes duplicity and badly synced rpm::PackageSetIterator::curent_value