### PR TITLE
Memory fixes discovered by running with memory sanitizers

### DIFF
--- a/python/hawkey/query-py.cpp
+++ b/python/hawkey/query-py.cpp
@@ -866,7 +866,6 @@ query_iter(PyObject *self) try
     if (!list)
         return NULL;
     PyObject *iter = PyObject_GetIter(list.get());
-    Py_INCREF(iter);
     return iter;
 } CATCH_TO_PYTHON
 

--- a/python/hawkey/query-py.cpp
+++ b/python/hawkey/query-py.cpp
@@ -724,7 +724,9 @@ filter_userinstalled(PyObject *self, PyObject *args, PyObject *kwds) try
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", (char **)kwlist, &pySwdb)) {
         return NULL;
     }
-    auto swigSwdb = reinterpret_cast< SwdbSwigPyObject * >(PyObject_GetAttrString(pySwdb, "this"));
+
+    UniquePtrPyObject thisPySwdb(PyObject_GetAttrString(pySwdb, "this"));
+    auto swigSwdb = reinterpret_cast< SwdbSwigPyObject * >(thisPySwdb.get());
 
     if (swigSwdb == nullptr) {
         PyErr_SetString(PyExc_SystemError, "Unable to parse SwigPyObject");
@@ -756,7 +758,9 @@ filter_unneeded_or_safe_to_remove(PyObject *self, PyObject *args, PyObject *kwds
             args, kwds, "O|O!", (char **)kwlist, &pySwdb, &PyBool_Type, &debug_solver)) {
         return NULL;
     }
-    auto swigSwdb = reinterpret_cast< SwdbSwigPyObject * >(PyObject_GetAttrString(pySwdb, "this"));
+
+    UniquePtrPyObject thisPySwdb(PyObject_GetAttrString(pySwdb, "this"));
+    auto swigSwdb = reinterpret_cast< SwdbSwigPyObject * >(thisPySwdb.get());
 
     if (swigSwdb == nullptr) {
         PyErr_SetString(PyExc_SystemError, "Unable to parse SwigPyObject");

--- a/python/hawkey/sack-py.cpp
+++ b/python/hawkey/sack-py.cpp
@@ -383,8 +383,8 @@ set_installonly_limit(_SackObject *self, PyObject *obj, void *unused) try
 static int
 set_module_container(_SackObject *self, PyObject *obj, void *unused) try
 {
-    auto swigContainer = reinterpret_cast< ModulePackageContainerPyObject * >(
-        PyObject_GetAttrString(obj, "this"));
+    UniquePtrPyObject thisPyContainer(PyObject_GetAttrString(obj, "this"));
+    auto swigContainer = reinterpret_cast< ModulePackageContainerPyObject * >(thisPyContainer.get());
     if (swigContainer == nullptr) {
         PyErr_SetString(PyExc_SystemError, "Unable to parse ModuleContainer object");
         return -1;
@@ -608,8 +608,8 @@ filter_modules(_SackObject *self, PyObject *args, PyObject *kwds) try
         return 0;
     bool updateOnly = pyUpdateOnly == NULL || PyObject_IsTrue(pyUpdateOnly);
     bool debugSolver = pyDebugSolver != NULL && PyObject_IsTrue(pyDebugSolver);
-    auto swigContainer = reinterpret_cast< ModulePackageContainerPyObject * >(
-        PyObject_GetAttrString(pyModuleContainer, "this"));
+    UniquePtrPyObject thisPyModuleContainer(PyObject_GetAttrString(pyModuleContainer, "this"));
+    auto swigContainer = reinterpret_cast< ModulePackageContainerPyObject * >(thisPyModuleContainer.get());
     auto moduleContainer = swigContainer->ptr;
     std::vector<std::string> hotfixRepos;
     try {
@@ -653,8 +653,8 @@ set_modules_enabled_by_pkgset(_SackObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    auto swigContainer = reinterpret_cast< ModulePackageContainerPyObject * >(
-        PyObject_GetAttrString(pyModuleContainer, "this"));
+    UniquePtrPyObject thisPyModuleContainer(PyObject_GetAttrString(pyModuleContainer, "this"));
+    auto swigContainer = reinterpret_cast< ModulePackageContainerPyObject * >(thisPyModuleContainer.get());
     auto moduleContainer = swigContainer->ptr;
     auto modules = moduleContainer->requiresModuleEnablement(*pset.get());
     moduleContainer->enableDependencyTree(modules);
@@ -691,7 +691,8 @@ load_system_repo(_SackObject *self, PyObject *args, PyObject *kwds)
 
         // Or is it swig object?
         if (!crepo) {
-            auto repoSwigPyObj = reinterpret_cast<RepoSwigPyObject *>(PyObject_GetAttrString(repoPyObj, "this"));
+            UniquePtrPyObject thisRepoPyObj(PyObject_GetAttrString(repoPyObj, "this"));
+            auto repoSwigPyObj = reinterpret_cast<RepoSwigPyObject *>(thisRepoPyObj.get());
             if (!repoSwigPyObj) {
                 PyErr_SetString(PyExc_SystemError, "Unable to parse repoSwigPyObject");
                 return NULL;
@@ -734,7 +735,8 @@ load_repo(_SackObject *self, PyObject *args, PyObject *kwds) try
 
     // Or is it swig object?
     if (!crepo) {
-        auto repoSwigPyObj = reinterpret_cast<RepoSwigPyObject *>(PyObject_GetAttrString(repoPyObj, "this"));
+        UniquePtrPyObject thisRepoPyObj(PyObject_GetAttrString(repoPyObj, "this"));
+        auto repoSwigPyObj = reinterpret_cast<RepoSwigPyObject *>(thisRepoPyObj.get());
         if (!repoSwigPyObj) {
             PyErr_SetString(PyExc_SystemError, "Unable to parse repoSwigPyObject");
             return NULL;

--- a/python/hawkey/tests/tests/test_advisorypkg.py
+++ b/python/hawkey/tests/tests/test_advisorypkg.py
@@ -44,9 +44,9 @@ class Test(base.TestCase):
 
     def setUp(self):
         """Prepare the test fixture."""
-        sack = base.TestSack(repo_dir=self.repo_dir)
-        sack.load_repo(load_updateinfo=True)
-        self.apackage = find_apackage(sack, 'tour.noarch.rpm')
+        self.sack = base.TestSack(repo_dir=self.repo_dir)
+        self.sack.load_repo(load_updateinfo=True)
+        self.apackage = find_apackage(self.sack, 'tour.noarch.rpm')
 
     def test_name(self):
         self.assertEqual(self.apackage.name, 'tour')


### PR DESCRIPTION
With this PR and the sanitizers enabled the unit tests pass.

There still are ~20 failing features in ci-dnf-stack caused by memory leaks and what not.