### PR TITLE
[dnf5][microdnf] Commands "install", "remove", "upgrade" write to database

### DIFF
--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -102,12 +102,23 @@ void CmdInstall::run(Context & ctx) {
 
     download_packages(goal, nullptr);
 
-    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
-    libdnf::rpm::Transaction ts(ctx.base);
-    prepare_transaction(goal, ts, transaction_items);
-
     std::cout << std::endl;
-    run_transaction(ts);
+
+    libdnf::rpm::Transaction rpm_transaction(ctx.base);
+    auto db_transaction = new_db_transaction(ctx);
+    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
+
+    fill_transactions(goal, db_transaction, rpm_transaction, transaction_items);
+
+    auto time = std::chrono::system_clock::now().time_since_epoch();
+    db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());
+    db_transaction->start();
+
+    run_transaction(rpm_transaction);
+
+    time = std::chrono::system_clock::now().time_since_epoch();
+    db_transaction->set_dt_end(std::chrono::duration_cast<std::chrono::seconds>(time).count());
+    db_transaction->finish(libdnf::transaction::TransactionState::DONE);
 }
 
 }  // namespace microdnf

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -100,12 +100,23 @@ void CmdUpgrade::run(Context & ctx) {
 
     download_packages(goal, nullptr);
 
-    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
-    libdnf::rpm::Transaction ts(ctx.base);
-    prepare_transaction(goal, ts, transaction_items);
-
     std::cout << std::endl;
-    run_transaction(ts);
+
+    libdnf::rpm::Transaction rpm_transaction(ctx.base);
+    auto db_transaction = new_db_transaction(ctx);
+    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
+
+    fill_transactions(goal, db_transaction, rpm_transaction, transaction_items);
+
+    auto time = std::chrono::system_clock::now().time_since_epoch();
+    db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());
+    db_transaction->start();
+
+    run_transaction(rpm_transaction);
+
+    time = std::chrono::system_clock::now().time_since_epoch();
+    db_transaction->set_dt_end(std::chrono::duration_cast<std::chrono::seconds>(time).count());
+    db_transaction->finish(libdnf::transaction::TransactionState::DONE);
 }
 
 }  // namespace microdnf

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -25,6 +25,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/base/base.hpp>
 #include <libdnf-cli/argument_parser.hpp>
 #include <libdnf/rpm/transaction.hpp>
+#include <libdnf/utils/span.hpp>
 
 #include <memory>
 #include <utility>
@@ -49,9 +50,18 @@ public:
     Command * selected_command{nullptr};
     libdnf::cli::ArgumentParser arg_parser;
 
+    /// Gets program arguments.
+    libdnf::Span<const char * const> get_prg_arguments() const { return prg_args; }
+
+    /// Stores reference to program arguments.
+    void set_prg_arguments(size_t argc, const char * const * argv) { prg_args = {argv, argc}; }
+
 private:
     /// Updates the repository metadata cache and load it into rpm::RepoSack.
     void load_rpm_repo(libdnf::rpm::Repo & repo);
+
+    /// Refers to program arguments.
+    libdnf::Span<const char * const> prg_args;
 };
 
 class RpmTransactionItem : public libdnf::rpm::TransactionItem {

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -56,12 +56,21 @@ public:
     /// Stores reference to program arguments.
     void set_prg_arguments(size_t argc, const char * const * argv) { prg_args = {argv, argc}; }
 
+    /// Gets user comment.
+    const char * get_comment() const noexcept { return comment; }
+
+    /// Stores pointer to user comment.
+    void set_comment(const char * comment) noexcept { this->comment = comment; }
+
 private:
     /// Updates the repository metadata cache and load it into rpm::RepoSack.
     void load_rpm_repo(libdnf::rpm::Repo & repo);
 
     /// Refers to program arguments.
     libdnf::Span<const char * const> prg_args;
+
+    /// Points to user comment.
+    const char * comment{nullptr};
 };
 
 class RpmTransactionItem : public libdnf::rpm::TransactionItem {

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -93,7 +93,12 @@ void download_packages(libdnf::Goal & goal, const char * dest_dir);
 
 void run_transaction(libdnf::rpm::Transaction & transaction);
 
-void prepare_transaction(libdnf::Goal & goal, libdnf::rpm::Transaction & ts, std::vector<std::unique_ptr<RpmTransactionItem>> & transaction_items);
+/// Creates, initializes and returns new database transaction.
+libdnf::transaction::TransactionWeakPtr new_db_transaction(Context & ctx);
+
+/// Fills transactions by packages from goal.
+// TODO(jrohel): Temporary code. Will be rewritten (depends on software database code) and moved to libdnf::cli later.
+void fill_transactions(libdnf::Goal & goal, libdnf::transaction::TransactionWeakPtr & transaction, libdnf::rpm::Transaction & rpm_ts, std::vector<std::unique_ptr<RpmTransactionItem>> & transaction_items);
 
 }  // namespace microdnf
 

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -118,6 +118,20 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
     assume_no->link_value(&config.assumeno());
     microdnf->register_named_arg(assume_no);
 
+    auto comment = ctx.arg_parser.add_new_named_arg("comment");
+    comment->set_long_name("comment");
+    comment->set_has_value(true);
+    comment->set_arg_value_help("COMMENT");
+    comment->set_short_description("add a comment to transaction");
+    comment->set_description("Adds a comment to the action. If a transaction takes place, the comment is stored in it.");
+    comment->set_parse_hook_func(
+        [&ctx](
+            [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            ctx.set_comment(value);
+            return true;
+        });
+    microdnf->register_named_arg(comment);
+
     ctx.arg_parser.set_root_command(microdnf);
 
     for (auto & command : ctx.commands) {

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -147,6 +147,8 @@ int main(int argc, char * argv[]) {
 
     log_router.info("Microdnf start");
 
+    context.set_prg_arguments(static_cast<size_t>(argc), argv);
+
     // Register commands
     context.commands.push_back(std::make_unique<microdnf::CmdInstall>());
     context.commands.push_back(std::make_unique<microdnf::CmdDownload>());

--- a/microdnf/utils.cpp
+++ b/microdnf/utils.cpp
@@ -19,8 +19,10 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils.hpp"
 
+#include <fcntl.h>
 #include <libsmartcols/libsmartcols.h>
 #include <pwd.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <fmt/format.h>
@@ -34,6 +36,50 @@ namespace microdnf {
 
 bool am_i_root() noexcept {
     return geteuid() == 0;
+}
+
+static constexpr uid_t INVALID_UID = static_cast<uid_t>(-1);
+
+/// Read the login uid from the "/proc/self/loginuid".
+static uid_t read_login_uid_from_proc() noexcept {
+    auto in = open("/proc/self/loginuid", O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (in == -1) {
+        return INVALID_UID;
+    }
+
+    ssize_t len;
+    char buf[16];
+    do {
+        errno = 0;
+        len = read(in, buf, sizeof(buf) - 1);
+    } while (len < 0 && errno == EINTR);
+
+    close(in);
+
+    if (len <= 0) {
+        return INVALID_UID;
+    }
+
+    buf[len] = '\0';
+    char * endptr;
+    errno = 0;
+    auto uid = static_cast<uid_t>(strtol(buf, &endptr, 10));
+    if (buf == endptr || errno != 0) {
+        return INVALID_UID;
+    }
+
+    return uid;
+}
+
+uid_t get_login_uid() noexcept {
+    static uid_t cached_uid = INVALID_UID;
+    if (cached_uid == INVALID_UID) {
+        cached_uid = read_login_uid_from_proc();
+        if (cached_uid == INVALID_UID) {
+            cached_uid = getuid();
+        }
+    }
+    return cached_uid;
 }
 
 namespace xdg {

--- a/microdnf/utils.hpp
+++ b/microdnf/utils.hpp
@@ -21,6 +21,7 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define MICRODNF_UTILS_HPP
 
 #include <libdnf/base/goal.hpp>
+#include <sys/types.h>
 
 #include <filesystem>
 #include <string>
@@ -29,6 +30,11 @@ namespace microdnf {
 
 /// Returns "true" if program runs with effective user ID = 0
 bool am_i_root() noexcept;
+
+/// Gets the login uid, if available.
+/// The getuid() is returned instead if there was a problem.
+/// The value is cached.
+uid_t get_login_uid() noexcept;
 
 namespace xdg {
 


### PR DESCRIPTION
The commands `install`, `remove`, and `upgrade` write transaction to database.

Missing:
Nevra of used application is not stored.
Begin and End rpmdb version is not stored.
Scriptlet output is not stored.
Reason of packages is set to UNKNOWN.
Return code is allways set to SUCCESS.

Include implementation of function `get_login_uid()`.