### PR TITLE
[dnf5] Add updateinfo capabilities (Advisory, AdvisorySack and AdvisoryQuery)

### DIFF
--- a/include/libdnf/advisory/advisory.hpp
+++ b/include/libdnf/advisory/advisory.hpp
@@ -1,0 +1,156 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_HPP
+#define LIBDNF_ADVISORY_ADVISORY_HPP
+
+#include <libdnf/rpm/solv_sack.hpp>
+
+#include <vector>
+
+
+namespace libdnf::advisory {
+
+class AdvisoryCollection;
+class AdvisoryReference;
+
+typedef libdnf::rpm::PackageId AdvisoryId;
+
+//TODO(amatej): consider defining these as individual numbers, not as bits in int.
+//              This allows us faster iteration, but all public APIs should accept
+//              only individual values (in a vector) not bitwise ored multiple values.
+//              (here the OR and AND operators are public)
+/// Type of advisory
+enum class AdvisoryType : uint32_t {
+    UNKNOWN = (1 << 0),
+    SECURITY = (1 << 1),
+    BUGFIX = (1 << 2),
+    ENHANCEMENT = (1 << 3),
+    NEWPACKAGE = (1 << 4)
+};
+
+inline AdvisoryType operator|(AdvisoryType lhs, AdvisoryType rhs) {
+    return static_cast<AdvisoryType>(
+        static_cast<std::underlying_type<AdvisoryType>::type>(lhs) |
+        static_cast<std::underlying_type<AdvisoryType>::type>(rhs));
+}
+
+inline AdvisoryType operator&(AdvisoryType lhs, AdvisoryType rhs) {
+    return static_cast<AdvisoryType>(
+        static_cast<std::underlying_type<AdvisoryType>::type>(lhs) &
+        static_cast<std::underlying_type<AdvisoryType>::type>(rhs));
+}
+
+//TODO(amatej): consider defining these as individual numbers, not as bits in int.
+//              This allows us faster iteration, but all public APIs should accept
+//              only individual values (in a vector) not bitwise ored multiple values.
+//              (here the OR and AND operators are public)
+/// Type of advisory reference
+enum class AdvisoryReferenceType : uint32_t {
+    UNKNOWN = (1 << 0),
+    BUGZILLA = (1 << 1),
+    CVE = (1 << 2),
+    VENDOR = (1 << 3),
+};
+
+inline AdvisoryReferenceType operator|(AdvisoryReferenceType lhs, AdvisoryReferenceType rhs) {
+    return static_cast<AdvisoryReferenceType>(
+        static_cast<std::underlying_type<AdvisoryReferenceType>::type>(lhs) |
+        static_cast<std::underlying_type<AdvisoryReferenceType>::type>(rhs));
+}
+
+inline AdvisoryReferenceType operator&(AdvisoryReferenceType lhs, AdvisoryReferenceType rhs) {
+    return static_cast<AdvisoryReferenceType>(
+        static_cast<std::underlying_type<AdvisoryReferenceType>::type>(lhs) &
+        static_cast<std::underlying_type<AdvisoryReferenceType>::type>(rhs));
+}
+
+/// An advisory, represents advisory used to track security updates
+class Advisory {
+public:
+    /// Construct the Advisory object
+    ///
+    /// @param sack   Reference to libdnf::rpm::SolvSack instance which holds are the data.
+    /// @param id     AdvisoryId into libsolv pool.
+    /// @return New Advisory instance.
+    Advisory(libdnf::rpm::SolvSack & sack, AdvisoryId id);
+
+    /// Destroy the Advisory object
+    ~Advisory();
+
+    using Type = AdvisoryType;
+
+    /// Get name of this advisory.
+    ///
+    /// @return Name of this advisory as std::string.
+    std::string get_name() const;
+
+    /// Get severity of this advisory.
+    ///
+    /// @return Severity of this advisory as std::string.
+    std::string get_severity() const;
+
+    /// Get type of this advisory.
+    ///
+    /// @return Type of this advisory.
+    Type get_type() const;
+
+    /// Get type of this advisory.
+    ///
+    /// @return Type of this advisory as const char* !! (temporal values)
+    const char * get_type_cstring() const;
+
+    /// Get AdvisoryId.
+    ///
+    /// @return AdvisoryId of this advisory.
+    AdvisoryId get_id() const;
+
+    /// Get all references of specified type from this advisory.
+    ///
+    /// @param ref_type     What type of references to get. If not specified gets all types.
+    /// @return Vector of AdvisoryReference objects.
+    std::vector<AdvisoryReference> get_references(
+        AdvisoryReferenceType ref_type = AdvisoryReferenceType::BUGZILLA | AdvisoryReferenceType::CVE |
+                                         AdvisoryReferenceType::VENDOR) const;
+
+    /// Get all collections from this advisory.
+    ///
+    /// @return Vector of AdvisoryCollection objects.
+    std::vector<AdvisoryCollection> get_collections() const;
+
+    /// Check whether at least one collection from this advisory is applicable.
+    ///
+    /// @return True if applicable, False otherwise.
+    bool is_applicable() const;
+
+    /// Convert AdvisoryType to c string representation
+    ///
+    /// @param type     AdvisoryType to convert.
+    /// @return Converted AdvisoryType as c string (temporal value).
+    static const char * advisory_type_to_cstring(Type type);
+
+private:
+    AdvisoryId id;
+    libdnf::rpm::SolvSackWeakPtr sack;
+};
+
+
+}  // namespace libdnf::advisory
+
+#endif

--- a/include/libdnf/advisory/advisory.hpp
+++ b/include/libdnf/advisory/advisory.hpp
@@ -30,7 +30,18 @@ namespace libdnf::advisory {
 class AdvisoryCollection;
 class AdvisoryReference;
 
-typedef libdnf::rpm::PackageId AdvisoryId;
+struct AdvisoryId {
+public:
+    AdvisoryId() = default;
+    explicit AdvisoryId(int id);
+
+    bool operator==(const AdvisoryId & other) const noexcept { return id == other.id; };
+    bool operator!=(const AdvisoryId & other) const noexcept { return id != other.id; };
+
+    int id{0};
+};
+
+inline AdvisoryId::AdvisoryId(int id) : id(id) {}
 
 //TODO(amatej): consider defining these as individual numbers, not as bits in int.
 //              This allows us faster iteration, but all public APIs should accept

--- a/include/libdnf/advisory/advisory_collection.hpp
+++ b/include/libdnf/advisory/advisory_collection.hpp
@@ -1,0 +1,97 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_COLLECTION_HPP
+#define LIBDNF_ADVISORY_ADVISORY_COLLECTION_HPP
+
+#include "advisory.hpp"
+#include "advisory_module.hpp"
+#include "advisory_package.hpp"
+
+#include <vector>
+
+
+namespace libdnf::advisory {
+
+//TODO(amatej): add unit tests for AdvisoryCollection
+class AdvisoryCollection {
+public:
+    /// Whether this AdvisoryCollection is applicable. True when at least one AdvisoryModule in this
+    /// AdvisoryCollection is active on the system, False otherwise.
+    bool is_applicable() const;
+
+    /// Get AdvisoryId of Advisory this AdvisoryCollection belongs to.
+    ///
+    /// @return AdvisoryId of this AdvisoryCollection.
+    AdvisoryId get_advisory_id() const;
+
+    /// Get all AdvisoryPackages stored in this AdvisoryCollection
+    ///
+    /// @return std::vector of AdvisorPackages used as output.
+    std::vector<AdvisoryPackage> get_packages();
+
+    /// Get all AdvisoryModules stored in this AdvisoryCollection
+    ///
+    /// @return std::vector of AdvisorModules.
+    std::vector<AdvisoryModule> get_modules();
+
+    //TODO(amatej): we should be able to get advisory information from a collection,
+    //              returning new advisory object is one option but it might be better
+    //              to set up so sort of inheritance among Advisory, AdvisoryCollection
+    //              and possibly AdvisoryPacakge, AdvisoryModule.
+    /// Get Advisory this AdvisoryCollection belongs to.
+    ///
+    /// @return newly construted Advisory object of this AdvisoryCollection.
+    Advisory get_advisory() const;
+
+private:
+    friend Advisory;
+    friend AdvisoryQuery;
+    friend AdvisoryPackage;
+    friend AdvisoryModule;
+
+    AdvisoryCollection(libdnf::rpm::SolvSack & sack, AdvisoryId advisory, int index);
+
+    //TODO(amatej): Hide into an Impl?
+    /// Get all AdvisoryPackages stored in this AdvisoryCollection
+    ///
+    /// @param output           std::vector of AdvisorPackages used as output.
+    ///                         This is much faster than returning new std::vector and later joining
+    ///                         them when collecting AdvisoryPackages from multiple collections.
+    /// @param with_filenames   Filenames of AdvisoryPackages are not always useful, this allows skipping them.
+    ///                         The filename is stored as a c string (not libsolv id) this incurs slowdown.
+    void get_packages(std::vector<AdvisoryPackage> & output, bool with_filenames = false);
+
+    //TODO(amatej): Hide into an Impl?
+    /// Get all AdvisoryModules stored in this AdvisoryCollection
+    /// @param output           std::vector of AdvisorModules used as output.
+    ///                         This is much faster than returning new std::vector and later joining
+    ///                         them when collecting AdvisoryModules from multiple collections.
+    void get_modules(std::vector<AdvisoryModule> & output);
+
+    libdnf::rpm::SolvSackWeakPtr sack;
+    AdvisoryId advisory;
+
+    /// AdvisoryCollections don't have their own Id, therefore store it's index in its Advisory (just like AdvisoryReference)
+    int index;
+};
+
+}  // namespace libdnf::advisory
+
+#endif

--- a/include/libdnf/advisory/advisory_module.hpp
+++ b/include/libdnf/advisory/advisory_module.hpp
@@ -1,0 +1,93 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_MODULE_HPP
+#define LIBDNF_ADVISORY_ADVISORY_MODULE_HPP
+
+#include "libdnf/advisory/advisory.hpp"
+
+#include <memory>
+
+namespace libdnf::advisory {
+
+class AdvisoryModule {
+public:
+    AdvisoryModule(const AdvisoryModule & src);
+    AdvisoryModule(AdvisoryModule && src);
+
+    AdvisoryModule & operator=(const AdvisoryModule & src);
+    AdvisoryModule & operator=(AdvisoryModule && src) noexcept;
+    ~AdvisoryModule();
+
+    /// Get name of this AdvisoryModule.
+    ///
+    /// @return Name of this AdvisoryModule as std::string.
+    std::string get_name() const;
+
+    /// Get stream of this AdvisoryModule.
+    ///
+    /// @return Stream of this AdvisoryModule as std::string.
+    std::string get_stream() const;
+
+    /// Get version of this AdvisoryModule.
+    ///
+    /// @return Version of this AdvisoryModule as std::string.
+    std::string get_version() const;
+
+    /// Get context of this AdvisoryModule.
+    ///
+    /// @return Context of this AdvisoryModule as std::string.
+    std::string get_context() const;
+
+    /// Get arch of this AdvisoryModule.
+    ///
+    /// @return Arch of this AdvisoryModule as std::string.
+    std::string get_arch() const;
+
+    /// Get AdvisoryId of Advisory this AdvisoryModule belongs to.
+    ///
+    /// @return AdvisoryId of this AdvisoryModule.
+    AdvisoryId get_advisory_id() const;
+
+    //TODO(amatej): we should be able to get Advisory and AdvisoryCollection information
+    //              from a advisory module, returning new advisory object is one option but it might
+    //              be better to set up so sort of inheritance among Advisory, AdvisoryCollection,
+    //              AdvisoryPacakge and AdvisoryModule.
+    /// Get Advisory this AdvisoryModule belongs to.
+    ///
+    /// @return newly construted Advisory object of this AdvisoryModule.
+    Advisory get_advisory() const;
+    /// Get AdvisoryCollection this AdvisoryModule belongs to.
+    ///
+    /// @return newly construted AdvisoryCollection object of this AdvisoryModule.
+    AdvisoryCollection get_advisory_collection() const;
+
+
+private:
+    friend class AdvisoryCollection;
+
+    class Impl;
+
+    AdvisoryModule(Impl * private_module);
+    std::unique_ptr<Impl> p_impl;
+};
+
+}  // namespace libdnf::advisory
+
+#endif

--- a/include/libdnf/advisory/advisory_package.hpp
+++ b/include/libdnf/advisory/advisory_package.hpp
@@ -1,0 +1,90 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_PACKAGE_HPP
+#define LIBDNF_ADVISORY_ADVISORY_PACKAGE_HPP
+
+#include "libdnf/advisory/advisory.hpp"
+
+#include <memory>
+#include <vector>
+
+
+namespace libdnf::advisory {
+
+class AdvisoryPackage {
+public:
+    AdvisoryPackage(const AdvisoryPackage & src);
+    AdvisoryPackage(AdvisoryPackage && src);
+
+    AdvisoryPackage & operator=(const AdvisoryPackage & src);
+    AdvisoryPackage & operator=(AdvisoryPackage && src) noexcept;
+    ~AdvisoryPackage();
+
+    /// Get name of this AdvisoryPackage.
+    ///
+    /// @return Name of this AdvisoryPackage as std::string.
+    std::string get_name() const;
+
+    /// Get version of this AdvisoryPackage.
+    ///
+    /// @return Version of this AdvisoryPackage as std::string.
+    std::string get_version() const;
+
+    /// Get evr of this AdvisoryPackage.
+    ///
+    /// @return Evr of this AdvisoryPackage as std::string.
+    std::string get_evr() const;
+
+    /// Get arch of this AdvisoryPackage.
+    ///
+    /// @return Arch of this AdvisoryPackage as std::string.
+    std::string get_arch() const;
+
+    /// Get AdvisoryId of Advisory this AdvisoryPackage belongs to.
+    ///
+    /// @return AdvisoryId of this AdvisoryPackage.
+    AdvisoryId get_advisory_id() const;
+
+    //TODO(amatej): we should be able to get Advisory and AdvisoryCollection information
+    //              from a package, returning new advisory object is one option but it might
+    //              be better to set up so sort of inheritance among Advisory, AdvisoryCollection,
+    //              AdvisoryPacakge and AdvisoryModule.
+    /// Get Advisory this AdvisoryPackage belongs to.
+    ///
+    /// @return newly construted Advisory object of this AdvisoryPackage.
+    Advisory get_advisory() const;
+    /// Get AdvisoryCollection this AdvisoryPackage belongs to.
+    ///
+    /// @return newly construted AdvisoryCollection object of this AdvisoryPackage.
+    AdvisoryCollection get_advisory_collection() const;
+
+private:
+    friend class AdvisoryCollection;
+    friend class AdvisoryQuery;
+    friend class libdnf::rpm::SolvQuery;
+
+    class Impl;
+    AdvisoryPackage(Impl * private_pkg);
+    std::unique_ptr<Impl> p_impl;
+};
+
+}  // namespace libdnf::advisory
+
+#endif

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_QUERY_HPP
+#define LIBDNF_ADVISORY_ADVISORY_QUERY_HPP
+
+#include "libdnf/advisory/advisory.hpp"
+#include "libdnf/advisory/advisory_collection.hpp"
+#include "libdnf/advisory/advisory_package.hpp"
+#include "libdnf/advisory/advisory_reference.hpp"
+#include "libdnf/advisory/advisory_sack.hpp"
+#include "libdnf/common/sack/query_cmp.hpp"
+#include "libdnf/rpm/package.hpp"
+
+namespace libdnf::advisory {
+
+class AdvisoryQuery {
+public:
+    explicit AdvisoryQuery(AdvisorySack * sack);
+    AdvisoryQuery(const AdvisoryQuery & src);
+    AdvisoryQuery(AdvisoryQuery && src);
+    ~AdvisoryQuery();
+
+    AdvisoryQuery & operator=(const AdvisoryQuery & src);
+    AdvisoryQuery & operator=(AdvisoryQuery && src) noexcept;
+
+    struct NotSupportedCmpType : public RuntimeError {
+        using RuntimeError::RuntimeError;
+        const char * get_domain_name() const noexcept override { return "libdnf::advisory::AdvisoryQuery"; }
+        const char * get_name() const noexcept override { return "NotSupportedCmpType"; }
+        const char * get_description() const noexcept override { return "AdvisoryQuery exception"; }
+    };
+
+    /// Filter Advisories by name
+    ///
+    /// @param pattern      Pattern used when matching agains advisory names.
+    /// @param cmp_type     What comparator to use with pattern, allows: EQ, GLOB, IGLOB.
+    AdvisoryQuery & ifilter_name(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & ifilter_name(
+        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+
+    AdvisoryQuery & ifilter_type(const Advisory::Type type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & ifilter_type(
+        const std::vector<Advisory::Type> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+
+    AdvisoryQuery & ifilter_reference(
+        const std::vector<std::string> & reference_id,
+        std::vector<AdvisoryReferenceType> types,
+        sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    //TODO(amatej): What about other reference fitlers (title, url?) - do we want them?
+    AdvisoryQuery & ifilter_CVE(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & ifilter_CVE(
+        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & ifilter_bug(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & ifilter_bug(
+        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+
+    AdvisoryQuery & ifilter_severity(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & ifilter_severity(
+        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+
+    //TODO(amatej): this might not be needed and could be possibly removed
+    /// Filter out advisories that don't contain at least one package fulfilling the cmp_type condition when compated to input packages
+    ///
+    /// @param package_set  libdnf::rpm::PackageSet used when filtering.
+    /// @param cmp_type     Condition to fulfill with packages.
+    /// @return This AdvisoryQuery with applied filter.
+    AdvisoryQuery & ifilter_packages(
+        const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+
+    std::vector<AdvisoryPackage> get_advisory_packages(
+        const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+
+    //TODO(amatej): create AdvisorySet (and its iterators), make AdvisoryQuery inherit AdvisorySet? (but its so many objects..)
+    std::vector<Advisory> get_advisories() const;
+    //TODO(amatej): This is only used for conveniece it might possibly be a method on AdvisorySet? Or there might be some other way of accessing AdvisoryPackages
+    std::vector<AdvisoryPackage> get_sorted_advisory_packages(bool only_applicable = false) const;
+
+private:
+    AdvisorySack * advisory_sack;
+
+    class Impl;
+    std::unique_ptr<Impl> p_impl;
+};
+
+
+}  // namespace libdnf::advisory
+
+#endif

--- a/include/libdnf/advisory/advisory_reference.hpp
+++ b/include/libdnf/advisory/advisory_reference.hpp
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_REFERENCE_HPP
+#define LIBDNF_ADVISORY_ADVISORY_REFERENCE_HPP
+
+#include "advisory.hpp"
+
+#include <memory>
+#include <vector>
+
+
+namespace libdnf::advisory {
+
+//TODO(amatej): add unit tests for AdvisoryReference
+class AdvisoryReference {
+public:
+    using Type = AdvisoryReferenceType;
+
+    /// Get id of this advisory reference, this id is like a name of this reference
+    /// (it is not libsolv id).
+    ///
+    /// @return id of this reference as std::string.
+    std::string get_id() const;
+
+    /// Get type of this reference.
+    ///
+    /// @return Type of this reference.
+    Type get_type() const;
+
+    /// Get title of this reference.
+    ///
+    /// @return Title of this reference.
+    std::string get_title() const;
+
+    /// Get url of this reference.
+    ///
+    /// @return Url of this reference.
+    std::string get_url() const;
+
+private:
+    friend class Advisory;
+
+    /// Construct AdvisoryReference
+    ///
+    /// @param base     Reference to Base instance.
+    /// @param advisory AdvisoryId into libsolv pool.
+    /// @param index    Index of this reference in its advisory.
+    /// @return New AdvisoryReference instance.
+    AdvisoryReference(libdnf::rpm::SolvSack & sack, AdvisoryId advisory, int index);
+
+    libdnf::rpm::SolvSackWeakPtr sack;
+    AdvisoryId advisory;
+
+    /// We cannot store IDs of reference data (id, type, title, url) because they
+    /// don't have ids set in libsolv (they are only strings), therefore we store
+    /// index of the reference.
+    int index;
+};
+
+}  // namespace libdnf::advisory
+
+#endif

--- a/include/libdnf/advisory/advisory_sack.hpp
+++ b/include/libdnf/advisory/advisory_sack.hpp
@@ -1,0 +1,60 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_SACK_HPP
+#define LIBDNF_ADVISORY_ADVISORY_SACK_HPP
+
+#include "advisory_query.hpp"
+
+#include "libdnf/rpm/solv/solv_map.hpp"
+
+namespace libdnf {
+class Base;
+}
+
+namespace libdnf::advisory {
+
+class AdvisorySack {
+public:
+    explicit AdvisorySack(libdnf::Base & base);
+    ~AdvisorySack();
+
+    /// Create new AdvisoryQuery on advisories loaded in this AdvisorySack
+    ///
+    /// @return new AdvisoryQuery.
+    AdvisoryQuery new_query();
+
+private:
+    friend AdvisoryQuery;
+
+    /// Load all advisories present in SolvSack from base. This method is
+    /// called automatically when creating a new query and the cached number
+    /// of solvables doesn't match the current number in solv sacks pool.
+    void load_advisories_from_solvsack();
+
+    libdnf::rpm::solv::SolvMap data_map;
+
+    int cached_solvables_size{0};
+
+    libdnf::Base * base;
+};
+
+}  // namespace libdnf::advisory
+
+#endif

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -20,14 +20,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_BASE_BASE_HPP
 #define LIBDNF_BASE_BASE_HPP
 
+#include "libdnf/advisory/advisory_sack.hpp"
+#include "libdnf/comps/comps.hpp"
 #include "libdnf/conf/config_main.hpp"
+#include "libdnf/conf/vars.hpp"
 #include "libdnf/logger/log_router.hpp"
+#include "libdnf/plugin/plugins.hpp"
 #include "libdnf/rpm/repo_sack.hpp"
 #include "libdnf/rpm/solv_sack.hpp"
-#include "libdnf/conf/vars.hpp"
 #include "libdnf/transaction/sack.hpp"
-#include "libdnf/plugin/plugins.hpp"
-#include "libdnf/comps/comps.hpp"
 
 #include <map>
 
@@ -59,6 +60,7 @@ public:
     rpm::SolvSack & get_rpm_solv_sack() { return rpm_solv_sack; }
     transaction::TransactionSack & get_transaction_sack() { return transaction_sack; }
     libdnf::comps::Comps & get_comps() { return comps; }
+    libdnf::advisory::AdvisorySack & get_rpm_advisory_sack() { return rpm_advisory_sack; }
 
     /// Gets base variables. They can be used in configuration files. Syntax in the config - ${var_name} or $var_name.
     Vars & get_vars() { return vars; }
@@ -90,6 +92,8 @@ private:
     comps::Comps comps{*this};
     Vars vars;
     plugin::Plugins plugins{*this};
+    libdnf::advisory::AdvisorySack rpm_advisory_sack{*this};
+    std::map<std::string, std::string> variables;
 };
 
 }  // namespace libdnf

--- a/include/libdnf/rpm/solv_query.hpp
+++ b/include/libdnf/rpm/solv_query.hpp
@@ -367,6 +367,13 @@ public:
     SolvQuery & ifilter_supplements(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
+    /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GT, GTE, LT, LTE
+    ///
+    /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_ADVISORY/_BUG/_CVE/_SEVERITY/_TYPE
+    SolvQuery & ifilter_advisories(
+        const libdnf::advisory::AdvisoryQuery & advisory_query,
+        libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+
     SolvQuery & ifilter_installed();
 
     SolvQuery & ifilter_available();

--- a/include/libdnf/rpm/solv_sack.hpp
+++ b/include/libdnf/rpm/solv_sack.hpp
@@ -41,6 +41,7 @@ class AdvisorySack;
 class AdvisoryQuery;
 class AdvisoryCollection;
 class AdvisoryPackage;
+class AdvisoryModule;
 
 }  // namespace libdnf::advisory
 
@@ -183,6 +184,7 @@ private:
     friend libdnf::advisory::AdvisoryQuery;
     friend libdnf::advisory::AdvisoryCollection;
     friend libdnf::advisory::AdvisoryPackage;
+    friend libdnf::advisory::AdvisoryModule;
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/include/libdnf/rpm/solv_sack.hpp
+++ b/include/libdnf/rpm/solv_sack.hpp
@@ -39,6 +39,7 @@ namespace libdnf::advisory {
 class Advisory;
 class AdvisorySack;
 class AdvisoryQuery;
+class AdvisoryCollection;
 
 }  // namespace libdnf::advisory
 
@@ -179,6 +180,7 @@ private:
     friend libdnf::advisory::Advisory;
     friend libdnf::advisory::AdvisorySack;
     friend libdnf::advisory::AdvisoryQuery;
+    friend libdnf::advisory::AdvisoryCollection;
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/include/libdnf/rpm/solv_sack.hpp
+++ b/include/libdnf/rpm/solv_sack.hpp
@@ -21,8 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_SOLV_SACK_HPP
 #define LIBDNF_RPM_SOLV_SACK_HPP
 
-#include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/common/weak_ptr.hpp"
 
 #include <memory>
 
@@ -33,6 +33,14 @@ class Goal;
 class Swdb;
 
 }  // namespace libdnf
+
+namespace libdnf::advisory {
+
+class Advisory;
+class AdvisorySack;
+class AdvisoryQuery;
+
+}  // namespace libdnf::advisory
 
 namespace libdnf::rpm::solv {
 
@@ -168,6 +176,9 @@ private:
     friend Transaction;
     friend libdnf::Swdb;
     friend solv::SolvPrivate;
+    friend libdnf::advisory::Advisory;
+    friend libdnf::advisory::AdvisorySack;
+    friend libdnf::advisory::AdvisoryQuery;
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/include/libdnf/rpm/solv_sack.hpp
+++ b/include/libdnf/rpm/solv_sack.hpp
@@ -42,6 +42,7 @@ class AdvisoryQuery;
 class AdvisoryCollection;
 class AdvisoryPackage;
 class AdvisoryModule;
+class AdvisoryReference;
 
 }  // namespace libdnf::advisory
 
@@ -185,6 +186,7 @@ private:
     friend libdnf::advisory::AdvisoryCollection;
     friend libdnf::advisory::AdvisoryPackage;
     friend libdnf::advisory::AdvisoryModule;
+    friend libdnf::advisory::AdvisoryReference;
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/include/libdnf/rpm/solv_sack.hpp
+++ b/include/libdnf/rpm/solv_sack.hpp
@@ -40,6 +40,7 @@ class Advisory;
 class AdvisorySack;
 class AdvisoryQuery;
 class AdvisoryCollection;
+class AdvisoryPackage;
 
 }  // namespace libdnf::advisory
 
@@ -181,6 +182,7 @@ private:
     friend libdnf::advisory::AdvisorySack;
     friend libdnf::advisory::AdvisoryQuery;
     friend libdnf::advisory::AdvisoryCollection;
+    friend libdnf::advisory::AdvisoryPackage;
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/libdnf/advisory/advisory.cpp
+++ b/libdnf/advisory/advisory.cpp
@@ -1,0 +1,170 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/advisory/advisory.hpp"
+
+#include "libdnf/advisory/advisory_collection.hpp"
+#include "libdnf/advisory/advisory_reference.hpp"
+#include "libdnf/common/exception.hpp"
+#include "libdnf/rpm/solv_sack_impl.hpp"
+#include "libdnf/utils/utils_internal.hpp"
+
+#include <fmt/format.h>
+#include <solv/pool.h>
+
+namespace libdnf::advisory {
+
+Advisory::Advisory(libdnf::rpm::SolvSack & sack, AdvisoryId id) : id(id), sack(sack.get_weak_ptr()) {}
+
+std::string Advisory::get_name() const {
+    const char * name;
+    Pool * pool = sack->p_impl->get_pool();
+
+    name = pool_lookup_str(pool, id.id, SOLVABLE_NAME);
+
+    if (strncmp(
+            libdnf::utils::SOLVABLE_NAME_ADVISORY_PREFIX, name, libdnf::utils::SOLVABLE_NAME_ADVISORY_PREFIX_LENGTH) !=
+        0) {
+        auto msg = fmt::format(
+            R"**(Bad libsolv id for advisory "{}", solvable name "{}" doesn't have advisory prefix "{}")**",
+            id.id,
+            name,
+            libdnf::utils::SOLVABLE_NAME_ADVISORY_PREFIX);
+        throw RuntimeError(msg);
+    }
+
+    return std::string(name + libdnf::utils::SOLVABLE_NAME_ADVISORY_PREFIX_LENGTH);
+}
+
+Advisory::Type Advisory::get_type() const {
+    const char * type;
+    Pool * pool = sack->p_impl->get_pool();
+    type = pool_lookup_str(pool, id.id, SOLVABLE_PATCHCATEGORY);
+
+    if (type == NULL) {
+        return Advisory::Type::UNKNOWN;
+    }
+    if (!strcmp(type, "bugfix")) {
+        return Advisory::Type::BUGFIX;
+    }
+    if (!strcmp(type, "enhancement")) {
+        return Advisory::Type::ENHANCEMENT;
+    }
+    if (!strcmp(type, "security")) {
+        return Advisory::Type::SECURITY;
+    }
+    if (!strcmp(type, "newpackage")) {
+        return Advisory::Type::NEWPACKAGE;
+    }
+
+    return Advisory::Type::UNKNOWN;
+}
+
+const char * Advisory::get_type_cstring() const {
+    Pool * pool = sack->p_impl->get_pool();
+    return pool_lookup_str(pool, id.id, SOLVABLE_PATCHCATEGORY);
+}
+
+const char * Advisory::advisory_type_to_cstring(Type type) {
+    switch (type) {
+        case Type::ENHANCEMENT:
+            return "enhancement";
+        case Type::SECURITY:
+            return "security";
+        case Type::NEWPACKAGE:
+            return "newpackage";
+        case Type::BUGFIX:
+            return "bugfix";
+        default:
+            return NULL;
+    }
+}
+
+std::string Advisory::get_severity() const {
+    Pool * pool = sack->p_impl->get_pool();
+
+    //TODO(amatej): should we call SolvPrivate::internalize_libsolv_repo(solvable->repo);
+    //              before pool_lookup_str?
+    //              If so do this just once in solv::advisroy_private
+    const char * severity = pool_lookup_str(pool, id.id, UPDATE_SEVERITY);
+    return severity ? std::string(severity) : std::string();
+}
+
+AdvisoryId Advisory::get_id() const {
+    return id;
+}
+
+std::vector<AdvisoryReference> Advisory::get_references(AdvisoryReferenceType ref_type) const {
+    Pool * pool = sack->p_impl->get_pool();
+
+    std::vector<AdvisoryReference> output;
+
+    Dataiterator di;
+    dataiterator_init(&di, pool, 0, id.id, UPDATE_REFERENCE, 0, 0);
+
+    for (int index = 0; dataiterator_step(&di); index++) {
+        dataiterator_setpos(&di);
+        const char * current_type = pool_lookup_str(pool, SOLVID_POS, UPDATE_REFERENCE_TYPE);
+
+        if (((ref_type & AdvisoryReferenceType::CVE) == AdvisoryReferenceType::CVE &&
+             (strcmp(current_type, "cve") == 0)) ||
+            ((ref_type & AdvisoryReferenceType::BUGZILLA) == AdvisoryReferenceType::BUGZILLA &&
+             (strcmp(current_type, "bugzilla") == 0)) ||
+            ((ref_type & AdvisoryReferenceType::VENDOR) == AdvisoryReferenceType::VENDOR &&
+             (strcmp(current_type, "vendor") == 0))) {
+            output.emplace_back(AdvisoryReference(*sack, id, index));
+        }
+    }
+
+    dataiterator_free(&di);
+    return output;
+}
+
+std::vector<AdvisoryCollection> Advisory::get_collections() const {
+    Pool * pool = sack->p_impl->get_pool();
+
+    std::vector<AdvisoryCollection> output;
+
+    Dataiterator di;
+    dataiterator_init(&di, pool, 0, id.id, UPDATE_COLLECTIONLIST, 0, 0);
+
+    for (int index = 0; dataiterator_step(&di); index++) {
+        dataiterator_setpos(&di);
+        output.emplace_back(AdvisoryCollection(*sack, id, index));
+    }
+
+    dataiterator_free(&di);
+
+    return output;
+}
+
+//TODO(amatej): this could be possibly removed?
+bool Advisory::is_applicable() const {
+    for (const auto & collection : get_collections()) {
+        if (collection.is_applicable()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+Advisory::~Advisory() = default;
+
+}  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_collection.cpp
+++ b/libdnf/advisory/advisory_collection.cpp
@@ -1,0 +1,119 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "libdnf/advisory/advisory_collection.hpp"
+
+#include "libdnf/advisory/advisory_module_private.hpp"
+#include "libdnf/advisory/advisory_package_private.hpp"
+#include "libdnf/rpm/solv_sack_impl.hpp"
+
+namespace libdnf::advisory {
+
+AdvisoryCollection::AdvisoryCollection(libdnf::rpm::SolvSack & sack, AdvisoryId advisory, int index)
+    : sack(sack.get_weak_ptr())
+    , advisory(advisory)
+    , index(index) {}
+
+bool AdvisoryCollection::is_applicable() const {
+    //TODO(amatej): check if collection is applicable
+    return true;
+}
+
+std::vector<AdvisoryPackage> AdvisoryCollection::get_packages() {
+    std::vector<AdvisoryPackage> output;
+    get_packages(output, true);
+    return output;
+}
+
+std::vector<AdvisoryModule> AdvisoryCollection::get_modules() {
+    std::vector<AdvisoryModule> output;
+    get_modules(output);
+    return output;
+}
+
+void AdvisoryCollection::get_packages(std::vector<AdvisoryPackage> & output, bool with_filemanes) {
+    Dataiterator di;
+    const char * filename = nullptr;
+    Pool * pool = sack->p_impl->get_pool();
+    int count = 0;
+
+    dataiterator_init(&di, pool, 0, advisory.id, UPDATE_COLLECTIONLIST, 0, 0);
+    while (dataiterator_step(&di)) {
+        dataiterator_setpos(&di);
+        if (count == index) {
+            Dataiterator di_inner;
+            dataiterator_init(&di_inner, pool, 0, SOLVID_POS, UPDATE_COLLECTION, 0, 0);
+            while (dataiterator_step(&di_inner)) {
+                dataiterator_setpos(&di_inner);
+                Id name = pool_lookup_id(pool, SOLVID_POS, UPDATE_COLLECTION_NAME);
+                Id evr = pool_lookup_id(pool, SOLVID_POS, UPDATE_COLLECTION_EVR);
+                Id arch = pool_lookup_id(pool, SOLVID_POS, UPDATE_COLLECTION_ARCH);
+                if (with_filemanes) {
+                    filename = pool_lookup_str(pool, SOLVID_POS, UPDATE_COLLECTION_FILENAME);
+                }
+                output.emplace_back(
+                    AdvisoryPackage(new AdvisoryPackage::Impl(*sack, advisory, index, name, evr, arch, filename)));
+            }
+            dataiterator_free(&di_inner);
+            break;
+        }
+        count++;
+    }
+    dataiterator_free(&di);
+}
+
+void AdvisoryCollection::get_modules(std::vector<AdvisoryModule> & output) {
+    Dataiterator di;
+    Pool * pool = sack->p_impl->get_pool();
+    int count = 0;
+
+    dataiterator_init(&di, pool, 0, advisory.id, UPDATE_COLLECTIONLIST, 0, 0);
+    while (dataiterator_step(&di)) {
+        dataiterator_setpos(&di);
+        if (count == index) {
+            Dataiterator di_inner;
+            dataiterator_init(&di_inner, pool, 0, SOLVID_POS, UPDATE_MODULE, 0, 0);
+            while (dataiterator_step(&di_inner)) {
+                dataiterator_setpos(&di_inner);
+                Id name = pool_lookup_id(pool, SOLVID_POS, UPDATE_MODULE_NAME);
+                Id stream = pool_lookup_id(pool, SOLVID_POS, UPDATE_MODULE_STREAM);
+                Id version = pool_lookup_id(pool, SOLVID_POS, UPDATE_MODULE_VERSION);
+                Id context = pool_lookup_id(pool, SOLVID_POS, UPDATE_MODULE_CONTEXT);
+                Id arch = pool_lookup_id(pool, SOLVID_POS, UPDATE_MODULE_ARCH);
+                output.emplace_back(AdvisoryModule(
+                    new AdvisoryModule::Impl(*sack, advisory, index, name, stream, version, context, arch)));
+            }
+            dataiterator_free(&di_inner);
+            break;
+        }
+        count++;
+    }
+    dataiterator_free(&di);
+}
+
+AdvisoryId AdvisoryCollection::get_advisory_id() const {
+    return advisory;
+}
+
+Advisory AdvisoryCollection::get_advisory() const {
+    return Advisory(*sack, advisory);
+}
+
+}  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_module.cpp
+++ b/libdnf/advisory/advisory_module.cpp
@@ -1,0 +1,141 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/advisory/advisory_module.hpp"
+
+#include "libdnf/advisory/advisory_module_private.hpp"
+#include "libdnf/rpm/solv_sack_impl.hpp"
+
+
+namespace libdnf::advisory {
+
+// AdvisoryModule
+AdvisoryModule::AdvisoryModule(AdvisoryModule::Impl * private_module) : p_impl(private_module) {}
+
+AdvisoryModule::~AdvisoryModule() = default;
+
+AdvisoryModule::AdvisoryModule(const AdvisoryModule & src) : p_impl(new Impl(*src.p_impl)) {}
+AdvisoryModule::AdvisoryModule(AdvisoryModule && other) : p_impl(new Impl(std::move(*other.p_impl))) {}
+
+AdvisoryModule & AdvisoryModule::operator=(const AdvisoryModule & src) {
+    *p_impl = *src.p_impl;
+    return *this;
+}
+
+AdvisoryModule & AdvisoryModule::operator=(AdvisoryModule && src) noexcept {
+    p_impl.swap(src.p_impl);
+    return *this;
+}
+
+
+std::string AdvisoryModule::get_name() const {
+    Pool * pool = p_impl->sack->p_impl->get_pool();
+    return pool_id2str(pool, p_impl->name);
+}
+
+std::string AdvisoryModule::get_stream() const {
+    Pool * pool = p_impl->sack->p_impl->get_pool();
+    return pool_id2str(pool, p_impl->stream);
+}
+std::string AdvisoryModule::get_version() const {
+    Pool * pool = p_impl->sack->p_impl->get_pool();
+    return pool_id2str(pool, p_impl->version);
+}
+std::string AdvisoryModule::get_context() const {
+    Pool * pool = p_impl->sack->p_impl->get_pool();
+    return pool_id2str(pool, p_impl->context);
+}
+std::string AdvisoryModule::get_arch() const {
+    Pool * pool = p_impl->sack->p_impl->get_pool();
+    return pool_id2str(pool, p_impl->arch);
+}
+AdvisoryId AdvisoryModule::get_advisory_id() const {
+    return p_impl->advisory;
+}
+Advisory AdvisoryModule::get_advisory() const {
+    return Advisory(*(p_impl->sack), p_impl->advisory);
+}
+AdvisoryCollection AdvisoryModule::get_advisory_collection() const {
+    return AdvisoryCollection(*(p_impl->sack), p_impl->advisory, p_impl->owner_collection_index);
+}
+
+// AdvisoryModule::Impl
+AdvisoryModule::Impl::Impl(
+    libdnf::rpm::SolvSack & sack,
+    AdvisoryId advisory,
+    int owner_collection_index,
+    Id name,
+    Id stream,
+    Id version,
+    Id context,
+    Id arch)
+    : sack(sack.get_weak_ptr())
+    , advisory(advisory)
+    , owner_collection_index(owner_collection_index)
+    , name(name)
+    , stream(stream)
+    , version(version)
+    , context(context)
+    , arch(arch) {}
+
+AdvisoryModule::Impl::Impl(const Impl & other)
+    : sack(other.sack)
+    , advisory(other.advisory)
+    , owner_collection_index(other.owner_collection_index)
+    , name(other.name)
+    , stream(other.stream)
+    , version(other.version)
+    , context(other.context)
+    , arch(other.arch) {}
+
+AdvisoryModule::Impl::Impl(Impl && other)
+    : sack(std::move(other.sack))
+    , advisory(std::move(other.advisory))
+    , owner_collection_index(other.owner_collection_index)
+    , name(std::move(other.name))
+    , stream(std::move(other.stream))
+    , version(std::move(other.version))
+    , context(std::move(other.context))
+    , arch(std::move(other.arch)) {}
+
+AdvisoryModule::Impl & AdvisoryModule::Impl::operator=(const Impl & other) {
+    sack = other.sack;
+    advisory = other.advisory;
+    owner_collection_index = other.owner_collection_index;
+    name = other.name;
+    stream = other.stream;
+    version = other.version;
+    context = other.context;
+    arch = other.arch;
+    return *this;
+}
+
+AdvisoryModule::Impl & AdvisoryModule::Impl::operator=(Impl && other) {
+    sack = std::move(other.sack);
+    advisory = std::move(other.advisory);
+    owner_collection_index = std::move(other.owner_collection_index);
+    name = std::move(other.name);
+    stream = std::move(other.stream);
+    version = std::move(other.version);
+    context = std::move(other.context);
+    arch = std::move(other.arch);
+    return *this;
+}
+
+}  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_module_private.hpp
+++ b/libdnf/advisory/advisory_module_private.hpp
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_MODULE_PRIVATE_HPP
+#define LIBDNF_ADVISORY_ADVISORY_MODULE_PRIVATE_HPP
+
+#include "libdnf/advisory/advisory.hpp"
+#include "libdnf/advisory/advisory_module.hpp"
+
+#include <solv/pooltypes.h>
+
+namespace libdnf::advisory {
+
+//TODO(amatej): We might want to remove the Impl idiom to speed up iterating over
+//              AdvisoryModules (less classes, less overhead), but we would end
+//              up with libsolv ints (Ids) in a public header.
+class AdvisoryModule::Impl {
+public:
+    /// Copy constructor: clone from an existing AdvisoryModule::Impl
+    Impl(const Impl & other);
+    /// Move constructor: clone from an existing AdvisoryModule::Impl
+    Impl(Impl && other);
+
+    Impl & operator=(const Impl & other);
+    Impl & operator=(Impl && other);
+
+private:
+    friend class AdvisoryCollection;
+    friend AdvisoryModule;
+
+    explicit Impl(
+        libdnf::rpm::SolvSack & sack,
+        AdvisoryId advisory,
+        int owner_collection_index,
+        Id name,
+        Id stream,
+        Id version,
+        Id context,
+        Id arch);
+
+    libdnf::rpm::SolvSackWeakPtr sack;
+    AdvisoryId advisory;
+    int owner_collection_index;
+
+    Id name;
+    Id stream;
+    Id version;
+    Id context;
+    Id arch;
+};
+
+}  // namespace libdnf::advisory
+
+
+#endif  // LIBDNF_ADVISORY_ADVISORY_MODULE_PRIVATE_HPP

--- a/libdnf/advisory/advisory_package.cpp
+++ b/libdnf/advisory/advisory_package.cpp
@@ -1,0 +1,160 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/advisory/advisory_package.hpp"
+
+#include "advisory_package_private.hpp"
+
+#include "libdnf/logger/logger.hpp"
+#include "libdnf/rpm/nevra.hpp"
+#include "libdnf/rpm/solv/package_private.hpp"
+
+#include <solv/chksum.h>
+#include <solv/repo.h>
+#include <solv/util.h>
+
+
+namespace libdnf::advisory {
+
+// AdvisoryPackage
+AdvisoryPackage::AdvisoryPackage(AdvisoryPackage::Impl * private_pkg) : p_impl(private_pkg) {}
+
+AdvisoryPackage::~AdvisoryPackage() = default;
+
+AdvisoryPackage::AdvisoryPackage(const AdvisoryPackage & src) : p_impl(new Impl(*src.p_impl)) {}
+AdvisoryPackage::AdvisoryPackage(AdvisoryPackage && src) : p_impl(new Impl(std::move(*src.p_impl))) {}
+
+AdvisoryPackage & AdvisoryPackage::operator=(const AdvisoryPackage & src) {
+    *p_impl = *src.p_impl;
+    return *this;
+}
+
+AdvisoryPackage & AdvisoryPackage::operator=(AdvisoryPackage && src) noexcept {
+    p_impl.swap(src.p_impl);
+    return *this;
+}
+
+
+std::string AdvisoryPackage::get_name() const {
+    return p_impl->get_name();
+}
+
+std::string AdvisoryPackage::get_version() const {
+    return p_impl->get_version();
+}
+
+std::string AdvisoryPackage::get_evr() const {
+    return p_impl->get_evr();
+}
+std::string AdvisoryPackage::get_arch() const {
+    return p_impl->get_arch();
+}
+AdvisoryId AdvisoryPackage::get_advisory_id() const {
+    return p_impl->get_advisory_id();
+}
+Advisory AdvisoryPackage::get_advisory() const {
+    return Advisory(*(p_impl->sack), p_impl->get_advisory_id());
+}
+AdvisoryCollection AdvisoryPackage::get_advisory_collection() const {
+    return AdvisoryCollection(*(p_impl->sack), p_impl->get_advisory_id(), p_impl->owner_collection_index);
+}
+
+// AdvisoryPackage::Impl
+AdvisoryPackage::Impl::Impl(
+    libdnf::rpm::SolvSack & sack,
+    AdvisoryId advisory,
+    int owner_collection_index,
+    Id name,
+    Id evr,
+    Id arch,
+    const char * filename)
+    : advisory(advisory)
+    , owner_collection_index(owner_collection_index)
+    , name(name)
+    , evr(evr)
+    , arch(arch)
+    , filename(filename)
+    , sack(sack.get_weak_ptr()) {}
+
+AdvisoryPackage::Impl::Impl(const Impl & other)
+    : advisory(other.advisory)
+    , owner_collection_index(other.owner_collection_index)
+    , name(other.name)
+    , evr(other.evr)
+    , arch(other.arch)
+    , filename(other.filename)
+    , sack(other.sack) {}
+
+AdvisoryPackage::Impl::Impl(Impl && other)
+    : advisory(std::move(other.advisory))
+    , owner_collection_index(other.owner_collection_index)
+    , name(std::move(other.name))
+    , evr(std::move(other.evr))
+    , arch(std::move(other.arch))
+    , filename(std::move(other.filename))
+    , sack(std::move(other.sack)) {}
+
+AdvisoryPackage::Impl & AdvisoryPackage::Impl::operator=(const Impl & other) {
+    advisory = other.advisory;
+    owner_collection_index = other.owner_collection_index;
+    name = other.name;
+    evr = other.evr;
+    arch = other.arch;
+    filename = other.filename;
+    sack = other.sack;
+    return *this;
+}
+
+AdvisoryPackage::Impl & AdvisoryPackage::Impl::operator=(Impl && other) {
+    advisory = std::move(other.advisory);
+    owner_collection_index = std::move(other.owner_collection_index);
+    name = std::move(other.name);
+    evr = std::move(other.evr);
+    arch = std::move(other.arch);
+    filename = std::move(other.filename);
+    sack = std::move(other.sack);
+    return *this;
+}
+
+
+std::string AdvisoryPackage::Impl::get_name() const {
+    Pool * pool = sack->p_impl->get_pool();
+    return pool_id2str(pool, name);
+}
+
+std::string AdvisoryPackage::Impl::get_version() const {
+    Pool * pool = sack->p_impl->get_pool();
+    char * e;
+    char * v;
+    char * r;
+    libdnf::rpm::solv::pool_split_evr(pool, pool_id2str(pool, evr), &e, &v, &r);
+    return std::string(v);
+}
+
+std::string AdvisoryPackage::Impl::get_evr() const {
+    Pool * pool = sack->p_impl->get_pool();
+    return pool_id2str(pool, evr);
+}
+
+std::string AdvisoryPackage::Impl::get_arch() const {
+    Pool * pool = sack->p_impl->get_pool();
+    return pool_id2str(pool, arch);
+}
+
+}  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_package_private.hpp
+++ b/libdnf/advisory/advisory_package_private.hpp
@@ -1,0 +1,138 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_PACKAGE_PRIVATE_HPP
+#define LIBDNF_ADVISORY_ADVISORY_PACKAGE_PRIVATE_HPP
+
+#include "libdnf/advisory/advisory_package.hpp"
+#include "libdnf/rpm/solv/package_private.hpp"
+#include "libdnf/rpm/solv_sack_impl.hpp"
+
+#include <solv/pooltypes.h>
+#include <solv/solvable.h>
+
+namespace libdnf::advisory {
+
+//TODO(amatej): We might want to remove the Impl idiom to speed up iterating over
+//              AdvisoryPackages (less classes, less overhead), but we would end
+//              up with libsolv ints (Ids) in a public header.
+class AdvisoryPackage::Impl {
+public:
+    /// Copy constructor: clone from an existing AdvisoryPackage::Impl
+    Impl(const Impl & other);
+    /// Move constructor: clone from an existing AdvisoryPackage::Impl
+    Impl(Impl && other);
+
+    Impl & operator=(const Impl & other);
+    Impl & operator=(Impl && other);
+
+    std::string get_name() const;
+    std::string get_version() const;
+    std::string get_evr() const;
+    std::string get_arch() const;
+    Id get_name_id() const { return name; };
+    Id get_evr_id() const { return evr; };
+    Id get_arch_id() const { return arch; };
+    AdvisoryId get_advisory_id() const { return advisory; };
+
+    //TODO(amatej): Is this the correct name?
+    /// Compare NEVRAs of two AdvisoryPackages
+    ///
+    /// @param first        First AdvisoryPackage to compare.
+    /// @param second       Secondf AdvisoryPackage to compare.
+    /// @return True if first AdvisoryPackage has smaller NEVRA, False otherwise.
+    inline static bool nevra_compare_lower_id(const AdvisoryPackage & first, const AdvisoryPackage & second) {
+        if (first.p_impl->name != second.p_impl->name)
+            return first.p_impl->name < second.p_impl->name;
+        if (first.p_impl->arch != second.p_impl->arch)
+            return first.p_impl->arch < second.p_impl->arch;
+        return first.p_impl->evr < second.p_impl->evr;
+    }
+
+    //TODO(amatej): Is this the correct name?
+    /// Compare Name and Architecture of AdvisoryPackage and libdnf::rpm::Package
+    ///
+    /// @param adv_pkg      AdvisoryPackage to compare.
+    /// @param pkg          libdnf::rpm::Package to compare.
+    /// @return True if AdvisoryPackage has smaller name or architecture than libdnf::rpm::package, False otherwise.
+    inline static bool name_arch_compare_lower_id(const AdvisoryPackage & adv_pkg, const rpm::Package & pkg) {
+        Pool * pool = adv_pkg.p_impl->sack->p_impl->get_pool();
+        Solvable * s = libdnf::rpm::solv::get_solvable(pool, pkg.get_id().id);
+
+        if (adv_pkg.p_impl->name != s->name)
+            return adv_pkg.p_impl->name < s->name;
+        return adv_pkg.p_impl->arch < s->arch;
+    }
+
+    //TODO(amatej): Is this the correct name?
+    /// Compare Name and Architecture of Solvable and AdvisoryPackage::Impl
+    ///
+    /// @param solvable     Solvable to compare
+    /// @param adv_pkg      AdvisoryPackage::Impl to compare.
+    /// @return True if Solvable has smaller name or architecture than AdvisoryPackage::Impl, False otherwise.
+    inline static bool name_arch_compare_lower_solvable(const Solvable * solvable, const AdvisoryPackage::Impl & adv_pkg) {
+        if (solvable->name != adv_pkg.name) {
+            return solvable->name < adv_pkg.name;
+        }
+        return solvable->arch < adv_pkg.arch;
+    }
+
+    //TODO(amatej): Is this the correct name?
+    /// Compare NEVRAs of Solvable and AdvisoryPackage::Impl
+    ///
+    /// @param solvable     Solvable to compare
+    /// @param adv_pkg      AdvisoryPackage::Impl to compare.
+    /// @return True if Solvable has smaller nevra than AdvisoryPackage::Impl, False otherwise.
+    inline static bool nevra_compare_lower_solvable(const Solvable * solvable, const AdvisoryPackage::Impl & adv_pkg) {
+        if (solvable->name != adv_pkg.name) {
+            return solvable->name < adv_pkg.name;
+        }
+        if (solvable->arch != adv_pkg.arch) {
+            return solvable->arch < adv_pkg.arch;
+        }
+        return solvable->evr < adv_pkg.evr;
+    }
+
+private:
+    friend class AdvisoryCollection;
+    friend AdvisoryPackage;
+
+    explicit Impl(
+        libdnf::rpm::SolvSack & sack,
+        AdvisoryId advisory,
+        int owner_collection_index,
+        Id name,
+        Id evr,
+        Id arch,
+        const char * filename);
+
+    AdvisoryId advisory;
+    int owner_collection_index;
+
+    Id name;
+    Id evr;
+    Id arch;
+    const char * filename;
+    libdnf::rpm::SolvSackWeakPtr sack;
+};
+
+}  // namespace libdnf::advisory
+
+
+#endif  // LIBDNF_ADVISORY_ADVISORY_PACKAGE_PRIVATE_HPP

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -1,0 +1,432 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/advisory/advisory_query.hpp"
+
+#include "libdnf/advisory/advisory_package_private.hpp"
+#include "libdnf/advisory/advisory_query_private.hpp"
+#include "libdnf/rpm/package_set.hpp"
+#include "libdnf/rpm/solv/package_private.hpp"
+#include "libdnf/rpm/solv_sack_impl.hpp"
+#include "libdnf/utils/utils_internal.hpp"
+
+#include <solv/evr.h>
+
+// For glob support
+#include <fnmatch.h>
+
+namespace libdnf::advisory {
+
+AdvisoryQuery::AdvisoryQuery(AdvisorySack * sack) : advisory_sack(sack), p_impl{new Impl(sack->data_map)} {};
+
+AdvisoryQuery::~AdvisoryQuery() = default;
+AdvisoryQuery::AdvisoryQuery(const AdvisoryQuery & src)
+    : advisory_sack(src.advisory_sack)
+    , p_impl(new Impl(*src.p_impl)) {}
+AdvisoryQuery::AdvisoryQuery(AdvisoryQuery && src)
+    : advisory_sack(std::move(src.advisory_sack))
+    , p_impl(new Impl(std::move(*src.p_impl))) {}
+
+AdvisoryQuery & AdvisoryQuery::operator=(const AdvisoryQuery & src) {
+    advisory_sack = src.advisory_sack;
+    *p_impl = *src.p_impl;
+    return *this;
+}
+
+AdvisoryQuery & AdvisoryQuery::operator=(AdvisoryQuery && src) noexcept {
+    advisory_sack = std::move(src.advisory_sack);
+    p_impl.swap(src.p_impl);
+    return *this;
+}
+
+AdvisoryQuery & AdvisoryQuery::ifilter_name(const std::string & pattern, sack::QueryCmp cmp_type) {
+    const std::vector<std::string> patterns = {pattern};
+    ifilter_name(patterns, cmp_type);
+    return *this;
+}
+
+AdvisoryQuery & AdvisoryQuery::ifilter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    Pool * pool = solv_sack.p_impl->get_pool();
+    libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
+
+    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
+    if (cmp_not) {
+        // Removal of NOT CmpType makes following comparissons easier and more effective
+        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
+    }
+
+    bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
+
+    for (const std::string & pattern : patterns) {
+        libdnf::sack::QueryCmp tmp_cmp_type = cmp_type;
+        const char * c_pattern = pattern.c_str();
+        // Remove GLOB when the pattern is not a glob
+        if (cmp_glob && !libdnf::utils::is_glob_pattern(c_pattern)) {
+            tmp_cmp_type = (tmp_cmp_type - libdnf::sack::QueryCmp::GLOB) | libdnf::sack::QueryCmp::EQ;
+        }
+
+        switch (tmp_cmp_type) {
+            case libdnf::sack::QueryCmp::EQ: {
+                std::string prefixed_name = std::string(libdnf::utils::SOLVABLE_NAME_ADVISORY_PREFIX) + pattern;
+                Id name_id = pool_str2id(pool, prefixed_name.c_str(), 0);
+                for (Id candidate_id : p_impl->data_map) {
+                    Id candidate_name = pool_lookup_id(pool, candidate_id, SOLVABLE_NAME);
+                    if (candidate_name == name_id) {
+                        filter_result.add_unsafe(candidate_id);
+                    }
+                }
+            } break;
+            case libdnf::sack::QueryCmp::GLOB: {
+                for (Id candidate_id : p_impl->data_map) {
+                    const char * candidate_name = pool_lookup_str(pool, candidate_id, SOLVABLE_NAME);
+                    if (fnmatch(c_pattern, candidate_name + libdnf::utils::SOLVABLE_NAME_ADVISORY_PREFIX_LENGTH, 0) ==
+                        0) {
+                        filter_result.add_unsafe(candidate_id);
+                    }
+                }
+
+            } break;
+            case libdnf::sack::QueryCmp::IGLOB: {
+                for (Id candidate_id : p_impl->data_map) {
+                    const char * candidate_name = pool_lookup_str(pool, candidate_id, SOLVABLE_NAME);
+                    if (fnmatch(
+                            c_pattern,
+                            candidate_name + libdnf::utils::SOLVABLE_NAME_ADVISORY_PREFIX_LENGTH,
+                            FNM_CASEFOLD) == 0) {
+                        filter_result.add_unsafe(candidate_id);
+                    }
+                }
+
+            } break;
+            default:
+                throw NotSupportedCmpType("Unsupported CmpType");
+        }
+    }
+
+    // Apply filter results to query
+    if (cmp_not) {
+        p_impl->data_map -= filter_result;
+    } else {
+        p_impl->data_map &= filter_result;
+    }
+    return *this;
+}
+
+//TODO(amatej): Add a wrapper that accepts string type, eg: "security" not enum
+AdvisoryQuery & AdvisoryQuery::ifilter_type(const Advisory::Type type, sack::QueryCmp cmp_type) {
+    const std::vector<Advisory::Type> types = {type};
+    ifilter_type(types, cmp_type);
+    return *this;
+}
+
+//TODO(amatej): Add a wrapper that accepts vector of string types, eg: "security", "bugfix" not enums
+AdvisoryQuery & AdvisoryQuery::ifilter_type(const std::vector<AdvisoryType> & types, sack::QueryCmp cmp_type) {
+    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    Pool * pool = solv_sack.p_impl->get_pool();
+    libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
+
+    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
+    if (cmp_not) {
+        // Removal of NOT CmpType makes following comparissons easier and more effective
+        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
+    }
+    switch (cmp_type) {
+        case libdnf::sack::QueryCmp::EQ: {
+            AdvisoryType ored_types_together = AdvisoryType::UNKNOWN;
+            for (const auto t : types) {
+                ored_types_together = ored_types_together | t;
+            }
+
+            //TODO(amatej): extract this into solv::advisroy_private once its created
+            for (Id candidate_id : p_impl->data_map) {
+                const char * candidate_type = pool_lookup_str(pool, candidate_id, SOLVABLE_PATCHCATEGORY);
+                if (((ored_types_together & AdvisoryType::SECURITY) == AdvisoryType::SECURITY &&
+                     (strcmp(candidate_type, "security") == 0)) ||
+                    ((ored_types_together & AdvisoryType::BUGFIX) == AdvisoryType::BUGFIX &&
+                     (strcmp(candidate_type, "bugfix") == 0)) ||
+                    ((ored_types_together & AdvisoryType::ENHANCEMENT) == AdvisoryType::ENHANCEMENT &&
+                     (strcmp(candidate_type, "enhancement") == 0)) ||
+                    ((ored_types_together & AdvisoryType::NEWPACKAGE) == AdvisoryType::NEWPACKAGE &&
+                     (strcmp(candidate_type, "newpackage") == 0))) {
+                    filter_result.add_unsafe(candidate_id);
+                }
+            }
+        } break;
+        default:
+            throw NotSupportedCmpType("Unsupported CmpType");
+    }
+
+    // Apply filter results to query
+    if (cmp_not) {
+        p_impl->data_map -= filter_result;
+    } else {
+        p_impl->data_map &= filter_result;
+    }
+
+    return *this;
+}
+
+AdvisoryQuery & AdvisoryQuery::ifilter_reference(
+    const std::vector<std::string> & reference_id, std::vector<AdvisoryReferenceType> types, sack::QueryCmp cmp_type) {
+    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
+
+    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
+    if (cmp_not) {
+        // Removal of NOT CmpType makes following comparissons easier and more effective
+        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
+    }
+
+    bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
+
+    // Since the types are defined as bit in an int or them together for faster iteration
+    AdvisoryReferenceType ored_types_together = AdvisoryReferenceType::UNKNOWN;
+    for (const auto t : types) {
+        ored_types_together = ored_types_together | t;
+    }
+
+    for (const std::string & pattern : reference_id) {
+        libdnf::sack::QueryCmp tmp_cmp_type = cmp_type;
+        const char * c_pattern = pattern.c_str();
+        // Remove GLOB when the pattern is not a glob
+        if (cmp_glob && !libdnf::utils::is_glob_pattern(c_pattern)) {
+            tmp_cmp_type = (tmp_cmp_type - libdnf::sack::QueryCmp::GLOB) | libdnf::sack::QueryCmp::EQ;
+        }
+
+        switch (tmp_cmp_type) {
+            case libdnf::sack::QueryCmp::EQ: {
+                for (Id candidate_id : p_impl->data_map) {
+                    //TODO(amatej): replace this with solv::advisroy_private (just like for package)
+                    //              So that we don't duplicate code and don't have to create Advisory object (big overhead, has weak pointer)
+                    Advisory a = Advisory(solv_sack, AdvisoryId(candidate_id));
+                    for (const auto & cve : a.get_references(ored_types_together)) {
+                        if (cve.get_id() == pattern) {
+                            filter_result.add_unsafe(candidate_id);
+                        }
+                    }
+                }
+            } break;
+            case libdnf::sack::QueryCmp::GLOB: {
+                for (Id candidate_id : p_impl->data_map) {
+                    Advisory a = Advisory(solv_sack, AdvisoryId(candidate_id));
+                    for (const auto & cve : a.get_references(ored_types_together)) {
+                        if (fnmatch(c_pattern, cve.get_id().c_str(), 0) == 0) {
+                            filter_result.add_unsafe(candidate_id);
+                        }
+                    }
+                }
+            } break;
+            default:
+                throw NotSupportedCmpType("Unsupported CmpType");
+        }
+    }
+
+    // Apply filter results to query
+    if (cmp_not) {
+        p_impl->data_map -= filter_result;
+    } else {
+        p_impl->data_map &= filter_result;
+    }
+    return *this;
+}
+AdvisoryQuery & AdvisoryQuery::ifilter_CVE(const std::string & pattern, sack::QueryCmp cmp_type) {
+    const std::vector<std::string> patterns = {pattern};
+    ifilter_reference(patterns, {AdvisoryReferenceType::CVE}, cmp_type);
+    return *this;
+}
+AdvisoryQuery & AdvisoryQuery::ifilter_CVE(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+    ifilter_reference(patterns, {AdvisoryReferenceType::CVE}, cmp_type);
+    return *this;
+}
+
+AdvisoryQuery & AdvisoryQuery::ifilter_bug(const std::string & pattern, sack::QueryCmp cmp_type) {
+    const std::vector<std::string> patterns = {pattern};
+    ifilter_reference(patterns, {AdvisoryReferenceType::BUGZILLA}, cmp_type);
+    return *this;
+}
+AdvisoryQuery & AdvisoryQuery::ifilter_bug(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+    ifilter_reference(patterns, {AdvisoryReferenceType::BUGZILLA}, cmp_type);
+    return *this;
+}
+
+AdvisoryQuery & AdvisoryQuery::ifilter_severity(const std::string & pattern, sack::QueryCmp cmp_type) {
+    const std::vector<std::string> patterns = {pattern};
+    ifilter_severity(patterns, cmp_type);
+    return *this;
+}
+AdvisoryQuery & AdvisoryQuery::ifilter_severity(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    Pool * pool = solv_sack.p_impl->get_pool();
+    libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
+
+    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
+    if (cmp_not) {
+        // Removal of NOT CmpType makes following comparissons easier and more effective
+        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
+    }
+
+    switch (cmp_type) {
+        case libdnf::sack::QueryCmp::EQ: {
+            for (const std::string & severity : patterns) {
+                for (Id candidate_id : p_impl->data_map) {
+                    const char * candidate_severity = pool_lookup_str(pool, candidate_id, UPDATE_SEVERITY);
+                    if (!strcmp(candidate_severity, severity.c_str())) {
+                        filter_result.add_unsafe(candidate_id);
+                    }
+                }
+            }
+        } break;
+        default:
+            throw NotSupportedCmpType("Unsupported CmpType");
+    }
+
+
+    // Apply filter results to query
+    if (cmp_not) {
+        p_impl->data_map -= filter_result;
+    } else {
+        p_impl->data_map &= filter_result;
+    }
+
+    return *this;
+}
+
+//TODO(amatej): this might not be needed and could be possibly removed
+AdvisoryQuery & AdvisoryQuery::ifilter_packages(const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
+    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    Pool * pool = solv_sack.p_impl->get_pool();
+    libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
+    std::vector<AdvisoryPackage> adv_pkgs = get_sorted_advisory_packages();
+
+    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
+    if (cmp_not) {
+        // Removal of NOT CmpType makes following comparissons easier and more effective
+        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
+    }
+
+    switch (cmp_type) {
+        case libdnf::sack::QueryCmp::EQ:
+            //TODO(amatej): faster EQ specific version (we can compare whole NEVRA)
+        case libdnf::sack::QueryCmp::GT:
+        case libdnf::sack::QueryCmp::LT:
+        case libdnf::sack::QueryCmp::GTE:
+        case libdnf::sack::QueryCmp::LTE: {
+            for (libdnf::rpm::PackageSet::iterator package = package_set.begin(); package != package_set.end();
+                 package++) {
+                Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, (*package).get_id());
+                auto low =
+                    std::lower_bound(adv_pkgs.begin(), adv_pkgs.end(), *package, AdvisoryPackage::Impl::name_arch_compare_lower_id);
+                while (low != adv_pkgs.end() && low->p_impl.get()->get_name_id() == solvable->name &&
+                       low->p_impl.get()->get_arch_id() == solvable->arch) {
+                    int libsolv_cmp = pool_evrcmp(pool, low->p_impl.get()->get_evr_id(), solvable->evr, EVRCMP_COMPARE);
+                    if (((libsolv_cmp > 0) && ((cmp_type & sack::QueryCmp::GT) == sack::QueryCmp::GT)) ||
+                        ((libsolv_cmp < 0) && ((cmp_type & sack::QueryCmp::LT) == sack::QueryCmp::LT)) ||
+                        ((libsolv_cmp == 0) && ((cmp_type & sack::QueryCmp::EQ) == sack::QueryCmp::EQ))) {
+                        filter_result.add_unsafe(libdnf::rpm::PackageId((*low).get_advisory_id()));
+                    }
+                    ++low;
+                }
+            }
+
+        } break;
+        default:
+            throw NotSupportedCmpType("Unsupported CmpType");
+    }
+
+    // Apply filter results to query
+    if (cmp_not) {
+        p_impl->data_map -= filter_result;
+    } else {
+        p_impl->data_map &= filter_result;
+    }
+
+    return *this;
+}
+
+std::vector<AdvisoryPackage> AdvisoryQuery::get_advisory_packages(
+    const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
+    std::vector<AdvisoryPackage> adv_pkgs = get_sorted_advisory_packages();
+    std::vector<AdvisoryPackage> after_filter;
+
+    auto solv_sack = package_set.get_sack();
+    Pool * pool = solv_sack->p_impl->get_pool();
+
+    switch (cmp_type) {
+        case libdnf::sack::QueryCmp::EQ:
+            //TODO(amatej): faster EQ specific version (we can compare whole NEVRA)
+        case libdnf::sack::QueryCmp::GT:
+        case libdnf::sack::QueryCmp::LT:
+        case libdnf::sack::QueryCmp::GTE:
+        case libdnf::sack::QueryCmp::LTE: {
+            for (libdnf::rpm::PackageSet::iterator package = package_set.begin(); package != package_set.end();
+                 package++) {
+                Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, (*package).get_id());
+                auto low =
+                    std::lower_bound(adv_pkgs.begin(), adv_pkgs.end(), *package, AdvisoryPackage::Impl::name_arch_compare_lower_id);
+                while (low != adv_pkgs.end() && low->p_impl.get()->get_name_id() == solvable->name &&
+                       low->p_impl.get()->get_arch_id() == solvable->arch) {
+                    int libsolv_cmp = pool_evrcmp(pool, low->p_impl.get()->get_evr_id(), solvable->evr, EVRCMP_COMPARE);
+                    if (((libsolv_cmp > 0) && ((cmp_type & sack::QueryCmp::GT) == sack::QueryCmp::GT)) ||
+                        ((libsolv_cmp < 0) && ((cmp_type & sack::QueryCmp::LT) == sack::QueryCmp::LT)) ||
+                        ((libsolv_cmp == 0) && ((cmp_type & sack::QueryCmp::EQ) == sack::QueryCmp::EQ))) {
+                        after_filter.push_back(*low);
+                    }
+                    ++low;
+                }
+            }
+        } break;
+        default:
+            throw NotSupportedCmpType("Unsupported CmpType");
+    }
+
+    //after_filter contains just advisoryPackages which comply to condition with package_set
+    return after_filter;
+}
+
+//TODO(amatej): create AdvisorySet (and its iterators), make AdvisoryQuery inherit AdvisorySet? (but its so many objects..)
+std::vector<Advisory> AdvisoryQuery::get_advisories() const {
+    std::vector<Advisory> out;
+    for (Id candidate_id : p_impl->data_map) {
+        out.emplace_back(
+            Advisory(advisory_sack->base->get_rpm_solv_sack(), libdnf::advisory::AdvisoryId(candidate_id)));
+    }
+
+    return out;
+}
+
+std::vector<AdvisoryPackage> AdvisoryQuery::get_sorted_advisory_packages(bool only_applicable) const {
+    std::vector<AdvisoryPackage> out;
+    for (Id candidate_id : p_impl->data_map) {
+        Advisory advisory = Advisory(advisory_sack->base->get_rpm_solv_sack(), AdvisoryId(candidate_id));
+        auto collections = advisory.get_collections();
+        for (auto & collection : collections) {
+            if (only_applicable && !collection.is_applicable()) {
+                continue;
+            }
+            collection.get_packages(out);
+        }
+    }
+
+    std::sort(out.begin(), out.end(), AdvisoryPackage::Impl::nevra_compare_lower_id);
+
+    return out;
+}
+
+}  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -330,7 +330,7 @@ AdvisoryQuery & AdvisoryQuery::ifilter_packages(const libdnf::rpm::PackageSet & 
         case libdnf::sack::QueryCmp::LTE: {
             for (libdnf::rpm::PackageSet::iterator package = package_set.begin(); package != package_set.end();
                  package++) {
-                Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, (*package).get_id());
+                Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, (*package).get_id().id);
                 auto low =
                     std::lower_bound(adv_pkgs.begin(), adv_pkgs.end(), *package, AdvisoryPackage::Impl::name_arch_compare_lower_id);
                 while (low != adv_pkgs.end() && low->p_impl.get()->get_name_id() == solvable->name &&
@@ -339,7 +339,7 @@ AdvisoryQuery & AdvisoryQuery::ifilter_packages(const libdnf::rpm::PackageSet & 
                     if (((libsolv_cmp > 0) && ((cmp_type & sack::QueryCmp::GT) == sack::QueryCmp::GT)) ||
                         ((libsolv_cmp < 0) && ((cmp_type & sack::QueryCmp::LT) == sack::QueryCmp::LT)) ||
                         ((libsolv_cmp == 0) && ((cmp_type & sack::QueryCmp::EQ) == sack::QueryCmp::EQ))) {
-                        filter_result.add_unsafe(libdnf::rpm::PackageId((*low).get_advisory_id()));
+                        filter_result.add_unsafe((*low).get_advisory_id().id);
                     }
                     ++low;
                 }
@@ -377,7 +377,7 @@ std::vector<AdvisoryPackage> AdvisoryQuery::get_advisory_packages(
         case libdnf::sack::QueryCmp::LTE: {
             for (libdnf::rpm::PackageSet::iterator package = package_set.begin(); package != package_set.end();
                  package++) {
-                Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, (*package).get_id());
+                Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, (*package).get_id().id);
                 auto low =
                     std::lower_bound(adv_pkgs.begin(), adv_pkgs.end(), *package, AdvisoryPackage::Impl::name_arch_compare_lower_id);
                 while (low != adv_pkgs.end() && low->p_impl.get()->get_name_id() == solvable->name &&

--- a/libdnf/advisory/advisory_query_private.hpp
+++ b/libdnf/advisory/advisory_query_private.hpp
@@ -1,0 +1,43 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_ADVISORY_ADVISORY_QUERY_PRIVATE_HPP
+#define LIBDNF_ADVISORY_ADVISORY_QUERY_PRIVATE_HPP
+
+#include "libdnf/advisory/advisory.hpp"
+#include "libdnf/advisory/advisory_query.hpp"
+#include "libdnf/rpm/solv/solv_map.hpp"
+
+namespace libdnf::advisory {
+
+//TODO(amatej): only temprary class to hide solv_map from advisory_query.hpp,
+//              should be replaced most likely by AdvisorySet?
+class AdvisoryQuery::Impl {
+    Impl(libdnf::rpm::solv::SolvMap m) : data_map(m){};
+
+private:
+    friend AdvisoryQuery;
+
+    libdnf::rpm::solv::SolvMap data_map;
+};
+
+}  // namespace libdnf::advisory
+
+
+#endif  // LIBDNF_ADVISORY_ADVISORY_QUERY_PRIVATE_HPP

--- a/libdnf/advisory/advisory_reference.cpp
+++ b/libdnf/advisory/advisory_reference.cpp
@@ -1,0 +1,81 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/advisory/advisory_reference.hpp"
+
+#include "libdnf/logger/logger.hpp"
+#include "libdnf/rpm/solv_sack_impl.hpp"
+
+#include <solv/chksum.h>
+#include <solv/repo.h>
+#include <solv/util.h>
+
+namespace libdnf::advisory {
+
+inline const char * get_str_from_pool(Id keyname, Id advisory, Pool * pool, int index) {
+    Dataiterator di;
+    const char * str = NULL;
+    int count = 0;
+
+    dataiterator_init(&di, pool, 0, advisory, UPDATE_REFERENCE, 0, 0);
+    while (dataiterator_step(&di)) {
+        dataiterator_setpos(&di);
+        if (count++ == index) {
+            str = pool_lookup_str(pool, SOLVID_POS, keyname);
+            break;
+        }
+    }
+    dataiterator_free(&di);
+
+    return str;
+}
+
+AdvisoryReference::AdvisoryReference(libdnf::rpm::SolvSack & sack, AdvisoryId advisory, int index)
+    : sack(sack.get_weak_ptr())
+    , advisory(advisory)
+    , index(index) {}
+
+std::string AdvisoryReference::get_id() const {
+    Pool * pool = sack->p_impl->get_pool();
+    return std::string(get_str_from_pool(UPDATE_REFERENCE_ID, advisory.id, pool, index));
+}
+AdvisoryReference::Type AdvisoryReference::get_type() const {
+    Pool * pool = sack->p_impl->get_pool();
+    const char * type = get_str_from_pool(UPDATE_REFERENCE_TYPE, advisory.id, pool, index);
+
+    if (type == NULL)
+        return Type::UNKNOWN;
+    if (!g_strcmp0(type, "bugzilla"))
+        return Type::BUGZILLA;
+    if (!g_strcmp0(type, "cve"))
+        return Type::CVE;
+    if (!g_strcmp0(type, "vendor"))
+        return Type::VENDOR;
+    return Type::UNKNOWN;
+}
+std::string AdvisoryReference::get_title() const {
+    Pool * pool = sack->p_impl->get_pool();
+    return std::string(get_str_from_pool(UPDATE_REFERENCE_TITLE, advisory.id, pool, index));
+}
+std::string AdvisoryReference::get_url() const {
+    Pool * pool = sack->p_impl->get_pool();
+    return std::string(get_str_from_pool(UPDATE_REFERENCE_HREF, advisory.id, pool, index));
+}
+
+}  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_sack.cpp
+++ b/libdnf/advisory/advisory_sack.cpp
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/advisory/advisory_sack.hpp"
+
+#include "libdnf/rpm/solv_sack_impl.hpp"
+
+#include <solv/dataiterator.h>
+
+namespace libdnf::advisory {
+
+AdvisorySack::AdvisorySack(libdnf::Base & base) : data_map(0), base(&base) {}
+
+AdvisorySack::~AdvisorySack() = default;
+
+AdvisoryQuery AdvisorySack::new_query() {
+    auto & solv_sack = base->get_rpm_solv_sack();
+
+    if (cached_solvables_size != solv_sack.p_impl->get_nsolvables()) {
+        load_advisories_from_solvsack();
+    }
+
+    return AdvisoryQuery(this);
+};
+
+void AdvisorySack::load_advisories_from_solvsack() {
+    auto & solv_sack = base->get_rpm_solv_sack();
+    Pool * pool = solv_sack.p_impl->get_pool();
+
+    data_map = libdnf::rpm::solv::SolvMap(pool->nsolvables);
+
+    Dataiterator di;
+
+    dataiterator_init(&di, pool, 0, 0, 0, 0, 0);
+
+    // - We want only advisories that have at least one package in them.
+    // - Advisories have their own Ids but advisory packages don't.
+    // - Keyname UPDATE_COLLECTION refers to packages (name, evr, arch) in advisories,
+    //   it is misnamed and should be rather called UPDATE_PACKAGE.
+    //
+    // This loop finds the first package in an advisory, adds the advisory
+    // Id to data_map and then skips it. Without the skip we would iterate
+    // over all packages in the advisory and added the same adivisory Id
+    // multiple times.
+    dataiterator_prepend_keyname(&di, UPDATE_COLLECTION);
+    while (dataiterator_step(&di)) {
+        data_map.add(libdnf::advisory::AdvisoryId(di.solvid));
+        dataiterator_skip_solvable(&di);
+    }
+    dataiterator_free(&di);
+
+    cached_solvables_size = pool->nsolvables;
+}
+
+}  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_sack.cpp
+++ b/libdnf/advisory/advisory_sack.cpp
@@ -60,7 +60,7 @@ void AdvisorySack::load_advisories_from_solvsack() {
     // multiple times.
     dataiterator_prepend_keyname(&di, UPDATE_COLLECTION);
     while (dataiterator_step(&di)) {
-        data_map.add(libdnf::advisory::AdvisoryId(di.solvid));
+        data_map.add(di.solvid);
         dataiterator_skip_solvable(&di);
     }
     dataiterator_free(&di);

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -34,265 +34,265 @@ namespace libdnf::rpm {
 
 const char * Package::get_name_cstring() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_name(pool, id);
+    return solv::get_name(pool, id.id);
 }
 
 std::string Package::get_name() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_name(pool, id));
+    return cstring2string(solv::get_name(pool, id.id));
 }
 
 const char * Package::get_epoch_cstring() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_epoch_cstring(pool, id);
+    return solv::get_epoch_cstring(pool, id.id);
 }
 
 std::string Package::get_epoch() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_epoch_cstring(pool, id);
+    return solv::get_epoch_cstring(pool, id.id);
 }
 
 const char * Package::get_version_cstring() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_version(pool, id);
+    return solv::get_version(pool, id.id);
 }
 
 std::string Package::get_version() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_version(pool, id));
+    return cstring2string(solv::get_version(pool, id.id));
 }
 
 const char * Package::get_release_cstring() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_release(pool, id);
+    return solv::get_release(pool, id.id);
 }
 
 std::string Package::get_release() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_release(pool, id));
+    return cstring2string(solv::get_release(pool, id.id));
 }
 
 const char * Package::get_arch_cstring() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_arch(pool, id);
+    return solv::get_arch(pool, id.id);
 }
 
 std::string Package::get_arch() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_arch(pool, id));
+    return cstring2string(solv::get_arch(pool, id.id));
 }
 
 const char * Package::get_evr_cstring() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_evr(pool, id);
+    return solv::get_evr(pool, id.id);
 }
 
 std::string Package::get_evr() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_evr(pool, id));
+    return cstring2string(solv::get_evr(pool, id.id));
 }
 
 std::string Package::get_nevra() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_nevra(pool, id));
+    return cstring2string(solv::get_nevra(pool, id.id));
 }
 
 std::string Package::get_full_nevra() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_full_nevra(pool, id));
+    return cstring2string(solv::get_full_nevra(pool, id.id));
 }
 
 std::string Package::get_group() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_group(pool, id));
+    return cstring2string(solv::get_group(pool, id.id));
 }
 
 unsigned long long Package::get_size() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_size(pool, id);
+    return solv::get_size(pool, id.id);
 }
 
 unsigned long long Package::get_download_size() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_download_size(pool, id);
+    return solv::get_download_size(pool, id.id);
 }
 
 unsigned long long Package::get_install_size() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_install_size(pool, id);
+    return solv::get_install_size(pool, id.id);
 }
 
 std::string Package::get_license() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_license(pool, id));
+    return cstring2string(solv::get_license(pool, id.id));
 }
 
 std::string Package::get_sourcerpm() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_sourcerpm(pool, id));
+    return cstring2string(solv::get_sourcerpm(pool, id.id));
 }
 
 unsigned long long Package::get_build_time() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_build_time(pool, id);
+    return solv::get_build_time(pool, id.id);
 }
 
 // TODO not supported by libsolv: https://github.com/openSUSE/libsolv/issues/400
 //std::string Package::get_build_host() {
 //    Pool * pool = sack->p_impl->pool;
-//    return cstring2string(solv::get_build_host(pool, id));
+//    return cstring2string(solv::get_build_host(pool, id).id);
 //}
 
 std::string Package::get_packager() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_packager(pool, id));
+    return cstring2string(solv::get_packager(pool, id.id));
 }
 
 std::string Package::get_vendor() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_vendor(pool, id));
+    return cstring2string(solv::get_vendor(pool, id.id));
 }
 
 std::string Package::get_url() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_url(pool, id));
+    return cstring2string(solv::get_url(pool, id.id));
 }
 
 std::string Package::get_summary() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_summary(pool, id));
+    return cstring2string(solv::get_summary(pool, id.id));
 }
 
 std::string Package::get_description() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_description(pool, id));
+    return cstring2string(solv::get_description(pool, id.id));
 }
 
 std::vector<std::string> Package::get_files() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_files(pool, id);
+    return solv::get_files(pool, id.id);
 }
 
 ReldepList Package::get_provides() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_provides(pool, id, list.p_impl->queue);
+    solv::get_provides(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_requires() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_requires(pool, id, list.p_impl->queue);
+    solv::get_requires(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_requires_pre() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_requires_pre(pool, id, list.p_impl->queue);
+    solv::get_requires_pre(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_conflicts() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_conflicts(pool, id, list.p_impl->queue);
+    solv::get_conflicts(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_obsoletes() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_obsoletes(pool, id, list.p_impl->queue);
+    solv::get_obsoletes(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_recommends() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_recommends(pool, id, list.p_impl->queue);
+    solv::get_recommends(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_suggests() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_suggests(pool, id, list.p_impl->queue);
+    solv::get_suggests(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_enhances() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_enhances(pool, id, list.p_impl->queue);
+    solv::get_enhances(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_supplements() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_supplements(pool, id, list.p_impl->queue);
+    solv::get_supplements(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_prereq_ignoreinst() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_prereq_ignoreinst(pool, id, list.p_impl->queue);
+    solv::get_prereq_ignoreinst(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_regular_requires() const {
     Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_regular_requires(pool, id, list.p_impl->queue);
+    solv::get_regular_requires(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 std::string Package::get_baseurl() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_baseurl(pool, id));
+    return cstring2string(solv::get_baseurl(pool, id.id));
 }
 
 std::string Package::get_location() const {
     Pool * pool = sack->p_impl->pool;
-    return cstring2string(solv::get_location(pool, id));
+    return cstring2string(solv::get_location(pool, id.id));
 }
 
 std::string Package::get_local_filepath() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_local_filepath(pool, id);
+    return solv::get_local_filepath(pool, id.id);
 }
 
 bool Package::is_installed() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::is_installed(pool, solv::get_solvable(pool, id));
+    return solv::is_installed(pool, solv::get_solvable(pool, id.id));
 }
 
 unsigned long long Package::get_hdr_end() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_hdr_end(pool, id);
+    return solv::get_hdr_end(pool, id.id);
 }
 
 unsigned long long Package::get_install_time() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_install_time(pool, id);
+    return solv::get_install_time(pool, id.id);
 }
 
 unsigned long long Package::get_media_number() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_media_number(pool, id);
+    return solv::get_media_number(pool, id.id);
 }
 
 unsigned long long Package::get_rpmdbid() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_rpmdbid(pool, id);
+    return solv::get_rpmdbid(pool, id.id);
 }
 
 Repo * Package::get_repo() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_repo(pool, id);
+    return solv::get_repo(pool, id.id);
 }
 
 std::string Package::get_repo_id() const {
@@ -302,7 +302,7 @@ std::string Package::get_repo_id() const {
 Checksum Package::get_checksum() const {
     Pool * pool = sack->p_impl->pool;
 
-    Solvable * solvable = solv::get_solvable(pool, id);
+    Solvable * solvable = solv::get_solvable(pool, id.id);
     int type;
     solv::SolvPrivate::internalize_libsolv_repo(solvable->repo);
     const char * chksum = solvable_lookup_checksum(solvable, SOLVABLE_CHECKSUM, &type);
@@ -314,7 +314,7 @@ Checksum Package::get_checksum() const {
 Checksum Package::get_hdr_checksum() const {
     Pool * pool = sack->p_impl->pool;
 
-    Solvable * solvable = solv::get_solvable(pool, id);
+    Solvable * solvable = solv::get_solvable(pool, id.id);
     int type;
     solv::SolvPrivate::internalize_libsolv_repo(solvable->repo);
     const char * chksum = solvable_lookup_checksum(solvable, SOLVABLE_HDRID, &type);

--- a/libdnf/rpm/package_set.cpp
+++ b/libdnf/rpm/package_set.cpp
@@ -23,8 +23,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "package_set_impl.hpp"
 
 #include "libdnf/rpm/package_set_iterator.hpp"
-#include "libdnf/rpm/solv_sack.hpp"
 #include "libdnf/rpm/solv/solv_map.hpp"
+#include "libdnf/rpm/solv_sack.hpp"
 
 
 namespace libdnf::rpm {
@@ -112,22 +112,24 @@ std::size_t PackageSet::size() const noexcept {
     return p_impl->size();
 }
 
+
 void PackageSet::swap(PackageSet & other) noexcept {
     p_impl.swap(other.p_impl);
 }
 
+
 void PackageSet::add(const Package & pkg) {
-    p_impl->add(pkg.get_id());
+    p_impl->add(pkg.get_id().id);
 }
 
 
 bool PackageSet::contains(const Package & pkg) const noexcept {
-    return p_impl->contains(pkg.get_id());
+    return p_impl->contains(pkg.get_id().id);
 }
 
 
 void PackageSet::remove(const Package & pkg) {
-    p_impl->remove(pkg.get_id());
+    p_impl->remove(pkg.get_id().id);
 }
 
 

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -41,7 +41,7 @@ void PackageSetIterator::end() {
 
 
 Package PackageSetIterator::operator*() {
-    return {p_impl->package_set.get_sack(), **p_impl};
+    return {p_impl->package_set.get_sack(), libdnf::rpm::PackageId(**p_impl)};
 }
 
 

--- a/libdnf/rpm/solv/goal_private.cpp
+++ b/libdnf/rpm/solv/goal_private.cpp
@@ -40,7 +40,7 @@ void allow_uninstall_all_but_protected(
         not_protected_pkgs -= *protected_packages;
     }
     if (protected_kernel.id > 0) {
-        not_protected_pkgs.remove_unsafe(protected_kernel);
+        not_protected_pkgs.remove_unsafe(protected_kernel.id);
     }
     if (pool->considered) {
         not_protected_pkgs &= pool->considered;
@@ -48,7 +48,7 @@ void allow_uninstall_all_but_protected(
 
     for (Id id = 1; id < pool->nsolvables; ++id) {
         Solvable * s = pool_id2solvable(pool, id);
-        if (pool->installed == s->repo && not_protected_pkgs.contains_unsafe(libdnf::rpm::PackageId(id))) {
+        if (pool->installed == s->repo && not_protected_pkgs.contains_unsafe(id)) {
             job.push_back(SOLVER_ALLOWUNINSTALL | SOLVER_SOLVABLE, id);
         }
     }
@@ -126,7 +126,7 @@ libdnf::rpm::solv::SolvMap list_results(
         }
 
         if (type == type_filter1 || (type_filter2 && type == type_filter2)) {
-            result_ids.add(libdnf::rpm::PackageId(p));
+            result_ids.add(p);
         }
     }
     return result_ids;
@@ -546,7 +546,7 @@ libdnf::GoalProblem GoalPrivate::protected_in_removals() {
         protected_pkgs |= *protected_packages;
     }
     if (protected_running_kernel.id > 0) {
-        protected_pkgs.add_unsafe(protected_running_kernel);
+        protected_pkgs.add_unsafe(protected_running_kernel.id);
     }
 
     removal_of_protected.reset(new SolvMap(std::move(pkg_remove_list)));

--- a/libdnf/rpm/solv/goal_private.hpp
+++ b/libdnf/rpm/solv/goal_private.hpp
@@ -200,7 +200,7 @@ inline void GoalPrivate::add_remove(const IdQueue & queue, bool clean_deps) {
 inline void GoalPrivate::add_remove(const SolvMap & solv_map, bool clean_deps) {
     Id flags = SOLVER_SOLVABLE | SOLVER_ERASE | (clean_deps ? SOLVER_CLEANDEPS : 0);
     for (auto what : solv_map) {
-        staging.push_back(flags, what.id);
+        staging.push_back(flags, what);
     }
 }
 

--- a/libdnf/rpm/solv/id_queue.hpp
+++ b/libdnf/rpm/solv/id_queue.hpp
@@ -176,7 +176,7 @@ inline IdQueue::iterator IdQueue::end() const {
 void inline solv_map_to_id_queue(IdQueue & ids, const SolvMap & src) {
     ids.clear();
     for (auto solv_id : src) {
-        ids.push_back(solv_id.id);
+        ids.push_back(solv_id);
     }
 }
 

--- a/libdnf/rpm/solv/package_private.cpp
+++ b/libdnf/rpm/solv/package_private.cpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::rpm::solv {
 
-const char * get_full_nevra(Pool * pool, libdnf::rpm::PackageId package_id) {
+const char * get_full_nevra(Pool * pool, Id package_id) {
     Solvable * solvable = get_solvable(pool, package_id);
     const char * name = pool_id2str(pool, solvable->name);
     const char * evr = pool_id2str(pool, solvable->evr);
@@ -70,7 +70,7 @@ const char * get_full_nevra(Pool * pool, libdnf::rpm::PackageId package_id) {
 }
 
 //TODO(jrohel): What about local repositories? The original code in DNF4 uses baseurl+get_location(pool, package_id).
-std::string get_local_filepath(Pool * pool, libdnf::rpm::PackageId package_id) {
+std::string get_local_filepath(Pool * pool, Id package_id) {
     auto solvable = get_solvable(pool, package_id);
     if (auto repo = static_cast<Repo *>(solvable->repo->appdata)) {
         auto dir = std::filesystem::path(repo->get_cachedir()) / "packages";

--- a/libdnf/rpm/solv/package_private.hpp
+++ b/libdnf/rpm/solv/package_private.hpp
@@ -43,13 +43,13 @@ namespace libdnf::rpm::solv {
 
 constexpr const char * BASE_EPOCH = "0";
 
-inline Solvable * get_solvable(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline Solvable * get_solvable(Pool * pool, Id package_id) noexcept {
     // Check that libsolv Id is identical with internal structure of PackageId
     static_assert(
         std::is_same<decltype(PackageId::id), ::Id>::value,
         "libdnf PackageId::id type differs from libsolv internal Id type");
 
-    return pool_id2solvable(pool, package_id.id);
+    return pool_id2solvable(pool, package_id);
 }
 
 inline libdnf::rpm::PackageId get_package_id(Pool * pool, Solvable * solvable) {
@@ -126,16 +126,16 @@ static inline void reldeps_for(Solvable * solvable, IdQueue & queue, Id type) {
     solvable_lookup_deparray(solvable, solv_type, &queue.get_queue(), marker);
 }
 
-inline const char * get_name(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_name(Pool * pool, Id package_id) noexcept {
     return pool_id2str(pool, get_solvable(pool, package_id)->name);
 }
 
-inline const char * get_evr(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_evr(Pool * pool, Id package_id) noexcept {
     return pool_id2str(pool, get_solvable(pool, package_id)->evr);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_epoch_cstring(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_epoch_cstring(Pool * pool, Id package_id) noexcept {
     char * e;
     char * v;
     char * r;
@@ -146,7 +146,7 @@ inline const char * get_epoch_cstring(Pool * pool, libdnf::rpm::PackageId packag
     return BASE_EPOCH;
 }
 
-inline unsigned long get_epoch(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline unsigned long get_epoch(Pool * pool, Id package_id) noexcept {
     char * e;
     char * v;
     char * r;
@@ -162,7 +162,7 @@ inline unsigned long get_epoch(Pool * pool, libdnf::rpm::PackageId package_id) n
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_version(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_version(Pool * pool, Id package_id) noexcept {
     char * e;
     char * v;
     char * r;
@@ -171,7 +171,7 @@ inline const char * get_version(Pool * pool, libdnf::rpm::PackageId package_id) 
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_release(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_release(Pool * pool, Id package_id) noexcept {
     char * e;
     char * v;
     char * r;
@@ -179,20 +179,20 @@ inline const char * get_release(Pool * pool, libdnf::rpm::PackageId package_id) 
     return r;
 }
 
-inline const char * get_arch(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_arch(Pool * pool, Id package_id) noexcept {
     return pool_id2str(pool, get_solvable(pool, package_id)->arch);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_nevra(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_nevra(Pool * pool, Id package_id) noexcept {
     return pool_solvable2str(pool, get_solvable(pool, package_id));
 }
 
 /// @return const char* !! Return temporal value !!
-const char * get_full_nevra(Pool * pool, libdnf::rpm::PackageId package_id);
+const char * get_full_nevra(Pool * pool, Id package_id);
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_group(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_group(Pool * pool, Id package_id) noexcept {
     return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_GROUP);
 }
 
@@ -200,16 +200,16 @@ inline bool is_installed(Pool * pool, Solvable * solvable) {
     return solvable->repo == pool->installed;
 }
 
-inline unsigned long long get_download_size(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline unsigned long long get_download_size(Pool * pool, Id package_id) noexcept {
     return lookup_num(get_solvable(pool, package_id), SOLVABLE_DOWNLOADSIZE);
 }
 
-inline unsigned long long get_install_size(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline unsigned long long get_install_size(Pool * pool, Id package_id) noexcept {
     return lookup_num(get_solvable(pool, package_id), SOLVABLE_INSTALLSIZE);
 }
 
 /// If package is installed, return get_install_size(). Return get_download_size() otherwise.
-inline unsigned long long get_size(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline unsigned long long get_size(Pool * pool, Id package_id) noexcept {
     Solvable * solvable = get_solvable(pool, package_id);
     if (is_installed(pool, solvable)) {
         return get_install_size(pool, package_id);
@@ -218,60 +218,60 @@ inline unsigned long long get_size(Pool * pool, libdnf::rpm::PackageId package_i
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_license(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_license(Pool * pool, Id package_id) noexcept {
     return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_LICENSE);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_sourcerpm(Pool * pool, libdnf::rpm::PackageId package_id) {
+inline const char * get_sourcerpm(Pool * pool, Id package_id) {
     Solvable * solvable = get_solvable(pool, package_id);
     SolvPrivate::internalize_libsolv_repo(solvable->repo);
     return solvable_lookup_sourcepkg(solvable);
 }
 
-inline unsigned long long get_build_time(Pool * pool, libdnf::rpm::PackageId package_id) {
+inline unsigned long long get_build_time(Pool * pool, Id package_id) {
     return lookup_num(get_solvable(pool, package_id), SOLVABLE_BUILDTIME);
 }
 
 // TODO not supported by libsolv: https://github.com/openSUSE/libsolv/issues/400
 /// @return const char* !! Return temporal value !!
-//inline const char * get_build_host(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+//inline const char * get_build_host(Pool * pool, Id package_id) noexcept {
 //    return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_BUILDHOST);
 //}
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_packager(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_packager(Pool * pool, Id package_id) noexcept {
     return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_PACKAGER);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_vendor(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_vendor(Pool * pool, Id package_id) noexcept {
     return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_VENDOR);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_url(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_url(Pool * pool, Id package_id) noexcept {
     return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_URL);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_summary(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_summary(Pool * pool, Id package_id) noexcept {
     return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_SUMMARY);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_description(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_description(Pool * pool, Id package_id) noexcept {
     return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_DESCRIPTION);
 }
 
-inline std::vector<std::string> get_files(Pool * pool, libdnf::rpm::PackageId package_id) {
+inline std::vector<std::string> get_files(Pool * pool, Id package_id) {
     Solvable * solvable = get_solvable(pool, package_id);
     Dataiterator di;
     std::vector<std::string> ret;
 
     SolvPrivate::internalize_libsolv_repo(solvable->repo);
     dataiterator_init(
-        &di, pool, solvable->repo, package_id.id, SOLVABLE_FILELIST, nullptr, SEARCH_FILES | SEARCH_COMPLETE_FILELIST);
+        &di, pool, solvable->repo, package_id, SOLVABLE_FILELIST, nullptr, SEARCH_FILES | SEARCH_COMPLETE_FILELIST);
     while (dataiterator_step(&di) != 0) {
         ret.emplace_back(di.kv.str);
     }
@@ -279,84 +279,84 @@ inline std::vector<std::string> get_files(Pool * pool, libdnf::rpm::PackageId pa
     return ret;
 }
 
-inline void get_provides(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_provides(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_PROVIDES);
 }
 
-inline void get_requires(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_requires(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_REQUIRES);
     IdQueue tmp_queue;
     reldeps_for(get_solvable(pool, package_id), tmp_queue, SOLVABLE_PREREQMARKER);
     queue.append(tmp_queue);
 }
 
-inline void get_requires_pre(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_requires_pre(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_PREREQMARKER);
 }
 
-inline void get_conflicts(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_conflicts(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_CONFLICTS);
 }
 
-inline void get_obsoletes(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_obsoletes(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_OBSOLETES);
 }
 
-inline void get_recommends(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_recommends(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_RECOMMENDS);
 }
 
-inline void get_suggests(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_suggests(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_SUGGESTS);
 }
 
-inline void get_enhances(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_enhances(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_ENHANCES);
 }
 
-inline void get_supplements(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_supplements(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_SUPPLEMENTS);
 }
 
-inline void get_prereq_ignoreinst(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_prereq_ignoreinst(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_PREREQ_IGNOREINST);
 }
 
-inline void get_regular_requires(Pool * pool, libdnf::rpm::PackageId package_id, IdQueue & queue) noexcept {
+inline void get_regular_requires(Pool * pool, Id package_id, IdQueue & queue) noexcept {
     reldeps_for(get_solvable(pool, package_id), queue, SOLVABLE_REQUIRES);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_baseurl(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_baseurl(Pool * pool, Id package_id) noexcept {
     return lookup_cstring(get_solvable(pool, package_id), SOLVABLE_MEDIABASE);
 }
 
 /// @return const char* !! Return temporal value !!
-inline const char * get_location(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline const char * get_location(Pool * pool, Id package_id) noexcept {
     auto solvable = get_solvable(pool, package_id);
     SolvPrivate::internalize_libsolv_repo(solvable->repo);
     return solvable_lookup_location(solvable, nullptr);
 }
 
-std::string get_local_filepath(Pool * pool, libdnf::rpm::PackageId package_id);
+std::string get_local_filepath(Pool * pool, Id package_id);
 
-inline unsigned long long get_hdr_end(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline unsigned long long get_hdr_end(Pool * pool, Id package_id) noexcept {
     return lookup_num(get_solvable(pool, package_id), SOLVABLE_HEADEREND);
 }
 
-inline unsigned long long get_install_time(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline unsigned long long get_install_time(Pool * pool, Id package_id) noexcept {
     return lookup_num(get_solvable(pool, package_id), SOLVABLE_INSTALLTIME);
 }
 
-inline unsigned long long get_media_number(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline unsigned long long get_media_number(Pool * pool, Id package_id) noexcept {
     return lookup_num(get_solvable(pool, package_id), SOLVABLE_MEDIANR);
 }
 
-inline unsigned long long get_rpmdbid(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline unsigned long long get_rpmdbid(Pool * pool, Id package_id) noexcept {
     return lookup_num(get_solvable(pool, package_id), RPM_RPMDBID);
 }
 
-inline Repo * get_repo(Pool * pool, libdnf::rpm::PackageId package_id) noexcept {
+inline Repo * get_repo(Pool * pool, Id package_id) noexcept {
     auto solvable = get_solvable(pool, package_id);
     return static_cast<Repo *>(solvable->repo->appdata);
 }

--- a/libdnf/rpm/solv/solv_map.hpp
+++ b/libdnf/rpm/solv/solv_map.hpp
@@ -93,22 +93,22 @@ public:
     // ITEM OPERATIONS
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.set(Id id)
-    void add(PackageId package_id);
+    void add(Id id);
 
     /// Faster, but unsafe version of add() method that is doesn't check bitmap range
-    void add_unsafe(PackageId package_id) noexcept;
+    void add_unsafe(Id id) noexcept;
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.has(Id id)
-    bool contains(PackageId package_id) const noexcept;
+    bool contains(Id id) const noexcept;
 
     /// Faster, but unsafe version of contains() method that is doesn't check bitmap range
-    bool contains_unsafe(PackageId package_id) const noexcept;
+    bool contains_unsafe(Id id) const noexcept;
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.remove(Id id)
-    void remove(PackageId package_id);
+    void remove(Id id);
 
     /// Faster, but unsafe version of remove() method that is doesn't check bitmap range
-    void remove_unsafe(PackageId package_id) noexcept;
+    void remove_unsafe(Id id) noexcept;
 
     // SET OPERATIONS - Map
 
@@ -143,7 +143,7 @@ public:
 protected:
     /// Check if `id` is in bitmap range.
     /// Throws std::out_of_range
-    void check_id_in_bitmap_range(PackageId package_id) const;
+    void check_id_in_bitmap_range(Id id) const;
 
 private:
     friend class rpm::SolvSack;
@@ -193,9 +193,9 @@ inline SolvMap & SolvMap::operator=(SolvMap && other) noexcept {
     return *this;
 }
 
-inline void SolvMap::check_id_in_bitmap_range(PackageId package_id) const {
+inline void SolvMap::check_id_in_bitmap_range(Id id) const {
     // map.size is in bytes, << 3 multiplies the number with 8 and gives size in bits
-    if (package_id.id < 0 || package_id.id >= (map.size << 3)) {
+    if (id < 0 || id >= (map.size << 3)) {
         throw std::out_of_range("Id is out of bitmap range");
     }
 }
@@ -214,44 +214,44 @@ inline SolvMap::iterator SolvMap::end() const {
 }
 
 
-inline void SolvMap::add(PackageId package_id) {
-    check_id_in_bitmap_range(package_id);
-    add_unsafe(package_id);
+inline void SolvMap::add(Id id) {
+    check_id_in_bitmap_range(id);
+    add_unsafe(id);
 }
 
 
-inline bool SolvMap::contains(PackageId package_id) const noexcept {
-    if (package_id.id < 0 || package_id.id >= (map.size << 3)) {
+inline bool SolvMap::contains(Id id) const noexcept {
+    if (id < 0 || id >= (map.size << 3)) {
         // if Id is outside bitmap range, then bitmap doesn't contain it
         return false;
     }
-    return contains_unsafe(package_id);
+    return contains_unsafe(id);
 }
 
 
-inline void SolvMap::remove(PackageId package_id) {
-    check_id_in_bitmap_range(package_id);
-    remove_unsafe(package_id);
+inline void SolvMap::remove(Id id) {
+    check_id_in_bitmap_range(id);
+    remove_unsafe(id);
 }
 
 
-inline void SolvMap::add_unsafe(PackageId package_id) noexcept {
+inline void SolvMap::add_unsafe(Id id) noexcept {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-    MAPSET(&map, package_id.id);
+    MAPSET(&map, id);
 #pragma GCC diagnostic pop
 }
 
 
-inline bool SolvMap::contains_unsafe(PackageId package_id) const noexcept {
-    return MAPTST(&map, package_id.id);
+inline bool SolvMap::contains_unsafe(Id id) const noexcept {
+    return MAPTST(&map, id);
 }
 
 
-inline void SolvMap::remove_unsafe(PackageId package_id) noexcept {
+inline void SolvMap::remove_unsafe(Id id) noexcept {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-    MAPCLR(&map, package_id.id);
+    MAPCLR(&map, id);
 #pragma GCC diagnostic pop
 }
 

--- a/libdnf/rpm/solv_sack.cpp
+++ b/libdnf/rpm/solv_sack.cpp
@@ -123,15 +123,15 @@ static void libsolv_repo_free(LibsolvRepo * libsolv_repo) {
 bool is_superset(const solv::IdQueue & q1, const solv::IdQueue * q2, solv::SolvMap & map) {
     int cnt = 0;
     for (int i = 0; i < q2->size(); i++) {
-        map.add_unsafe(PackageId((*q2)[i]));
+        map.add_unsafe((*q2)[i]);
     }
     for (int i = 0; i < q1.size(); i++) {
-        if (map.contains_unsafe(PackageId(q1[i]))) {
+        if (map.contains_unsafe(q1[i])) {
             cnt++;
         }
     }
     for (int i = 0; i < q2->size(); i++) {
-        map.remove_unsafe(PackageId((*q2)[i]));
+        map.remove_unsafe((*q2)[i]);
     }
     return cnt == q2->size();
 }

--- a/libdnf/rpm/solv_sack_impl.hpp
+++ b/libdnf/rpm/solv_sack_impl.hpp
@@ -190,8 +190,8 @@ inline std::vector<Solvable *> & SolvSack::Impl::get_sorted_solvables() {
     auto & solvables_map = get_solvables();
     cached_sorted_solvables.clear();
     cached_sorted_solvables.reserve(static_cast<size_t>(nsolvables));
-    for (PackageId id : solvables_map) {
-        cached_sorted_solvables.push_back(pool_id2solvable(pool, id.id));
+    for (Id id : solvables_map) {
+        cached_sorted_solvables.push_back(pool_id2solvable(pool, id));
     }
     std::sort(cached_sorted_solvables.begin(), cached_sorted_solvables.end(), nevra_solvable_cmp_key);
     cached_sorted_solvables_size = nsolvables;
@@ -233,7 +233,7 @@ inline solv::SolvMap & SolvSack::Impl::get_solvables() {
     // loop over all package solvables
     FOR_POOL_SOLVABLES(solvable_id) {
         if (utils::is_package(pool, solvable_id)) {
-            cached_solvables.add_unsafe(PackageId(solvable_id));
+            cached_solvables.add_unsafe(solvable_id);
         }
     }
     return cached_solvables;

--- a/microdnf/commands/advisory/advisory.cpp
+++ b/microdnf/commands/advisory/advisory.cpp
@@ -1,0 +1,232 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "advisory.hpp"
+
+#include "../../context.hpp"
+
+#include <libdnf/conf/option_string.hpp>
+#include <libdnf/rpm/solv_query.hpp>
+
+//TODO(amatej): just for test output -> remove
+#include <iostream>
+
+namespace microdnf {
+
+using namespace libdnf::cli;
+
+void CmdAdvisory::set_argument_parser(Context & ctx) {
+    availability_option = dynamic_cast<libdnf::OptionEnum<std::string> *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionEnum<std::string>>(
+            new libdnf::OptionEnum<std::string>("available", {"all", "available", "installed", "updates"}))));
+
+    auto all = ctx.arg_parser.add_new_named_arg("all");
+    all->set_long_name("all");
+    all->set_short_description("show advisories about any version of installed packages");
+    all->set_const_value("all");
+    all->link_value(availability_option);
+
+    auto available = ctx.arg_parser.add_new_named_arg("available");
+    available->set_long_name("available");
+    available->set_short_description("show advisories about newer versions of installed packages (default)");
+    available->set_const_value("available");
+    available->link_value(availability_option);
+
+    auto installed = ctx.arg_parser.add_new_named_arg("installed");
+    installed->set_long_name("installed");
+    installed->set_short_description("show advisories about equal and older versions of installed packages");
+    installed->set_const_value("installed");
+    installed->link_value(availability_option);
+
+    auto updates = ctx.arg_parser.add_new_named_arg("updates");
+    updates->set_long_name("updates");
+    updates->set_short_description(
+        "show advisories about newer versions of installed packages for which a newer version is available");
+    updates->set_const_value("updates");
+    updates->link_value(availability_option);
+
+    auto conflict_args =
+        ctx.arg_parser.add_conflict_args_group(std::unique_ptr<std::vector<ArgumentParser::Argument *>>(
+            new std::vector<ArgumentParser::Argument *>{all, available, installed, updates}));
+
+    all->set_conflict_arguments(conflict_args);
+    available->set_conflict_arguments(conflict_args);
+    installed->set_conflict_arguments(conflict_args);
+    updates->set_conflict_arguments(conflict_args);
+
+
+    patterns_to_show_options = ctx.arg_parser.add_new_values();
+    auto specs = ctx.arg_parser.add_new_positional_arg(
+        "specs_to_show",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_to_show_options);
+    specs->set_short_description("List of specs to use when searching for advisory");
+
+
+    output_type_option = dynamic_cast<libdnf::OptionEnum<std::string> *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionEnum<std::string>>(
+            new libdnf::OptionEnum<std::string>("summary", {"summary", "list", "info"}))));
+
+    auto summary = ctx.arg_parser.add_new_named_arg("summary");
+    summary->set_long_name("summary");
+    summary->set_short_description("show just counts of advisory types (default)");
+    summary->set_const_value("summary");
+    summary->link_value(output_type_option);
+
+    auto list = ctx.arg_parser.add_new_named_arg("list");
+    list->set_long_name("list");
+    list->set_short_description("show list of advisories");
+    list->set_const_value("list");
+    list->link_value(output_type_option);
+
+    auto info = ctx.arg_parser.add_new_named_arg("info");
+    info->set_long_name("info");
+    info->set_short_description("show detailed information about advisories");
+    info->set_const_value("info");
+    info->link_value(output_type_option);
+
+    conflict_args = ctx.arg_parser.add_conflict_args_group(std::unique_ptr<std::vector<ArgumentParser::Argument *>>(
+        new std::vector<ArgumentParser::Argument *>{summary, list, info}));
+
+    summary->set_conflict_arguments(conflict_args);
+    list->set_conflict_arguments(conflict_args);
+    info->set_conflict_arguments(conflict_args);
+
+
+    with_cve_option = dynamic_cast<libdnf::OptionBool *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(false))));
+    auto with_cve = ctx.arg_parser.add_new_named_arg("with_cve");
+    with_cve->set_long_name("with_cve");
+    with_cve->set_short_description("show only advisories with CVE reference");
+    with_cve->set_const_value("false");
+    with_cve->link_value(with_cve_option);
+
+
+    with_bz_option = dynamic_cast<libdnf::OptionBool *>(
+        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(false))));
+    auto with_bz = ctx.arg_parser.add_new_named_arg("with_bz");
+    with_bz->set_long_name("with_bz");
+    with_bz->set_short_description("show only advisories with bugzilla reference");
+    with_bz->set_const_value("false");
+    with_bz->link_value(with_bz_option);
+
+
+    auto advisory = ctx.arg_parser.add_new_command("advisory");
+    advisory->set_short_description("display information about update advisories");
+    advisory->set_description("");
+    advisory->set_named_args_help_header("Optional arguments:");
+    advisory->set_positional_args_help_header("Positional arguments:");
+    advisory->set_parse_hook_func([this, &ctx](
+                               [[maybe_unused]] ArgumentParser::Argument * arg,
+                               [[maybe_unused]] const char * option,
+                               [[maybe_unused]] int argc,
+                               [[maybe_unused]] const char * const argv[]) {
+        ctx.select_command(this);
+        return true;
+    });
+
+    advisory->register_named_arg(all);
+    advisory->register_named_arg(available);
+    advisory->register_named_arg(installed);
+    advisory->register_named_arg(updates);
+
+    advisory->register_named_arg(summary);
+    advisory->register_named_arg(list);
+    advisory->register_named_arg(info);
+
+    advisory->register_named_arg(with_cve);
+    advisory->register_named_arg(with_bz);
+
+    advisory->register_positional_arg(specs);
+
+
+    ctx.arg_parser.get_root_command()->register_command(advisory);
+}
+
+void CmdAdvisory::run(Context & ctx) {
+    std::vector<std::string> patterns_to_show;
+    if (patterns_to_show_options->size() > 0) {
+        patterns_to_show.reserve(patterns_to_show_options->size());
+        for (auto & pattern : *patterns_to_show_options) {
+            auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());
+            patterns_to_show.emplace_back(option->get_value());
+        }
+    }
+
+    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+    solv_sack.create_system_repo(false);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
+    ctx.load_rpm_repos(enabled_repos, LoadFlags::USE_UPDATEINFO);
+
+    libdnf::rpm::SolvQuery solv_query(&solv_sack);
+    using QueryCmp = libdnf::sack::QueryCmp;
+    if (patterns_to_show.size() > 0) {
+        solv_query.ifilter_name(patterns_to_show, QueryCmp::IGLOB);
+    }
+
+    //DATA IS PREPARED
+
+    //TODO(amatej): create advisory_query with filters on advisories prensent (if we want to limit by severity, reference..)
+    auto advisory_query = ctx.base.get_rpm_advisory_sack().new_query();
+    if (with_cve_option->get_value()) {
+        advisory_query.ifilter_CVE("*", QueryCmp::IGLOB);
+    }
+    if (with_bz_option->get_value()) {
+        advisory_query.ifilter_bug("*", QueryCmp::IGLOB);
+    }
+    //advisory_query.ifilter_name(QueryCmp::IGLOB, input_name);
+    //advisory_query.ifilter_severity(QueryCmp::EQ, input_severity);
+
+    std::vector<libdnf::advisory::AdvisoryPackage> result_pkgs;
+
+    if (availability_option->get_value() == "installed") {
+        auto installed_solv_query = solv_query.ifilter_installed();
+        result_pkgs = advisory_query.get_advisory_packages(installed_solv_query, QueryCmp::LTE);
+    } else if (availability_option->get_value() == "available") {
+        //TODO(amatej): filter for latest and add kernel..
+        auto installed_solv_query = solv_query.ifilter_installed();
+        result_pkgs = advisory_query.get_advisory_packages(installed_solv_query, QueryCmp::GT);
+    } else if (availability_option->get_value() == "all") {
+        auto installed_solv_query = solv_query.ifilter_installed();
+        result_pkgs =
+            advisory_query.get_advisory_packages(installed_solv_query, QueryCmp::LT | QueryCmp::EQ | QueryCmp::GT);
+    } else if (availability_option->get_value() == "updates") {
+        //auto upgradable_solv_query = solv_query.ifilter_upgradable().ifilter_nevra(keys, QueryCmp::GT);
+        //result_pkgs = advisory_query.get_advisory_packages(upgradable_solv_query, QueryCmp::LT | QueryCmp::EQ | QueryCmp::GT);
+    }
+
+    //TODO(amatej): output code move to libdnf-cli
+    for (auto pkg : result_pkgs) {
+        //auto adv = advisories_map.find(pkg.get_name() + "-" + pkg.get_arch());
+        //if (adv == advisories_map.end()) {
+        //    //std::cout << pkg.get_name() << std::endl << std::flush;
+        std::cout
+            << libdnf::advisory::Advisory(solv_sack, libdnf::advisory::AdvisoryId(pkg.get_advisory_id())).get_name()
+            << " - " << pkg.get_name() << "-" << pkg.get_evr() << "." << pkg.get_arch() << std::endl;
+        //} else {
+        //    //std::cout << pkg.get_nevra() << " : " << advisories_map.find(pkg.get_name() + "-" + pkg.get_arch())->second.get()->get_name() << std::endl;
+        //    std::cout << pkg.get_nevra() << std::endl;
+        //   // std::cout << adv->first << std::endl;
+        //}
+    }
+}
+
+}  // namespace microdnf

--- a/microdnf/commands/advisory/advisory.hpp
+++ b/microdnf/commands/advisory/advisory.hpp
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
+
+Microdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Microdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICRODNF_COMMANDS_ADVISORY_ADVISORY_HPP
+#define MICRODNF_COMMANDS_ADVISORY_ADVISORY_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_bool.hpp>
+#include <libdnf/conf/option_enum.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace microdnf {
+
+class CmdAdvisory : public Command {
+public:
+    void set_argument_parser(Context & ctx) override;
+    void run(Context & ctx) override;
+
+private:
+    libdnf::OptionBool * with_cve_option{nullptr};
+    libdnf::OptionBool * with_bz_option{nullptr};
+    libdnf::OptionEnum<std::string> * availability_option{nullptr};
+    libdnf::OptionEnum<std::string> * output_type_option{nullptr};
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_show_options{nullptr};
+};
+
+}  // namespace microdnf
+
+#endif

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "commands/advisory/advisory.hpp"
 #include "commands/downgrade/downgrade.hpp"
 #include "commands/download/download.hpp"
 #include "commands/groupinfo/groupinfo.hpp"
@@ -225,6 +226,7 @@ int main(int argc, char * argv[]) {
     context.commands.push_back(std::make_unique<microdnf::CmdRepolist>());
     context.commands.push_back(std::make_unique<microdnf::CmdRepoquery>());
     context.commands.push_back(std::make_unique<microdnf::CmdUpgrade>());
+    context.commands.push_back(std::make_unique<microdnf::CmdAdvisory>());
 
     // Parse command line arguments
     bool help_printed = microdnf::parse_args(context, argc, argv);

--- a/test/data/repos-repomd/repomd-repo1/repodata/repomd.xml
+++ b/test/data/repos-repomd/repomd-repo1/repodata/repomd.xml
@@ -24,4 +24,12 @@
     <size>13799</size>
     <open-size>52054</open-size>
   </data>
+  <data type="updateinfo">
+    <checksum type="sha256">0bad6ed78db8e058e59eefddd20744d71219b736045b10821811180972f6d1fa</checksum>
+    <open-checksum type="sha256">0bad6ed78db8e058e59eefddd20744d71219b736045b10821811180972f6d1fa</open-checksum>
+    <location href="repodata/updateinfo.xml" />
+    <timestamp>1597222003</timestamp>
+    <size>646</size>
+    <open-size>2510</open-size>
+  </data>
 </repomd>

--- a/test/data/repos-repomd/repomd-repo1/repodata/updateinfo.xml
+++ b/test/data/repos-repomd/repomd-repo1/repodata/updateinfo.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-1</id>
+        <title>bugfix_A-1.0-1</title>
+        <release>Fedora 29</release>
+        <issued date="2019-02-22 15:30:01" />
+        <severity>moderate</severity>
+        <references>
+            <reference href="https://foobar/foobarupdate_2" id="1111" type="cve" title="CVE-2999"/>
+        </references>
+        <description>testing advisory 2019</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <module name="perl-DBI" stream="master" version="2" context="2a" arch="x86_64"/>
+                <module name="ethereum" stream="2.0" version="2" context="3b" arch="x86_64"/>
+                <package name="pkg" version="1.2" release="3" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>pkg-1.2-3.x86_64.rpm</filename>
+                </package>
+                <package name="filesystem" version="3.9" release="2.fc29" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>filesystem-3.9-2.fc29.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="bugfix" version="1">
+        <id>DNF-2020-1</id>
+        <title>bugfix_B-2.0-1</title>
+        <release>Fedora 29</release>
+        <issued date="2012-02-22 15:30:02" />
+        <severity>critical</severity>
+        <references>
+            <reference href="https://foobar/foobarupdate_2" id="2222" type="bugzilla" title="222"/>
+            <reference href="https://foobar/foobarupdate_2" id="3333" type="cve" title="CVE-2999"/>
+        </references>
+        <description>testing advisory 2020</description>
+        <pkglist>
+            <collection short="foo">
+                <name>Foolishness</name>
+                <module name="perl-DBI" stream="master" version="2" context="2b" arch="x86_64"/>
+                <package name="wget" version="1.19.5" release="5.fc29" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>wget-1.19.5-5.fc29.x86_64.rpm</filename>
+                </package>
+                <package name="yum" version="3.4.3" release="0" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>yum-3.4.3-0.x86_64.rpm</filename>
+                </package>
+            </collection>
+            <collection short="bar">
+                <name>Genius</name>
+                <module name="perl" stream="master" version="1" context="1c" arch="x86_64"/>
+                <package name="bitcoin" version="2.5" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>bitcoin-2.5-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="enhancement" version="1">
+        <id>PKG-NEWER</id>
+        <title>newer-version</title>
+        <release>Fedora 29</release>
+        <issued date="2012-02-22 15:30:02" />
+        <severity>low</severity>
+        <description>testing advisory with newer package</description>
+        <pkglist>
+            <collection short="newer">
+                <name>Newer pkg</name>
+                <package name="pkg" version="4.0" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>pkg-4.0-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="bugfix" version="1">
+        <id>PKG-OLDER</id>
+        <title>older-version</title>
+        <release>Fedora 29</release>
+        <issued date="2012-02-22 15:30:02" />
+        <severity>low</severity>
+        <description>testing advisory with older package</description>
+        <pkglist>
+            <collection short="older">
+                <name>Older pkg</name>
+                <package name="pkg" version="0.1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>pkg-0.1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>

--- a/test/libdnf/advisory/test_advisory.cpp
+++ b/test/libdnf/advisory/test_advisory.cpp
@@ -1,0 +1,122 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_advisory.hpp"
+
+#include "libdnf/rpm/package_set.hpp"
+#include "libdnf/rpm/solv_query.hpp"
+
+#include <filesystem>
+#include <set>
+#include <vector>
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(AdvisoryAdvisoryTest);
+
+//This allows running only this single test suite, by using `getRegistry("AdvisoryAdvisoryTest_suite")` in run_tests.cpp
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryTest, "AdvisoryAdvisoryTest_suite");
+
+void AdvisoryAdvisoryTest::setUp() {
+    RepoFixture::setUp();
+    RepoFixture::add_repo_repomd("repomd-repo1");
+    advisory_sack = &(base->get_rpm_advisory_sack());
+    libdnf::advisory::AdvisoryQuery q =
+        advisory_sack->new_query().ifilter_type(libdnf::advisory::Advisory::Type::SECURITY);
+    advisories = q.get_advisories();
+    advisory = &(advisories[0]);
+}
+
+void AdvisoryAdvisoryTest::test_get_name() {
+    // Tests get_name method
+    CPPUNIT_ASSERT_EQUAL(advisory->get_name(), std::string("DNF-2019-1"));
+}
+
+void AdvisoryAdvisoryTest::test_get_type() {
+    // Tests get_type method
+    CPPUNIT_ASSERT_EQUAL(advisory->get_type(), libdnf::advisory::Advisory::Type::SECURITY);
+}
+
+void AdvisoryAdvisoryTest::test_get_type_cstring() {
+    // Tests get_type method
+    CPPUNIT_ASSERT(!strcmp(advisory->get_type_cstring(), "security"));
+}
+
+void AdvisoryAdvisoryTest::test_get_severity() {
+    // Tests get_severity method
+    CPPUNIT_ASSERT_EQUAL(advisory->get_severity(), std::string("moderate"));
+}
+
+void AdvisoryAdvisoryTest::test_get_references() {
+    // Tests get_references method
+    std::vector<libdnf::advisory::AdvisoryReference> refs = advisory->get_references();
+    CPPUNIT_ASSERT_EQUAL(1lu, refs.size());
+
+    libdnf::advisory::AdvisoryReference r = refs[0];
+    CPPUNIT_ASSERT_EQUAL(std::string("1111"), r.get_id());
+    CPPUNIT_ASSERT_EQUAL(libdnf::advisory::AdvisoryReference::Type::CVE, r.get_type());
+    CPPUNIT_ASSERT_EQUAL(std::string("CVE-2999"), r.get_title());
+    CPPUNIT_ASSERT_EQUAL(std::string("https://foobar/foobarupdate_2"), r.get_url());
+}
+
+void AdvisoryAdvisoryTest::test_get_collections() {
+    // Tests get_collections method
+    std::vector<libdnf::advisory::AdvisoryCollection> colls = advisory->get_collections();
+    CPPUNIT_ASSERT_EQUAL(1lu, colls.size());
+
+    libdnf::advisory::AdvisoryCollection c = colls[0];
+    std::vector<libdnf::advisory::AdvisoryPackage> pkgs = c.get_packages();
+    CPPUNIT_ASSERT_EQUAL(2lu, pkgs.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), pkgs[0].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), pkgs[1].get_name());
+
+    std::vector<libdnf::advisory::AdvisoryModule> mods = c.get_modules();
+    CPPUNIT_ASSERT_EQUAL(2lu, mods.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), mods[0].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), mods[1].get_name());
+
+    auto adv_vec = advisory_sack->new_query().ifilter_name("DNF-2020-1").get_advisories();
+    CPPUNIT_ASSERT_EQUAL(1lu, adv_vec.size());
+    libdnf::advisory::Advisory * advisory2 = &(adv_vec[0]);
+    colls = advisory2->get_collections();
+    CPPUNIT_ASSERT_EQUAL(2lu, colls.size());
+
+    libdnf::advisory::AdvisoryCollection c1 = colls[0];
+    pkgs.clear();
+    pkgs = c1.get_packages();
+    CPPUNIT_ASSERT_EQUAL(2lu, pkgs.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("wget"), pkgs[0].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("yum"), pkgs[1].get_name());
+
+    mods.clear();
+    mods = c1.get_modules();
+    CPPUNIT_ASSERT_EQUAL(1lu, mods.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), mods[0].get_name());
+
+    libdnf::advisory::AdvisoryCollection c2 = colls[1];
+    pkgs.clear();
+    pkgs = c2.get_packages();
+    CPPUNIT_ASSERT_EQUAL(1lu, pkgs.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("bitcoin"), pkgs[0].get_name());
+
+    mods.clear();
+    mods = c2.get_modules();
+    CPPUNIT_ASSERT_EQUAL(1lu, mods.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("perl"), mods[0].get_name());
+}

--- a/test/libdnf/advisory/test_advisory.hpp
+++ b/test/libdnf/advisory/test_advisory.hpp
@@ -1,0 +1,63 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF_ADVISORY_ADVISORY_HPP
+#define TEST_LIBDNF_ADVISORY_ADVISORY_HPP
+
+
+#include "../rpm/repo_fixture.hpp"
+
+#include "libdnf/advisory/advisory_collection.hpp"
+#include "libdnf/advisory/advisory_sack.hpp"
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class AdvisoryAdvisoryTest : public RepoFixture {
+    CPPUNIT_TEST_SUITE(AdvisoryAdvisoryTest);
+
+    CPPUNIT_TEST(test_get_name);
+    CPPUNIT_TEST(test_get_type);
+    CPPUNIT_TEST(test_get_type_cstring);
+    CPPUNIT_TEST(test_get_severity);
+    CPPUNIT_TEST(test_get_references);
+    CPPUNIT_TEST(test_get_collections);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+
+    void test_get_name();
+    void test_get_type();
+    void test_get_type_cstring();
+    void test_get_severity();
+    //void test_ifilter_package();
+
+    void test_get_references();
+    void test_get_collections();
+
+private:
+    libdnf::advisory::AdvisorySack * advisory_sack;
+    std::vector<libdnf::advisory::Advisory> advisories;
+    libdnf::advisory::Advisory * advisory;
+};
+
+
+#endif  // TEST_LIBDNF_ADVISORY_ADVISORY_HPP

--- a/test/libdnf/advisory/test_advisory_module.cpp
+++ b/test/libdnf/advisory/test_advisory_module.cpp
@@ -1,0 +1,84 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_advisory_module.hpp"
+
+#include <filesystem>
+#include <set>
+#include <vector>
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(AdvisoryAdvisoryModuleTest);
+
+//This allows running only this single test suite, by using `getRegistry("AdvisoryAdvisoryTest_suite")` in run_tests.cpp
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryModuleTest, "AdvisoryAdvisoryModuleTest_suite");
+
+void AdvisoryAdvisoryModuleTest::setUp() {
+    RepoFixture::setUp();
+    RepoFixture::add_repo_repomd("repomd-repo1");
+    auto advisory = base->get_rpm_advisory_sack().new_query().ifilter_name("DNF-2019-1").get_advisories()[0];
+    std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
+    modules = collections[0].get_modules();
+}
+
+void AdvisoryAdvisoryModuleTest::test_get_name() {
+    // Tests get_name method
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), std::string(modules[0].get_name()));
+}
+
+void AdvisoryAdvisoryModuleTest::test_get_stream() {
+    // Tests get_stream method
+    CPPUNIT_ASSERT_EQUAL(std::string("master"), std::string(modules[0].get_stream()));
+}
+
+void AdvisoryAdvisoryModuleTest::test_get_version() {
+    // Tests get_version method
+    CPPUNIT_ASSERT_EQUAL(std::string("2"), std::string(modules[0].get_version()));
+}
+
+void AdvisoryAdvisoryModuleTest::test_get_context() {
+    // Tests get_context method
+    CPPUNIT_ASSERT_EQUAL(std::string("2a"), std::string(modules[0].get_context()));
+}
+
+void AdvisoryAdvisoryModuleTest::test_get_arch() {
+    // Tests get_arch method
+    CPPUNIT_ASSERT_EQUAL(std::string("x86_64"), std::string(modules[0].get_arch()));
+}
+
+void AdvisoryAdvisoryModuleTest::test_get_advisory_id() {
+    // Tests get_advisory_id method
+    libdnf::advisory::AdvisoryId adv_id = modules[0].get_advisory_id();
+    CPPUNIT_ASSERT(adv_id.id > 0);
+}
+
+void AdvisoryAdvisoryModuleTest::test_get_advisory() {
+    // Tests get_advisory method
+    libdnf::advisory::Advisory a = modules[0].get_advisory();
+    CPPUNIT_ASSERT_EQUAL(std::string("DNF-2019-1"), a.get_name());
+}
+
+void AdvisoryAdvisoryModuleTest::test_get_advisory_collection() {
+    // Tests get_advisory_collection method
+    libdnf::advisory::AdvisoryCollection ac = modules[0].get_advisory_collection();
+    std::vector<libdnf::advisory::AdvisoryModule> out_mods = ac.get_modules();
+    size_t target_size = 2;
+    CPPUNIT_ASSERT_EQUAL(target_size, out_mods.size());
+}

--- a/test/libdnf/advisory/test_advisory_module.hpp
+++ b/test/libdnf/advisory/test_advisory_module.hpp
@@ -1,0 +1,65 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF_ADVISORY_ADVISORY_MODULE_HPP
+#define TEST_LIBDNF_ADVISORY_ADVISORY_MODULE_HPP
+
+
+#include "../rpm/repo_fixture.hpp"
+
+#include "libdnf/advisory/advisory_collection.hpp"
+#include "libdnf/advisory/advisory_module.hpp"
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class AdvisoryAdvisoryModuleTest : public RepoFixture {
+    CPPUNIT_TEST_SUITE(AdvisoryAdvisoryModuleTest);
+
+    CPPUNIT_TEST(test_get_name);
+    CPPUNIT_TEST(test_get_stream);
+    CPPUNIT_TEST(test_get_version);
+    CPPUNIT_TEST(test_get_context);
+    CPPUNIT_TEST(test_get_arch);
+
+    CPPUNIT_TEST(test_get_advisory_id);
+    CPPUNIT_TEST(test_get_advisory);
+    CPPUNIT_TEST(test_get_advisory_collection);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+
+    void test_get_name();
+    void test_get_stream();
+    void test_get_version();
+    void test_get_context();
+    void test_get_arch();
+
+    void test_get_advisory_id();
+    void test_get_advisory();
+    void test_get_advisory_collection();
+
+private:
+    std::vector<libdnf::advisory::AdvisoryModule> modules;
+};
+
+
+#endif  // TEST_LIBDNF_ADVISORY_ADVISORY_MODULE_HPP

--- a/test/libdnf/advisory/test_advisory_package.cpp
+++ b/test/libdnf/advisory/test_advisory_package.cpp
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_advisory_package.hpp"
+
+#include <filesystem>
+#include <set>
+#include <vector>
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(AdvisoryAdvisoryPackageTest);
+
+//This allows running only this single test suite, by using `getRegistry("AdvisoryAdvisoryTest_suite")` in run_tests.cpp
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryPackageTest, "AdvisoryAdvisoryPackageTest_suite");
+
+void AdvisoryAdvisoryPackageTest::setUp() {
+    RepoFixture::setUp();
+    RepoFixture::add_repo_repomd("repomd-repo1");
+    auto advisory = base->get_rpm_advisory_sack().new_query().ifilter_name("DNF-2019-1").get_advisories()[0];
+    std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
+    packages = collections[0].get_packages();
+}
+
+void AdvisoryAdvisoryPackageTest::test_get_name() {
+    // Tests get_name method
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), std::string(packages[0].get_name()));
+}
+
+void AdvisoryAdvisoryPackageTest::test_get_version() {
+    // Tests get_version method
+    CPPUNIT_ASSERT_EQUAL(std::string("1.2"), std::string(packages[0].get_version()));
+}
+
+void AdvisoryAdvisoryPackageTest::test_get_evr() {
+    // Tests get_evr method
+    CPPUNIT_ASSERT_EQUAL(std::string("1.2-3"), std::string(packages[0].get_evr()));
+}
+
+void AdvisoryAdvisoryPackageTest::test_get_arch() {
+    // Tests get_arch method
+    CPPUNIT_ASSERT_EQUAL(std::string("x86_64"), std::string(packages[0].get_arch()));
+}
+
+void AdvisoryAdvisoryPackageTest::test_get_advisory_id() {
+    // Tests get_advisory_id method
+    libdnf::advisory::AdvisoryId adv_id = packages[0].get_advisory_id();
+    CPPUNIT_ASSERT(adv_id.id > 0);
+}
+
+void AdvisoryAdvisoryPackageTest::test_get_advisory() {
+    // Tests get_advisory method
+    libdnf::advisory::Advisory a = packages[0].get_advisory();
+    CPPUNIT_ASSERT_EQUAL(std::string("DNF-2019-1"), a.get_name());
+}
+
+void AdvisoryAdvisoryPackageTest::test_get_advisory_collection() {
+    // Tests get_advisory_collection method
+    libdnf::advisory::AdvisoryCollection ac = packages[0].get_advisory_collection();
+    std::vector<libdnf::advisory::AdvisoryPackage> out_pkgs = ac.get_packages();
+    size_t target_size = 2;
+    CPPUNIT_ASSERT_EQUAL(target_size, out_pkgs.size());
+}

--- a/test/libdnf/advisory/test_advisory_package.hpp
+++ b/test/libdnf/advisory/test_advisory_package.hpp
@@ -1,0 +1,61 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF_ADVISORY_ADVISORY_PACKAGE_HPP
+#define TEST_LIBDNF_ADVISORY_ADVISORY_PACKAGE_HPP
+
+
+#include "../rpm/repo_fixture.hpp"
+
+#include "libdnf/advisory/advisory_collection.hpp"
+#include "libdnf/advisory/advisory_package.hpp"
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class AdvisoryAdvisoryPackageTest : public RepoFixture {
+    CPPUNIT_TEST_SUITE(AdvisoryAdvisoryPackageTest);
+
+    CPPUNIT_TEST(test_get_name);
+    CPPUNIT_TEST(test_get_version);
+    CPPUNIT_TEST(test_get_evr);
+    CPPUNIT_TEST(test_get_arch);
+    CPPUNIT_TEST(test_get_advisory_id);
+    CPPUNIT_TEST(test_get_advisory);
+    CPPUNIT_TEST(test_get_advisory_collection);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+
+    void test_get_name();
+    void test_get_version();
+    void test_get_evr();
+    void test_get_arch();
+    void test_get_advisory_id();
+    void test_get_advisory();
+    void test_get_advisory_collection();
+
+private:
+    std::vector<libdnf::advisory::AdvisoryPackage> packages;
+};
+
+
+#endif  // TEST_LIBDNF_ADVISORY_ADVISORY_PACKAGE_HPP

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -1,0 +1,188 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_advisory_query.hpp"
+
+#include "test/libdnf/utils.hpp"
+
+#include "libdnf/rpm/package_set.hpp"
+#include "libdnf/rpm/solv_query.hpp"
+
+#include <filesystem>
+#include <set>
+#include <vector>
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(AdvisoryAdvisoryQueryTest);
+
+void AdvisoryAdvisoryQueryTest::setUp() {
+    RepoFixture::setUp();
+    RepoFixture::add_repo_repomd("repomd-repo1");
+    advisory_sack = &(base->get_rpm_advisory_sack());
+}
+
+void AdvisoryAdvisoryQueryTest::test_size() {
+    auto adv_query = advisory_sack->new_query();
+    std::vector<std::string> expected = {"DNF-2019-1", "DNF-2020-1", "PKG-NEWER", "PKG-OLDER"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_ifilter_name() {
+    // Tests ifilter_name method
+    libdnf::advisory::AdvisoryQuery adv_query =
+        advisory_sack->new_query().ifilter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
+    std::vector<std::string> expected = {"DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
+    expected = {"DNF-2019-1", "DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_name(
+        std::vector<std::string>{"DNF-2019-1", "DNF-2020-1"}, libdnf::sack::QueryCmp::EQ);
+    expected = {"DNF-2019-1", "DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_ifilter_type() {
+    // Tests ifilter_type method
+    libdnf::advisory::AdvisoryQuery adv_query =
+        advisory_sack->new_query().ifilter_type(libdnf::advisory::Advisory::Type::BUGFIX);
+    std::vector<std::string> expected = {"DNF-2020-1", "PKG-OLDER"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_type(libdnf::advisory::Advisory::Type::ENHANCEMENT);
+    expected = {"PKG-NEWER"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_type(
+        std::vector<libdnf::advisory::Advisory::Type>{
+            libdnf::advisory::Advisory::Type::BUGFIX, libdnf::advisory::Advisory::Type::SECURITY},
+        libdnf::sack::QueryCmp::EQ);
+    expected = {"DNF-2019-1", "DNF-2020-1", "PKG-OLDER"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_ifilter_packages() {
+    // Tests ifilter_packages method
+    libdnf::rpm::SolvQuery pkg_query(sack);
+
+    libdnf::advisory::AdvisoryQuery adv_query =
+        advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
+    std::vector<std::string> expected = {"PKG-NEWER"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
+    expected = {"DNF-2019-1", "PKG-NEWER"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
+    expected = {"DNF-2019-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
+    expected = {"DNF-2019-1", "PKG-OLDER"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
+    expected = {"PKG-OLDER"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_ifilter_cve() {
+    // Tests ifilter_cve method
+    libdnf::advisory::AdvisoryQuery adv_query =
+        advisory_sack->new_query().ifilter_CVE("3333", libdnf::sack::QueryCmp::EQ);
+    std::vector<std::string> expected = {"DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query =
+        advisory_sack->new_query().ifilter_CVE(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
+    expected = {"DNF-2019-1", "DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query =
+        advisory_sack->new_query().ifilter_CVE(std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ);
+    expected = {"DNF-2019-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_CVE("*", libdnf::sack::QueryCmp::GLOB);
+    expected = {"DNF-2019-1", "DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_ifilter_bug() {
+    // Tests ifilter_bug method
+    libdnf::advisory::AdvisoryQuery adv_query =
+        advisory_sack->new_query().ifilter_bug("2222", libdnf::sack::QueryCmp::EQ);
+    std::vector<std::string> expected = {"DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query =
+        advisory_sack->new_query().ifilter_bug(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
+    expected = {};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_bug("*", libdnf::sack::QueryCmp::GLOB);
+    expected = {"DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_ifilter_severity() {
+    // Tests ifilter_severity method
+    libdnf::advisory::AdvisoryQuery adv_query =
+        advisory_sack->new_query().ifilter_severity("moderate", libdnf::sack::QueryCmp::EQ);
+    std::vector<std::string> expected = {"DNF-2019-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = advisory_sack->new_query().ifilter_severity(
+        std::vector<std::string>{"moderate", "critical"}, libdnf::sack::QueryCmp::EQ);
+    expected = {"DNF-2019-1", "DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_get_sorted_advisory_packages() {
+    // Tests get_sorted_advisory_packages method
+    std::vector<libdnf::advisory::AdvisoryPackage> adv_pkgs = advisory_sack->new_query().get_sorted_advisory_packages();
+    CPPUNIT_ASSERT_EQUAL(7lu, adv_pkgs.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[0].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("1.2-3"), adv_pkgs[0].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[1].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("0.1-1"), adv_pkgs[1].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[2].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("4.0-1"), adv_pkgs[2].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("bitcoin"), adv_pkgs[3].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("2.5-1"), adv_pkgs[3].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), adv_pkgs[4].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("3.9-2.fc29"), adv_pkgs[4].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("wget"), adv_pkgs[5].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("1.19.5-5.fc29"), adv_pkgs[5].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("yum"), adv_pkgs[6].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("3.4.3-0"), adv_pkgs[6].get_evr());
+
+    adv_pkgs = advisory_sack->new_query().ifilter_name("DNF-2020-1").get_sorted_advisory_packages();
+    CPPUNIT_ASSERT_EQUAL(3lu, adv_pkgs.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("bitcoin"), adv_pkgs[0].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("2.5-1"), adv_pkgs[0].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("wget"), adv_pkgs[1].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("1.19.5-5.fc29"), adv_pkgs[1].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("yum"), adv_pkgs[2].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("3.4.3-0"), adv_pkgs[2].get_evr());
+}

--- a/test/libdnf/advisory/test_advisory_query.hpp
+++ b/test/libdnf/advisory/test_advisory_query.hpp
@@ -1,0 +1,62 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF_ADVISORY_ADVISORY_QUERY_HPP
+#define TEST_LIBDNF_ADVISORY_ADVISORY_QUERY_HPP
+
+
+#include "../rpm/repo_fixture.hpp"
+
+#include "libdnf/advisory/advisory_sack.hpp"
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class AdvisoryAdvisoryQueryTest : public RepoFixture {
+    CPPUNIT_TEST_SUITE(AdvisoryAdvisoryQueryTest);
+
+    CPPUNIT_TEST(test_size);
+    CPPUNIT_TEST(test_ifilter_name);
+    CPPUNIT_TEST(test_ifilter_type);
+    CPPUNIT_TEST(test_ifilter_packages);
+    CPPUNIT_TEST(test_ifilter_cve);
+    CPPUNIT_TEST(test_ifilter_bug);
+    CPPUNIT_TEST(test_ifilter_severity);
+    CPPUNIT_TEST(test_get_sorted_advisory_packages);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+
+    void test_size();
+    void test_ifilter_name();
+    void test_ifilter_type();
+    void test_ifilter_packages();
+    void test_ifilter_cve();
+    void test_ifilter_bug();
+    void test_ifilter_severity();
+    void test_get_sorted_advisory_packages();
+
+private:
+    libdnf::advisory::AdvisorySack * advisory_sack;
+};
+
+
+#endif  // TEST_LIBDNF_ADVISORY_ADVISORY_QUERY_HPP

--- a/test/libdnf/rpm/solv/test_solv_map.cpp
+++ b/test/libdnf/rpm/solv/test_solv_map.cpp
@@ -28,14 +28,14 @@ CPPUNIT_TEST_SUITE_REGISTRATION(SolvMapTest);
 
 void SolvMapTest::setUp() {
     map1 = new libdnf::rpm::solv::SolvMap(32);
-    map1->add(libdnf::rpm::PackageId(0));
-    map1->add(libdnf::rpm::PackageId(2));
-    map1->add(libdnf::rpm::PackageId(28));
-    map1->add(libdnf::rpm::PackageId(30));
+    map1->add(0);
+    map1->add(2);
+    map1->add(28);
+    map1->add(30);
 
     map2 = new libdnf::rpm::solv::SolvMap(32);
-    map2->add(libdnf::rpm::PackageId(0));
-    map2->add(libdnf::rpm::PackageId(1));
+    map2->add(0);
+    map2->add(1);
 }
 
 
@@ -49,50 +49,50 @@ void SolvMapTest::test_add() {
     // test if the maps created in the constructor
     // have the correct bits set
 
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(0)) == true);
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(1)) == false);
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(2)) == true);
+    CPPUNIT_ASSERT(map1->contains(0) == true);
+    CPPUNIT_ASSERT(map1->contains(1) == false);
+    CPPUNIT_ASSERT(map1->contains(2) == true);
 
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(0)) == true);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(1)) == true);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(2)) == false);
+    CPPUNIT_ASSERT(map2->contains(0) == true);
+    CPPUNIT_ASSERT(map2->contains(1) == true);
+    CPPUNIT_ASSERT(map2->contains(2) == false);
 
     // add an item that is in the map already
-    map1->add(libdnf::rpm::PackageId(0));
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(0)) == true);
+    map1->add(0);
+    CPPUNIT_ASSERT(map1->contains(0) == true);
 
     // test invalid ranges
-    CPPUNIT_ASSERT_THROW(map1->add(libdnf::rpm::PackageId(-1)), std::out_of_range);
-    CPPUNIT_ASSERT_THROW(map1->add(libdnf::rpm::PackageId(33)), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(map1->add(-1), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(map1->add(33), std::out_of_range);
 }
 
 
 void SolvMapTest::test_contains() {
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(0)) == true);
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(1)) == false);
+    CPPUNIT_ASSERT(map1->contains(0) == true);
+    CPPUNIT_ASSERT(map1->contains(1) == false);
 
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(0)) == true);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(1)) == true);
+    CPPUNIT_ASSERT(map2->contains(0) == true);
+    CPPUNIT_ASSERT(map2->contains(1) == true);
 
     // test invalid ranges
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(-1)) == false);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(33)) == false);
+    CPPUNIT_ASSERT(map2->contains(-1) == false);
+    CPPUNIT_ASSERT(map2->contains(33) == false);
 }
 
 
 void SolvMapTest::test_remove() {
     // remove an item that is in the map
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(0)) == true);
-    map1->remove(libdnf::rpm::PackageId(0));
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(0)) == false);
+    CPPUNIT_ASSERT(map1->contains(0) == true);
+    map1->remove(0);
+    CPPUNIT_ASSERT(map1->contains(0) == false);
 
     // remove an item that is not in the map
-    map1->remove(libdnf::rpm::PackageId(0));
-    CPPUNIT_ASSERT(map1->contains(libdnf::rpm::PackageId(1)) == false);
+    map1->remove(0);
+    CPPUNIT_ASSERT(map1->contains(1) == false);
 
     // test invalid ranges
-    CPPUNIT_ASSERT_THROW(map1->remove(libdnf::rpm::PackageId(-1)), std::out_of_range);
-    CPPUNIT_ASSERT_THROW(map1->remove(libdnf::rpm::PackageId(33)), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(map1->remove(-1), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(map1->remove(33), std::out_of_range);
 }
 
 
@@ -101,46 +101,45 @@ void SolvMapTest::test_map_allocation_range() {
     libdnf::rpm::solv::SolvMap map(25);
 
     // setting bit 31 works
-    map.add(libdnf::rpm::PackageId(31));
+    map.add(31);
 
     // setting bit 32 does not work (we're indexing from 0)
-    CPPUNIT_ASSERT_THROW(map1->add(libdnf::rpm::PackageId(32)), std::out_of_range);
+    CPPUNIT_ASSERT_THROW(map1->add(32), std::out_of_range);
 }
 
 
 void SolvMapTest::test_union() {
     *map2 |= *map1;
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(0)) == true);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(1)) == true);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(2)) == true);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(3)) == false);
+    CPPUNIT_ASSERT(map2->contains(0) == true);
+    CPPUNIT_ASSERT(map2->contains(1) == true);
+    CPPUNIT_ASSERT(map2->contains(2) == true);
+    CPPUNIT_ASSERT(map2->contains(3) == false);
 }
 
 
 void SolvMapTest::test_intersection() {
     *map2 &= *map1;
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(0)) == true);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(1)) == false);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(2)) == false);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(3)) == false);
+    CPPUNIT_ASSERT(map2->contains(0) == true);
+    CPPUNIT_ASSERT(map2->contains(1) == false);
+    CPPUNIT_ASSERT(map2->contains(2) == false);
+    CPPUNIT_ASSERT(map2->contains(3) == false);
 }
 
 
 void SolvMapTest::test_difference() {
     *map2 -= *map1;
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(0)) == false);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(1)) == true);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(2)) == false);
-    CPPUNIT_ASSERT(map2->contains(libdnf::rpm::PackageId(3)) == false);
+    CPPUNIT_ASSERT(map2->contains(0) == false);
+    CPPUNIT_ASSERT(map2->contains(1) == true);
+    CPPUNIT_ASSERT(map2->contains(2) == false);
+    CPPUNIT_ASSERT(map2->contains(3) == false);
 }
 
 
-
 void SolvMapTest::test_iterator_empty() {
-    std::vector<libdnf::rpm::PackageId> expected = {};
-    std::vector<libdnf::rpm::PackageId> result;
+    std::vector<Id> expected = {};
+    std::vector<Id> result;
     libdnf::rpm::solv::SolvMap map(16);
-    for(auto it = map.begin(); it != map.end(); it++) {
+    for (auto it = map.begin(); it != map.end(); it++) {
         result.push_back(*it);
     }
     CPPUNIT_ASSERT(result == expected);
@@ -148,31 +147,13 @@ void SolvMapTest::test_iterator_empty() {
 
 
 void SolvMapTest::test_iterator_full() {
-    std::vector<libdnf::rpm::PackageId> expected = {
-        libdnf::rpm::PackageId(0),
-        libdnf::rpm::PackageId(1),
-        libdnf::rpm::PackageId(2),
-        libdnf::rpm::PackageId(3),
-        libdnf::rpm::PackageId(4),
-        libdnf::rpm::PackageId(5),
-        libdnf::rpm::PackageId(6),
-        libdnf::rpm::PackageId(7),
-        libdnf::rpm::PackageId(8),
-        libdnf::rpm::PackageId(9),
-        libdnf::rpm::PackageId(10),
-        libdnf::rpm::PackageId(11),
-        libdnf::rpm::PackageId(12),
-        libdnf::rpm::PackageId(13),
-        libdnf::rpm::PackageId(14),
-        libdnf::rpm::PackageId(15)
-    };
-    std::vector<libdnf::rpm::PackageId> result;
-
+    std::vector<Id> expected = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    std::vector<Id> result;
     libdnf::rpm::solv::SolvMap map(16);
     for (int i = 0; i < 16; i++) {
-        map.add(libdnf::rpm::PackageId(i));
+        map.add(i);
     }
-    for(auto package_id : map) {
+    for (auto package_id : map) {
         result.push_back(package_id);
     }
     CPPUNIT_ASSERT(result == expected);
@@ -180,13 +161,7 @@ void SolvMapTest::test_iterator_full() {
 
 
 void SolvMapTest::test_iterator_sparse() {
-    std::vector<libdnf::rpm::PackageId> expected = {
-        libdnf::rpm::PackageId(4),
-        libdnf::rpm::PackageId(6),
-        libdnf::rpm::PackageId(10),
-        libdnf::rpm::PackageId(11),
-        libdnf::rpm::PackageId(12),
-    };
+    std::vector<Id> expected = {4, 6, 10, 11, 12};
 
     libdnf::rpm::solv::SolvMap map(16);
     for (auto it : expected) {
@@ -195,25 +170,25 @@ void SolvMapTest::test_iterator_sparse() {
 
     // test begin
     auto it1 = map.begin();
-    CPPUNIT_ASSERT_EQUAL((*it1).id, 4);
+    CPPUNIT_ASSERT_EQUAL(*it1, 4);
 
     // test pre-increment operator
     auto it2 = ++it1;
-    CPPUNIT_ASSERT_EQUAL((*it1).id, 6);
-    CPPUNIT_ASSERT_EQUAL((*it2).id, 6);
+    CPPUNIT_ASSERT_EQUAL(*it1, 6);
+    CPPUNIT_ASSERT_EQUAL(*it2, 6);
 
     // test post-increment operator
     auto it3 = it2++;
-    CPPUNIT_ASSERT_EQUAL((*it2).id, 10);
-    CPPUNIT_ASSERT_EQUAL((*it3).id, 6);
+    CPPUNIT_ASSERT_EQUAL(*it2, 10);
+    CPPUNIT_ASSERT_EQUAL(*it3, 6);
 
     // test move back to begin
     it2.begin();
-    CPPUNIT_ASSERT_EQUAL((*it2).id, 4);
+    CPPUNIT_ASSERT_EQUAL(*it2, 4);
 
     // test increment after begin
     ++it2;
-    CPPUNIT_ASSERT_EQUAL((*it2).id, 6);
+    CPPUNIT_ASSERT_EQUAL(*it2, 6);
 
     // test end
     it2.end();
@@ -221,8 +196,8 @@ void SolvMapTest::test_iterator_sparse() {
 
     // test loop with pre-increment operator
     {
-        std::vector<libdnf::rpm::PackageId> result;
-        for(auto it = map.begin(), end = map.end(); it !=end; ++it) {
+        std::vector<Id> result;
+        for (auto it = map.begin(), end = map.end(); it != end; ++it) {
             result.push_back(*it);
         }
         CPPUNIT_ASSERT(result == expected);
@@ -230,40 +205,40 @@ void SolvMapTest::test_iterator_sparse() {
 
     // test loop with post-increment operator
     {
-        std::vector<libdnf::rpm::PackageId> result;
-        for(auto it = map.begin(), end = map.end(); it != end; it++) {
+        std::vector<Id> result;
+        for (auto it = map.begin(), end = map.end(); it != end; it++) {
             result.push_back(*it);
         }
         CPPUNIT_ASSERT(result == expected);
     }
 
     // test jump to existing package
-    it1.jump(libdnf::rpm::PackageId(11));
-    CPPUNIT_ASSERT_EQUAL((*it1).id, 11);
+    it1.jump(11);
+    CPPUNIT_ASSERT_EQUAL(*it1, 11);
 
     // test jump behind last existing package
-    it1.jump(libdnf::rpm::PackageId(14));
+    it1.jump(14);
     CPPUNIT_ASSERT(it1 == map.end());
 
     // test jump to existing package
-    it1.jump(libdnf::rpm::PackageId(6));
-    CPPUNIT_ASSERT_EQUAL((*it1).id, 6);
+    it1.jump(6);
+    CPPUNIT_ASSERT_EQUAL(*it1, 6);
 
     // test jump to non-existing package, moves to the next existing
-    it1.jump(libdnf::rpm::PackageId(7));
-    CPPUNIT_ASSERT_EQUAL((*it1).id, 10);
+    it1.jump(7);
+    CPPUNIT_ASSERT_EQUAL(*it1, 10);
 
     // test jump behind map
-    it1.jump(libdnf::rpm::PackageId(240));
+    it1.jump(240);
     CPPUNIT_ASSERT(it1 == map.end());
 
     // test jump to negative id, sets to begin
-    it1.jump(libdnf::rpm::PackageId(-240));
-    CPPUNIT_ASSERT_EQUAL((*it1).id, 4);
+    it1.jump(-240);
+    CPPUNIT_ASSERT_EQUAL(*it1, 4);
 
     // test increment after jump to negative id
     ++it1;
-    CPPUNIT_ASSERT_EQUAL((*it1).id, 6);
+    CPPUNIT_ASSERT_EQUAL(*it1, 6);
 }
 
 
@@ -273,8 +248,8 @@ void SolvMapTest::test_iterator_performance_empty() {
     libdnf::rpm::solv::SolvMap map(max);
 
     for (int i = 0; i < 500; i++) {
-        std::vector<libdnf::rpm::PackageId> result;
-        for(auto it = map.begin(); it != map.end(); it++) {
+        std::vector<Id> result;
+        for (auto it = map.begin(); it != map.end(); it++) {
             result.push_back(*it);
         }
     }
@@ -288,8 +263,8 @@ void SolvMapTest::test_iterator_performance_full() {
     memset(map.get_map()->map, 255, static_cast<std::size_t>(map.get_map()->size));
 
     for (int i = 0; i < 500; i++) {
-        std::vector<libdnf::rpm::PackageId> result;
-        for(auto it = map.begin(); it != map.end(); it++) {
+        std::vector<Id> result;
+        for (auto it = map.begin(); it != map.end(); it++) {
             result.push_back(*it);
         }
     }
@@ -303,8 +278,8 @@ void SolvMapTest::test_iterator_performance_4bits() {
     memset(map.get_map()->map, 15, static_cast<std::size_t>(map.get_map()->size));
 
     for (int i = 0; i < 500; i++) {
-        std::vector<libdnf::rpm::PackageId> result;
-        for(auto it = map.begin(); it != map.end(); it++) {
+        std::vector<Id> result;
+        for (auto it = map.begin(); it != map.end(); it++) {
             result.push_back(*it);
         }
     }

--- a/test/libdnf/rpm/test_solv_query.cpp
+++ b/test/libdnf/rpm/test_solv_query.cpp
@@ -377,6 +377,68 @@ void RpmSolvQueryTest::test_ifilter_requires() {
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
 }
 
+void RpmSolvQueryTest::test_ifilter_advisories() {
+    // Run setUp again to have a clean sack (without solv-repo1)
+    RepoFixture::setUp();
+    add_repo_repomd("repomd-repo1");
+    auto & advisory_sack = base->get_rpm_advisory_sack();
+
+    {
+        // Test QueryCmp::EQ with equal advisory pkg
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("DNF-2019-1");
+        libdnf::rpm::SolvQuery query(sack);
+        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
+        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+    }
+
+    {
+        // Test QueryCmp::GT with older advisory pkg
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("PKG-OLDER");
+        libdnf::rpm::SolvQuery query(sack);
+        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::GT);
+        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+    }
+
+    {
+        // Test QueryCmp::LTE with older advisory pkg
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("PKG-OLDER");
+        libdnf::rpm::SolvQuery query(sack);
+        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::LTE);
+        std::vector<std::string> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+    }
+
+    {
+        // Test QueryCmp::LT with newer advisory pkg
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("PKG-NEWER");
+        libdnf::rpm::SolvQuery query(sack);
+        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::LT);
+        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+    }
+
+    {
+        // Test QueryCmp::GTE with newer advisory pkg
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("PKG-NEWER");
+        libdnf::rpm::SolvQuery query(sack);
+        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::GTE);
+        std::vector<std::string> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+    }
+
+    {
+        // Test QueryCmp::EQ with older and newer advisory pkg
+        libdnf::advisory::AdvisoryQuery adv_query =
+            advisory_sack.new_query().ifilter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
+        ;
+        libdnf::rpm::SolvQuery query(sack);
+        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
+        std::vector<std::string> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+    }
+}
 
 void RpmSolvQueryTest::test_ifilter_chain() {
     libdnf::rpm::SolvQuery query(sack);

--- a/test/libdnf/rpm/test_solv_query.hpp
+++ b/test/libdnf/rpm/test_solv_query.hpp
@@ -42,6 +42,7 @@ class RpmSolvQueryTest : public RepoFixture {
     CPPUNIT_TEST(test_ifilter_priority);
     CPPUNIT_TEST(test_ifilter_provides);
     CPPUNIT_TEST(test_ifilter_requires);
+    CPPUNIT_TEST(test_ifilter_advisories);
     CPPUNIT_TEST(test_ifilter_chain);
     CPPUNIT_TEST(test_resolve_pkg_spec);
     CPPUNIT_TEST(test_update);
@@ -68,6 +69,7 @@ public:
     void test_ifilter_provides();
     void test_ifilter_priority();
     void test_ifilter_requires();
+    void test_ifilter_advisories();
     void test_ifilter_chain();
     void test_resolve_pkg_spec();
     void test_update();

--- a/test/libdnf/utils.cpp
+++ b/test/libdnf/utils.cpp
@@ -46,3 +46,12 @@ std::vector<std::string> to_vector_string(const std::vector<libdnf::rpm::Package
     }
     return result;
 }
+
+
+std::vector<std::string> to_vector_name_string(const libdnf::advisory::AdvisoryQuery & advisory_query) {
+    std::vector<std::string> result;
+    for (auto & adv : advisory_query.get_advisories()) {
+        result.emplace_back(adv.get_name());
+    }
+    return result;
+}

--- a/test/libdnf/utils.hpp
+++ b/test/libdnf/utils.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef TEST_LIBDNF_UTILS_HPP
 #define TEST_LIBDNF_UTILS_HPP
 
+#include "libdnf/advisory/advisory_query.hpp"
 #include "libdnf/rpm/package_set.hpp"
 
 #include <cppunit/extensions/HelperMacros.h>
@@ -86,5 +87,7 @@ std::vector<std::string> to_vector_string(const libdnf::rpm::PackageSet & pset);
 /// Convert vector<Package> to a vector of strings for easy assertions.
 std::vector<std::string> to_vector_string(const std::vector<libdnf::rpm::Package> & pkg_list);
 
+/// Convert AdvisoryQuery to a vector of strings of their names for easy assertions.
+std::vector<std::string> to_vector_name_string(const libdnf::advisory::AdvisoryQuery & advisory_query);
 
 #endif  // TEST_LIBDNF_UTILS_HPP

--- a/test/python3/libdnf/rpm/test_reldep_list.py
+++ b/test/python3/libdnf/rpm/test_reldep_list.py
@@ -160,7 +160,7 @@ class TestReldepList(unittest.TestCase):
         list1 = libdnf.rpm.ReldepList(self.sack)
         list1.add_reldep_with_glob("pkg*")
 
-        expected = ["pkg", "pkg.conf", "pkg.conf.d", "pkg-libs"]
+        expected = ["pkg", "pkg.conf", "pkg.conf.d", "pkg-libs", "pkg", "pkg", "pkg", "pkg", "pkg", "pkg"]
         # TODO(dmach): implement __str__()
         result = [reldep.to_string() for reldep in list1]
         self.assertEqual(expected, result)


### PR DESCRIPTION
Adding only basic advisory, sack and query.

So far trying to figure out why in `AdvisorySack::load_advisories_from_solvsack` `dataiterator` doesn't find any `UPDATE_COLLECTIONs` even though loaded repository dnf-ci-fedora has an updateinfo.xml file.