### PR TITLE
[context][log] Log messages from C++ logger to GLib logger

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -74,6 +74,7 @@
 #include "dnf-repo.hpp"
 #include "goal/Goal.hpp"
 #include "plugin/plugin-private.hpp"
+#include "utils/GLibLogger.hpp"
 #include "utils/os-release.hpp"
 
 
@@ -185,6 +186,7 @@ enum {
     SIGNAL_LAST
 };
 
+static libdnf::GLibLogger glibLogger(G_LOG_DOMAIN);
 static std::string pluginsDir = DEFAULT_PLUGINS_DIRECTORY;
 static std::unique_ptr<std::string> configFilePath;
 static std::set<std::string> pluginsEnabled;
@@ -331,6 +333,8 @@ static void
 dnf_context_init(DnfContext *context)
 {
     DnfContextPrivate *priv = GET_PRIVATE(context);
+
+    libdnf::Log::setLogger(&glibLogger);
 
     priv->install_root = g_strdup("/");
     priv->check_disk_space = TRUE;

--- a/libdnf/utils/CMakeLists.txt
+++ b/libdnf/utils/CMakeLists.txt
@@ -13,6 +13,7 @@ set(UTILS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/File.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CompressedFile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/logger.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/GLibLogger.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/os-release.cpp
     PARENT_SCOPE
 )

--- a/libdnf/utils/GLibLogger.cpp
+++ b/libdnf/utils/GLibLogger.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <GLibLogger.hpp>
+
+#include <glib.h>
+
+namespace libdnf {
+
+static inline void write_g_log(const std::string & domain, Logger::Level level, const std::string & message)
+{
+    GLogLevelFlags gLogLevel;
+    switch (level) {
+        // In GLib, the "G_LOG_LEVEL_ERROR" is more severe than "G_LOG_LEVEL_CRITICAL".
+        // In fact, the "G_LOG_LEVEL_ERROR" is always fatal. We won't use it now.
+        case Logger::Level::CRITICAL:
+            gLogLevel = G_LOG_LEVEL_CRITICAL;
+            break;
+        case Logger::Level::ERROR:
+            gLogLevel = G_LOG_LEVEL_CRITICAL;
+            break;
+
+        case Logger::Level::WARNING:
+            gLogLevel = G_LOG_LEVEL_WARNING;
+            break;
+        case Logger::Level::NOTICE:
+            gLogLevel = G_LOG_LEVEL_MESSAGE;
+            break;
+        case Logger::Level::INFO:
+            gLogLevel = G_LOG_LEVEL_INFO;
+            break;
+        case Logger::Level::DEBUG:
+        case Logger::Level::TRACE:
+        default:
+            gLogLevel = G_LOG_LEVEL_DEBUG;
+            break;
+    }
+    g_log(domain.c_str(), gLogLevel, "%s", message.c_str());
+}
+
+void GLibLogger::write(int /*source*/, Level level, const std::string & message)
+{
+    write_g_log(domain, level, message);
+}
+
+void GLibLogger::write(int /*source*/, time_t /*time*/, pid_t /*pid*/, Level level, const std::string & message)
+{
+    write_g_log(domain, level, message);
+}
+
+}

--- a/libdnf/utils/GLibLogger.hpp
+++ b/libdnf/utils/GLibLogger.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _GLIB_LOGGER_HPP_
+#define _GLIB_LOGGER_HPP_
+
+#include <logger.hpp>
+
+namespace libdnf {
+
+class GLibLogger : public Logger {
+public:
+    explicit GLibLogger(std::string domain) : domain(domain) {}
+    void write(int source, Level level, const std::string & message) override;
+    void write(int source, time_t time, pid_t pid, Level level, const std::string & message) override;
+
+private:
+    std::string domain;
+};
+
+}
+
+#endif // _GLIB_LOGGER_HPP_


### PR DESCRIPTION
- Added `GLibLogger` class. GLibLogger is an implementation of the logger that logs the messages using the GLib `g_log()` function.

- The C++ logger is set to `GLibLogger` in the `dnf_context_init()` function. Therefore, applications that use the old "context" API will receive all log messages, including messages from C++ logger. Before this change the log message from C++ logger were discarded.