### PR TITLE
[dnf5][swig] Fix: Python iterator wrapper - save container reference

### DIFF
--- a/bindings/libdnf/common.i
+++ b/bindings/libdnf/common.i
@@ -71,7 +71,11 @@ namespace std {
 #if defined(SWIGPYTHON)
 %pythoncode %{
 class Iterator:
-    def __init__(self, begin, end):
+    def __init__(self, container, begin, end):
+        # Store a reference to the iterated container to prevent the Python
+        # gargabe collector from freeing the container from memory.
+        self.container = container
+
         self.cur = begin
         self.end = end
 
@@ -92,7 +96,7 @@ class Iterator:
 #if defined(SWIGPYTHON)
 %pythoncode %{
 def ClassName##__iter__(self):
-    return libdnf.common.Iterator(self.begin(), self.end())
+    return libdnf.common.Iterator(self, self.begin(), self.end())
 ClassName.__iter__ = ClassName##__iter__
 del ClassName##__iter__
 %}

--- a/include/libdnf/rpm/solv_sack.hpp
+++ b/include/libdnf/rpm/solv_sack.hpp
@@ -154,6 +154,9 @@ public:
     /// Create WeakPtr to SolvSack
     SolvSackWeakPtr get_weak_ptr();
 
+    /// Returns number of solvables in pool.
+    int get_nsolvables() const noexcept;
+
 private:
     friend libdnf::Goal;
     friend Package;

--- a/libdnf/rpm/solv_sack.cpp
+++ b/libdnf/rpm/solv_sack.cpp
@@ -640,6 +640,10 @@ SolvSackWeakPtr SolvSack::get_weak_ptr() {
     return SolvSackWeakPtr(this, &pImpl->data_guard);
 }
 
+int SolvSack::get_nsolvables() const noexcept {
+    return pImpl->get_nsolvables();
+};
+
 // TODO(jrohel): we want to change directory for solv(x) cache (into repo metadata directory?)
 std::string SolvSack::Impl::give_repo_solv_cache_fn(const std::string & repoid, const char * ext) {
     std::filesystem::path cachedir = base->get_config().cachedir().get_value();

--- a/libdnf/rpm/solv_sack_impl.hpp
+++ b/libdnf/rpm/solv_sack_impl.hpp
@@ -91,7 +91,7 @@ public:
     Pool * get_pool() { return pool; };
 
     /// Return number of solvables in pool
-    int get_nsolvables() { return pool->nsolvables; };
+    int get_nsolvables() const noexcept { return pool->nsolvables; };
 
     /// Return SolvMap with all package solvables
     solv::SolvMap & get_solvables();


### PR DESCRIPTION
The iterator must to store a reference to the iterated container. Otherwise, if there is no one to reference to the container, the Python gargabe colector can free it from memory.