### PR TITLE
[dnf5] Switch sanitizers from LD_PRELOAD to ASAN_OPTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,6 @@ if(WITH_SANITIZERS)
     message(WARNING "Building with sanitizers enabled!")
     add_compile_options(-fsanitize=address -fsanitize=undefined -fsanitize=leak)
     link_libraries(asan ubsan)
-    # find installed libasan.so.* in the list and use it in LD_PRELOAD when running python tests
-    find_library(ASAN_LIBRARIES libasan.so.5 libasan.so.6 libasan.so.7 libasan.so.8 REQUIRED)
 endif()
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,9 +7,14 @@ message("Building tests")
 
 
 if(WITH_SANITIZERS)
-    set(ASAN_LD_PRELOAD "LD_PRELOAD=${ASAN_LIBRARIES}")
-    set(ASAN_OPTIONS "ASAN_OPTIONS=detect_odr_violation=0")
-    set(LSAN_OPTIONS "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/lsan-suppresions.txt")
+    # This fixes the "ASan runtime does not come first in initial library
+    # list" message. Note the better solution should be to use
+    # LD_PRELOAD=`ls /lib64/libasan.so.?`. With the solution used here the
+    # sanitizer library is loaded when the DSO linked against it is loaded. For
+    # any calls up to that point the sanitizers aren't active. While hackish,
+    # this is convenient because e.g. python is causing some leaks during
+    # module loading which this works around.
+    set(ASAN_OPTIONS "ASAN_OPTIONS=verify_asan_link_order=0")
 endif()
 
 

--- a/test/dnfdaemon-server/CMakeLists.txt
+++ b/test/dnfdaemon-server/CMakeLists.txt
@@ -10,8 +10,4 @@ add_test(
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
-set_property(TEST test_dnfdaemon_server PROPERTY ENVIRONMENT
-    "${ASAN_LD_PRELOAD}"
-    "${ASAN_OPTIONS}"
-    "${LSAN_OPTIONS}"
-)
+set_property(TEST test_dnfdaemon_server PROPERTY ENVIRONMENT "${ASAN_OPTIONS}")

--- a/test/lsan-suppresions.txt
+++ b/test/lsan-suppresions.txt
@@ -1,3 +1,0 @@
-leak:libperl.so*
-leak:libpython*.so*
-leak:libruby.so*

--- a/test/perl5/CMakeLists.txt
+++ b/test/perl5/CMakeLists.txt
@@ -23,11 +23,7 @@ macro(add_perl_test)
         COMMAND "${PERL_EXECUTABLE}" "-I${CMAKE_BINARY_DIR}/bindings/perl5" "${ARGV1}"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
-    set_property(TEST ${target} PROPERTY ENVIRONMENT
-        "${ASAN_LD_PRELOAD}"
-        "${ASAN_OPTIONS}"
-        "${LSAN_OPTIONS}"
-    )
+    set_property(TEST ${target} PROPERTY ENVIRONMENT "${ASAN_OPTIONS}")
 endmacro()
 
 

--- a/test/python3/libdnf/CMakeLists.txt
+++ b/test/python3/libdnf/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_test(NAME test_python3_libdnf COMMAND ${Python3_EXECUTABLE} -m unittest WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 set_property(TEST test_python3_libdnf PROPERTY ENVIRONMENT
     "PYTHONPATH=${CMAKE_BINARY_DIR}/bindings/python3"
-    "${ASAN_LD_PRELOAD}"
     "${ASAN_OPTIONS}"
-    "${LSAN_OPTIONS}"
 )

--- a/test/python3/libdnf_cli/CMakeLists.txt
+++ b/test/python3/libdnf_cli/CMakeLists.txt
@@ -6,7 +6,5 @@ endif()
 add_test(NAME test_python3_libdnf_cli COMMAND ${Python3_EXECUTABLE} -m unittest WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 set_property(TEST test_python3_libdnf_cli PROPERTY ENVIRONMENT
     "PYTHONPATH=${CMAKE_BINARY_DIR}/bindings/python3"
-    "${ASAN_LD_PRELOAD}"
     "${ASAN_OPTIONS}"
-    "${LSAN_OPTIONS}"
 )

--- a/test/ruby/CMakeLists.txt
+++ b/test/ruby/CMakeLists.txt
@@ -13,11 +13,11 @@ macro(add_ruby_test)
         COMMAND "${RUBY_EXECUTABLE}" "-I${CMAKE_BINARY_DIR}/bindings/ruby" "${ARGV1}"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
-    set_property(TEST ${target} PROPERTY ENVIRONMENT
-        "${ASAN_LD_PRELOAD}"
-        "${ASAN_OPTIONS}"
-        "${LSAN_OPTIONS}"
-    )
+
+    # TODO the ODR violation seems like a problem with the Ruby bindings that
+    # should be fixed
+    set(ASAN_OPTIONS "${ASAN_OPTIONS},detect_odr_violation=0")
+    set_property(TEST ${target} PROPERTY ENVIRONMENT "${ASAN_OPTIONS}")
 endmacro()
 
 


### PR DESCRIPTION
Use ASAN_OPTIONS=verify_asan_link_order=0 instead of LD_PRELOAD=`ls
/lib64/libasan.so.?` in tests.