### PR TITLE
Fix sanitizer builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,3 +176,6 @@ add_subdirectory(tests)
 if(WITH_BINDINGS)
     add_subdirectory(python/hawkey)
 endif()
+
+
+add_subdirectory(etc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,15 +146,8 @@ endif()
 
 if(WITH_SANITIZERS)
     message(WARNING "Building with sanitizers enabled!")
-    set(SANITIZER_FLAGS "-fsanitize=address -fsanitize=leak -fsanitize=undefined")
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # requires: compiler-rt package on Fedora
-        set(SANITIZER_FLAGS "${SANITIZER_FLAGS} -static-libsan")
-    else()
-        set(SANITIZER_FLAGS "${SANITIZER_FLAGS} -static-libasan -static-liblsan -static-libubsan")
-    endif()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SANITIZER_FLAGS}")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${SANITIZER_FLAGS}")
+    add_compile_options(-fsanitize=address -fsanitize=undefined -fsanitize=leak)
+    link_libraries(asan ubsan)
 endif()
 
 

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(WITH_SANITIZERS)
+    INSTALL (FILES "dnf-sanitizers.sh" DESTINATION /etc/profile.d/)
+endif()

--- a/etc/dnf-sanitizers.sh
+++ b/etc/dnf-sanitizers.sh
@@ -1,0 +1,5 @@
+function dnf {
+    ASAN_OPTIONS=verify_asan_link_order=0 /usr/bin/dnf "$@"
+}
+
+export -f dnf

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -90,9 +90,9 @@ BuildRequires:  gettext
 BuildRequires:  gpgme-devel
 
 %if %{with sanitizers}
-BuildRequires:  libasan-static
-BuildRequires:  liblsan-static
-BuildRequires:  libubsan-static
+BuildRequires:  libasan
+BuildRequires:  liblsan
+BuildRequires:  libubsan
 %endif
 
 Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -280,6 +280,9 @@ popd
 %dir %{_libdir}/libdnf/
 %dir %{_libdir}/libdnf/plugins/
 %{_libdir}/libdnf/plugins/README
+%if %{with sanitizers}
+%{_sysconfdir}/profile.d/dnf-sanitizers.sh
+%endif
 
 %files devel
 %doc %{_datadir}/gtk-doc/html/%{name}/

--- a/python/hawkey/tests/tests/run_nosetests.in
+++ b/python/hawkey/tests/tests/run_nosetests.in
@@ -18,6 +18,16 @@ def fatal(msg):
 childenv = dict(os.environ)
 childenv['LD_LIBRARY_PATH'] = '${CMAKE_BINARY_DIR}/libdnf/'
 childenv['PYTHONPATH'] = '${CMAKE_BINARY_DIR}/python/hawkey'
+
+# This fixes the "ASan runtime does not come first in initial library list"
+# message when built with sanitizers. Note the better solution should be to use
+# LD_PRELOAD for the sanitizer library. With the solution used here the
+# sanitizer library is loaded when the DSO linked against it is loaded. For any
+# calls up to that point the sanitizers aren't active. While hackish, this is
+# convenient because python is causing some leaks during module loading which
+# this works around.
+childenv['ASAN_OPTIONS'] = 'verify_asan_link_order=0'
+
 subprocess.check_call(['${PYTHON_EXECUTABLE}', '-m', 'nose',
                        '--with-xunit', '--xunit-file=xunit.xml',
                        '-s', '-v', '${CMAKE_CURRENT_SOURCE_DIR}'],


### PR DESCRIPTION
The -fsanitize option is a compiler option, not a linker option, the
DSOs were still being built without the sanitizers.

The sanitizer builds require either libasan being preloaded in
LD_PRELOAD (preferred in theory) or
ASAN_OPTIONS=verify_asan_link_order=0 to avoid the link order check
(which causes the sanitizer to be loaded later and hence ignore some
errors, but e.g. for python this avoids failing on some memory leaks
python exhibits during module loading).