### PR TITLE
[dnf5] fix number of packages in unit tests

### DIFF
--- a/test/perl5/libdnf/rpm/test_solv_query.t
+++ b/test/perl5/libdnf/rpm/test_solv_query.t
@@ -51,7 +51,7 @@ $sack->load_repo($repo->get(), $libdnf::rpm::SolvSack::LoadRepoFlags_NONE);
 #test_size()
 {
     my $query = new libdnf::rpm::SolvQuery($sack);
-    is($query->size(), 289);
+    is($query->size(), 291);
 }
 
 my @nevras = ("CQRlib-1.1.1-4.fc29.src", "CQRlib-1.1.1-4.fc29.x86_64");

--- a/test/python3/libdnf/rpm/test_solv_query.py
+++ b/test/python3/libdnf/rpm/test_solv_query.py
@@ -49,7 +49,7 @@ class TestSolvQuery(unittest.TestCase):
 
     def test_size(self):
         query = libdnf.rpm.SolvQuery(self.sack)
-        self.assertEqual(query.size(), 289)
+        self.assertEqual(query.size(), 291)
 
     def test_ifilter_name(self):
 

--- a/test/ruby/libdnf/rpm/test_solv_query.rb
+++ b/test/ruby/libdnf/rpm/test_solv_query.rb
@@ -54,7 +54,7 @@ class TestSimpleNumber < Test::Unit::TestCase
 
     def test_size()
         query = Rpm::SolvQuery.new(@sack)
-        assert_equal(query.size(), 289, 'Number of items in the newly created query')
+        assert_equal(query.size(), 291, 'Number of items in the newly created query')
     end
 
     def test_ifilter_name()


### PR DESCRIPTION
The commit "test/libdnf/rpm: Add packages for the Package class unittests" added 2 new packages into the dnf-ci-fedora test repository. Therefore, it is necessary to update the number of packages in the tests.
The original commit updates only C++ tests. This fix updates the Perl, Python, and Ruby tests.