### PR TITLE
[dnf5] Fix and improve cpp iterators and their unit tests

### DIFF
--- a/include/libdnf/rpm/package_set_iterator.hpp
+++ b/include/libdnf/rpm/package_set_iterator.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "package.hpp"
 
+#include <cstddef>
 #include <iterator>
 #include <memory>
 
@@ -41,10 +42,10 @@ public:
     ~PackageSetIterator();
 
     using iterator_category = std::forward_iterator_tag;
-    using difference_type = int;
+    using difference_type = std::ptrdiff_t;
     using value_type = Package;
     using pointer = void;
-    using reference = void;
+    using reference = Package;
 
     Package operator*();
 

--- a/include/libdnf/rpm/reldep_list_iterator.hpp
+++ b/include/libdnf/rpm/reldep_list_iterator.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "reldep.hpp"
 
+#include <cstddef>
 #include <iterator>
 #include <memory>
 
@@ -41,10 +42,10 @@ public:
     ~ReldepListIterator();
 
     using iterator_category = std::forward_iterator_tag;
-    using difference_type = int;
+    using difference_type = std::ptrdiff_t;
     using value_type = Reldep;
     using pointer = void;
-    using reference = void;
+    using reference = Reldep;
 
     Reldep operator*();
 

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -18,10 +18,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
-#include "libdnf/rpm/package_set_iterator.hpp"
-
-#include "libdnf/rpm/package_set.hpp"
-#include "libdnf/rpm/package_set_impl.hpp"
 #include "libdnf/rpm/package_set_iterator_impl.hpp"
 
 
@@ -36,18 +32,16 @@ PackageSetIterator::~PackageSetIterator() {}
 
 void PackageSetIterator::begin() {
     pImpl->begin();
-    pImpl->current_value.id = PackageId(*(*pImpl));
 }
 
 
 void PackageSetIterator::end() {
     pImpl->end();
-    pImpl->current_value.id = PackageId(*(*pImpl));
 }
 
 
 Package PackageSetIterator::operator*() {
-    return pImpl->current_value;
+    return {pImpl->package_set.get_sack(), **pImpl};
 }
 
 
@@ -65,12 +59,12 @@ PackageSetIterator PackageSetIterator::operator++(int) {
 
 
 bool PackageSetIterator::operator==(const PackageSetIterator & other) const {
-    return pImpl->current_value == other.pImpl->current_value;
+    return *pImpl == *other.pImpl;
 }
 
 
 bool PackageSetIterator::operator!=(const PackageSetIterator & other) const {
-    return pImpl->current_value != other.pImpl->current_value;
+    return *pImpl != *other.pImpl;
 }
 
 

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -52,14 +52,15 @@ Package PackageSetIterator::operator*() {
 
 
 PackageSetIterator & PackageSetIterator::operator++() {
-    ++(*pImpl);
+    ++*pImpl;
     return *this;
 }
 
 
 PackageSetIterator PackageSetIterator::operator++(int) {
-    ++(*pImpl);
-    return *this;
+    PackageSetIterator it(*this);
+    ++*pImpl;
+    return it;
 }
 
 

--- a/libdnf/rpm/package_set_iterator_impl.hpp
+++ b/libdnf/rpm/package_set_iterator_impl.hpp
@@ -22,16 +22,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_RPM_PACKAGE_SET_ITERATOR_IMPL_HPP
 
 
-#include "libdnf/rpm/package_set.hpp"
 #include "libdnf/rpm/package_set_impl.hpp"
 #include "libdnf/rpm/package_set_iterator.hpp"
-#include "libdnf/rpm/solv/solv_map.hpp"
 
 
 namespace libdnf::rpm {
 
 
-class PackageSetIterator::Impl : public libdnf::rpm::solv::SolvMap::iterator {
+class PackageSetIterator::Impl : public solv::SolvMap::iterator {
 public:
     Impl(const PackageSet & package_set);
     Impl(const PackageSetIterator::Impl & package_set_iterator_impl) = default;
@@ -41,19 +39,15 @@ public:
 private:
     friend PackageSetIterator;
     const PackageSet & package_set;
-    Package current_value;
 };
 
 
 inline PackageSetIterator::Impl::Impl(const PackageSet & package_set)
-    : libdnf::rpm::solv::SolvMap::iterator(package_set.pImpl->get_map())
-    , package_set{package_set}
-    , current_value{package_set.get_sack(), PackageId(-1)} {}
+    : solv::SolvMap::iterator(package_set.pImpl->get_map())
+    , package_set{package_set} {}
 
 inline PackageSetIterator::Impl & PackageSetIterator::Impl::operator++() {
-    // construct and store package based on Id obtained from the underlying iterator
-    libdnf::rpm::solv::SolvMap::iterator::operator++();
-    current_value.id = PackageId(libdnf::rpm::solv::SolvMap::iterator::operator*());
+    solv::SolvMap::iterator::operator++();
     return *this;
 }
 

--- a/libdnf/rpm/reldep_list_iterator.cpp
+++ b/libdnf/rpm/reldep_list_iterator.cpp
@@ -18,10 +18,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
-#include "libdnf/rpm/reldep_list_iterator.hpp"
-
-#include "libdnf/rpm/reldep_list.hpp"
-#include "libdnf/rpm/reldep_list_impl.hpp"
 #include "libdnf/rpm/reldep_list_iterator_impl.hpp"
 
 
@@ -36,18 +32,16 @@ ReldepListIterator::~ReldepListIterator() {}
 
 void ReldepListIterator::begin() {
     pImpl->begin();
-    pImpl->current_value.id = ReldepId(*(*pImpl));
 }
 
 
 void ReldepListIterator::end() {
     pImpl->end();
-    pImpl->current_value.id = ReldepId(*(*pImpl));
 }
 
 
 Reldep ReldepListIterator::operator*() {
-    return pImpl->current_value;
+    return {pImpl->reldep_list.get_sack(), ReldepId(**pImpl)};
 }
 
 
@@ -65,12 +59,12 @@ ReldepListIterator ReldepListIterator::operator++(int) {
 
 
 bool ReldepListIterator::operator==(const ReldepListIterator & other) const {
-    return pImpl->current_value == other.pImpl->current_value;
+    return *pImpl == *other.pImpl;
 }
 
 
 bool ReldepListIterator::operator!=(const ReldepListIterator & other) const {
-    return pImpl->current_value != other.pImpl->current_value;
+    return *pImpl != *other.pImpl;
 }
 
 

--- a/libdnf/rpm/reldep_list_iterator.cpp
+++ b/libdnf/rpm/reldep_list_iterator.cpp
@@ -52,14 +52,15 @@ Reldep ReldepListIterator::operator*() {
 
 
 ReldepListIterator & ReldepListIterator::operator++() {
-    ++(*pImpl);
+    ++*pImpl;
     return *this;
 }
 
 
 ReldepListIterator ReldepListIterator::operator++(int) {
-    ++(*pImpl);
-    return *this;
+    ReldepListIterator it(*this);
+    ++*pImpl;
+    return it;
 }
 
 

--- a/libdnf/rpm/reldep_list_iterator_impl.hpp
+++ b/libdnf/rpm/reldep_list_iterator_impl.hpp
@@ -22,7 +22,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_RPM_RELDEP_LIST_ITERATOR_IMPL_HPP
 
 
-#include "libdnf/rpm/reldep_list.hpp"
 #include "libdnf/rpm/reldep_list_impl.hpp"
 #include "libdnf/rpm/reldep_list_iterator.hpp"
 
@@ -30,7 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::rpm {
 
 
-class ReldepListIterator::Impl : public libdnf::rpm::solv::IdQueue::iterator {
+class ReldepListIterator::Impl : public solv::IdQueue::iterator {
 public:
     Impl(const ReldepList & reldep_list);
     Impl(const ReldepListIterator::Impl & reldep_list_iterator_impl) = default;
@@ -40,19 +39,15 @@ public:
 private:
     friend ReldepListIterator;
     const ReldepList & reldep_list;
-    Reldep current_value;
 };
 
 
 inline ReldepListIterator::Impl::Impl(const ReldepList & reldep_list)
-    : libdnf::rpm::solv::IdQueue::iterator(&(reldep_list.pImpl->get_idqueue().get_queue()))
-    , reldep_list{reldep_list}
-    , current_value{reldep_list.get_sack(), ReldepId(-1)} {}
+    : solv::IdQueue::iterator(&(reldep_list.pImpl->get_idqueue().get_queue()))
+    , reldep_list{reldep_list} {}
 
 inline ReldepListIterator::Impl & ReldepListIterator::Impl::operator++() {
-    // construct and store ReldepId based on Id obtained from the underlying iterator
-    libdnf::rpm::solv::IdQueue::iterator::operator++();
-    current_value.id = ReldepId(libdnf::rpm::solv::IdQueue::iterator::operator*());
+    solv::IdQueue::iterator::operator++();
     return *this;
 }
 

--- a/libdnf/rpm/solv/map_iterator.hpp
+++ b/libdnf/rpm/solv/map_iterator.hpp
@@ -27,6 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <solv/bitmap.h>
 #include <solv/pooltypes.h>
 
+#include <cstddef>
 #include <iterator>
 
 
@@ -38,25 +39,25 @@ class SolvMap;
 
 class SolvMapIterator {
 public:
-    explicit SolvMapIterator(const Map * map);
-    SolvMapIterator(const SolvMapIterator & other) = default;
+    explicit SolvMapIterator(const Map * map) noexcept;
+    SolvMapIterator(const SolvMapIterator & other) noexcept = default;
 
     using iterator_category = std::forward_iterator_tag;
-    using difference_type = PackageId;
+    using difference_type = std::ptrdiff_t;
     using value_type = PackageId;
     using pointer = void;
-    using reference = void;
+    using reference = PackageId;
 
-    PackageId operator*() const { return current_value; }
+    PackageId operator*() const noexcept { return current_value; }
 
-    SolvMapIterator & operator++();
-    SolvMapIterator operator++(int);
+    SolvMapIterator & operator++() noexcept;
+    SolvMapIterator operator++(int) noexcept;
 
-    bool operator==(const SolvMapIterator & other) const { return current_value == other.current_value; }
-    bool operator!=(const SolvMapIterator & other) const { return current_value != other.current_value; }
+    bool operator==(const SolvMapIterator & other) const noexcept { return current_value == other.current_value; }
+    bool operator!=(const SolvMapIterator & other) const noexcept { return current_value != other.current_value; }
 
-    void begin();
-    void end() { current_value.id = END; }
+    void begin() noexcept;
+    void end() noexcept { current_value.id = END; }
 
 protected:
     const Map * get_map() const noexcept { return map; }
@@ -79,19 +80,19 @@ private:
 };
 
 
-inline SolvMapIterator::SolvMapIterator(const Map * map) : map{map} {
+inline SolvMapIterator::SolvMapIterator(const Map * map) noexcept : map{map} {
     map_current = map->map;
     map_end = map_current + map->size;
-    current_value.id = BEGIN;
-    ++(*this);
-}
-
-inline void SolvMapIterator::begin() {
     current_value.id = BEGIN;
     ++*this;
 }
 
-inline SolvMapIterator & SolvMapIterator::operator++() {
+inline void SolvMapIterator::begin() noexcept {
+    current_value.id = BEGIN;
+    ++*this;
+}
+
+inline SolvMapIterator & SolvMapIterator::operator++() noexcept {
     if (current_value.id >= 0) {
         // skip (previous / 8) bytes
         //current += previous >> 3;
@@ -142,7 +143,7 @@ inline SolvMapIterator & SolvMapIterator::operator++() {
     return *this;
 }
 
-inline SolvMapIterator SolvMapIterator::operator++(int) {
+inline SolvMapIterator SolvMapIterator::operator++(int) noexcept {
     SolvMapIterator it(*this);
     ++*this;
     return it;

--- a/libdnf/rpm/solv/map_iterator.hpp
+++ b/libdnf/rpm/solv/map_iterator.hpp
@@ -59,6 +59,9 @@ public:
     void begin() noexcept;
     void end() noexcept;
 
+    /// Sets iterator to the first contained package in the range <id, end>.
+    void jump(PackageId id) noexcept;
+
 protected:
     const Map * get_map() const noexcept { return map; }
 
@@ -150,6 +153,28 @@ inline SolvMapIterator SolvMapIterator::operator++(int) noexcept {
     SolvMapIterator it(*this);
     ++*this;
     return it;
+}
+
+inline void SolvMapIterator::jump(PackageId id) noexcept {
+    if (id.id < 0) {
+        begin();
+        return;
+    }
+
+    const unsigned char * current = map->map + (id.id >> 3);
+
+    if (current >= map_end) {
+        end();
+        return;
+    }
+
+    current_value = id;
+    map_current = current;
+
+    // If the element with requested id does not exist in the map, it moves to the next.
+    if (!(*current & (1 << (id.id & 7)))) {
+        ++*this;
+    }
 }
 
 

--- a/libdnf/rpm/solv/map_iterator.hpp
+++ b/libdnf/rpm/solv/map_iterator.hpp
@@ -50,7 +50,7 @@ public:
     PackageId operator*() const { return current_value; }
 
     SolvMapIterator & operator++();
-    SolvMapIterator operator++(int) { return ++(*this); }
+    SolvMapIterator operator++(int);
 
     bool operator==(const SolvMapIterator & other) const { return current_value == other.current_value; }
     bool operator!=(const SolvMapIterator & other) const { return current_value != other.current_value; }
@@ -140,6 +140,12 @@ inline SolvMapIterator & SolvMapIterator::operator++() {
     // not found
     current_value.id = END;
     return *this;
+}
+
+inline SolvMapIterator SolvMapIterator::operator++(int) {
+    SolvMapIterator it(*this);
+    ++*this;
+    return it;
 }
 
 

--- a/libdnf/rpm/solv/map_iterator.hpp
+++ b/libdnf/rpm/solv/map_iterator.hpp
@@ -57,7 +57,7 @@ public:
     bool operator!=(const SolvMapIterator & other) const noexcept { return current_value != other.current_value; }
 
     void begin() noexcept;
-    void end() noexcept { current_value.id = END; }
+    void end() noexcept;
 
 protected:
     const Map * get_map() const noexcept { return map; }
@@ -70,7 +70,7 @@ private:
     const Map * map;
 
     // current address in the map
-    unsigned char * map_current;
+    const unsigned char * map_current;
 
     // the last address in the map
     const unsigned char * map_end;
@@ -80,16 +80,19 @@ private:
 };
 
 
-inline SolvMapIterator::SolvMapIterator(const Map * map) noexcept : map{map} {
-    map_current = map->map;
-    map_end = map_current + map->size;
-    current_value.id = BEGIN;
-    ++*this;
+inline SolvMapIterator::SolvMapIterator(const Map * map) noexcept : map{map}, map_end{map->map + map->size} {
+    begin();
 }
 
 inline void SolvMapIterator::begin() noexcept {
     current_value.id = BEGIN;
+    map_current = map->map;
     ++*this;
+}
+
+inline void SolvMapIterator::end() noexcept {
+    current_value.id = END;
+    map_current = map_end;
 }
 
 inline SolvMapIterator & SolvMapIterator::operator++() noexcept {

--- a/libdnf/rpm/solv/queue_iterator.hpp
+++ b/libdnf/rpm/solv/queue_iterator.hpp
@@ -21,84 +21,58 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_SOLV_QUEUE_ITERATOR_HPP
 #define LIBDNF_RPM_SOLV_QUEUE_ITERATOR_HPP
 
-#include "libdnf/rpm/solv_sack.hpp"
-
-#include <bits/stdc++.h>
-#include <solv/pooltypes.h>
 #include <solv/queue.h>
 
+#include <cstddef>
 #include <iterator>
-
 
 namespace libdnf::rpm::solv {
 
-
-class IdQueue;
-
-
 class IdQueueIterator {
 public:
-    explicit IdQueueIterator(const Queue * queue);
-    IdQueueIterator(const IdQueueIterator & other) = default;
+    explicit IdQueueIterator(const Queue * queue) noexcept;
+    IdQueueIterator(const IdQueueIterator & other) noexcept = default;
 
     using iterator_category = std::forward_iterator_tag;
-    using difference_type = Id;
+    using difference_type = std::ptrdiff_t;
     using value_type = Id;
     using pointer = void;
-    using reference = void;
+    using reference = Id;
 
-    Id operator*() const { return current_value; }
+    Id operator*() const noexcept { return queue->elements[current_index]; }
 
-    IdQueueIterator & operator++();
-    IdQueueIterator operator++(int) { return ++(*this); }
+    IdQueueIterator & operator++() noexcept;
+    IdQueueIterator operator++(int) noexcept;
 
-    bool operator==(const IdQueueIterator & other) const { return current_index == other.current_index; }
-    bool operator!=(const IdQueueIterator & other) const { return current_index != other.current_index; }
+    bool operator==(const IdQueueIterator & other) const noexcept { return current_index == other.current_index; }
+    bool operator!=(const IdQueueIterator & other) const noexcept { return current_index != other.current_index; }
 
-    void begin();
-    void end();
+    void begin() noexcept { current_index = 0; }
+    void end() noexcept { current_index = queue->count; }
 
 protected:
     const Queue * get_queue() const noexcept { return queue; }
 
 private:
-    constexpr static int END = -2;
-
-    // pointer to a queue owned by IdQueue
     const Queue * queue;
-
     int current_index;
-    Id current_value;
 };
 
-
-inline IdQueueIterator::IdQueueIterator(const Queue * queue) : queue{queue} {
-    current_index = -1;
-    ++(*this);
+inline IdQueueIterator::IdQueueIterator(const Queue * queue) noexcept : queue{queue} {
+    begin();
 }
 
-inline void IdQueueIterator::begin() {
-    current_index = -1;
-    ++(*this);
-}
-
-inline void IdQueueIterator::end() {
-    current_value = END;
-    current_index = queue->count;
-}
-
-inline IdQueueIterator & IdQueueIterator::operator++() {
-    current_index++;
-    if (current_index >= queue->count) {
-        current_value = END;
-    } else {
-        current_value = queue->elements[current_index];
-    }
+inline IdQueueIterator & IdQueueIterator::operator++() noexcept {
+    ++current_index;
     return *this;
 }
 
+inline IdQueueIterator IdQueueIterator::operator++(int) noexcept {
+    IdQueueIterator ret(*this);
+    ++*this;
+    return ret;
+}
 
 }  // namespace libdnf::rpm::solv
-
 
 #endif  // LIBDNF_RPM_SOLV_QUEUE_ITERATOR_HPP

--- a/test/libdnf/rpm/solv/test_id_queue.cpp
+++ b/test/libdnf/rpm/solv/test_id_queue.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../../../../libdnf/rpm/solv/id_queue.hpp"
 
+#include <iterator>
 
 CPPUNIT_TEST_SUITE_REGISTRATION(IdQueueTest);
 
@@ -108,17 +109,63 @@ void IdQueueTest::test_iterator_empty() {
 }
 
 void IdQueueTest::test_iterator_full() {
-    std::vector<Id> expected = {0, 1, 2, 3, 4};
-    std::vector<Id> result;
+    std::vector<Id> expected = {5, 6, 8, 10, 14};
     libdnf::rpm::solv::IdQueue queue;
-    queue.push_back(0, 1);
-    queue.push_back(2, 3);
-    queue.push_back(4);
+    queue.push_back(5, 6);
+    queue.push_back(8, 10);
+    queue.push_back(14);
 
-    for (auto it = queue.begin(); it != queue.end(); it++) {
-        result.push_back(*it);
+    // test begin
+    auto it1 = queue.begin();
+    CPPUNIT_ASSERT_EQUAL(*it1, 5);
+
+    // test pre-increment operator
+    auto it2 = ++it1;
+    CPPUNIT_ASSERT_EQUAL(*it1, 6);
+    CPPUNIT_ASSERT_EQUAL(*it2, 6);
+
+    // test post-increment operator
+    auto it3 = it2++;
+    CPPUNIT_ASSERT_EQUAL(*it2, 8);
+    CPPUNIT_ASSERT_EQUAL(*it3, 6);
+
+    // test move back to the begin
+    it2.begin();
+    CPPUNIT_ASSERT_EQUAL(*it2, 5);
+    CPPUNIT_ASSERT(it2 == queue.begin());
+
+    // test increment after begin
+    ++it2;
+    CPPUNIT_ASSERT_EQUAL(*it2, 6);
+
+    auto it4 = std::next(it2);
+    CPPUNIT_ASSERT_EQUAL(*it2, 6);
+    CPPUNIT_ASSERT_EQUAL(*it4, 8);
+
+    std::advance(it4, 2);
+    CPPUNIT_ASSERT_EQUAL(*it4, 14);
+
+    // test move to the end
+    it2.end();
+    CPPUNIT_ASSERT(it2 == queue.end());
+
+    // test loop with pre-increment operator
+    {
+        std::vector<Id> result;
+        for (auto it = queue.begin(), end = queue.end(); it != end; ++it) {
+            result.push_back(*it);
+        }
+        CPPUNIT_ASSERT(result == expected);
     }
-    CPPUNIT_ASSERT(result == expected);
+
+    // test loop with post-increment operator
+    {
+        std::vector<Id> result;
+        for (auto it = queue.begin(), end = queue.end(); it != end; it++) {
+            result.push_back(*it);
+        }
+        CPPUNIT_ASSERT(result == expected);
+    }
 }
 
 void IdQueueTest::test_iterator_performance() {

--- a/test/libdnf/rpm/solv/test_solv_map.cpp
+++ b/test/libdnf/rpm/solv/test_solv_map.cpp
@@ -236,6 +236,34 @@ void SolvMapTest::test_iterator_sparse() {
         }
         CPPUNIT_ASSERT(result == expected);
     }
+
+    // test jump to existing package
+    it1.jump(libdnf::rpm::PackageId(11));
+    CPPUNIT_ASSERT_EQUAL((*it1).id, 11);
+
+    // test jump behind last existing package
+    it1.jump(libdnf::rpm::PackageId(14));
+    CPPUNIT_ASSERT(it1 == map.end());
+
+    // test jump to existing package
+    it1.jump(libdnf::rpm::PackageId(6));
+    CPPUNIT_ASSERT_EQUAL((*it1).id, 6);
+
+    // test jump to non-existing package, moves to the next existing
+    it1.jump(libdnf::rpm::PackageId(7));
+    CPPUNIT_ASSERT_EQUAL((*it1).id, 10);
+
+    // test jump behind map
+    it1.jump(libdnf::rpm::PackageId(240));
+    CPPUNIT_ASSERT(it1 == map.end());
+
+    // test jump to negative id, sets to begin
+    it1.jump(libdnf::rpm::PackageId(-240));
+    CPPUNIT_ASSERT_EQUAL((*it1).id, 4);
+
+    // test increment after jump to negative id
+    ++it1;
+    CPPUNIT_ASSERT_EQUAL((*it1).id, 6);
 }
 
 

--- a/test/libdnf/rpm/solv/test_solv_map.cpp
+++ b/test/libdnf/rpm/solv/test_solv_map.cpp
@@ -167,15 +167,63 @@ void SolvMapTest::test_iterator_full() {
         libdnf::rpm::PackageId(15)
     };
     std::vector<libdnf::rpm::PackageId> result;
-    
+
     libdnf::rpm::solv::SolvMap map(16);
     for (int i = 0; i < 16; i++) {
         map.add(libdnf::rpm::PackageId(i));
     }
-    for(auto it = map.begin(); it != map.end(); it++) {
-        result.push_back(*it);
+    for(auto package_id : map) {
+        result.push_back(package_id);
     }
     CPPUNIT_ASSERT(result == expected);
+}
+
+
+void SolvMapTest::test_iterator_sparse() {
+    std::vector<libdnf::rpm::PackageId> expected = {
+        libdnf::rpm::PackageId(4),
+        libdnf::rpm::PackageId(6),
+        libdnf::rpm::PackageId(10),
+        libdnf::rpm::PackageId(11),
+        libdnf::rpm::PackageId(12),
+    };
+
+    libdnf::rpm::solv::SolvMap map(16);
+    for (auto it : expected) {
+        map.add(it);
+    }
+
+    // test begin
+    auto it1 = map.begin();
+    CPPUNIT_ASSERT_EQUAL((*it1).id, 4);
+
+    // test pre-increment operator
+    auto it2 = ++it1;
+    CPPUNIT_ASSERT_EQUAL((*it1).id, 6);
+    CPPUNIT_ASSERT_EQUAL((*it2).id, 6);
+
+    // test post-increment operator
+    auto it3 = it2++;
+    CPPUNIT_ASSERT_EQUAL((*it2).id, 10);
+    CPPUNIT_ASSERT_EQUAL((*it3).id, 6);
+
+    // test loop with pre-increment operator
+    {
+        std::vector<libdnf::rpm::PackageId> result;
+        for(auto it = map.begin(), end = map.end(); it !=end; ++it) {
+            result.push_back(*it);
+        }
+        CPPUNIT_ASSERT(result == expected);
+    }
+
+    // test loop with post-increment operator
+    {
+        std::vector<libdnf::rpm::PackageId> result;
+        for(auto it = map.begin(), end = map.end(); it != end; it++) {
+            result.push_back(*it);
+        }
+        CPPUNIT_ASSERT(result == expected);
+    }
 }
 
 

--- a/test/libdnf/rpm/solv/test_solv_map.cpp
+++ b/test/libdnf/rpm/solv/test_solv_map.cpp
@@ -207,6 +207,18 @@ void SolvMapTest::test_iterator_sparse() {
     CPPUNIT_ASSERT_EQUAL((*it2).id, 10);
     CPPUNIT_ASSERT_EQUAL((*it3).id, 6);
 
+    // test move back to begin
+    it2.begin();
+    CPPUNIT_ASSERT_EQUAL((*it2).id, 4);
+
+    // test increment after begin
+    ++it2;
+    CPPUNIT_ASSERT_EQUAL((*it2).id, 6);
+
+    // test end
+    it2.end();
+    CPPUNIT_ASSERT(it2 == map.end());
+
     // test loop with pre-increment operator
     {
         std::vector<libdnf::rpm::PackageId> result;

--- a/test/libdnf/rpm/solv/test_solv_map.hpp
+++ b/test/libdnf/rpm/solv/test_solv_map.hpp
@@ -43,6 +43,7 @@ class SolvMapTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_difference);
     CPPUNIT_TEST(test_iterator_empty);
     CPPUNIT_TEST(test_iterator_full);
+    CPPUNIT_TEST(test_iterator_sparse);
     #endif
 
     #ifdef WITH_PERFORMANCE_TESTS
@@ -69,6 +70,7 @@ public:
 
     void test_iterator_empty();
     void test_iterator_full();
+    void test_iterator_sparse();
 
     void test_iterator_performance_empty();
     void test_iterator_performance_full();

--- a/test/libdnf/rpm/test_package_set.cpp
+++ b/test/libdnf/rpm/test_package_set.cpp
@@ -158,7 +158,6 @@ void RpmPackageSetTest::test_difference() {
 
 void RpmPackageSetTest::test_iterator() {
     std::vector<libdnf::rpm::Package> expected;
-    std::vector<libdnf::rpm::Package> result;
 
     for (int i = 0; i < 16; i++) {
         TestPackage pkg(sack, libdnf::rpm::PackageId(i));
@@ -166,20 +165,43 @@ void RpmPackageSetTest::test_iterator() {
     }
 
     // check if begin() points to the first package
-    auto beg = set1->begin();
-    CPPUNIT_ASSERT((*beg).get_id().id == 0);
+    auto it1 = set1->begin();
+    CPPUNIT_ASSERT_EQUAL((*it1).get_id().id, 0);
 
-    // test if end() points to package with id == -2
-    auto end = set1->end();
-    CPPUNIT_ASSERT((*end).get_id().id == -2);
+    // test pre-increment operator
+    auto it2 = ++it1;
+    CPPUNIT_ASSERT_EQUAL((*it1).get_id().id, 1);
+    CPPUNIT_ASSERT_EQUAL((*it2).get_id().id, 1);
 
-    // test if increasing an iterator moves to the second package
-    ++beg;
-    CPPUNIT_ASSERT((*beg).get_id().id == 1);
+    // test post-increment operator
+    auto it3 = it2++;
+    CPPUNIT_ASSERT_EQUAL((*it2).get_id().id, 2);
+    CPPUNIT_ASSERT_EQUAL((*it3).get_id().id, 1);
 
-    // test iterating the whole package set
-    for (auto it = set1->begin(); it != set1->end(); it++) {
-        result.push_back((*it));
+    // test begin()
+    it1.begin();
+    CPPUNIT_ASSERT_EQUAL((*it1).get_id().id, 0);
+    CPPUNIT_ASSERT(it1 == set1->begin());
+
+    // test end()
+    it1.end();
+    CPPUNIT_ASSERT(it1 == set1->end());
+
+    // test loop with pre-increment operator
+    {
+        std::vector<libdnf::rpm::Package> result;
+        for(auto it = set1->begin(), end = set1->end(); it != end; ++it) {
+            result.push_back(*it);
+        }
+        CPPUNIT_ASSERT(result == expected);
     }
-    CPPUNIT_ASSERT(result == expected);
+
+    // test loop with post-increment operator
+    {
+        std::vector<libdnf::rpm::Package> result;
+        for(auto it = set1->begin(), end = set1->end(); it != end; it++) {
+            result.push_back(*it);
+        }
+        CPPUNIT_ASSERT(result == expected);
+    }
 }

--- a/test/libdnf/rpm/test_reldep_list.cpp
+++ b/test/libdnf/rpm/test_reldep_list.cpp
@@ -117,7 +117,6 @@ void ReldepListTest::test_iterator() {
     libdnf::rpm::Reldep c(sack, "(labirinto unless labirinto_c)");
     libdnf::rpm::Reldep d(sack, "labirinto.txt");
     std::vector<libdnf::rpm::Reldep> expected;
-    std::vector<libdnf::rpm::Reldep> result;
     libdnf::rpm::ReldepList list(sack);
 
     expected.push_back(a);
@@ -130,22 +129,45 @@ void ReldepListTest::test_iterator() {
     list.add(d);
 
     // check if begin() points to the first Reldep
-    auto beg = list.begin();
-    CPPUNIT_ASSERT((*beg) == a);
+    auto it1 = list.begin();
+    CPPUNIT_ASSERT(*it1 == a);
 
-    // test if increasing an iterator moves to the second Reldep
-    ++beg;
-    CPPUNIT_ASSERT(*beg == b);
+    // test pre-increment operator
+    auto it2 = ++it1;
+    CPPUNIT_ASSERT(*it1 == b);
+    CPPUNIT_ASSERT(*it2 == b);
 
-    // test if end() points to Reldep with id == -2
-    auto end = list.end();
-    CPPUNIT_ASSERT((*end).get_id().id == -2);
+    // test post-increment operator
+    auto it3 = it2++;
+    CPPUNIT_ASSERT(*it2 == c);
+    CPPUNIT_ASSERT(*it3 == b);
 
-    // test iterating the whole Reldep list
-    for (auto it = list.begin(); it != list.end(); it++) {
-        result.push_back((*it));
+    // test begin()
+    it3.begin();
+    CPPUNIT_ASSERT(*it3 == a);
+    CPPUNIT_ASSERT(it3 == list.begin());
+
+    // test end()
+    it3.end();
+    CPPUNIT_ASSERT(it3 == list.end());
+
+    // test loop with pre-increment operator
+    {
+        std::vector<libdnf::rpm::Reldep> result;
+        for(auto it = list.begin(), end = list.end(); it !=end; ++it) {
+            result.push_back(*it);
+        }
+        CPPUNIT_ASSERT(result == expected);
     }
-    CPPUNIT_ASSERT(result == expected);
+
+    // test loop with post-increment operator
+    {
+        std::vector<libdnf::rpm::Reldep> result;
+        for(auto it = list.begin(), end = list.end(); it != end; it++) {
+            result.push_back(*it);
+        }
+        CPPUNIT_ASSERT(result == expected);
+    }
 }
 
 // add_reldep_with_glob uses libsolvs Dataiterator which needs the actual packages


### PR DESCRIPTION
- Fixed and optimized `rpm::solv::SolvMapIterator`, `rpm::PackageSetIterator`, `rpm::ReldepListIterator` iterators.
- Rewroted `rpm::solv::IdQueueIterator` - the was buggy.

- Added `jump()` into `rpm::solv::SolvMapIterator`

- Fixed and extend coverage of unit tests for iterators.