### PR TITLE
[dnf5] Fix SolvQuery::Impl::filter_nevra() IGLOB support 

### DIFF
--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -1438,10 +1438,12 @@ void SolvQuery::Impl::filter_nevra(
                     filter_result.add_unsafe(candidate_id);
                 }
             } break;
-            case libdnf::sack::QueryCmp::GLOB: {
+            case libdnf::sack::QueryCmp::GLOB:
+            case libdnf::sack::QueryCmp::IGLOB: {
+                int fnmatch_flags = name_cmp_type == libdnf::sack::QueryCmp::IGLOB ? FNM_CASEFOLD : 0;
                 for (PackageId candidate_id : query_result) {
                     const char * candidate_name = solv::get_name(pool, candidate_id);
-                    if (!all_names && fnmatch(name_c_pattern, candidate_name, 0) != 0) {
+                    if (!all_names && fnmatch(name_c_pattern, candidate_name, fnmatch_flags) != 0) {
                         continue;
                     }
 

--- a/test/libdnf/rpm/test_solv_query.cpp
+++ b/test/libdnf/rpm/test_solv_query.cpp
@@ -371,6 +371,23 @@ void RpmSolvQueryTest::test_resolve_pkg_spec() {
         }
     }
     {
+        // Test NEVRA glob - icase == false, nothing found
+        libdnf::rpm::SolvQuery query(sack.get());
+        auto return_value = query.resolve_pkg_spec("wGe?-?:1.1?.5-?.fc29.x8?_64", false, true, false, false, true, {});
+        CPPUNIT_ASSERT_EQUAL(query.size(), 0lu);
+    }
+    {
+        // Test NEVRA glob - icase == true
+        libdnf::rpm::SolvQuery query(sack.get());
+        auto return_value = query.resolve_pkg_spec("wGe?-?:1.1?.5-?.fc29.x8?_64", true, true, false, false, true, {});
+        CPPUNIT_ASSERT_EQUAL(query.size(), 1lu);
+        CPPUNIT_ASSERT_EQUAL(return_value.first, true);
+        auto pset = query.get_package_set();
+        for (auto pkg : pset) {
+            CPPUNIT_ASSERT_EQUAL(pkg.get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
+        }
+    }
+    {
         // Test NEVRA icase
         libdnf::rpm::SolvQuery query(sack.get());
         auto return_value = query.resolve_pkg_spec("wgeT-0:1.19.5-5.Fc29.X86_64", true, true, false, false, true, {});


### PR DESCRIPTION
Needed for SolvQuery::resolve_pkg_spec() if icase == true.
Unit tests added.