### PR TITLE
[dnf5] ArgumentParser: improvements and move it from microdnf to libdnf-cli

### DIFF
--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -87,9 +87,8 @@ public:
         /// Can contain this argument. Groups of conflicting argument can be used.
         void set_conflict_arguments(std::vector<Argument *> * args) noexcept { conflict_args = args; }
 
-        /// Gets argument name.
-        /// It is like id. Do not confuse with the long name of the named argument.
-        const std::string & get_name() const noexcept { return name; }
+        /// Gets argument id.
+        const std::string & get_id() const noexcept { return id; }
 
         /// Gets a description of the argument.
         const std::string & get_description() const { return description; }
@@ -113,12 +112,12 @@ public:
     private:
         friend class ArgumentParser;
 
-        Argument(ArgumentParser & owner, std::string name) : owner(owner), name(std::move(name)) {}
+        Argument(ArgumentParser & owner, std::string id) : owner(owner), id(std::move(id)) {}
         static std::string get_conflict_arg_msg(const Argument * conflict_arg);
         ArgumentParser & get_owner() const noexcept { return owner; }
 
         ArgumentParser & owner;
-        std::string name;
+        std::string id;
         std::string description;
         std::string short_description;
         std::vector<Argument *> * conflict_args{nullptr};
@@ -166,10 +165,10 @@ public:
         friend class ArgumentParser;
 
         PositionalArg(
-            ArgumentParser & owner, const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values);
+            ArgumentParser & owner, const std::string & id, std::vector<std::unique_ptr<libdnf::Option>> * values);
         PositionalArg(
             ArgumentParser & owner,
-            const std::string & name,
+            const std::string & id,
             int nvals,
             libdnf::Option * init_value,
             std::vector<std::unique_ptr<libdnf::Option>> * values);
@@ -264,7 +263,7 @@ public:
     private:
         friend class ArgumentParser;
 
-        NamedArg(ArgumentParser & owner, const std::string & name) : Argument(owner, name) {}
+        NamedArg(ArgumentParser & owner, const std::string & id) : Argument(owner, id) {}
 
         /// Parses long argument.
         /// Returns number of consumed arguments from the input.
@@ -321,13 +320,13 @@ public:
         void parse(const char * option, int argc, const char * const argv[]);
 
         /// Registers (sub)command to the command.
-        void add_command(Command * arg) { cmds.push_back(arg); }
+        void register_command(Command * arg) { cmds.push_back(arg); }
 
         /// Registers named argument to the command.
-        void add_named_arg(NamedArg * arg) { named_args.push_back(arg); }
+        void register_named_arg(NamedArg * arg) { named_args.push_back(arg); }
 
         /// Registers positional argument to the command.
-        void add_positional_arg(PositionalArg * arg) { pos_args.push_back(arg); }
+        void register_positional_arg(PositionalArg * arg) { pos_args.push_back(arg); }
 
         /// Gets a list of registered commands.
         const std::vector<Command *> & get_commands() const noexcept { return cmds; }
@@ -340,15 +339,15 @@ public:
 
         /// Returns (sub)command with given ID.
         /// Exception CommandNotFound is thrown if command is not found.
-        Command & get_command(const std::string & name) const;
+        Command & get_command(const std::string & id) const;
 
         /// Returns named argument with given ID.
         /// Exception NamedArgNotFound is thrown if argument is not found.
-        NamedArg & get_named_arg(const std::string & name) const;
+        NamedArg & get_named_arg(const std::string & id) const;
 
         /// Returns positional argument with given ID.
         /// Exception PositionalArgNotFound is thrown if argument is not found.
-        PositionalArg & get_positional_arg(const std::string & name) const;
+        PositionalArg & get_positional_arg(const std::string & id) const;
 
         /// Sets the user function for parsing the argument.
         void set_parse_hook_func(ParseHookFunc && func) { parse_hook = std::move(func); }
@@ -379,7 +378,7 @@ public:
     private:
         friend class ArgumentParser;
 
-        Command(ArgumentParser & owner, const std::string & name) : Argument(owner, name) {}
+        Command(ArgumentParser & owner, const std::string & id) : Argument(owner, id) {}
 
         std::vector<Command *> cmds;
         std::vector<NamedArg *> named_args;
@@ -392,21 +391,21 @@ public:
 
     /// Constructs a new command and stores it to the argument parser.
     /// Returns a pointer to the newly created command.
-    Command * add_new_command(const std::string & name);
+    Command * add_new_command(const std::string & id);
 
     /// Constructs a new named argument and stores it to the argument parser.
     /// Returns a pointer to the newly created named argument.
-    NamedArg * add_new_named_arg(const std::string & name);
+    NamedArg * add_new_named_arg(const std::string & id);
 
     /// Constructs a new positional argument and stores it to the argument parser.
     /// Returns a pointer to the newly created positional argument.
     PositionalArg * add_new_positional_arg(
-        const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values);
+        const std::string & id, std::vector<std::unique_ptr<libdnf::Option>> * values);
 
     /// Constructs a new positional argument and stores it to the argument parser.
     /// Returns a pointer to the newly created positional argument.
     PositionalArg * add_new_positional_arg(
-        const std::string & name,
+        const std::string & id,
         int nargs,
         libdnf::Option * init_value,
         std::vector<std::unique_ptr<libdnf::Option>> * values);
@@ -453,34 +452,34 @@ private:
     Command * root_command{nullptr};
 };
 
-inline ArgumentParser::Command * ArgumentParser::add_new_command(const std::string & name) {
-    std::unique_ptr<Command> arg(new Command(*this, name));
+inline ArgumentParser::Command * ArgumentParser::add_new_command(const std::string & id) {
+    std::unique_ptr<Command> arg(new Command(*this, id));
     auto * ptr = arg.get();
     cmds.push_back(std::move(arg));
     return ptr;
 }
 
-inline ArgumentParser::NamedArg * ArgumentParser::add_new_named_arg(const std::string & name) {
-    std::unique_ptr<NamedArg> arg(new NamedArg(*this, name));
+inline ArgumentParser::NamedArg * ArgumentParser::add_new_named_arg(const std::string & id) {
+    std::unique_ptr<NamedArg> arg(new NamedArg(*this, id));
     auto * ptr = arg.get();
     named_args.push_back(std::move(arg));
     return ptr;
 }
 
 inline ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
-    const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values) {
-    std::unique_ptr<PositionalArg> arg(new PositionalArg(*this, name, values));
+    const std::string & id, std::vector<std::unique_ptr<libdnf::Option>> * values) {
+    std::unique_ptr<PositionalArg> arg(new PositionalArg(*this, id, values));
     auto * ptr = arg.get();
     pos_args.push_back(std::move(arg));
     return ptr;
 }
 
 inline ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
-    const std::string & name,
+    const std::string & id,
     int nargs,
     libdnf::Option * init_value,
     std::vector<std::unique_ptr<libdnf::Option>> * values) {
-    std::unique_ptr<PositionalArg> arg(new PositionalArg(*this, name, nargs, init_value, values));
+    std::unique_ptr<PositionalArg> arg(new PositionalArg(*this, id, nargs, init_value, values));
     auto * ptr = arg.get();
     pos_args.push_back(std::move(arg));
     return ptr;

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -77,15 +77,38 @@ public:
         Argument & operator=(const Argument &) = delete;
         Argument & operator=(Argument &&) = delete;
         virtual ~Argument() = default;
+
+        /// Sets a description of the argument.
         void set_description(std::string descr) noexcept { description = std::move(descr); }
+
+        /// Sets a brief description of the argument.
         void set_short_description(std::string descr) noexcept { short_description = std::move(descr); }
+
+        /// Passes a list of arguments that cannot be used with this argument.
+        /// Can contain this argument. Groups of conflicting argument can be used.
         void set_conflict_arguments(std::vector<Argument *> * args) noexcept { conflict_args = args; }
+
+        /// Gets argument name.
+        /// It is like id. Do not confuse with the long name of the named argument.
         const std::string & get_name() const noexcept { return name; }
+
+        /// Gets a description of the argument.
         const std::string & get_description() const { return description; }
+
+        /// Gets a brief description of the argument.
         const std::string & get_short_description() const { return short_description; }
+
+        /// Gets the number of times the argument was used during analysis.
+        /// Can be used to determine how many times the argument has been used on the command line.
         int get_parse_count() const noexcept { return parse_count; }
+
+        /// Set the number of times the argument was used during analysis count to 0.
         void reset_parse_count() noexcept { parse_count = 0; }
+
+        /// Tests input for arguments that cannot be used with this argument.
+        /// Returns the first conflicting argument.
         Argument * get_conflict_argument() const noexcept;
+
         static std::string get_conflict_arg_msg(const Argument * conflict_arg);
         virtual void help() const noexcept {}
         ArgumentParser & get_owner() const noexcept { return owner; }
@@ -128,13 +151,26 @@ public:
             libdnf::Option * init_value,
             std::vector<std::unique_ptr<libdnf::Option>> * values);
 
+        /// Gets the number of values required by this argument on the command line.
+        /// May return special values: OPTIONAL, UNLIMITED, UNLIMITED_BUT_ONE
         int get_nvals() const noexcept { return nvals; }
+
+        /// Enables/disables storing parsed values.
+        /// Values can be processed / stored in the user parse hook function.
         void set_store_value(bool enable) noexcept { store_value = enable; }
+
+        /// Returns true if storing the parsed values is enabled.
         bool get_store_value() const noexcept { return store_value; }
+
+        /// Gets list of values.
+        /// Parsed values are stored there if if get_store_value() == true.
         std::vector<std::unique_ptr<libdnf::Option>> * get_linked_values() noexcept { return values; }
+
+        /// Sets the user function for parsing the argument.
         void set_parse_hook_func(ParseHookFunc && func) { parse_hook = std::move(func); }
 
-        // returns number of consumed arguments
+        /// Parses input.
+        /// Returns number of consumed arguments from the input.
         int parse(const char * option, int argc, const char * const argv[]);
 
     private:
@@ -168,27 +204,68 @@ public:
         using ParseHookFunc = std::function<bool(NamedArg * arg, const char * option, const char * value)>;
 
         NamedArg(ArgumentParser & owner, const std::string & name) : Argument(owner, name) {}
+
+        /// Sets long name of argument. Long name is prefixed with two dashes on the command line (e.g. "--help").
         void set_long_name(std::string long_name) noexcept { this->long_name = std::move(long_name); }
+
+        /// Sets short name of argument. Short name is prefixed with one dash on the command line (e.g. "-h").
         void set_short_name(char short_name) { this->short_name = short_name; }
+
+        /// Does the argument need a value on the command line?
         void set_has_value(bool has_value) { this->has_value = has_value; }
+
+        /// Links the value to the argument.
+        /// Parsed value is stored there if if get_store_value() == true.
         void link_value(libdnf::Option * value) { this->value = value; }
+
+        /// Sets constant argument value.
+        /// It is used for argument without value on command line (get_has_value() == false).
         void set_const_value(std::string const_value) noexcept { const_val = std::move(const_value); }
+
+        /// Gets long name of argument. Long name is prefixed with two dashes on the command line (e.g. "--help").
         const std::string & get_long_name() const noexcept { return long_name; }
+
+        /// Gets short name of argument. Short name is prefixed with one dash on the command line (e.g. "-h").
         char get_short_name() const noexcept { return short_name; }
+
+        /// Returns true if the argument need a value on the command line.
         bool get_has_value() const noexcept { return has_value; }
+
+        /// Gets constant argument value.
+        /// It is used for argument without value on command line (get_has_value() == false).
         const std::string & get_const_value() const noexcept { return const_val; }
+
+        /// Gets the value.
+        /// Parsed value is stored there if if get_store_value() == true.
         libdnf::Option * get_linked_value() noexcept { return value; }
+
+        /// Gets value.
+        /// Parsed value is stored there if if get_store_value() == true.
         const libdnf::Option * get_linked_value() const noexcept { return value; }
+
+        /// Enables/disables storing parsed values.
+        /// Values can be processed / stored in the user parse hook function.
         void set_store_value(bool enable) noexcept { store_value = enable; }
+
+        /// Returns true if storing the parsed values is enabled.
         bool get_store_value() const noexcept { return store_value; }
+
+        /// Sets the user function for parsing the argument.
         void set_parse_hook_func(ParseHookFunc && func) { parse_hook = std::move(func); }
 
-        // returns number of consumed arguments
+        /// Parses long argument.
+        /// Returns number of consumed arguments from the input.
         int parse_long(const char * option, int argc, const char * const argv[]);
-        // returns number of consumed arguments
+
+        /// Parses short argument.
+        /// Returns the number of arguments consumed from the input. It may be zero.
+        /// Multiple short arguments can be packed in one item. (e.g. "-v -f" -> "-vf").
         int parse_short(const char * option, int argc, const char * const argv[]);
 
+        /// Sets help text for argument value.
         void set_arg_value_help(std::string text) { arg_value_help = std::move(text); }
+
+        /// Gets help text for argument value.
         const std::string & get_arg_value_help() const noexcept { return arg_value_help; }
 
     private:
@@ -235,25 +312,65 @@ public:
         using ParseHookFunc = std::function<bool(Command * arg, const char * cmd, int argc, const char * const argv[])>;
 
         Command(ArgumentParser & owner, const std::string & name) : Argument(owner, name) {}
+
+        /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
+        /// Returns number of consumed arguments from the input.
         void parse(const char * option, int argc, const char * const argv[]);
+
+        /// Registers (sub)command to the command.
         void add_command(Command * arg) { cmds.push_back(arg); }
+
+        /// Registers named argument to the command.
         void add_named_arg(NamedArg * arg) { named_args.push_back(arg); }
+
+        /// Registers positional argument to the command.
         void add_positional_arg(PositionalArg * arg) { pos_args.push_back(arg); }
+
+        /// Gets a list of registered commands.
         const std::vector<Command *> & get_commands() const noexcept { return cmds; }
+
+        /// Gets a list of registered named arguments.
         const std::vector<NamedArg *> & get_named_args() const noexcept { return named_args; }
+
+        /// Gets a list of registered positional arguments.
         const std::vector<PositionalArg *> & get_positional_args() const noexcept { return pos_args; }
+
+        /// Returns (sub)command with given ID.
+        /// Exception CommandNotFound is thrown if command is not found.
         Command & get_command(const std::string & name) const;
+
+        /// Returns named argument with given ID.
+        /// Exception NamedArgNotFound is thrown if argument is not found.
         NamedArg & get_named_arg(const std::string & name) const;
+
+        /// Returns positional argument with given ID.
+        /// Exception PositionalArgNotFound is thrown if argument is not found.
         PositionalArg & get_positional_arg(const std::string & name) const;
+
+        /// Sets the user function for parsing the argument.
         void set_parse_hook_func(ParseHookFunc && func) { parse_hook = std::move(func); }
+
+        /// Prints command help text.
         void help() const noexcept override;
+
+        /// Sets the header of the subcommand table. Used to generate help.
         void set_commands_help_header(std::string text) noexcept { commands_help_header = std::move(text); }
+
+        /// Sets the header of the named arguments table. Used to generate help.
         void set_named_args_help_header(std::string text) noexcept { named_args_help_header = std::move(text); }
+
+        /// Sets the header of the positional arguments table. Used to generate help.
         void set_positional_args_help_header(std::string text) noexcept {
             positional_args_help_header = std::move(text);
         }
+
+        /// Gets the header of the subcommand table. Used to generate help.
         const std::string & get_commands_help_header() const noexcept { return commands_help_header; }
+
+        /// Gets the header of the named arguments table. Used to generate help.
         const std::string & get_named_args_help_header() const noexcept { return named_args_help_header; }
+
+        /// Gets the header of the positional arguments table. Used to generate help.
         const std::string & get_positional_args_help_header() const noexcept { return positional_args_help_header; }
 
     private:
@@ -267,24 +384,57 @@ public:
         std::string positional_args_help_header;
     };
 
+    /// Constructs a new command and stores it to the argument parser.
+    /// Returns a pointer to the newly created command.
     Command * add_new_command(const std::string & name);
+
+    /// Constructs a new named argument and stores it to the argument parser.
+    /// Returns a pointer to the newly created named argument.
     NamedArg * add_new_named_arg(const std::string & name);
+
+    /// Constructs a new positional argument and stores it to the argument parser.
+    /// Returns a pointer to the newly created positional argument.
     PositionalArg * add_new_positional_arg(
         const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values);
+
+    /// Constructs a new positional argument and stores it to the argument parser.
+    /// Returns a pointer to the newly created positional argument.
     PositionalArg * add_new_positional_arg(
         const std::string & name,
         int nargs,
         libdnf::Option * init_value,
         std::vector<std::unique_ptr<libdnf::Option>> * values);
+
+    /// Moves a list of conflicting argument to the parser.
+    /// Returns a pointer to the list.
     std::vector<Argument *> * add_conflict_args_group(std::unique_ptr<std::vector<Argument *>> && conflict_args_group);
+
+    /// Moves the option with the initial value to the argument parser.
+    /// Returns a pointer to the option.
     libdnf::Option * add_init_value(std::unique_ptr<libdnf::Option> && src);
+
+    /// Constructs a new empty list of values and stores it to the argument parser.
+    /// Returns a pointer to the newly created list.
     std::vector<std::unique_ptr<libdnf::Option>> * add_new_values();
+
+    /// Moves an existing list of values to the argument parser.
+    /// Returns a pointer to the list.
     std::vector<std::unique_ptr<libdnf::Option>> * add_values(
         std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> && values);
 
+    /// Sets the "root" command.
+    /// This is the top-level command in the command hierarchy. It can contain named and positional arguments and subcommands.
     void set_root_command(Command * command) noexcept { root_command = command; }
+
+    /// Gets the "root" command.
+    /// This is the top-level command in the command hierarchy. It can contain named and positional arguments and subcommands.
     Command * get_root_command() noexcept { return root_command; }
+
+    /// Parses input. The parser from the "root" command is called.
+    /// The "LogicError" exception is thrown when the "root" command is not set.
     void parse(int argc, const char * const argv[]);
+
+    /// Reset parse count in all arguments.
     void reset_parse_count();
 
 private:

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -488,66 +488,6 @@ private:
     Command * root_command{nullptr};
 };
 
-inline ArgumentParser::Command * ArgumentParser::add_new_command(const std::string & id) {
-    std::unique_ptr<Command> arg(new Command(*this, id));
-    auto * ptr = arg.get();
-    cmds.push_back(std::move(arg));
-    return ptr;
-}
-
-inline ArgumentParser::NamedArg * ArgumentParser::add_new_named_arg(const std::string & id) {
-    std::unique_ptr<NamedArg> arg(new NamedArg(*this, id));
-    auto * ptr = arg.get();
-    named_args.push_back(std::move(arg));
-    return ptr;
-}
-
-inline ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
-    const std::string & id, std::vector<std::unique_ptr<libdnf::Option>> * values) {
-    std::unique_ptr<PositionalArg> arg(new PositionalArg(*this, id, values));
-    auto * ptr = arg.get();
-    pos_args.push_back(std::move(arg));
-    return ptr;
-}
-
-inline ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
-    const std::string & id,
-    int nargs,
-    libdnf::Option * init_value,
-    std::vector<std::unique_ptr<libdnf::Option>> * values) {
-    std::unique_ptr<PositionalArg> arg(new PositionalArg(*this, id, nargs, init_value, values));
-    auto * ptr = arg.get();
-    pos_args.push_back(std::move(arg));
-    return ptr;
-}
-
-inline std::vector<ArgumentParser::Argument *> * ArgumentParser::add_conflict_args_group(
-    std::unique_ptr<std::vector<Argument *>> && conflict_args_group) {
-    auto * ptr = conflict_args_group.get();
-    conflict_args_groups.push_back(std::move(conflict_args_group));
-    return ptr;
-}
-
-inline libdnf::Option * ArgumentParser::add_init_value(std::unique_ptr<libdnf::Option> && src) {
-    auto * ptr = src.get();
-    values_init.push_back(std::move(src));
-    return ptr;
-}
-
-inline std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_new_values() {
-    std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> tmp(new std::vector<std::unique_ptr<libdnf::Option>>);
-    auto * ptr = tmp.get();
-    values.push_back(std::move(tmp));
-    return ptr;
-}
-
-inline std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_values(
-    std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> && values) {
-    auto * ptr = values.get();
-    this->values.push_back(std::move(values));
-    return ptr;
-}
-
 }  // namespace libdnf::cli
 
 #endif

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -17,17 +17,17 @@ You should have received a copy of the GNU General Public License
 along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef MICRODNF_ARGUMENT_PARSER_HPP
-#define MICRODNF_ARGUMENT_PARSER_HPP
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_HPP
 
-#include <libdnf/conf/option.hpp>
+#include "libdnf/conf/option.hpp"
 
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
 
-namespace microdnf {
+namespace libdnf::cli {
 
 class ArgumentParser {
 public:
@@ -258,6 +258,6 @@ inline std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_values
     return ptr;
 }
 
-}  // namespace microdnf
+}  // namespace libdnf::cli
 
 #endif

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -113,7 +113,7 @@ public:
         PositionalArg(const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values);
         PositionalArg(
             const std::string & name,
-            int nargs,
+            int nvals,
             libdnf::Option * init_value,
             std::vector<std::unique_ptr<libdnf::Option>> * values);
 
@@ -126,7 +126,7 @@ public:
         int parse(const char * option, int argc, const char * const argv[]);
 
     private:
-        int nargs;
+        int nvals;
         libdnf::Option * init_value;
         std::vector<std::unique_ptr<libdnf::Option>> * values;
         bool store_value{true};
@@ -158,12 +158,12 @@ public:
         explicit NamedArg(const std::string & name) : Argument(name) {}
         void set_long_name(std::string long_name) noexcept { this->long_name = std::move(long_name); }
         void set_short_name(char short_name) { this->short_name = short_name; }
-        void set_has_arg(bool has_arg) { this->has_arg = has_arg; }
+        void set_has_value(bool has_value) { this->has_value = has_value; }
         void link_value(libdnf::Option * value) { this->value = value; }
         void set_const_value(std::string const_value) noexcept { const_val = std::move(const_value); }
         const std::string & get_long_name() const noexcept { return long_name; }
         char get_short_name() const noexcept { return short_name; }
-        bool get_has_arg() const noexcept { return has_arg; }
+        bool get_has_value() const noexcept { return has_value; }
         const std::string & get_const_value() const noexcept { return const_val; }
         libdnf::Option * get_linked_value() noexcept { return value; }
         const libdnf::Option * get_linked_value() const noexcept { return value; }
@@ -183,7 +183,7 @@ public:
         friend class ArgumentParser;
         std::string long_name;
         char short_name{'\0'};
-        bool has_arg{false};
+        bool has_value{false};
         std::string const_val;  // used if params == 0
         libdnf::Option * value{nullptr};
         bool store_value{true};

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -54,6 +54,13 @@ public:
         const char * get_description() const noexcept override { return "Conflicting arguments"; }
     };
 
+    /// Exception is thrown when a command requires a positional argument that was not found.
+    class MissingPositionalArgument : public Exception {
+        using Exception::Exception;
+        const char * get_name() const noexcept override { return "MissingPositionalArgument"; }
+        const char * get_description() const noexcept override { return "Missing positional argument"; }
+    };
+
     /// Exception is generated in the case of an unexpected argument.
     class UnknownArgument : public Exception {
     public:
@@ -117,6 +124,7 @@ public:
             libdnf::Option * init_value,
             std::vector<std::unique_ptr<libdnf::Option>> * values);
 
+        int get_nvals() const noexcept { return nvals; }
         void set_store_value(bool enable) noexcept { store_value = enable; }
         bool get_store_value() const noexcept { return store_value; }
         std::vector<std::unique_ptr<libdnf::Option>> * get_linked_values() noexcept { return values; }

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -313,6 +313,39 @@ public:
             const char * get_description() const noexcept override { return "Positional argument not found"; }
         };
 
+        /// Exception is thrown when a command with the same ID is already registered.
+        class CommandIdExists : public Exception {
+        public:
+            using Exception::Exception;
+            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
+            const char * get_name() const noexcept override { return "CommandIdExists"; }
+            const char * get_description() const noexcept override {
+                return "Command with the same ID is already registered";
+            }
+        };
+
+        /// Exception is thrown when a named argument with the same ID is already registered.
+        class NamedArgIdExists : public Exception {
+        public:
+            using Exception::Exception;
+            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
+            const char * get_name() const noexcept override { return "NamedArgIdExists"; }
+            const char * get_description() const noexcept override {
+                return "Named argument with the same ID is already registered";
+            }
+        };
+
+        /// Exception is thrown when a positional argument with the same ID is already registered.
+        class PositionalArgIdExists : public Exception {
+        public:
+            using Exception::Exception;
+            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
+            const char * get_name() const noexcept override { return "PositionalArgIdExists"; }
+            const char * get_description() const noexcept override {
+                return "Positional argument with the same ID is already registered";
+            }
+        };
+
         using ParseHookFunc = std::function<bool(Command * arg, const char * cmd, int argc, const char * const argv[])>;
 
         /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
@@ -320,13 +353,16 @@ public:
         void parse(const char * option, int argc, const char * const argv[]);
 
         /// Registers (sub)command to the command.
-        void register_command(Command * arg) { cmds.push_back(arg); }
+        /// An exception is thrown when a command with the same ID is already registered.
+        void register_command(Command * cmd);
 
         /// Registers named argument to the command.
-        void register_named_arg(NamedArg * arg) { named_args.push_back(arg); }
+        /// An exception is thrown when a named argument with the same ID is already registered.
+        void register_named_arg(NamedArg * arg);
 
         /// Registers positional argument to the command.
-        void register_positional_arg(PositionalArg * arg) { pos_args.push_back(arg); }
+        /// An exception is thrown when a positional argument with the same ID is already registered.
+        void register_positional_arg(PositionalArg * arg);
 
         /// Gets a list of registered commands.
         const std::vector<Command *> & get_commands() const noexcept { return cmds; }

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -54,6 +54,14 @@ public:
         const char * get_description() const noexcept override { return "Conflicting arguments"; }
     };
 
+    /// Exception is generated in the case of an unexpected argument.
+    class UnknownArgument : public Exception {
+    public:
+        using Exception::Exception;
+        const char * get_name() const noexcept override { return "UnknownArgument"; }
+        const char * get_description() const noexcept override { return "Unknown argument"; }
+    };
+
     class Argument {
     public:
         explicit Argument(std::string name) : name(std::move(name)) {}

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -393,6 +393,65 @@ void ArgumentParser::Command::help() const noexcept {
     }
 }
 
+ArgumentParser::Command * ArgumentParser::add_new_command(const std::string & id) {
+    std::unique_ptr<Command> arg(new Command(*this, id));
+    auto * ptr = arg.get();
+    cmds.push_back(std::move(arg));
+    return ptr;
+}
+
+ArgumentParser::NamedArg * ArgumentParser::add_new_named_arg(const std::string & id) {
+    std::unique_ptr<NamedArg> arg(new NamedArg(*this, id));
+    auto * ptr = arg.get();
+    named_args.push_back(std::move(arg));
+    return ptr;
+}
+
+ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
+    const std::string & id, std::vector<std::unique_ptr<libdnf::Option>> * values) {
+    std::unique_ptr<PositionalArg> arg(new PositionalArg(*this, id, values));
+    auto * ptr = arg.get();
+    pos_args.push_back(std::move(arg));
+    return ptr;
+}
+
+ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
+    const std::string & id,
+    int nargs,
+    libdnf::Option * init_value,
+    std::vector<std::unique_ptr<libdnf::Option>> * values) {
+    std::unique_ptr<PositionalArg> arg(new PositionalArg(*this, id, nargs, init_value, values));
+    auto * ptr = arg.get();
+    pos_args.push_back(std::move(arg));
+    return ptr;
+}
+
+std::vector<ArgumentParser::Argument *> * ArgumentParser::add_conflict_args_group(
+    std::unique_ptr<std::vector<Argument *>> && conflict_args_group) {
+    auto * ptr = conflict_args_group.get();
+    conflict_args_groups.push_back(std::move(conflict_args_group));
+    return ptr;
+}
+
+libdnf::Option * ArgumentParser::add_init_value(std::unique_ptr<libdnf::Option> && src) {
+    auto * ptr = src.get();
+    values_init.push_back(std::move(src));
+    return ptr;
+}
+
+std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_new_values() {
+    std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> tmp(new std::vector<std::unique_ptr<libdnf::Option>>);
+    auto * ptr = tmp.get();
+    values.push_back(std::move(tmp));
+    return ptr;
+}
+
+std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_values(
+    std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> && values) {
+    auto * ptr = values.get();
+    this->values.push_back(std::move(values));
+    return ptr;
+}
 
 void ArgumentParser::parse(int argc, const char * const argv[]) {
     if (!root_command) {

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -283,6 +283,15 @@ void ArgumentParser::Command::parse(const char * option, int argc, const char * 
         }
     }
     ++parse_count;
+
+    // Test that all required positional arguments are present.
+    for (const auto * pos_arg : pos_args) {
+        const auto nvals = pos_arg->get_nvals();
+        if (pos_arg->get_parse_count() == 0 && nvals != PositionalArg::UNLIMITED && nvals != PositionalArg::OPTIONAL) {
+            throw MissingPositionalArgument(pos_arg->get_name());
+        }
+    }
+
     if (parse_hook) {
         parse_hook(this, option, argc, argv);
     }

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -279,7 +279,7 @@ void ArgumentParser::Command::parse(const char * option, int argc, const char * 
             used = true;
         }
         if (!used) {
-            ++i;
+            throw UnknownArgument(argv[i]);
         }
     }
     ++parse_count;

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -265,6 +265,7 @@ void ArgumentParser::Command::parse(const char * option, int argc, const char * 
         if (!used && used_values < pos_args.size()) {
             i += pos_args[used_values]->parse(argv[i], argc - i, &argv[i]);
             ++used_values;
+            used = true;
         }
         if (!used) {
             ++i;

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -17,7 +17,8 @@ You should have received a copy of the GNU General Public License
 along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "argument_parser.hpp"
+#include "libdnf-cli/argument_parser.hpp"
+#include "libdnf-cli/output/argument_parser.hpp"
 
 #include <fmt/format.h>
 
@@ -25,9 +26,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <iomanip>
 #include <iostream>
 
-#include "libdnf-cli/output/argument_parser.hpp"
-
-namespace microdnf {
+namespace libdnf::cli {
 
 ArgumentParser::Argument * ArgumentParser::Argument::get_conflict_argument() const noexcept {
     if (conflict_args) {
@@ -365,5 +364,4 @@ void ArgumentParser::reset_parse_count() {
     }
 }
 
-
-}  // namespace microdnf
+}  // namespace libdnf::cli

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -195,6 +195,33 @@ int ArgumentParser::NamedArg::parse_short(const char * option, int argc, const c
     return consumed_args;
 }
 
+void ArgumentParser::Command::register_command(Command * cmd) {
+    for (auto * item : cmds) {
+        if (item->id == cmd->id) {
+            throw CommandIdExists(cmd->id);
+        }
+    }
+    cmds.push_back(cmd);
+}
+
+void ArgumentParser::Command::register_named_arg(NamedArg * arg) {
+    for (auto * item : named_args) {
+        if (item->id == arg->id) {
+            throw NamedArgIdExists(arg->id);
+        }
+    }
+    named_args.push_back(arg);
+}
+
+void ArgumentParser::Command::register_positional_arg(PositionalArg * arg) {
+    for (auto * item : pos_args) {
+        if (item->id == arg->id) {
+            throw PositionalArgIdExists(arg->id);
+        }
+    }
+    pos_args.push_back(arg);
+}
+
 ArgumentParser::Command & ArgumentParser::Command::get_command(const std::string & id) const {
     for (auto * item : cmds) {
         if (item->get_id() == id) {

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -62,8 +62,8 @@ std::string ArgumentParser::Argument::get_conflict_arg_msg(const Argument * conf
 }
 
 ArgumentParser::PositionalArg::PositionalArg(
-    const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values)
-    : Argument(name)
+    ArgumentParser & owner, const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values)
+    : Argument(owner, name)
     , nvals(static_cast<int>(values->size()))
     , init_value(nullptr)
     , values(values) {
@@ -73,11 +73,12 @@ ArgumentParser::PositionalArg::PositionalArg(
 }
 
 ArgumentParser::PositionalArg::PositionalArg(
+    ArgumentParser & owner,
     const std::string & name,
     int nvals,
     libdnf::Option * init_value,
     std::vector<std::unique_ptr<libdnf::Option>> * values)
-    : Argument(name)
+    : Argument(owner, name)
     , nvals(nvals)
     , init_value(init_value)
     , values(values) {

--- a/microdnf/argument_parser.cpp
+++ b/microdnf/argument_parser.cpp
@@ -29,7 +29,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace microdnf {
 
-ArgumentParser::Argument * ArgumentParser::Argument::get_conflict_argument() const {
+ArgumentParser::Argument * ArgumentParser::Argument::get_conflict_argument() const noexcept {
     if (conflict_args) {
         for (auto arg : *conflict_args) {
             if (arg != this && arg->get_parse_count() > 0) {

--- a/microdnf/argument_parser.hpp
+++ b/microdnf/argument_parser.hpp
@@ -48,7 +48,7 @@ public:
         int get_parse_count() const noexcept { return parse_count; }
         void reset_parse_count() noexcept { parse_count = 0; }
         Argument * get_conflict_argument() const noexcept;
-        static std::string get_conflict_arg_msg(Argument * conflict_arg);
+        static std::string get_conflict_arg_msg(const Argument * conflict_arg);
         virtual void help() const noexcept {}
 
     private:
@@ -148,12 +148,14 @@ public:
         PositionalArg & get_positional_arg(const std::string & name) const;
         void set_parse_hook_func(ParseHookFunc && func) { parse_hook = std::move(func); }
         void help() const noexcept override;
-        void set_commands_help_header(std::string text) noexcept { commands_help_header = std::move(text);}
-        void set_named_args_help_header(std::string text) noexcept { named_args_help_header = std::move(text);}
-        void set_positional_args_help_header(std::string text) noexcept { positional_args_help_header = std::move(text);}
-        const std::string & get_commands_help_header() const noexcept { return commands_help_header;}
-        const std::string & get_named_args_help_header() const noexcept { return named_args_help_header;}
-        const std::string & get_positional_args_help_header() const noexcept { return positional_args_help_header;}
+        void set_commands_help_header(std::string text) noexcept { commands_help_header = std::move(text); }
+        void set_named_args_help_header(std::string text) noexcept { named_args_help_header = std::move(text); }
+        void set_positional_args_help_header(std::string text) noexcept {
+            positional_args_help_header = std::move(text);
+        }
+        const std::string & get_commands_help_header() const noexcept { return commands_help_header; }
+        const std::string & get_named_args_help_header() const noexcept { return named_args_help_header; }
+        const std::string & get_positional_args_help_header() const noexcept { return positional_args_help_header; }
 
     private:
         friend class ArgumentParser;
@@ -198,14 +200,14 @@ private:
 
 inline ArgumentParser::Command * ArgumentParser::add_new_command(const std::string & name) {
     std::unique_ptr<Command> arg(new Command(name));
-    auto ptr = arg.get();
+    auto * ptr = arg.get();
     cmds.push_back(std::move(arg));
     return ptr;
 }
 
 inline ArgumentParser::NamedArg * ArgumentParser::add_new_named_arg(const std::string & name) {
     std::unique_ptr<NamedArg> arg(new NamedArg(name));
-    auto ptr = arg.get();
+    auto * ptr = arg.get();
     named_args.push_back(std::move(arg));
     return ptr;
 }
@@ -213,7 +215,7 @@ inline ArgumentParser::NamedArg * ArgumentParser::add_new_named_arg(const std::s
 inline ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
     const std::string & name, std::vector<std::unique_ptr<libdnf::Option>> * values) {
     std::unique_ptr<PositionalArg> arg(new PositionalArg(name, values));
-    auto ptr = arg.get();
+    auto * ptr = arg.get();
     pos_args.push_back(std::move(arg));
     return ptr;
 }
@@ -224,34 +226,34 @@ inline ArgumentParser::PositionalArg * ArgumentParser::add_new_positional_arg(
     libdnf::Option * init_value,
     std::vector<std::unique_ptr<libdnf::Option>> * values) {
     std::unique_ptr<PositionalArg> arg(new PositionalArg(name, nargs, init_value, values));
-    auto ptr = arg.get();
+    auto * ptr = arg.get();
     pos_args.push_back(std::move(arg));
     return ptr;
 }
 
 inline std::vector<ArgumentParser::Argument *> * ArgumentParser::add_conflict_args_group(
     std::unique_ptr<std::vector<Argument *>> && conflict_args_group) {
-    auto ptr = conflict_args_group.get();
+    auto * ptr = conflict_args_group.get();
     conflict_args_groups.push_back(std::move(conflict_args_group));
     return ptr;
 }
 
 inline libdnf::Option * ArgumentParser::add_init_value(std::unique_ptr<libdnf::Option> && src) {
-    auto ptr = src.get();
+    auto * ptr = src.get();
     values_init.push_back(std::move(src));
     return ptr;
 }
 
 inline std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_new_values() {
     std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> tmp(new std::vector<std::unique_ptr<libdnf::Option>>);
-    auto ptr = tmp.get();
+    auto * ptr = tmp.get();
     values.push_back(std::move(tmp));
     return ptr;
 }
 
 inline std::vector<std::unique_ptr<libdnf::Option>> * ArgumentParser::add_values(
     std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>> && values) {
-    auto ptr = values.get();
+    auto * ptr = values.get();
     this->values.push_back(std::move(values));
     return ptr;
 }

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -46,16 +46,16 @@ void CmdDownload::set_argument_parser(Context & ctx) {
     auto download = ctx.arg_parser.add_new_command("download");
     download->set_short_description("download packages to current directory");
     download->set_description("");
-    download->named_args_help_header = "Optional arguments:";
-    download->positional_args_help_header = "Positional arguments:";
-    download->parse_hook = [this, &ctx](
+    download->set_named_args_help_header("Optional arguments:");
+    download->set_positional_args_help_header("Positional arguments:");
+    download->set_parse_hook_func([this, &ctx](
                                [[maybe_unused]] ArgumentParser::Argument * arg,
                                [[maybe_unused]] const char * option,
                                [[maybe_unused]] int argc,
                                [[maybe_unused]] const char * const argv[]) {
         ctx.select_command(this);
         return true;
-    };
+    });
 
     download->add_positional_arg(keys);
 

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -34,6 +34,8 @@ namespace fs = std::filesystem;
 
 namespace microdnf {
 
+using namespace libdnf::cli;
+
 void CmdDownload::set_argument_parser(Context & ctx) {
     patterns_to_download_options = ctx.arg_parser.add_new_values();
     auto keys = ctx.arg_parser.add_new_positional_arg(

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -59,9 +59,9 @@ void CmdDownload::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    download->add_positional_arg(keys);
+    download->register_positional_arg(keys);
 
-    ctx.arg_parser.get_root_command()->add_command(download);
+    ctx.arg_parser.get_root_command()->register_command(download);
 }
 
 void CmdDownload::configure([[maybe_unused]] Context & ctx) {}

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -61,9 +61,9 @@ void CmdInstall::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    install->add_positional_arg(keys);
+    install->register_positional_arg(keys);
 
-    ctx.arg_parser.get_root_command()->add_command(install);
+    ctx.arg_parser.get_root_command()->register_command(install);
 }
 
 void CmdInstall::configure([[maybe_unused]] Context & ctx) {}

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -48,16 +48,16 @@ void CmdInstall::set_argument_parser(Context & ctx) {
     auto install = ctx.arg_parser.add_new_command("install");
     install->set_short_description("install a package or packages on your system");
     install->set_description("");
-    install->named_args_help_header = "Optional arguments:";
-    install->positional_args_help_header = "Positional arguments:";
-    install->parse_hook = [this, &ctx](
+    install->set_named_args_help_header("Optional arguments:");
+    install->set_positional_args_help_header("Positional arguments:");
+    install->set_parse_hook_func([this, &ctx](
                                 [[maybe_unused]] ArgumentParser::Argument * arg,
                                 [[maybe_unused]] const char * option,
                                 [[maybe_unused]] int argc,
                                 [[maybe_unused]] const char * const argv[]) {
         ctx.select_command(this);
         return true;
-    };
+    });
 
     install->add_positional_arg(keys);
 

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -35,6 +35,8 @@ namespace fs = std::filesystem;
 
 namespace microdnf {
 
+using namespace libdnf::cli;
+
 void CmdInstall::set_argument_parser(Context & ctx) {
 
     patterns_to_install_options = ctx.arg_parser.add_new_values();

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -34,6 +34,8 @@ namespace fs = std::filesystem;
 
 namespace microdnf {
 
+using namespace libdnf::cli;
+
 void CmdReinstall::set_argument_parser(Context & ctx) {
     patterns_to_reinstall_options = ctx.arg_parser.add_new_values();
     auto keys = ctx.arg_parser.add_new_positional_arg(

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -59,9 +59,9 @@ void CmdReinstall::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    reinstall->add_positional_arg(keys);
+    reinstall->register_positional_arg(keys);
 
-    ctx.arg_parser.get_root_command()->add_command(reinstall);
+    ctx.arg_parser.get_root_command()->register_command(reinstall);
 }
 
 void CmdReinstall::configure([[maybe_unused]] Context & ctx) {}

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -46,16 +46,16 @@ void CmdReinstall::set_argument_parser(Context & ctx) {
     auto reinstall = ctx.arg_parser.add_new_command("reinstall");
     reinstall->set_short_description("reinstall a package or packages");
     reinstall->set_description("");
-    reinstall->named_args_help_header = "Optional arguments:";
-    reinstall->positional_args_help_header = "Positional arguments:";
-    reinstall->parse_hook = [this, &ctx](
+    reinstall->set_named_args_help_header("Optional arguments:");
+    reinstall->set_positional_args_help_header("Positional arguments:");
+    reinstall->set_parse_hook_func([this, &ctx](
                                 [[maybe_unused]] ArgumentParser::Argument * arg,
                                 [[maybe_unused]] const char * option,
                                 [[maybe_unused]] int argc,
                                 [[maybe_unused]] const char * const argv[]) {
         ctx.select_command(this);
         return true;
-    };
+    });
 
     reinstall->add_positional_arg(keys);
 

--- a/microdnf/commands/remove/remove.cpp
+++ b/microdnf/commands/remove/remove.cpp
@@ -44,16 +44,16 @@ void CmdRemove::set_argument_parser(Context & ctx) {
     auto remove = ctx.arg_parser.add_new_command("remove");
     remove->set_short_description("remove a package or packages from your system");
     remove->set_description("");
-    remove->named_args_help_header = "Optional arguments:";
-    remove->positional_args_help_header = "Positional arguments:";
-    remove->parse_hook = [this, &ctx](
+    remove->set_named_args_help_header("Optional arguments:");
+    remove->set_positional_args_help_header("Positional arguments:");
+    remove->set_parse_hook_func([this, &ctx](
                                 [[maybe_unused]] ArgumentParser::Argument * arg,
                                 [[maybe_unused]] const char * option,
                                 [[maybe_unused]] int argc,
                                 [[maybe_unused]] const char * const argv[]) {
         ctx.select_command(this);
         return true;
-    };
+    });
 
     remove->add_positional_arg(keys);
 

--- a/microdnf/commands/remove/remove.cpp
+++ b/microdnf/commands/remove/remove.cpp
@@ -31,6 +31,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace microdnf {
 
+using namespace libdnf::cli;
 
 void CmdRemove::set_argument_parser(Context & ctx) {
     patterns_to_remove_options = ctx.arg_parser.add_new_values();

--- a/microdnf/commands/remove/remove.cpp
+++ b/microdnf/commands/remove/remove.cpp
@@ -56,9 +56,9 @@ void CmdRemove::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    remove->add_positional_arg(keys);
+    remove->register_positional_arg(keys);
 
-    ctx.arg_parser.get_root_command()->add_command(remove);
+    ctx.arg_parser.get_root_command()->register_command(remove);
 }
 
 void CmdRemove::configure([[maybe_unused]] Context & ctx) {}

--- a/microdnf/commands/repolist/repolist.cpp
+++ b/microdnf/commands/repolist/repolist.cpp
@@ -81,12 +81,12 @@ void CmdRepolist::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    repolist->add_named_arg(all);
-    repolist->add_named_arg(enabled);
-    repolist->add_named_arg(disabled);
-    repolist->add_positional_arg(repos);
+    repolist->register_named_arg(all);
+    repolist->register_named_arg(enabled);
+    repolist->register_named_arg(disabled);
+    repolist->register_positional_arg(repos);
 
-    ctx.arg_parser.get_root_command()->add_command(repolist);
+    ctx.arg_parser.get_root_command()->register_command(repolist);
 
     auto repoinfo = ctx.arg_parser.add_new_command("repoinfo");
     repoinfo->set_short_description("display the configured software repositories");
@@ -104,12 +104,12 @@ void CmdRepolist::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    repoinfo->add_named_arg(all);
-    repoinfo->add_named_arg(enabled);
-    repoinfo->add_named_arg(disabled);
-    repoinfo->add_positional_arg(repos);
+    repoinfo->register_named_arg(all);
+    repoinfo->register_named_arg(enabled);
+    repoinfo->register_named_arg(disabled);
+    repoinfo->register_positional_arg(repos);
 
-    ctx.arg_parser.get_root_command()->add_command(repoinfo);
+    ctx.arg_parser.get_root_command()->register_command(repoinfo);
 }
 
 void CmdRepolist::run(Context & ctx) {

--- a/microdnf/commands/repolist/repolist.cpp
+++ b/microdnf/commands/repolist/repolist.cpp
@@ -26,6 +26,8 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace microdnf {
 
+using namespace libdnf::cli;
+
 void CmdRepolist::set_argument_parser(Context & ctx) {
     enable_disable_option = dynamic_cast<libdnf::OptionEnum<std::string> *>(
         ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionEnum<std::string>>(

--- a/microdnf/commands/repolist/repolist.cpp
+++ b/microdnf/commands/repolist/repolist.cpp
@@ -68,16 +68,16 @@ void CmdRepolist::set_argument_parser(Context & ctx) {
     auto repolist = ctx.arg_parser.add_new_command("repolist");
     repolist->set_short_description("display the configured software repositories");
     repolist->set_description("");
-    repolist->named_args_help_header = "Optional arguments:";
-    repolist->positional_args_help_header = "Positional arguments:";
-    repolist->parse_hook = [this, &ctx](
+    repolist->set_named_args_help_header("Optional arguments:");
+    repolist->set_positional_args_help_header("Positional arguments:");
+    repolist->set_parse_hook_func([this, &ctx](
                                [[maybe_unused]] ArgumentParser::Argument * arg,
                                [[maybe_unused]] const char * option,
                                [[maybe_unused]] int argc,
                                [[maybe_unused]] const char * const argv[]) {
         ctx.select_command(this);
         return true;
-    };
+    });
 
     repolist->add_named_arg(all);
     repolist->add_named_arg(enabled);
@@ -89,9 +89,9 @@ void CmdRepolist::set_argument_parser(Context & ctx) {
     auto repoinfo = ctx.arg_parser.add_new_command("repoinfo");
     repoinfo->set_short_description("display the configured software repositories");
     repoinfo->set_description("");
-    repoinfo->named_args_help_header = "Optional arguments:";
-    repoinfo->positional_args_help_header = "Positional arguments:";
-    repoinfo->parse_hook = [this, &ctx](
+    repoinfo->set_named_args_help_header("Optional arguments:");
+    repoinfo->set_positional_args_help_header("Positional arguments:");
+    repoinfo->set_parse_hook_func([this, &ctx](
                                [[maybe_unused]] ArgumentParser::Argument * arg,
                                [[maybe_unused]] const char * option,
                                [[maybe_unused]] int argc,
@@ -100,7 +100,7 @@ void CmdRepolist::set_argument_parser(Context & ctx) {
         throw std::logic_error("Not implemented");
         ctx.select_command(this);
         return true;
-    };
+    });
 
     repoinfo->add_named_arg(all);
     repoinfo->add_named_arg(enabled);

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -88,16 +88,16 @@ void CmdRepoquery::set_argument_parser(Context & ctx) {
     auto repoquery = ctx.arg_parser.add_new_command("repoquery");
     repoquery->set_short_description("search for packages matching keyword");
     repoquery->set_description("");
-    repoquery->named_args_help_header = "Optional arguments:";
-    repoquery->positional_args_help_header = "Positional arguments:";
-    repoquery->parse_hook = [this, &ctx](
+    repoquery->set_named_args_help_header("Optional arguments:");
+    repoquery->set_positional_args_help_header("Positional arguments:");
+    repoquery->set_parse_hook_func([this, &ctx](
                                 [[maybe_unused]] ArgumentParser::Argument * arg,
                                 [[maybe_unused]] const char * option,
                                 [[maybe_unused]] int argc,
                                 [[maybe_unused]] const char * const argv[]) {
         ctx.select_command(this);
         return true;
-    };
+    });
 
     repoquery->add_named_arg(available);
     repoquery->add_named_arg(installed);

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -100,13 +100,13 @@ void CmdRepoquery::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    repoquery->add_named_arg(available);
-    repoquery->add_named_arg(installed);
-    repoquery->add_named_arg(info);
-    repoquery->add_named_arg(nevra);
-    repoquery->add_positional_arg(keys);
+    repoquery->register_named_arg(available);
+    repoquery->register_named_arg(installed);
+    repoquery->register_named_arg(info);
+    repoquery->register_named_arg(nevra);
+    repoquery->register_positional_arg(keys);
 
-    ctx.arg_parser.get_root_command()->add_command(repoquery);
+    ctx.arg_parser.get_root_command()->register_command(repoquery);
 }
 
 void CmdRepoquery::configure([[maybe_unused]] Context & ctx) {}

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -32,6 +32,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace microdnf {
 
+using namespace libdnf::cli;
 void CmdRepoquery::set_argument_parser(Context & ctx) {
     available_option = dynamic_cast<libdnf::OptionBool *>(
         ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(true))));

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -34,6 +34,8 @@ namespace fs = std::filesystem;
 
 namespace microdnf {
 
+using namespace libdnf::cli;
+
 void CmdUpgrade::set_argument_parser(Context & ctx) {
     patterns_to_upgrade_options = ctx.arg_parser.add_new_values();
     auto keys = ctx.arg_parser.add_new_positional_arg(

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -59,9 +59,9 @@ void CmdUpgrade::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    upgrade->add_positional_arg(keys);
+    upgrade->register_positional_arg(keys);
 
-    ctx.arg_parser.get_root_command()->add_command(upgrade);
+    ctx.arg_parser.get_root_command()->register_command(upgrade);
 }
 
 void CmdUpgrade::configure([[maybe_unused]] Context & ctx) {}

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -46,16 +46,16 @@ void CmdUpgrade::set_argument_parser(Context & ctx) {
     auto upgrade = ctx.arg_parser.add_new_command("upgrade");
     upgrade->set_short_description("upgrade a package or packages on your system");
     upgrade->set_description("");
-    upgrade->named_args_help_header = "Optional arguments:";
-    upgrade->positional_args_help_header = "Positional arguments:";
-    upgrade->parse_hook = [this, &ctx](
+    upgrade->set_named_args_help_header("Optional arguments:");
+    upgrade->set_positional_args_help_header("Positional arguments:");
+    upgrade->set_parse_hook_func([this, &ctx](
                                 [[maybe_unused]] ArgumentParser::Argument * arg,
                                 [[maybe_unused]] const char * option,
                                 [[maybe_unused]] int argc,
                                 [[maybe_unused]] const char * const argv[]) {
         ctx.select_command(this);
         return true;
-    };
+    });
 
     upgrade->add_positional_arg(keys);
 

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -20,10 +20,10 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef MICRODNF_CONTEXT_HPP
 #define MICRODNF_CONTEXT_HPP
 
-#include "argument_parser.hpp"
 #include "commands/command.hpp"
 
 #include <libdnf/base/base.hpp>
+#include <libdnf-cli/argument_parser.hpp>
 #include <libdnf/rpm/transaction.hpp>
 
 #include <memory>
@@ -47,7 +47,7 @@ public:
     std::vector<std::pair<std::string, std::string>> setopts;
     std::vector<std::unique_ptr<Command>> commands;
     Command * selected_command{nullptr};
-    ArgumentParser arg_parser;
+    libdnf::cli::ArgumentParser arg_parser;
 
 private:
     /// Updates the repository metadata cache and load it into rpm::RepoSack.

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -65,7 +65,7 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
 
     auto setopt = ctx.arg_parser.add_new_named_arg("setopt");
     setopt->set_long_name("setopt");
-    setopt->set_has_arg(true);
+    setopt->set_has_value(true);
     setopt->set_arg_value_help("KEY=VALUE");
     setopt->set_short_description("set arbitrary config and repo options");
     setopt->set_description(R"**(Override a configuration option from the configuration file. To override configuration options for repositories, use repoid.option for  the

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -61,7 +61,7 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
                                [[maybe_unused]] const char * value) {
         microdnf->help();
         return true;});
-    microdnf->add_named_arg(help);
+    microdnf->register_named_arg(help);
 
     auto setopt = ctx.arg_parser.add_new_named_arg("setopt");
     setopt->set_long_name("setopt");
@@ -99,7 +99,7 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
             }
         }
         return true;});
-    microdnf->add_named_arg(setopt);
+    microdnf->register_named_arg(setopt);
 
 
     ctx.arg_parser.set_root_command(microdnf);

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "argument_parser.hpp"
 #include "commands/install/install.hpp"
 #include "commands/download/download.hpp"
 #include "commands/reinstall/reinstall.hpp"
@@ -43,6 +42,8 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace fs = std::filesystem;
 
 namespace microdnf {
+
+using namespace libdnf::cli;
 
 static bool parse_args(Context & ctx, int argc, char * argv[]) {
     auto microdnf = ctx.arg_parser.add_new_command("microdnf");

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -48,31 +48,31 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
     auto microdnf = ctx.arg_parser.add_new_command("microdnf");
     microdnf->set_short_description("Utility for packages maintaining");
     microdnf->set_description("Microdnf is a program for maintaining packages.");
-    microdnf->commands_help_header = "List of commands:";
-    microdnf->named_args_help_header = "Global arguments:";
+    microdnf->set_commands_help_header("List of commands:");
+    microdnf->set_named_args_help_header("Global arguments:");
     auto help = ctx.arg_parser.add_new_named_arg("help");
     help->set_long_name("help");
     help->set_short_name('h');
     help->set_short_description("Print help");
-    help->parse_hook = [microdnf](
+    help->set_parse_hook_func([microdnf](
                                [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                [[maybe_unused]] const char * option,
                                [[maybe_unused]] const char * value) {
         microdnf->help();
-        return true;};
+        return true;});
     microdnf->add_named_arg(help);
 
     auto setopt = ctx.arg_parser.add_new_named_arg("setopt");
     setopt->set_long_name("setopt");
     setopt->set_has_arg(true);
-    setopt->arg_value_help = "KEY=VALUE";
+    setopt->set_arg_value_help("KEY=VALUE");
     setopt->set_short_description("set arbitrary config and repo options");
     setopt->set_description(R"**(Override a configuration option from the configuration file. To override configuration options for repositories, use repoid.option for  the
               <option>.  Values  for configuration options like excludepkgs, includepkgs, installonlypkgs and tsflags are appended to the original value,
               they do not override it. However, specifying an empty value (e.g. --setopt=tsflags=) will clear the option.)**");
 
     // --setopt option support
-    setopt->parse_hook = [&ctx](
+    setopt->set_parse_hook_func([&ctx](
                                [[maybe_unused]] ArgumentParser::NamedArg * arg,
                                [[maybe_unused]] const char * option,
                                const char * value) {
@@ -97,7 +97,7 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
                 throw std::runtime_error(std::string("setopt: \"") + value + "\": " + ex.what());
             }
         }
-        return true;};
+        return true;});
     microdnf->add_named_arg(setopt);
 
 


### PR DESCRIPTION
- Moves argument parser from microdnf into lbdnf-cli.
- Adds documentation strings.
- Rename some methods to better fit their functionality.
- Adds getters and setters.
- Makes some methods and all data members private.
- Defines exceptions that inherits from libdnf exceptions.
- Fixes a bug that the argument after the positional argument was skipped.
- It never analyzes an argument beginning with a "-" as a positional.
- Adds check for unknown arguments.
- Adds check that all required positional argument are present.