### PR TITLE
[dnf5] Fix: WeakPtr and SolvSack memory

### DIFF
--- a/include/libdnf/utils/weak_ptr.hpp
+++ b/include/libdnf/utils/weak_ptr.hpp
@@ -176,6 +176,7 @@ public:
                 src.guard->unregister_ptr(&src);
             }
             src.guard = nullptr;
+            delete ptr;
             ptr = src.ptr;
             src.ptr = nullptr;
         } else {
@@ -187,6 +188,7 @@ public:
             }
             guard = src.guard;
             src.guard = nullptr;
+            delete ptr;
             ptr = src.ptr;
             src.ptr = nullptr;
             if (is_valid()) {

--- a/libdnf/rpm/solv_sack_impl.hpp
+++ b/libdnf/rpm/solv_sack_impl.hpp
@@ -152,6 +152,13 @@ inline SolvSack::Impl::Impl(Base & base) : base(&base) {
 
 
 inline SolvSack::Impl::~Impl() {
+    Id repo_id;
+    LibsolvRepo * r;
+    FOR_REPOS(repo_id, r) {
+        if (auto repo = static_cast<Repo *>(r->appdata)) {
+            repo->p_impl->detach_libsolv_repo();
+        }
+    }
     pool_free(pool);
 }
 


### PR DESCRIPTION
- fix memory leak in operator=(WeakPtr && src)
- fix rpm::SolvSack::Impl::~Impl(): doble memory free - detach repositories before pool_free()