### PR TITLE
 Check `/lib/modules` in running_kernel first.

### DIFF
--- a/libdnf/hy-iutil.cpp
+++ b/libdnf/hy-iutil.cpp
@@ -490,9 +490,14 @@ running_kernel(DnfSack *sack)
         g_debug("uname(): %s", g_strerror(errno));
         return -1;
     }
-    char *fn = pool_tmpjoin(pool, "/boot/vmlinuz-", un.release, NULL);
 
+    char *fn = pool_tmpjoin(pool, "/boot/vmlinuz-", un.release, NULL);
     Id kernel_id = running_kernel_check_path(sack, fn);
+
+    if (kernel_id < 0) {
+        fn = pool_tmpjoin(pool, "/lib/modules/", un.release, NULL);
+        kernel_id = running_kernel_check_path(sack, fn);
+    }
 
     if (kernel_id >= 0)
         g_debug("running_kernel(): %s.", id2nevra(pool, kernel_id));


### PR DESCRIPTION
The location of the installed kernel image depends on the bootloader used
by the system. `/lib/modules/` should be more reliable.

I tested this on my system and it seems to detect the kernel based on `/lib/modules`.