### PR TITLE
cmake/tests/hawkey: add libcheck linkage dependencies

### DIFF
--- a/tests/hawkey/CMakeLists.txt
+++ b/tests/hawkey/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(test_hawkey_main ${hawkeytest_SRCS})
 set_target_properties(test_hawkey_main PROPERTIES COMPILE_FLAGS -fPIC)
 target_link_libraries(test_hawkey_main
     libdnf
-    ${CHECK_LIBRARIES}
+    ${CHECK_LDFLAGS}
     ${SOLV_LIBRARY}
     ${SOLVEXT_LIBRARY}
     ${RPMDB_LIBRARY}


### PR DESCRIPTION
This tweaks hawkey tests linkage in order to bring in transitive flags
for `libcheck`. It fixes pthread linking issues when building tests on
systems with a static `libcheck` library.