### PR TITLE
[dnf5] rpm: Make the Package object compatible with to(_full)_nevra_string() template functions

### DIFF
--- a/CHANGES-DNF-5.md
+++ b/CHANGES-DNF-5.md
@@ -2,3 +2,8 @@ PackageSet::operator[]
 ----------------------
 It was removed due to insufficient O(n^2) performance.
 Use PackageSet iterator to access the data instead.
+
+
+Package::get_epoch()
+--------------------
+The return type was changed from `unsigned long` to `std::string`.

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -41,6 +41,10 @@ namespace libdnf::rpm {
 class PackageSetIterator;
 
 
+// IMPORTANT: Package methods MUST NOT be 'noexcept'
+// because accessing deleted sack throws an exception.
+
+
 /// @replaces libdnf/hy-package.h:struct:DnfPackage
 /// @replaces dnf:dnf/package.py:class:Package
 class Package {
@@ -59,17 +63,17 @@ public:
     /// @replaces dnf:dnf/package.py:attribute:Package.e
     /// @replaces dnf:dnf/package.py:attribute:Package.epoch
     /// @replaces libdnf/hy-package.h:function:dnf_package_get_epoch(DnfPackage *pkg);
-    unsigned long get_epoch();
+    std::string get_epoch() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.v
     /// @replaces dnf:dnf/package.py:attribute:Package.version
     /// @replaces libdnf/hy-package.h:function:dnf_package_get_version(DnfPackage *pkg);
-    std::string get_version();
+    std::string get_version() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.r
     /// @replaces dnf:dnf/package.py:attribute:Package.release
     /// @replaces libdnf/hy-package.h:function:dnf_package_get_release(DnfPackage *pkg);
-    std::string get_release();
+    std::string get_release() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.a
     /// @replaces dnf:dnf/package.py:attribute:Package.arch
@@ -82,68 +86,68 @@ public:
 
     /// Reurn nevra withou epoch when epoch is 0
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_nevra(DnfPackage * pkg)
-    std::string get_nevra();
+    std::string get_nevra() const;
 
     /// Reurn always nevra with epoch
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_nevra(DnfPackage * pkg)
-    std::string get_full_nevra();
+    std::string get_full_nevra() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.group
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_group(DnfPackage * pkg)
-    std::string get_group();
+    std::string get_group() const;
 
     /// If package is installed, return get_install_size(). Return get_download_size() otherwise.
     /// @replaces dnf:dnf/package.py:attribute:Package.size
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_size(DnfPackage * pkg)
-    unsigned long long get_size() noexcept;
+    unsigned long long get_size() const;
 
     /// Return size of an RPM package: <size package="..."/>
     /// @replaces dnf:dnf/package.py:attribute:Package.downloadsize
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_downloadsize(DnfPackage * pkg)
-    unsigned long long get_download_size() noexcept;
+    unsigned long long get_download_size() const;
 
     /// Return size of an RPM package installed on a system: <size installed="..."/>
     /// @replaces dnf:dnf/package.py:attribute:Package.installsize
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_installsize(DnfPackage * pkg)
-    unsigned long long get_install_size() noexcept;
+    unsigned long long get_install_size() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.license
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_license(DnfPackage * pkg)
-    std::string get_license();
+    std::string get_license() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.sourcerpm
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_sourcerpm(DnfPackage * pkg)
-    std::string get_sourcerpm();
+    std::string get_sourcerpm() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.buildtime
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_buildtime(DnfPackage * pkg)
-    unsigned long long get_build_time() noexcept;
+    unsigned long long get_build_time() const;
 
     // TODO not supported by libsolv: https://github.com/openSUSE/libsolv/issues/400
     //std::string get_build_host();
 
     /// @replaces dnf:dnf/package.py:attribute:Package.packager
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_packager(DnfPackage * pkg)
-    std::string get_packager();
+    std::string get_packager() const;
 
-    std::string get_vendor();
+    std::string get_vendor() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.url
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_url(DnfPackage * pkg)
-    std::string get_url();
+    std::string get_url() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.summary
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_summary(DnfPackage * pkg)
-    std::string get_summary();
+    std::string get_summary() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.description
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_description(DnfPackage * pkg)
-    std::string get_description();
+    std::string get_description() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.files
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_files(DnfPackage * pkg)
     /// TODO(dmach): files, directories, info about ghost etc. - existing implementation returns incomplete data
-    std::vector<std::string> get_files();
+    std::vector<std::string> get_files() const;
 
     // DEPENDENCIES
 
@@ -197,12 +201,12 @@ public:
 
     /// @replaces dnf:dnf/package.py:attribute:Package.baseurl
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_baseurl(DnfPackage * pkg)
-    std::string get_baseurl();
+    std::string get_baseurl() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.location
     /// @replaces dnf:dnf/package.py:attribute:Package.relativepath
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_location(DnfPackage * pkg)
-    std::string get_location();
+    std::string get_location() const;
 
     /// Returns package location (file path) in the filesystem.
     /// For packages in remote repo returns where the package will be/has been downloaded.
@@ -211,11 +215,11 @@ public:
 
     /// @replaces dnf:dnf/package.py:attribute:Package.chksum
     /// @replaces libdnf:libdnf/hy-package-private.hpp:function:dnf_package_get_chksum(DnfPackage *pkg, int *type)
-    Checksum get_checksum();
+    Checksum get_checksum() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.hdr_chksum
     /// @replaces libdnf:libdnf/hy-package-private.hpp:function:dnf_package_get_hdr_chksum(DnfPackage *pkg, int *type)
-    Checksum get_hdr_checksum();
+    Checksum get_hdr_checksum() const;
 
     /// TODO get_changelogs - requires changelog
     /// @replaces dnf:dnf/package.py:attribute:Package.changelogs
@@ -243,23 +247,23 @@ public:
 
     /// @replaces dnf:dnf/package.py:attribute:Package.hdr_end
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_hdr_end(DnfPackage * pkg)
-    unsigned long long get_hdr_end() noexcept;
+    unsigned long long get_hdr_end() const;
 
     /// @replaces dnf:dnf/package.py:attribute:Package.installtime
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_installtime(DnfPackage * pkg)
-    unsigned long long get_install_time() noexcept;
+    unsigned long long get_install_time() const;
 
     /// @brief Media number for the package
     ///
     /// @replaces dnf:dnf/package.py:attribute:Package.medianr
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_medianr(DnfPackage * pkg)
-    unsigned long long get_media_number() noexcept;
+    unsigned long long get_media_number() const;
 
     /// @brief The rpmdb ID for the package
     ///
     /// @replaces dnf:dnf/package.py:attribute:Package.rpmdbid
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_rpmdbid(DnfPackage * pkg)
-    unsigned long long get_rpmdbid() const noexcept;
+    unsigned long long get_rpmdbid() const;
 
     /// TODO get_repo - requires Repo
     /// @replaces dnf:dnf/package.py:attribute:Package.repo
@@ -267,27 +271,27 @@ public:
     /// @replaces dnf:dnf/package.py:attribute:Package.reponame
     /// @replaces libdnf:libdnf/dnf-package.h:function:dnf_package_get_repo(DnfPackage * pkg)
     /// @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_reponame(DnfPackage * pkg)
-    Repo * get_repo() const noexcept;
+    Repo * get_repo() const;
 
     // TODO(dmach): getBugUrl() not possible due to lack of support in libsolv and metadata?
 
 protected:
     /// @replaces libdnf:libdnf/dnf-package.h:function:dnf_package_new(DnfSack *sack, Id id)
     Package(SolvSack * sack, PackageId id);
-    const char * get_name_cstring() const noexcept;
+    const char * get_name_cstring() const;
 
     /// @return const char* !! Return temporal values !!
-    const char * get_epoch_cstring();
+    const char * get_epoch_cstring() const;
 
     /// @return const char* !! Return temporal values !!
-    const char * get_version_cstring() noexcept;
+    const char * get_version_cstring() const;
 
     /// @return const char* !! Return temporal values !!
-    const char * get_release_cstring() noexcept;
+    const char * get_release_cstring() const;
 
-    const char * get_arch_cstring() const noexcept;
+    const char * get_arch_cstring() const;
 
-    const char * get_evr_cstring() const noexcept;
+    const char * get_evr_cstring() const;
 
 private:
     friend PackageSetIterator;

--- a/libdnf-cli/output/repoquery.hpp
+++ b/libdnf-cli/output/repoquery.hpp
@@ -43,9 +43,8 @@ static struct libscols_table * create_package_info_table(Package & package) {
 
     add_line_into_package_info_table(table, "Name", package.get_name().c_str());
     auto epoch = package.get_epoch();
-    if (epoch != 0) {
-        auto str_epoch = std::to_string(epoch);
-        add_line_into_package_info_table(table, "Epoch", str_epoch.c_str());
+    if (epoch != "0") {
+        add_line_into_package_info_table(table, "Epoch", package.get_epoch().c_str());
     }
     add_line_into_package_info_table(table, "Version", package.get_version().c_str());
     add_line_into_package_info_table(table, "Release", package.get_release().c_str());

--- a/libdnf-cli/output/repoquery.hpp
+++ b/libdnf-cli/output/repoquery.hpp
@@ -42,10 +42,7 @@ static struct libscols_table * create_package_info_table(Package & package) {
     scols_column_set_wrapfunc(cl, scols_wrapnl_chunksize, scols_wrapnl_nextchunk, nullptr);
 
     add_line_into_package_info_table(table, "Name", package.get_name().c_str());
-    auto epoch = package.get_epoch();
-    if (epoch != "0") {
-        add_line_into_package_info_table(table, "Epoch", package.get_epoch().c_str());
-    }
+    add_line_into_package_info_table(table, "Epoch", package.get_epoch().c_str());
     add_line_into_package_info_table(table, "Version", package.get_version().c_str());
     add_line_into_package_info_table(table, "Release", package.get_release().c_str());
     add_line_into_package_info_table(table, "Architecture", package.get_arch().c_str());

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -32,7 +32,7 @@ inline static std::string cstring2string(const char * input) {
 
 namespace libdnf::rpm {
 
-const char * Package::get_name_cstring() const noexcept {
+const char * Package::get_name_cstring() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_name(pool, id);
 }
@@ -42,37 +42,37 @@ std::string Package::get_name() const {
     return cstring2string(solv::get_name(pool, id));
 }
 
-const char * Package::get_epoch_cstring() {
+const char * Package::get_epoch_cstring() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_epoch_cstring(pool, id);
 }
 
-unsigned long Package::get_epoch() {
+std::string Package::get_epoch() const {
     Pool * pool = sack->p_impl->pool;
-    return solv::get_epoch(pool, id);
+    return solv::get_epoch_cstring(pool, id);
 }
 
-const char * Package::get_version_cstring() noexcept {
+const char * Package::get_version_cstring() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_version(pool, id);
 }
 
-std::string Package::get_version() {
+std::string Package::get_version() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_version(pool, id));
 }
 
-const char * Package::get_release_cstring() noexcept {
+const char * Package::get_release_cstring() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_release(pool, id);
 }
 
-std::string Package::get_release() {
+std::string Package::get_release() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_release(pool, id));
 }
 
-const char * Package::get_arch_cstring() const noexcept {
+const char * Package::get_arch_cstring() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_arch(pool, id);
 }
@@ -82,7 +82,7 @@ std::string Package::get_arch() const {
     return cstring2string(solv::get_arch(pool, id));
 }
 
-const char * Package::get_evr_cstring() const noexcept {
+const char * Package::get_evr_cstring() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_evr(pool, id);
 }
@@ -92,47 +92,47 @@ std::string Package::get_evr() const {
     return cstring2string(solv::get_evr(pool, id));
 }
 
-std::string Package::get_nevra() {
+std::string Package::get_nevra() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_nevra(pool, id));
 }
 
-std::string Package::get_full_nevra() {
+std::string Package::get_full_nevra() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_full_nevra(pool, id));
 }
 
-std::string Package::get_group() {
+std::string Package::get_group() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_group(pool, id));
 }
 
-unsigned long long Package::get_size() noexcept {
+unsigned long long Package::get_size() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_size(pool, id);
 }
 
-unsigned long long Package::get_download_size() noexcept {
+unsigned long long Package::get_download_size() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_download_size(pool, id);
 }
 
-unsigned long long Package::get_install_size() noexcept {
+unsigned long long Package::get_install_size() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_install_size(pool, id);
 }
 
-std::string Package::get_license() {
+std::string Package::get_license() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_license(pool, id));
 }
 
-std::string Package::get_sourcerpm() {
+std::string Package::get_sourcerpm() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_sourcerpm(pool, id));
 }
 
-unsigned long long Package::get_build_time() noexcept {
+unsigned long long Package::get_build_time() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_build_time(pool, id);
 }
@@ -143,32 +143,32 @@ unsigned long long Package::get_build_time() noexcept {
 //    return cstring2string(solv::get_build_host(pool, id));
 //}
 
-std::string Package::get_packager() {
+std::string Package::get_packager() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_packager(pool, id));
 }
 
-std::string Package::get_vendor() {
+std::string Package::get_vendor() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_vendor(pool, id));
 }
 
-std::string Package::get_url() {
+std::string Package::get_url() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_url(pool, id));
 }
 
-std::string Package::get_summary() {
+std::string Package::get_summary() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_summary(pool, id));
 }
 
-std::string Package::get_description() {
+std::string Package::get_description() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_description(pool, id));
 }
 
-std::vector<std::string> Package::get_files() {
+std::vector<std::string> Package::get_files() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_files(pool, id);
 }
@@ -250,12 +250,12 @@ ReldepList Package::get_regular_requires() const {
     return list;
 }
 
-std::string Package::get_baseurl() {
+std::string Package::get_baseurl() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_baseurl(pool, id));
 }
 
-std::string Package::get_location() {
+std::string Package::get_location() const {
     Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_location(pool, id));
 }
@@ -270,32 +270,32 @@ bool Package::is_installed() const {
     return solv::is_installed(pool, solv::get_solvable(pool, id));
 }
 
-unsigned long long Package::get_hdr_end() noexcept {
+unsigned long long Package::get_hdr_end() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_hdr_end(pool, id);
 }
 
-unsigned long long Package::get_install_time() noexcept {
+unsigned long long Package::get_install_time() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_install_time(pool, id);
 }
 
-unsigned long long Package::get_media_number() noexcept {
+unsigned long long Package::get_media_number() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_media_number(pool, id);
 }
 
-unsigned long long Package::get_rpmdbid() const noexcept {
+unsigned long long Package::get_rpmdbid() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_rpmdbid(pool, id);
 }
 
-Repo * Package::get_repo() const noexcept {
+Repo * Package::get_repo() const {
     Pool * pool = sack->p_impl->pool;
     return solv::get_repo(pool, id);
 }
 
-Checksum Package::get_checksum() {
+Checksum Package::get_checksum() const {
     Pool * pool = sack->p_impl->pool;
 
     Solvable * solvable = solv::get_solvable(pool, id);
@@ -307,7 +307,7 @@ Checksum Package::get_checksum() {
     return checksum;
 }
 
-Checksum Package::get_hdr_checksum() {
+Checksum Package::get_hdr_checksum() const {
     Pool * pool = sack->p_impl->pool;
 
     Solvable * solvable = solv::get_solvable(pool, id);

--- a/libdnf/transaction/rpm_package.cpp
+++ b/libdnf/transaction/rpm_package.cpp
@@ -44,7 +44,7 @@ uint32_t Package::get_epoch_int() const {
 
 
 std::string Package::to_string() const {
-    return libdnf::rpm::to_nevra_string(*this);
+    return libdnf::rpm::to_full_nevra_string(*this);
 }
 
 

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -689,11 +689,7 @@ libdnf::transaction::TransactionWeakPtr new_db_transaction(Context & ctx) {
 }
 
 static void set_trans_pkg(libdnf::rpm::Package & package, libdnf::transaction::Package & trans_pkg, libdnf::transaction::TransactionItemAction action) {
-        trans_pkg.set_name(package.get_name());
-        trans_pkg.set_epoch(std::to_string(package.get_epoch()));
-        trans_pkg.set_version(package.get_version());
-        trans_pkg.set_release(package.get_release());
-        trans_pkg.set_arch(package.get_arch());
+        libdnf::rpm::copy_nevra_attributes(package, trans_pkg);
         trans_pkg.set_repoid(package.get_repo()->get_id());
         trans_pkg.set_action(action);
         //TODO(jrohel): set actual reason

--- a/test/libdnf/rpm/test_nevra.cpp
+++ b/test/libdnf/rpm/test_nevra.cpp
@@ -41,6 +41,10 @@ void NevraTest::test_nevra() {
         CPPUNIT_ASSERT(nevra.get_arch() == "x86_64");
     }
 
+    // test that to_nevra_string() and to_full_nevra_string() template functions work
+    CPPUNIT_ASSERT_EQUAL(std::string("four-of-fish-8:3.6.9-11.fc100.x86_64"), to_nevra_string(nevra));
+    CPPUNIT_ASSERT_EQUAL(std::string("four-of-fish-8:3.6.9-11.fc100.x86_64"), to_full_nevra_string(nevra));
+
     {
         CPPUNIT_ASSERT(nevra.parse("four-of-fish-3.6.9-11.fc100.x86_64", libdnf::rpm::Nevra::Form::NEVRA));
         CPPUNIT_ASSERT(nevra.get_name() == "four-of-fish");
@@ -87,7 +91,7 @@ void NevraTest::test_nevra() {
         CPPUNIT_ASSERT(!nevra.parse("four-of(fish.i686)", libdnf::rpm::Nevra::Form::NA));
     }
 
-    // Test for correct parsin with glob in epoch
+    // Test parsing NEVRA with glob in epoch
     {
         CPPUNIT_ASSERT(nevra.parse("four-of-fish-[01]:3.6.9-11.fc100.x86_64", libdnf::rpm::Nevra::Form::NEVRA));
         CPPUNIT_ASSERT(nevra.get_name() == "four-of-fish");
@@ -97,7 +101,7 @@ void NevraTest::test_nevra() {
         CPPUNIT_ASSERT(nevra.get_arch() == "x86_64");
     }
 
-    // Test for correct parsin with glob in epoch
+    // Test parsing NEVRA with glob in epoch
     {
         CPPUNIT_ASSERT(nevra.parse("four-of-fish-?:3.6.9-11.fc100.x86_64", libdnf::rpm::Nevra::Form::NEVRA));
         CPPUNIT_ASSERT(nevra.get_name() == "four-of-fish");

--- a/test/libdnf/rpm/test_package.cpp
+++ b/test/libdnf/rpm/test_package.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../utils.hpp"
 
+#include "libdnf/rpm/nevra.hpp"
 #include "libdnf/rpm/solv_query.hpp"
 
 #include <vector>
@@ -73,8 +74,8 @@ void RpmPackageTest::test_get_name() {
 
 
 void RpmPackageTest::test_get_epoch() {
-    CPPUNIT_ASSERT_EQUAL(0lu, get_pkg("CQRlib-1.1.1-4.fc29.x86_64").get_epoch());
-    CPPUNIT_ASSERT_EQUAL(1lu, get_pkg("nodejs-1:5.12.1-1.fc29.x86_64").get_epoch());
+    CPPUNIT_ASSERT_EQUAL(std::string("0"), get_pkg("CQRlib-1.1.1-4.fc29.x86_64").get_epoch());
+    CPPUNIT_ASSERT_EQUAL(std::string("1"), get_pkg("nodejs-1:5.12.1-1.fc29.x86_64").get_epoch());
 }
 
 
@@ -353,4 +354,18 @@ void RpmPackageTest::test_get_media_number() {
 void RpmPackageTest::test_get_rpmdbid() {
     // TODO zeros everywhere
     CPPUNIT_ASSERT_EQUAL(0llu, get_pkg("CQRlib-1.1.1-4.fc29.x86_64").get_rpmdbid());
+}
+
+
+void RpmPackageTest::test_nevra_to_string() {
+    // test that to_nevra_string() template function works
+    auto pkg = get_pkg("CQRlib-1.1.1-4.fc29.x86_64");
+    CPPUNIT_ASSERT_EQUAL(std::string("CQRlib-1.1.1-4.fc29.x86_64"), libdnf::rpm::to_nevra_string(pkg));
+}
+
+
+void RpmPackageTest::test_full_nevra_to_string() {
+    // test that to_full_nevra_string() template function works
+    auto pkg = get_pkg("CQRlib-1.1.1-4.fc29.x86_64");
+    CPPUNIT_ASSERT_EQUAL(std::string("CQRlib-0:1.1.1-4.fc29.x86_64"), libdnf::rpm::to_full_nevra_string(pkg));
 }

--- a/test/libdnf/rpm/test_package.hpp
+++ b/test/libdnf/rpm/test_package.hpp
@@ -75,6 +75,9 @@ class RpmPackageTest : public RepoFixture {
     CPPUNIT_TEST(test_get_install_time);
     CPPUNIT_TEST(test_get_media_number);
     CPPUNIT_TEST(test_get_rpmdbid);
+
+    CPPUNIT_TEST(test_nevra_to_string);
+    CPPUNIT_TEST(test_full_nevra_to_string);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -126,6 +129,9 @@ public:
     void test_get_install_time();
     void test_get_media_number();
     void test_get_rpmdbid();
+
+    void test_nevra_to_string();
+    void test_full_nevra_to_string();
 };
 
 


### PR DESCRIPTION
Package::get_epoch() returns string instead of long int.
Most of the Package methods are now const.
Removed noexcept, because an exception can occur when Package's Sack is deleted.