### PR TITLE
Add a config option sslverify_status, defaults to false (RhBug:1814383)

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -353,6 +353,7 @@ class ConfigMain::Impl {
     OptionBool deltarpm{true};
     OptionNumber<std::uint32_t> deltarpm_percentage{75};
     OptionBool skip_if_unavailable{false};
+    OptionBool sslverifystatus{false};
 };
 
 ConfigMain::Impl::Impl(Config & owner)
@@ -504,6 +505,7 @@ ConfigMain::Impl::Impl(Config & owner)
     owner.optBinds().add("deltarpm", deltarpm);
     owner.optBinds().add("deltarpm_percentage", deltarpm_percentage);
     owner.optBinds().add("skip_if_unavailable", skip_if_unavailable);
+    owner.optBinds().add("sslverifystatus", sslverifystatus);
 }
 
 ConfigMain::ConfigMain() { pImpl = std::unique_ptr<Impl>(new Impl(*this)); }
@@ -622,6 +624,7 @@ OptionString & ConfigMain::proxy_sslclientkey() { return pImpl->proxy_sslclientk
 OptionBool & ConfigMain::deltarpm() { return pImpl->deltarpm; }
 OptionNumber<std::uint32_t> & ConfigMain::deltarpm_percentage() { return pImpl->deltarpm_percentage; }
 OptionBool & ConfigMain::skip_if_unavailable() { return pImpl->skip_if_unavailable; }
+OptionBool & ConfigMain::sslverifystatus() { return pImpl->sslverifystatus; }
 
 static void DIRClose(DIR *d) { closedir(d); }
 

--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -166,6 +166,7 @@ public:
     OptionBool & deltarpm();
     OptionNumber<std::uint32_t> & deltarpm_percentage();
     OptionBool & skip_if_unavailable();
+    OptionBool & sslverifystatus();
 
     /**
     * @brief Adds variables from directory

--- a/libdnf/conf/ConfigRepo.cpp
+++ b/libdnf/conf/ConfigRepo.cpp
@@ -80,6 +80,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionString> user_agent{mainConfig.user_agent()};
     OptionChild<OptionBool> countme{mainConfig.countme()};
     OptionEnum<std::string> failovermethod{"priority", {"priority", "roundrobin"}};
+    OptionChild<OptionBool> sslverifystatus{mainConfig.sslverifystatus()};
 };
 
 ConfigRepo::Impl::Impl(Config & owner, ConfigMain & mainConfig)
@@ -173,6 +174,7 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & mainConfig)
     owner.optBinds().add("enabled_metadata", enabled_metadata);
     owner.optBinds().add("user_agent", user_agent);
     owner.optBinds().add("countme", countme);
+    owner.optBinds().add("sslverifystatus", sslverifystatus);
 }
 
 ConfigRepo::ConfigRepo(ConfigMain & mainConfig) : pImpl(new Impl(*this, mainConfig)) {}
@@ -229,5 +231,6 @@ OptionString & ConfigRepo::enabled_metadata() { return pImpl->enabled_metadata; 
 OptionChild<OptionString> & ConfigRepo::user_agent() { return pImpl->user_agent; }
 OptionChild<OptionBool> & ConfigRepo::countme() { return pImpl->countme; }
 OptionEnum<std::string> & ConfigRepo::failovermethod() { return pImpl->failovermethod; }
+OptionChild<OptionBool> & ConfigRepo::sslverifystatus() { return pImpl->sslverifystatus; }
 
 }

--- a/libdnf/conf/ConfigRepo.hpp
+++ b/libdnf/conf/ConfigRepo.hpp
@@ -96,6 +96,7 @@ public:
     OptionChild<OptionBool> & countme();
     // yum compatibility options
     OptionEnum<std::string> & failovermethod();
+    OptionChild<OptionBool> & sslverifystatus();
 
 private:
     class Impl;

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1246,6 +1246,9 @@ dnf_repo_setup(DnfRepo *repo, GError **error) try
             return FALSE;
     }
 
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYSTATUS, conf->sslverifystatus().getValue() ? 1L : 0L))
+        return FALSE;
+
 #ifdef LRO_SUPPORTS_CACHEDIR
     /* Set cache dir */
     if (dnf_context_get_zchunk(priv->context)) {

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -562,6 +562,7 @@ static void setHandle(LrHandle * h, ConfigT & config, const char * repoId = null
     long sslverify = config.sslverify().getValue() ? 1L : 0L;
     handleSetOpt(h, LRO_SSLVERIFYHOST, sslverify);
     handleSetOpt(h, LRO_SSLVERIFYPEER, sslverify);
+    handleSetOpt(h, LRO_SSLVERIFYSTATUS, config.sslverifystatus().getValue() ? 1L : 0L);
 
     // setup proxy ssl stuff
     if (!config.proxy_sslcacert().getValue().empty())


### PR DESCRIPTION
This option determines whether libcurl (used by librepo) verifies the
status of the server cert using the "Certificate Status Request" TLS
extension (aka. OCSP stapling).

Requires: https://github.com/rpm-software-management/librepo/pull/213

= changelog =
msg: Add a config option to check TLS certificate revocation status (using OCSP stapling), defaults to false
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1814383