### PR TITLE
[dnf5] SWIG: declare pid_t and time_t types

### DIFF
--- a/bindings/libdnf/logger.i
+++ b/bindings/libdnf/logger.i
@@ -11,6 +11,9 @@
 %import(module="libdnf::common") "common.i"
 #endif
 
+typedef int64_t time_t;
+typedef int32_t pid_t;
+
 %{
     #include "libdnf/logger/log_router.hpp"
     #include "libdnf/logger/memory_buffer_logger.hpp"


### PR DESCRIPTION
It fixes:
swig/python detected a memory leak of type 'pid_t *', no destructor found.
swig/python detected a memory leak of type 'time_t *', no destructor found.