### PR TITLE
Fix removal step during modular enable in context part

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -3087,7 +3087,7 @@ static std::vector<std::tuple<libdnf::ModulePackageContainer::ModuleErrorType, s
             }
             for (auto iter = stream_dict.begin(); iter != stream_dict.end(); ) {
                 if (iter->first != enabledOrDefaultStream) {
-                    stream_dict.erase(iter);
+                    stream_dict.erase(iter++);
                 } else {
                     ++iter;
                 }


### PR DESCRIPTION
It resolves `free(): double free detected in tcache 2`