### PR TITLE
Context part of libdnf cannot assume zchunk is on (RhBug:1851841,1779104)

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -2991,6 +2991,10 @@ dnf_context_load_vars(DnfContext * context)
     priv->varsCached = true;
 }
 
+/* Context part of libdnf (microdnf, packagekit) needs to support global configuration
+ * because of options such as best, zchunk.. This static std::unique_ptr is a hacky way
+ * to do it without touching packagekit.
+ */
 static std::unique_ptr<libdnf::ConfigMain> globalMainConfig;
 static std::atomic_flag cfgMainLoaded = ATOMIC_FLAG_INIT;
 

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -337,7 +337,7 @@ dnf_context_init(DnfContext *context)
     priv->check_disk_space = TRUE;
     priv->check_transaction = TRUE;
     priv->enable_filelists = TRUE;
-    priv->zchunk = TRUE;
+    priv->zchunk = libdnf::getGlobalMainConfig().zchunk().getValue();
     priv->write_history = TRUE;
     priv->state = dnf_state_new();
     priv->lock = dnf_lock_new();


### PR DESCRIPTION
This was causing problems because if available only zchunk metadata was
donwloaded but later when individual repos are created and config is
loaded it couldn't be used if zchunk was off. This typically resulted in:
error: loading of MD_TYPE_PRIMARY has failed.

https://bugzilla.redhat.com/show_bug.cgi?id=1851841
https://bugzilla.redhat.com/show_bug.cgi?id=1779104