### PR TITLE
Unify hawkey.log line format with the rest of the logs

### DIFF
--- a/python/hawkey/sack-py.cpp
+++ b/python/hawkey/sack-py.cpp
@@ -196,13 +196,12 @@ log_handler(const gchar *log_domain, GLogLevelFlags log_level, const gchar *mess
 {
     time_t t = time(NULL);
     struct tm tm;
-    char timestr[26];
+    char timestr[32];
 
     FILE *log_out = (FILE*) user_data;
     localtime_r(&t, &tm);
-    strftime(timestr, 26, "%b-%d %H:%M:%S ", &tm);
-    gchar *msg = g_strjoin("", log_level_name(log_level), " ",
-                           timestr, message, "\n", NULL);
+    strftime(timestr, sizeof(timestr), "%Y-%m-%dT%H:%M:%S%z ", &tm);
+    gchar *msg = g_strjoin("", timestr, log_level_name(log_level), " ", message, "\n", NULL);
     fwrite(msg, strlen(msg), 1, log_out);
     fflush(log_out);
     g_free(msg);


### PR DESCRIPTION
Changes the timestamp of log records to adhere to ISO 8601 (with times
being in local time already and now it prints the offset from UTC) and
also swaps the order the timestamp and loglevel, so that now the line
has the same format as the rest of the logs that dnf writes.

msg: Unify hawkey.log line format with the rest of the logs
type: enhancement
related: https://bugzilla.redhat.com/show_bug.cgi?id=1834538