### PR TITLE
[dnf5][argparser] Improve PositionalArg

### DIFF
--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -149,7 +149,8 @@ public:
 
         /// Enables/disables storing parsed values.
         /// Values can be processed / stored in the user parse hook function.
-        void set_store_value(bool enable) noexcept { store_value = enable; }
+        /// The "LogicError" exception is thrown when "true" is requested but the storage array "values" is not set.
+        void set_store_value(bool enable);
 
         /// Returns true if storing the parsed values is enabled.
         bool get_store_value() const noexcept { return store_value; }

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -81,10 +81,18 @@ ArgumentParser::PositionalArg::PositionalArg(
     : Argument(owner, id)
     , nvals(nvals)
     , init_value(init_value)
-    , values(values) {
-    if (!values) {
-        throw LogicError("PositionalArg: \"values\" constructor parameter can't be nullptr");
+    , values(values)
+    , store_value(values) {
+    if (values && !init_value) {
+        throw LogicError("PositionalArg: \"init_value\" constructor parameter can't be nullptr if \"value\" is set");
     }
+}
+
+void ArgumentParser::PositionalArg::set_store_value(bool enable) {
+    if (enable && !values) {
+        throw LogicError("PositionalArg::set_store_value(true) was called but storage array \"values\" is not set");
+    }
+    store_value = enable;
 }
 
 int ArgumentParser::PositionalArg::parse(const char * option, int argc, const char * const argv[]) {

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -64,12 +64,12 @@ std::string ArgumentParser::Argument::get_conflict_arg_msg(const Argument * conf
 ArgumentParser::PositionalArg::PositionalArg(
     ArgumentParser & owner, const std::string & id, std::vector<std::unique_ptr<libdnf::Option>> * values)
     : Argument(owner, id)
-    , nvals(static_cast<int>(values->size()))
     , init_value(nullptr)
     , values(values) {
     if (!values || values->empty()) {
         throw LogicError("PositionalArg: \"values\" constructor parameter can't be nullptr or empty vector");
     }
+    nvals = static_cast<int>(values->size());
 }
 
 ArgumentParser::PositionalArg::PositionalArg(


### PR DESCRIPTION
Fixed: `values->size()` was called before checking the `values` to `nullptr`.

Support `PositionalArg` without setting storage field `values`  -  Good in case the user has his own parsing function and does not want to store values using ArgumentParser.

