### PR TITLE
[dnf5] logger: Rename write(level, message) to log(level, message)

### DIFF
--- a/include/libdnf/logger/log_router.hpp
+++ b/include/libdnf/logger/log_router.hpp
@@ -49,7 +49,7 @@ public:
     /// Returns number of loggers registered in LogRouter.
     size_t get_loggers_count() const noexcept { return loggers.size(); }
 
-    void write(Level level, const std::string & message) noexcept override;
+    void log(Level level, const std::string & message) noexcept override;
     void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept override;
 
 private:

--- a/include/libdnf/logger/logger.hpp
+++ b/include/libdnf/logger/logger.hpp
@@ -51,28 +51,28 @@ public:
     }
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.critical(const std::string & message)
-    void critical(const std::string & message) noexcept { write(Level::CRITICAL, message); }
+    void critical(const std::string & message) noexcept { log(Level::CRITICAL, message); }
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.error(const std::string & message)
-    void error(const std::string & message) noexcept { write(Level::ERROR, message); }
+    void error(const std::string & message) noexcept { log(Level::ERROR, message); }
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.warning(const std::string & message)
-    void warning(const std::string & message) noexcept { write(Level::WARNING, message); }
+    void warning(const std::string & message) noexcept { log(Level::WARNING, message); }
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.notice(const std::string & message)
-    void notice(const std::string & message) noexcept { write(Level::NOTICE, message); }
+    void notice(const std::string & message) noexcept { log(Level::NOTICE, message); }
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.info(const std::string & message)
-    void info(const std::string & message) noexcept { write(Level::INFO, message); }
+    void info(const std::string & message) noexcept { log(Level::INFO, message); }
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.debug(const std::string & message)
-    void debug(const std::string & message) noexcept { write(Level::DEBUG, message); }
+    void debug(const std::string & message) noexcept { log(Level::DEBUG, message); }
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.trace(const std::string & message)
-    void trace(const std::string & message) noexcept { write(Level::TRACE, message); }
+    void trace(const std::string & message) noexcept { log(Level::TRACE, message); }
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.write(libdnf::Logger::Level level, const std::string & message)
-    virtual void write(Level level, const std::string & message) noexcept;
+    virtual void log(Level level, const std::string & message) noexcept;
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.write(time_t time, pid_t pid, libdnf::Logger::Level level, const std::string & message)
     virtual void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept = 0;

--- a/include/libdnf/logger/null_logger.hpp
+++ b/include/libdnf/logger/null_logger.hpp
@@ -33,7 +33,7 @@ namespace libdnf {
 class NullLogger : public Logger {
 public:
     /// @replaces libdnf:utils/logger.hpp:method:NullLogger.write(int , libdnf::Logger::Level , const std::string & )
-    void write(Level /*level*/, const std::string & /*message*/) noexcept override {}
+    void log(Level /*level*/, const std::string & /*message*/) noexcept override {}
 
     /// @replaces libdnf:utils/logger.hpp:method:NullLogger.write(int , time_t , pid_t , libdnf::Logger::Level , const std::string & )
     void write(time_t /*time*/, pid_t /*pid*/, Level /*level*/, const std::string & /*message*/) noexcept override {}

--- a/libdnf/logger/log_router.cpp
+++ b/libdnf/logger/log_router.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<Logger> LogRouter::release_logger(size_t index) {
     return ret;
 }
 
-void LogRouter::write(Level level, const std::string & message) noexcept {
+void LogRouter::log(Level level, const std::string & message) noexcept {
     auto now = time(nullptr);
     auto pid = getpid();
     for (auto & logger : loggers) {

--- a/libdnf/logger/logger.cpp
+++ b/libdnf/logger/logger.cpp
@@ -21,7 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
-void Logger::write(Level level, const std::string & message) noexcept {
+void Logger::log(Level level, const std::string & message) noexcept {
     write(time(nullptr), getpid(), level, message);
 }
 


### PR DESCRIPTION
There was overloaded virtual method write() in the logger API.
To simplify the bindings to other languages (to simplify the overloading of these methods in inherited classes in these languages) one of the write() methods was renamed to log().