### PR TITLE
[DNF5] libdnf: Bump shared object version

### DIFF
--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -11,7 +11,7 @@ add_definitions(-DGETTEXT_DOMAIN=\"libdnf\")
 
 # build libdnf.so
 add_library(libdnf SHARED ${LIBDNF_SOURCES})
-set(DNF_SO_VERSION 2)
+set(DNF_SO_VERSION 3)
 set_target_properties(libdnf PROPERTIES OUTPUT_NAME "dnf")
 set_target_properties(libdnf PROPERTIES SOVERSION ${DNF_SO_VERSION})
 # required by clang


### PR DESCRIPTION
The libdnf API is completely different now, so let's bump the shared
object version so that the older version of the library and this one
can coexist until all consumers are ported to this new API.