### PR TITLE
Fix SolvQuery.ifilter_version() and release

### DIFF
--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -602,14 +602,16 @@ SolvQuery & SolvQuery::ifilter_nevra(libdnf::sack::QueryCmp cmp_type, const libd
 template <bool (*cmp_fnc)(int value_to_cmp)>
 inline static void filter_version_internal(
     Pool * pool, const char * c_pattern, solv::SolvMap & candidates, solv::SolvMap & filter_result) {
+    char * formated_c_pattern = solv_dupjoin(c_pattern, "-0", nullptr);
     for (PackageId candidate_id : candidates) {
         const char * version = solv::get_version(pool, candidate_id);
         char * vr = pool_tmpjoin(pool, version, "-0", nullptr);
-        int cmp = pool_evrcmp_str(pool, vr, c_pattern, EVRCMP_COMPARE);
+        int cmp = pool_evrcmp_str(pool, vr, formated_c_pattern, EVRCMP_COMPARE);
         if (cmp_eq(cmp)) {
             filter_result.add_unsafe(candidate_id);
         }
     }
+    solv_free(formated_c_pattern);
 }
 
 SolvQuery & SolvQuery::ifilter_version(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {
@@ -667,14 +669,16 @@ SolvQuery & SolvQuery::ifilter_version(libdnf::sack::QueryCmp cmp_type, const st
 template <bool (*cmp_fnc)(int value_to_cmp)>
 inline static void filter_release_internal(
     Pool * pool, const char * c_pattern, solv::SolvMap & candidates, solv::SolvMap & filter_result) {
+    char * formated_c_pattern = solv_dupjoin("0-", c_pattern, nullptr);
     for (PackageId candidate_id : candidates) {
         const char * release = solv::get_release(pool, candidate_id);
         char * vr = pool_tmpjoin(pool, "0-", release, nullptr);
-        int cmp = pool_evrcmp_str(pool, vr, c_pattern, EVRCMP_COMPARE);
+        int cmp = pool_evrcmp_str(pool, vr, formated_c_pattern, EVRCMP_COMPARE);
         if (cmp_eq(cmp)) {
             filter_result.add_unsafe(candidate_id);
         }
     }
+    solv_free(formated_c_pattern);
 }
 
 SolvQuery & SolvQuery::ifilter_release(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {

--- a/test/libdnf/rpm/test_solv_query.cpp
+++ b/test/libdnf/rpm/test_solv_query.cpp
@@ -259,6 +259,38 @@ void RpmSolvQueryTest::test_ifilter_nevra() {
     }
 }
 
+void RpmSolvQueryTest::test_ifilter_version() {
+    std::set<std::string> nevras{"CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64"};
+
+    {
+        // Test QueryCmp::EQ - argument without 0 epoch - two elements
+        libdnf::rpm::SolvQuery query(sack.get());
+        std::vector<std::string> version{"1.1.1"};
+        query.ifilter_version(libdnf::sack::QueryCmp::EQ, version);
+        CPPUNIT_ASSERT(query.size() == 2);
+        auto pset = query.get_package_set();
+        for (auto pkg : pset) {
+            CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
+        }
+    }
+}
+
+void RpmSolvQueryTest::test_ifilter_release() {
+    std::set<std::string> nevras{"CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64", "lame-0:3.100-4.fc29.src", "lame-0:3.100-4.fc29.x86_64", "lame-libs-0:3.100-4.fc29.x86_64"};
+
+    {
+        // Test QueryCmp::EQ - argument without 0 epoch - two elements
+        libdnf::rpm::SolvQuery query(sack.get());
+        std::vector<std::string> release{"4.fc29"};
+        query.ifilter_release(libdnf::sack::QueryCmp::EQ, release);
+        CPPUNIT_ASSERT(query.size() == 5);
+        auto pset = query.get_package_set();
+        for (auto pkg : pset) {
+            CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
+        }
+    }
+}
+
 void RpmSolvQueryTest::test_ifilter_provides() {
     {
         // Test QueryCmp::EQ - string

--- a/test/libdnf/rpm/test_solv_query.hpp
+++ b/test/libdnf/rpm/test_solv_query.hpp
@@ -40,6 +40,8 @@ class RpmSolvQueryTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_size);
     CPPUNIT_TEST(test_ifilter_name);
     CPPUNIT_TEST(test_ifilter_nevra);
+    CPPUNIT_TEST(test_ifilter_version);
+    CPPUNIT_TEST(test_ifilter_release);
     CPPUNIT_TEST(test_ifilter_provides);
     CPPUNIT_TEST(test_ifilter_requires);
     CPPUNIT_TEST(test_resolve_pkg_spec);
@@ -57,6 +59,8 @@ public:
     void test_size();
     void test_ifilter_name();
     void test_ifilter_nevra();
+    void test_ifilter_version();
+    void test_ifilter_release();
     void test_ifilter_provides();
     void test_ifilter_requires();
     void test_resolve_pkg_spec();


### PR DESCRIPTION
String patterns were incorrectly formatted before comparisons.

It also includes tests.