### PR TITLE
[dnf5] Improve performance of ifilter_installed() and ifilter_available()

### DIFF
--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -1790,10 +1790,16 @@ SolvQuery & SolvQuery::ifilter_installed() {
         return *this;
     }
     solv::SolvMap filter_result(p_impl->sack->pImpl->get_nsolvables());
-    for (PackageId candidate_id : p_impl->query_result) {
-        Solvable * solvable = solv::get_solvable(pool, candidate_id);
+    auto it = p_impl->query_result.begin();
+    auto end = p_impl->query_result.end();
+    for (it.jump(PackageId(installed_repo->start)); it != end; ++it) {
+        Solvable * solvable = solv::get_solvable(pool, *it);
         if (solvable->repo == installed_repo) {
-            filter_result.add_unsafe(candidate_id);
+            filter_result.add_unsafe(*it);
+            continue;
+        }
+        if ((*it).id >= installed_repo->end) {
+            break;
         }
     }
     p_impl->query_result &= filter_result;
@@ -1806,10 +1812,16 @@ SolvQuery & SolvQuery::ifilter_available() {
     if (installed_repo == nullptr) {
         return *this;
     }
-    for (PackageId candidate_id : p_impl->query_result) {
-        Solvable * solvable = solv::get_solvable(pool, candidate_id);
+    auto it = p_impl->query_result.begin();
+    auto end = p_impl->query_result.end();
+    for (it.jump(PackageId(installed_repo->start)); it != end; ++it) {
+        Solvable * solvable = solv::get_solvable(pool, *it);
         if (solvable->repo == installed_repo) {
-            p_impl->query_result.remove_unsafe(candidate_id);
+            p_impl->query_result.remove_unsafe(*it);
+            continue;
+        }
+        if ((*it).id >= installed_repo->end) {
+            break;
         }
     }
     return *this;

--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -1802,7 +1802,9 @@ SolvQuery & SolvQuery::ifilter_installed() {
             break;
         }
     }
-    p_impl->query_result &= filter_result;
+    // TODO(jrohel): The optimization replaces the original query_result buffer. Is it OK?
+    // Or we need to use a slower version "p_impl->query_result &= filter_result;"
+    p_impl->query_result = std::move(filter_result);
     return *this;
 }
 


### PR DESCRIPTION
The code adds/removes only installed packages.
Optimization: The cycle goes through only part of the pool from `installed_repo->start` to `installed_repo->end`.

Requires https://github.com/rpm-software-management/libdnf/pull/1092