### PR TITLE
[dnf5] rpm::SolvQuery inherits rpm::PackageSet, improve SolvMap and PackageSet

### DIFF
--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -49,8 +49,8 @@ uint64_t repo_size(libdnf::rpm::SolvSack & sack, const libdnf::WeakPtr<libdnf::r
     uint64_t size = 0;
     libdnf::rpm::SolvQuery query(&sack);
     std::vector<std::string> reponames = {repo->get_id()};
-    auto pkgset = query.ifilter_repoid(libdnf::sack::QueryCmp::EQ, reponames).get_package_set();
-    for (auto pkg : pkgset) {
+    query.ifilter_repoid(libdnf::sack::QueryCmp::EQ, reponames);
+    for (auto pkg : query) {
         size += pkg.get_download_size();
     }
     return size;

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -48,16 +48,13 @@ public:
         const std::vector<libdnf::rpm::Nevra::Form> & forms);
     void add_rpm_install(const libdnf::rpm::Package & rpm_package, bool strict);
     void add_rpm_install(const libdnf::rpm::PackageSet & package_set, bool strict);
-    void add_rpm_install(const libdnf::rpm::SolvQuery & query, bool strict);
     void add_rpm_remove(
         const std::string & spec, const std::string & repo_id, const std::vector<libdnf::rpm::Nevra::Form> & forms);
     void add_rpm_remove(const libdnf::rpm::Package & rpm_package);
     void add_rpm_remove(const libdnf::rpm::PackageSet & package_set);
-    void add_rpm_remove(const libdnf::rpm::SolvQuery & query);
     void add_rpm_upgrade(const std::string & spec, const std::vector<std::string> & repo_ids);
     void add_rpm_upgrade(const libdnf::rpm::Package & rpm_package);
     void add_rpm_upgrade(const libdnf::rpm::PackageSet & package_set);
-    void add_rpm_upgrade(const libdnf::rpm::SolvQuery & query);
 
     bool resolve();
 

--- a/include/libdnf/rpm/package_set.hpp
+++ b/include/libdnf/rpm/package_set.hpp
@@ -70,17 +70,17 @@ public:
     PackageSet & operator&=(const PackageSet & other);
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.clear()
-    void clear();
+    void clear() noexcept;
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.empty()
-    bool empty();
+    bool empty() const noexcept;
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.set(DnfPackage * pkg)
     /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_add(DnfPackageSet * pset, DnfPackage * pkg)
     void add(const Package & pkg);
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.has(DnfPackage * pkg)
-    bool contains(const Package & pkg) const;
+    bool contains(const Package & pkg) const noexcept;
 
     void remove(const Package & pkg);
 
@@ -89,7 +89,9 @@ public:
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.size()
     /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_count(DnfPackageSet * pset)
-    size_t size() const;
+    size_t size() const noexcept;
+
+    void swap(PackageSet & other) noexcept;
 
 private:
     friend PackageSetIterator;

--- a/include/libdnf/rpm/package_set.hpp
+++ b/include/libdnf/rpm/package_set.hpp
@@ -111,7 +111,7 @@ private:
     friend libdnf::Swdb;
     PackageSet(SolvSack * sack, libdnf::rpm::solv::SolvMap & solv_map);
     class Impl;
-    std::unique_ptr<Impl> pImpl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 

--- a/include/libdnf/rpm/package_set.hpp
+++ b/include/libdnf/rpm/package_set.hpp
@@ -45,6 +45,13 @@ class Transaction;
 /// @replaces libdnf:sack/packageset.hpp:struct:PackageSet
 class PackageSet {
 public:
+    struct UsedDifferentSack : public RuntimeError {
+        using RuntimeError::RuntimeError;
+        const char * get_domain_name() const noexcept override { return "libdnf::rpm::PackageSet"; }
+        const char * get_name() const noexcept override { return "UsedDifferentSack"; }
+        const char * get_description() const noexcept override { return "PackageSet exception"; }
+    };
+
     /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_new(DnfSack * sack)
     explicit PackageSet(SolvSack * sack);
 

--- a/include/libdnf/rpm/package_set.hpp
+++ b/include/libdnf/rpm/package_set.hpp
@@ -56,6 +56,9 @@ public:
     /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_free(DnfPackageSet * pset)
     ~PackageSet();
 
+    PackageSet & operator=(const PackageSet & src);
+    PackageSet & operator=(PackageSet && src);
+
     using iterator = PackageSetIterator;
     iterator begin() const;
     iterator end() const;

--- a/include/libdnf/rpm/package_set_iterator.hpp
+++ b/include/libdnf/rpm/package_set_iterator.hpp
@@ -60,7 +60,7 @@ public:
 
 private:
     class Impl;
-    std::unique_ptr<Impl> pImpl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 

--- a/include/libdnf/rpm/reldep_list.hpp
+++ b/include/libdnf/rpm/reldep_list.hpp
@@ -104,7 +104,7 @@ private:
     friend ReldepListIterator;
     friend Package;
     class Impl;
-    std::unique_ptr<Impl> pImpl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 

--- a/include/libdnf/rpm/reldep_list_iterator.hpp
+++ b/include/libdnf/rpm/reldep_list_iterator.hpp
@@ -60,7 +60,7 @@ public:
 
 private:
     class Impl;
-    std::unique_ptr<Impl> pImpl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 

--- a/include/libdnf/rpm/solv_query.hpp
+++ b/include/libdnf/rpm/solv_query.hpp
@@ -44,7 +44,7 @@ namespace libdnf::rpm {
 /// @replaces libdnf/hy-query.h:struct:HyQuery
 /// @replaces libdnf/sack/query.hpp:struct:Query
 /// @replaces hawkey:hawkey/__init__.py:class:Query
-class SolvQuery {
+class SolvQuery : public PackageSet {
 public:
     enum class InitFlags {
         APPLY_EXCLUDES = 0,
@@ -73,12 +73,12 @@ public:
     /// @replaces libdnf/sack/query.hpp:method:Query(DnfSack* sack, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES)
     /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_free(DnfReldep *reldep)
     explicit SolvQuery(SolvSack * sack, InitFlags flags = InitFlags::APPLY_EXCLUDES);
-    SolvQuery(const SolvQuery & src);
+    SolvQuery(const SolvQuery & src) = default;
     SolvQuery(SolvQuery && src) noexcept = default;
-    ~SolvQuery();
+    ~SolvQuery() = default;
 
-    SolvQuery & operator=(const SolvQuery & src);
-    SolvQuery & operator=(SolvQuery && src) noexcept;
+    SolvQuery & operator=(const SolvQuery & src) = default;
+    SolvQuery & operator=(SolvQuery && src) noexcept = default;
 
     /// Union operator
     SolvQuery & operator|=(const SolvQuery & other);
@@ -355,14 +355,6 @@ public:
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_DOWNGRADABLE
     SolvQuery & ifilter_downgradable();
 
-    /// Return the number of packages in the SolvQuery.
-    ///
-    /// @replaces libdnf/sack/query.hpp:method:Query.size()
-    std::size_t size() const noexcept;
-
-    /// @replaces libdnf/sack/query.hpp:method:Query.empty()
-    bool empty() const noexcept;
-
     // TODO(jmracek) return std::pair<bool, std::unique_ptr<libdnf::rpm::Nevra>>
     /// @replaces libdnf/sack/query.hpp:method:std::pair<bool, std::unique_ptr<Nevra>> filterSubject(const char * subject, HyForm * forms, bool icase, bool with_nevra, bool with_provides, bool with_filenames);
     std::pair<bool, libdnf::rpm::Nevra> resolve_pkg_spec(
@@ -379,7 +371,6 @@ public:
 private:
     friend libdnf::Goal;
     class Impl;
-    PackageSet pkg_set;
 };
 
 

--- a/include/libdnf/rpm/solv_query.hpp
+++ b/include/libdnf/rpm/solv_query.hpp
@@ -348,6 +348,7 @@ public:
 private:
     friend libdnf::Goal;
     class Impl;
+    InitFlags init_flags;
 };
 
 

--- a/include/libdnf/rpm/solv_query.hpp
+++ b/include/libdnf/rpm/solv_query.hpp
@@ -28,7 +28,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/sack/query_cmp.hpp"
 #include "libdnf/utils/exception.hpp"
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -116,7 +115,8 @@ public:
     ///
     /// @replaces libdnf/sack/query.hpp:method:Query.runSet()
     /// @replaces libdnf/sack/query.hpp:method:Query.run()
-    PackageSet get_package_set() const;
+    PackageSet & get_package_set();
+    const PackageSet & get_package_set() const;
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB, IEXACT, NOT_IEXACT, ICONTAINS, NOT_ICONTAINS, IGLOB, NOT_IGLOB, CONTAINS, NOT_CONTAINS.
     ///
@@ -374,10 +374,12 @@ public:
         bool with_src,
         const std::vector<libdnf::rpm::Nevra::Form> & forms);
 
+    void swap(SolvQuery & other) noexcept;
+
 private:
     friend libdnf::Goal;
     class Impl;
-    std::unique_ptr<Impl> p_impl;
+    PackageSet pkg_set;
 };
 
 

--- a/include/libdnf/rpm/solv_query.hpp
+++ b/include/libdnf/rpm/solv_query.hpp
@@ -111,13 +111,6 @@ public:
     /// @replaces libdnf/sack/query.hpp:method:queryDifference(Query & other)
     void difference(const SolvQuery & other) { *this -= other; }
 
-    /// Return query result in PackageSet
-    ///
-    /// @replaces libdnf/sack/query.hpp:method:Query.runSet()
-    /// @replaces libdnf/sack/query.hpp:method:Query.run()
-    PackageSet & get_package_set();
-    const PackageSet & get_package_set() const;
-
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB, IEXACT, NOT_IEXACT, ICONTAINS, NOT_ICONTAINS, IGLOB, NOT_IGLOB, CONTAINS, NOT_CONTAINS.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NAME

--- a/include/libdnf/rpm/solv_query.hpp
+++ b/include/libdnf/rpm/solv_query.hpp
@@ -61,13 +61,6 @@ public:
         const char * get_description() const noexcept override { return "SolvQuery exception"; }
     };
 
-    struct UsedDifferentSack : public RuntimeError {
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::rpm::SolvQuery"; }
-        const char * get_name() const noexcept override { return "UsedDifferentSack"; }
-        const char * get_description() const noexcept override { return "SolvQuery exception"; }
-    };
-
     /// @replaces libdnf/hy-query.h:function:hy_query_create(DnfSack *sack);
     /// @replaces libdnf/hy-query.h:function:hy_query_create_flags(DnfSack *sack, int flags);
     /// @replaces libdnf/sack/query.hpp:method:Query(DnfSack* sack, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES)
@@ -79,15 +72,6 @@ public:
 
     SolvQuery & operator=(const SolvQuery & src) = default;
     SolvQuery & operator=(SolvQuery && src) noexcept = default;
-
-    /// Union operator
-    SolvQuery & operator|=(const SolvQuery & other);
-
-    /// Intersection operator
-    SolvQuery & operator&=(const SolvQuery & other);
-
-    /// Difference operator
-    SolvQuery & operator-=(const SolvQuery & other);
 
     /// update == union
     /// Unites query with other query (aka logical or)

--- a/include/libdnf/rpm/solv_sack.hpp
+++ b/include/libdnf/rpm/solv_sack.hpp
@@ -168,7 +168,7 @@ private:
     friend libdnf::Swdb;
     friend solv::SolvPrivate;
     class Impl;
-    std::unique_ptr<Impl> pImpl;
+    std::unique_ptr<Impl> p_impl;
 };
 
 inline constexpr SolvSack::LoadRepoFlags operator|(SolvSack::LoadRepoFlags lhs, SolvSack::LoadRepoFlags rhs) {

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -112,14 +112,6 @@ void Goal::add_rpm_install(const libdnf::rpm::PackageSet & package_set, bool str
     p_impl->install_rpm_ids.push_back(std::make_pair(std::move(ids), strict));
 }
 
-void Goal::add_rpm_install(const libdnf::rpm::SolvQuery & query, bool strict) {
-    libdnf::rpm::solv::IdQueue ids;
-    for (auto package_id : *query.p_impl) {
-        ids.push_back(package_id.id);
-    }
-    p_impl->install_rpm_ids.push_back(std::make_pair(std::move(ids), strict));
-}
-
 void Goal::add_rpm_remove(
     const std::string & spec, const std::string & repo_id, const std::vector<libdnf::rpm::Nevra::Form> & forms) {
     p_impl->remove_rpm_specs.push_back(std::make_tuple(spec, repo_id, forms));
@@ -131,12 +123,6 @@ void Goal::add_rpm_remove(const libdnf::rpm::Package & rpm_package) {
 
 void Goal::add_rpm_remove(const libdnf::rpm::PackageSet & package_set) {
     for (auto package_id : *package_set.p_impl) {
-        p_impl->remove_rpm_ids.push_back(package_id.id);
-    }
-}
-
-void Goal::add_rpm_remove(const libdnf::rpm::SolvQuery & query) {
-    for (auto package_id : *query.p_impl) {
         p_impl->remove_rpm_ids.push_back(package_id.id);
     }
 }
@@ -154,14 +140,6 @@ void Goal::add_rpm_upgrade(const libdnf::rpm::Package & rpm_package) {
 void Goal::add_rpm_upgrade(const libdnf::rpm::PackageSet & package_set) {
     libdnf::rpm::solv::IdQueue ids;
     for (auto package_id : *package_set.p_impl) {
-        ids.push_back(package_id.id);
-    }
-    p_impl->upgrade_rpm_ids.push_back(std::move(ids));
-}
-
-void Goal::add_rpm_upgrade(const libdnf::rpm::SolvQuery & query) {
-    libdnf::rpm::solv::IdQueue ids;
-    for (auto package_id : *query.p_impl) {
         ids.push_back(package_id.id);
     }
     p_impl->upgrade_rpm_ids.push_back(std::move(ids));

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -80,7 +80,7 @@ Goal::Goal(Base * base) : p_impl(new Impl(base)) {}
 
 Goal::Impl::Impl(Base * base)
     : base(base)
-    , rpm_goal(rpm::solv::GoalPrivate(base->get_rpm_solv_sack().pImpl->get_pool())) {}
+    , rpm_goal(rpm::solv::GoalPrivate(base->get_rpm_solv_sack().p_impl->get_pool())) {}
 
 Goal::~Goal() = default;
 
@@ -106,7 +106,7 @@ void Goal::add_rpm_install(const libdnf::rpm::Package & rpm_package, bool strict
 
 void Goal::add_rpm_install(const libdnf::rpm::PackageSet & package_set, bool strict) {
     libdnf::rpm::solv::IdQueue ids;
-    for (auto package_id : *package_set.pImpl) {
+    for (auto package_id : *package_set.p_impl) {
         ids.push_back(package_id.id);
     }
     p_impl->install_rpm_ids.push_back(std::make_pair(std::move(ids), strict));
@@ -114,7 +114,7 @@ void Goal::add_rpm_install(const libdnf::rpm::PackageSet & package_set, bool str
 
 void Goal::add_rpm_install(const libdnf::rpm::SolvQuery & query, bool strict) {
     libdnf::rpm::solv::IdQueue ids;
-    for (auto package_id : *query.pImpl) {
+    for (auto package_id : *query.p_impl) {
         ids.push_back(package_id.id);
     }
     p_impl->install_rpm_ids.push_back(std::make_pair(std::move(ids), strict));
@@ -130,13 +130,13 @@ void Goal::add_rpm_remove(const libdnf::rpm::Package & rpm_package) {
 }
 
 void Goal::add_rpm_remove(const libdnf::rpm::PackageSet & package_set) {
-    for (auto package_id : *package_set.pImpl) {
+    for (auto package_id : *package_set.p_impl) {
         p_impl->remove_rpm_ids.push_back(package_id.id);
     }
 }
 
 void Goal::add_rpm_remove(const libdnf::rpm::SolvQuery & query) {
-    for (auto package_id : *query.pImpl) {
+    for (auto package_id : *query.p_impl) {
         p_impl->remove_rpm_ids.push_back(package_id.id);
     }
 }
@@ -153,7 +153,7 @@ void Goal::add_rpm_upgrade(const libdnf::rpm::Package & rpm_package) {
 
 void Goal::add_rpm_upgrade(const libdnf::rpm::PackageSet & package_set) {
     libdnf::rpm::solv::IdQueue ids;
-    for (auto package_id : *package_set.pImpl) {
+    for (auto package_id : *package_set.p_impl) {
         ids.push_back(package_id.id);
     }
     p_impl->upgrade_rpm_ids.push_back(std::move(ids));
@@ -161,7 +161,7 @@ void Goal::add_rpm_upgrade(const libdnf::rpm::PackageSet & package_set) {
 
 void Goal::add_rpm_upgrade(const libdnf::rpm::SolvQuery & query) {
     libdnf::rpm::solv::IdQueue ids;
-    for (auto package_id : *query.pImpl) {
+    for (auto package_id : *query.p_impl) {
         ids.push_back(package_id.id);
     }
     p_impl->upgrade_rpm_ids.push_back(std::move(ids));
@@ -169,7 +169,7 @@ void Goal::add_rpm_upgrade(const libdnf::rpm::SolvQuery & query) {
 
 void Goal::Impl::add_install_to_goal() {
     auto & sack = base->get_rpm_solv_sack();
-    Pool * pool = sack.pImpl->get_pool();
+    Pool * pool = sack.p_impl->get_pool();
 
     auto multilib_policy = base->get_config().multilib_policy().get_value();
     auto obsoletes = base->get_config().obsoletes().get_value();
@@ -250,22 +250,22 @@ void Goal::Impl::add_install_to_goal() {
 
                 // keep only installed that has a partner in available
                 std::unordered_set<Id> names;
-                for (auto package_id : *available.pImpl) {
+                for (auto package_id : *available.p_impl) {
                     Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, package_id);
                     names.insert(solvable->name);
                 }
-                for (auto package_id : *installed.pImpl) {
+                for (auto package_id : *installed.p_impl) {
                     Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, package_id);
                     auto name_iterator = names.find(solvable->name);
                     if (name_iterator == names.end()) {
-                        installed.pImpl->remove_unsafe(package_id);
+                        installed.p_impl->remove_unsafe(package_id);
                     }
                 }
                 // TODO(jmracek): if reports: self._report_installed(installed)
                 // TODO(jmracek) Replace by union query operator
                 available |= installed;
                 tmp_solvables.clear();
-                for (auto package_id : *available.pImpl) {
+                for (auto package_id : *available.p_impl) {
                     Solvable * solvable = libdnf::rpm::solv::get_solvable(pool, package_id);
                     tmp_solvables.push_back(solvable);
                 }
@@ -275,28 +275,28 @@ void Goal::Impl::add_install_to_goal() {
                     auto * first = tmp_solvables[0];
                     current_name = first->name;
                     // TODO(jmracek) Allow to skip creation of libdnf::rpm::PackageId
-                    selected.pImpl->add_unsafe(libdnf::rpm::PackageId(pool_solvable2id(pool, first)));
+                    selected.p_impl->add_unsafe(libdnf::rpm::PackageId(pool_solvable2id(pool, first)));
                 }
                 std::sort(tmp_solvables.begin(), tmp_solvables.end(), nevra_solvable_cmp_key);
 
                 for (auto * solvable : tmp_solvables) {
                     if (solvable->name == current_name) {
-                        selected.pImpl->add_unsafe(libdnf::rpm::PackageId(pool_solvable2id(pool, solvable)));
+                        selected.p_impl->add_unsafe(libdnf::rpm::PackageId(pool_solvable2id(pool, solvable)));
                         continue;
                     }
                     if (add_obsoletes) {
                         add_obseletes(base_query, selected);
                     }
-                    solv_map_to_id_queue(tmp_queue, static_cast<libdnf::rpm::solv::SolvMap>(*selected.pImpl));
+                    solv_map_to_id_queue(tmp_queue, static_cast<libdnf::rpm::solv::SolvMap>(*selected.p_impl));
                     rpm_goal.add_install(tmp_queue, strict);
                     selected.clear();
-                    selected.pImpl->add_unsafe(libdnf::rpm::PackageId(pool_solvable2id(pool, solvable)));
+                    selected.p_impl->add_unsafe(libdnf::rpm::PackageId(pool_solvable2id(pool, solvable)));
                     current_name = solvable->name;
                 }
                 if (add_obsoletes) {
                     add_obseletes(base_query, selected);
                 }
-                solv_map_to_id_queue(tmp_queue, static_cast<libdnf::rpm::solv::SolvMap>(*selected.pImpl));
+                solv_map_to_id_queue(tmp_queue, static_cast<libdnf::rpm::solv::SolvMap>(*selected.p_impl));
                 rpm_goal.add_install(tmp_queue, strict);
             } else {
                 if (add_obsoletes) {
@@ -315,7 +315,7 @@ void Goal::Impl::add_install_to_goal() {
                 }
                 // TODO(jmracek) if reports:
                 // base._report_already_installed(installed_query)
-                solv_map_to_id_queue(tmp_queue, *query.pImpl);
+                solv_map_to_id_queue(tmp_queue, *query.p_impl);
                 rpm_goal.add_install(tmp_queue, strict);
             }
         } else {
@@ -372,7 +372,7 @@ void Goal::Impl::add_remove_to_goal() {
                 continue;
             }
         }
-        rpm_goal.add_remove(*query.pImpl, remove_dependencies);
+        rpm_goal.add_remove(*query.p_impl, remove_dependencies);
     }
     rpm_goal.add_remove(remove_rpm_ids, remove_dependencies);
 }
@@ -418,7 +418,7 @@ void Goal::Impl::add_upgrades_to_goal() {
         // TODO(jmracek) Apply security filters
         // TODO(jmracek) q = q.available().union(installed_query.latest())
         // Required for a correct upgrade of installonly packages
-        solv_map_to_id_queue(tmp_queue, *query.pImpl);
+        solv_map_to_id_queue(tmp_queue, *query.p_impl);
         rpm_goal.add_upgrade(tmp_queue);
 
 
@@ -474,13 +474,13 @@ void Goal::Impl::add_upgrades_to_goal() {
 
 bool Goal::resolve() {
     auto & sack = p_impl->base->get_rpm_solv_sack();
-    Pool * pool = sack.pImpl->get_pool();
+    Pool * pool = sack.p_impl->get_pool();
     // TODO(jmracek) Move pool settings in base
     pool_setdisttype(pool, DISTTYPE_RPM);
     // TODO(jmracek) Move pool settings in base and replace it with a Substitotion class arch value
     pool_setarch(pool, "x86_64");
 
-    sack.pImpl->make_provides_ready();
+    sack.p_impl->make_provides_ready();
     // TODO(jmracek) Apply modules first
     // TODO(jmracek) Apply comps second or later
     // TODO(jmracek) Reset rpm_goal, setup rpm-goal flags according to conf, (allow downgrade), obsoletes, vendor, ...

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -33,270 +33,270 @@ inline static std::string cstring2string(const char * input) {
 namespace libdnf::rpm {
 
 const char * Package::get_name_cstring() const noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_name(pool, id);
 }
 
 std::string Package::get_name() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_name(pool, id));
 }
 
 const char * Package::get_epoch_cstring() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_epoch_cstring(pool, id);
 }
 
 unsigned long Package::get_epoch() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_epoch(pool, id);
 }
 
 const char * Package::get_version_cstring() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_version(pool, id);
 }
 
 std::string Package::get_version() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_version(pool, id));
 }
 
 const char * Package::get_release_cstring() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_release(pool, id);
 }
 
 std::string Package::get_release() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_release(pool, id));
 }
 
 const char * Package::get_arch_cstring() const noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_arch(pool, id);
 }
 
 std::string Package::get_arch() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_arch(pool, id));
 }
 
 const char * Package::get_evr_cstring() const noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_evr(pool, id);
 }
 
 std::string Package::get_evr() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_evr(pool, id));
 }
 
 std::string Package::get_nevra() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_nevra(pool, id));
 }
 
 std::string Package::get_full_nevra() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_full_nevra(pool, id));
 }
 
 std::string Package::get_group() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_group(pool, id));
 }
 
 unsigned long long Package::get_size() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_size(pool, id);
 }
 
 unsigned long long Package::get_download_size() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_download_size(pool, id);
 }
 
 unsigned long long Package::get_install_size() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_install_size(pool, id);
 }
 
 std::string Package::get_license() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_license(pool, id));
 }
 
 std::string Package::get_sourcerpm() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_sourcerpm(pool, id));
 }
 
 unsigned long long Package::get_build_time() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_build_time(pool, id);
 }
 
 // TODO not supported by libsolv: https://github.com/openSUSE/libsolv/issues/400
 //std::string Package::get_build_host() {
-//    Pool * pool = sack->pImpl->pool;
+//    Pool * pool = sack->p_impl->pool;
 //    return cstring2string(solv::get_build_host(pool, id));
 //}
 
 std::string Package::get_packager() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_packager(pool, id));
 }
 
 std::string Package::get_vendor() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_vendor(pool, id));
 }
 
 std::string Package::get_url() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_url(pool, id));
 }
 
 std::string Package::get_summary() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_summary(pool, id));
 }
 
 std::string Package::get_description() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_description(pool, id));
 }
 
 std::vector<std::string> Package::get_files() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_files(pool, id);
 }
 
 ReldepList Package::get_provides() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_provides(pool, id, list.pImpl->queue);
+    solv::get_provides(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_requires() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_requires(pool, id, list.pImpl->queue);
+    solv::get_requires(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_requires_pre() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_requires_pre(pool, id, list.pImpl->queue);
+    solv::get_requires_pre(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_conflicts() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_conflicts(pool, id, list.pImpl->queue);
+    solv::get_conflicts(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_obsoletes() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_obsoletes(pool, id, list.pImpl->queue);
+    solv::get_obsoletes(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_recommends() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_recommends(pool, id, list.pImpl->queue);
+    solv::get_recommends(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_suggests() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_suggests(pool, id, list.pImpl->queue);
+    solv::get_suggests(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_enhances() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_enhances(pool, id, list.pImpl->queue);
+    solv::get_enhances(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_supplements() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_supplements(pool, id, list.pImpl->queue);
+    solv::get_supplements(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_prereq_ignoreinst() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_prereq_ignoreinst(pool, id, list.pImpl->queue);
+    solv::get_prereq_ignoreinst(pool, id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_regular_requires() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     ReldepList list(sack.get());
-    solv::get_regular_requires(pool, id, list.pImpl->queue);
+    solv::get_regular_requires(pool, id, list.p_impl->queue);
     return list;
 }
 
 std::string Package::get_baseurl() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_baseurl(pool, id));
 }
 
 std::string Package::get_location() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return cstring2string(solv::get_location(pool, id));
 }
 
 std::string Package::get_local_filepath() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_local_filepath(pool, id);
 }
 
 bool Package::is_installed() const {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::is_installed(pool, solv::get_solvable(pool, id));
 }
 
 unsigned long long Package::get_hdr_end() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_hdr_end(pool, id);
 }
 
 unsigned long long Package::get_install_time() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_install_time(pool, id);
 }
 
 unsigned long long Package::get_media_number() noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_media_number(pool, id);
 }
 
 unsigned long long Package::get_rpmdbid() const noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_rpmdbid(pool, id);
 }
 
 Repo * Package::get_repo() const noexcept {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     return solv::get_repo(pool, id);
 }
 
 Checksum Package::get_checksum() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
 
     Solvable * solvable = solv::get_solvable(pool, id);
     int type;
@@ -308,7 +308,7 @@ Checksum Package::get_checksum() {
 }
 
 Checksum Package::get_hdr_checksum() {
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
 
     Solvable * solvable = solv::get_solvable(pool, id);
     int type;

--- a/libdnf/rpm/package_set.cpp
+++ b/libdnf/rpm/package_set.cpp
@@ -77,27 +77,30 @@ PackageSet & PackageSet::operator&=(const PackageSet & other) {
 }
 
 
-void PackageSet::clear() {
+void PackageSet::clear() noexcept {
     pImpl->clear();
 }
 
 
-bool PackageSet::empty() {
+bool PackageSet::empty() const noexcept {
     return pImpl->empty();
 }
 
 
-std::size_t PackageSet::size() const {
+std::size_t PackageSet::size() const noexcept {
     return pImpl->size();
 }
 
+void PackageSet::swap(PackageSet & other) noexcept {
+    pImpl.swap(other.pImpl);
+}
 
 void PackageSet::add(const Package & pkg) {
     pImpl->add(pkg.get_id());
 }
 
 
-bool PackageSet::contains(const Package & pkg) const {
+bool PackageSet::contains(const Package & pkg) const noexcept {
     return pImpl->contains(pkg.get_id());
 }
 

--- a/libdnf/rpm/package_set.cpp
+++ b/libdnf/rpm/package_set.cpp
@@ -30,27 +30,27 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::rpm {
 
 
-PackageSet::PackageSet(SolvSack * sack) : pImpl(new Impl(sack)) {}
+PackageSet::PackageSet(SolvSack * sack) : p_impl(new Impl(sack)) {}
 
 
-PackageSet::PackageSet(const PackageSet & other) : pImpl(new Impl(*other.pImpl)) {}
+PackageSet::PackageSet(const PackageSet & other) : p_impl(new Impl(*other.p_impl)) {}
 
 
-PackageSet::PackageSet(PackageSet && other) noexcept : pImpl(new Impl(std::move(*other.pImpl))) {}
+PackageSet::PackageSet(PackageSet && other) noexcept : p_impl(new Impl(std::move(*other.p_impl))) {}
 
 
-PackageSet::PackageSet(SolvSack * sack, libdnf::rpm::solv::SolvMap & solv_map) : pImpl(new Impl(sack, solv_map)) {}
+PackageSet::PackageSet(SolvSack * sack, libdnf::rpm::solv::SolvMap & solv_map) : p_impl(new Impl(sack, solv_map)) {}
 
 
 PackageSet::~PackageSet() = default;
 
 PackageSet & PackageSet::operator=(const PackageSet & other) {
-    *pImpl = *other.pImpl;
+    *p_impl = *other.p_impl;
     return *this;
 }
 
 PackageSet & PackageSet::operator=(PackageSet && other) {
-    *pImpl = std::move(*other.pImpl);
+    *p_impl = std::move(*other.p_impl);
     return *this;
 }
 
@@ -69,70 +69,70 @@ PackageSet::iterator PackageSet::end() const {
 
 
 PackageSet & PackageSet::operator|=(const PackageSet & other) {
-    if (pImpl->sack != other.pImpl->sack) {
+    if (p_impl->sack != other.p_impl->sack) {
         throw UsedDifferentSack(
             "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
     }
-    *pImpl |= *other.pImpl;
+    *p_impl |= *other.p_impl;
     return *this;
 }
 
 
 PackageSet & PackageSet::operator-=(const PackageSet & other) {
-    if (pImpl->sack != other.pImpl->sack) {
+    if (p_impl->sack != other.p_impl->sack) {
         throw UsedDifferentSack(
             "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
     }
-    *pImpl -= *other.pImpl;
+    *p_impl -= *other.p_impl;
     return *this;
 }
 
 
 PackageSet & PackageSet::operator&=(const PackageSet & other) {
-    if (pImpl->sack != other.pImpl->sack) {
+    if (p_impl->sack != other.p_impl->sack) {
         throw UsedDifferentSack(
             "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
     }
-    *pImpl &= *other.pImpl;
+    *p_impl &= *other.p_impl;
     return *this;
 }
 
 
 void PackageSet::clear() noexcept {
-    pImpl->clear();
+    p_impl->clear();
 }
 
 
 bool PackageSet::empty() const noexcept {
-    return pImpl->empty();
+    return p_impl->empty();
 }
 
 
 std::size_t PackageSet::size() const noexcept {
-    return pImpl->size();
+    return p_impl->size();
 }
 
 void PackageSet::swap(PackageSet & other) noexcept {
-    pImpl.swap(other.pImpl);
+    p_impl.swap(other.p_impl);
 }
 
 void PackageSet::add(const Package & pkg) {
-    pImpl->add(pkg.get_id());
+    p_impl->add(pkg.get_id());
 }
 
 
 bool PackageSet::contains(const Package & pkg) const noexcept {
-    return pImpl->contains(pkg.get_id());
+    return p_impl->contains(pkg.get_id());
 }
 
 
 void PackageSet::remove(const Package & pkg) {
-    pImpl->remove(pkg.get_id());
+    p_impl->remove(pkg.get_id());
 }
 
 
 SolvSack * PackageSet::get_sack() const {
-    return pImpl->get_sack();
+    return p_impl->get_sack();
 }
 
 

--- a/libdnf/rpm/package_set.cpp
+++ b/libdnf/rpm/package_set.cpp
@@ -69,18 +69,30 @@ PackageSet::iterator PackageSet::end() const {
 
 
 PackageSet & PackageSet::operator|=(const PackageSet & other) {
+    if (pImpl->sack != other.pImpl->sack) {
+        throw UsedDifferentSack(
+            "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
+    }
     *pImpl |= *other.pImpl;
     return *this;
 }
 
 
 PackageSet & PackageSet::operator-=(const PackageSet & other) {
+    if (pImpl->sack != other.pImpl->sack) {
+        throw UsedDifferentSack(
+            "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
+    }
     *pImpl -= *other.pImpl;
     return *this;
 }
 
 
 PackageSet & PackageSet::operator&=(const PackageSet & other) {
+    if (pImpl->sack != other.pImpl->sack) {
+        throw UsedDifferentSack(
+            "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
+    }
     *pImpl &= *other.pImpl;
     return *this;
 }

--- a/libdnf/rpm/package_set.cpp
+++ b/libdnf/rpm/package_set.cpp
@@ -33,10 +33,10 @@ namespace libdnf::rpm {
 PackageSet::PackageSet(SolvSack * sack) : pImpl(new Impl(sack)) {}
 
 
-PackageSet::PackageSet(const PackageSet & other) : pImpl(new Impl(other)) {}
+PackageSet::PackageSet(const PackageSet & other) : pImpl(new Impl(*other.pImpl)) {}
 
 
-PackageSet::PackageSet(PackageSet && other) noexcept : pImpl(std::move(other.pImpl)) {}
+PackageSet::PackageSet(PackageSet && other) noexcept : pImpl(new Impl(std::move(*other.pImpl))) {}
 
 
 PackageSet::PackageSet(SolvSack * sack, libdnf::rpm::solv::SolvMap & solv_map) : pImpl(new Impl(sack, solv_map)) {}
@@ -44,6 +44,15 @@ PackageSet::PackageSet(SolvSack * sack, libdnf::rpm::solv::SolvMap & solv_map) :
 
 PackageSet::~PackageSet() = default;
 
+PackageSet & PackageSet::operator=(const PackageSet & other) {
+    *pImpl = *other.pImpl;
+    return *this;
+}
+
+PackageSet & PackageSet::operator=(PackageSet && other) {
+    *pImpl = std::move(*other.pImpl);
+    return *this;
+}
 
 PackageSet::iterator PackageSet::begin() const {
     PackageSet::iterator it(*this);

--- a/libdnf/rpm/package_set_impl.hpp
+++ b/libdnf/rpm/package_set_impl.hpp
@@ -56,6 +56,7 @@ public:
 
 private:
     friend PackageSet;
+    friend SolvQuery;
     SolvSackWeakPtr sack;
 };
 

--- a/libdnf/rpm/package_set_impl.hpp
+++ b/libdnf/rpm/package_set_impl.hpp
@@ -43,11 +43,14 @@ public:
     /// Clone from an existing map
     explicit Impl(SolvSack * sack, solv::SolvMap & solv_map);
 
-    /// Clone from an existing PackageSet
-    explicit Impl(const PackageSet & other);
-
     /// Copy constructor: clone from an existing PackageSet::Impl
     Impl(const Impl & other);
+
+    /// Move constructor: clone from an existing PackageSet::Impl
+    Impl(Impl && other);
+
+    Impl & operator=(const Impl & other);
+    Impl & operator=(Impl && other);
 
     SolvSack * get_sack() const { return sack.get(); }
 
@@ -61,19 +64,29 @@ inline PackageSet::Impl::Impl(SolvSack * sack)
     : solv::SolvMap::SolvMap(sack->pImpl->pool->nsolvables)
     , sack(sack->get_weak_ptr()) {}
 
-
 inline PackageSet::Impl::Impl(SolvSack * sack, solv::SolvMap & solv_map)
     : solv::SolvMap::SolvMap(solv_map)
     , sack(sack->get_weak_ptr()) {}
 
-
-inline PackageSet::Impl::Impl(const PackageSet & other) : Impl(*other.pImpl) {}
-
-
-inline PackageSet::Impl::Impl(const PackageSet::Impl & other)
+inline PackageSet::Impl::Impl(const Impl & other)
     : solv::SolvMap::SolvMap(other.get_map())
-    , sack(other.get_sack()->get_weak_ptr()) {}
+    , sack(other.sack) {}
 
+inline PackageSet::Impl::Impl(Impl && other)
+    : solv::SolvMap::SolvMap(std::move(other.get_map()))
+    , sack(std::move(other.sack)) {}
+
+inline PackageSet::Impl & PackageSet::Impl::operator=(const Impl & other) {
+    solv::SolvMap::operator=(other);
+    sack = other.sack;
+    return *this;
+}
+
+inline PackageSet::Impl & PackageSet::Impl::operator=(Impl && other) {
+    solv::SolvMap::operator=(std::move(other));
+    sack = std::move(other.sack);
+    return *this;
+}
 
 }  // namespace libdnf::rpm
 

--- a/libdnf/rpm/package_set_impl.hpp
+++ b/libdnf/rpm/package_set_impl.hpp
@@ -62,7 +62,7 @@ private:
 
 
 inline PackageSet::Impl::Impl(SolvSack * sack)
-    : solv::SolvMap::SolvMap(sack->pImpl->pool->nsolvables)
+    : solv::SolvMap::SolvMap(sack->p_impl->pool->nsolvables)
     , sack(sack->get_weak_ptr()) {}
 
 inline PackageSet::Impl::Impl(SolvSack * sack, solv::SolvMap & solv_map)

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -24,47 +24,47 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::rpm {
 
 
-PackageSetIterator::PackageSetIterator(const PackageSet & package_set) : pImpl{new Impl(package_set)} {}
+PackageSetIterator::PackageSetIterator(const PackageSet & package_set) : p_impl{new Impl(package_set)} {}
 
-PackageSetIterator::PackageSetIterator(const PackageSetIterator & other) : pImpl{new Impl(*other.pImpl)} {}
+PackageSetIterator::PackageSetIterator(const PackageSetIterator & other) : p_impl{new Impl(*other.p_impl)} {}
 
 PackageSetIterator::~PackageSetIterator() {}
 
 void PackageSetIterator::begin() {
-    pImpl->begin();
+    p_impl->begin();
 }
 
 
 void PackageSetIterator::end() {
-    pImpl->end();
+    p_impl->end();
 }
 
 
 Package PackageSetIterator::operator*() {
-    return {pImpl->package_set.get_sack(), **pImpl};
+    return {p_impl->package_set.get_sack(), **p_impl};
 }
 
 
 PackageSetIterator & PackageSetIterator::operator++() {
-    ++*pImpl;
+    ++*p_impl;
     return *this;
 }
 
 
 PackageSetIterator PackageSetIterator::operator++(int) {
     PackageSetIterator it(*this);
-    ++*pImpl;
+    ++*p_impl;
     return it;
 }
 
 
 bool PackageSetIterator::operator==(const PackageSetIterator & other) const {
-    return *pImpl == *other.pImpl;
+    return *p_impl == *other.p_impl;
 }
 
 
 bool PackageSetIterator::operator!=(const PackageSetIterator & other) const {
-    return *pImpl != *other.pImpl;
+    return *p_impl != *other.p_impl;
 }
 
 

--- a/libdnf/rpm/package_set_iterator_impl.hpp
+++ b/libdnf/rpm/package_set_iterator_impl.hpp
@@ -43,7 +43,7 @@ private:
 
 
 inline PackageSetIterator::Impl::Impl(const PackageSet & package_set)
-    : solv::SolvMap::iterator(package_set.pImpl->get_map())
+    : solv::SolvMap::iterator(package_set.p_impl->get_map())
     , package_set{package_set} {}
 
 inline PackageSetIterator::Impl & PackageSetIterator::Impl::operator++() {

--- a/libdnf/rpm/reldep.cpp
+++ b/libdnf/rpm/reldep.cpp
@@ -48,16 +48,16 @@ Reldep::Reldep(SolvSack * sack, const std::string & reldep_string) : sack(sack->
 Reldep::Reldep(Reldep && reldep) : sack(std::move(reldep.sack)), id(std::move(reldep.id)) {}
 
 const char * Reldep::get_name() const {
-    return pool_id2str(sack->pImpl->pool, id.id);
+    return pool_id2str(sack->p_impl->pool, id.id);
 }
 const char * Reldep::get_relation() const {
-    return pool_id2rel(sack->pImpl->pool, id.id);
+    return pool_id2rel(sack->p_impl->pool, id.id);
 }
 const char * Reldep::get_version() const {
-    return pool_id2evr(sack->pImpl->pool, id.id);
+    return pool_id2evr(sack->p_impl->pool, id.id);
 }
 std::string Reldep::to_string() {
-    auto * cstring = pool_dep2str(sack->pImpl->pool, id.id);
+    auto * cstring = pool_dep2str(sack->p_impl->pool, id.id);
     return cstring ? std::string(cstring) : std::string();
 }
 
@@ -68,7 +68,7 @@ ReldepId Reldep::get_reldep_id(SolvSack * sack, const char * name, const char * 
         static_cast<int>(Reldep::CmpType::LT) == REL_LT, "Reldep::ComparisonType::LT is not identical to solv/REL_LT");
     static_assert(
         static_cast<int>(Reldep::CmpType::GT) == REL_GT, "Reldep::ComparisonType::GT is not identical to solv/REL_GT");
-    Pool * pool = sack->pImpl->pool;
+    Pool * pool = sack->p_impl->pool;
     Id id = pool_str2id(pool, name, 1);
 
     if (version) {
@@ -81,7 +81,7 @@ ReldepId Reldep::get_reldep_id(SolvSack * sack, const char * name, const char * 
 ReldepId Reldep::get_reldep_id(SolvSack * sack, const std::string & reldep_str) {
     if (reldep_str[0] == '(') {
         // Rich dependency
-        Pool * pool = sack->pImpl->pool;
+        Pool * pool = sack->p_impl->pool;
         Id id = pool_parserpmrichdep(pool, reldep_str.c_str());
         // TODO(jmracek) Replace runtime_error. Do we need to throw an error?
         if (id == 0) {

--- a/libdnf/rpm/reldep_list.cpp
+++ b/libdnf/rpm/reldep_list.cpp
@@ -34,20 +34,20 @@ extern "C" {
 
 namespace libdnf::rpm {
 
-ReldepList::ReldepList(const ReldepList & src) : pImpl(new Impl(*src.pImpl)) {}
+ReldepList::ReldepList(const ReldepList & src) : p_impl(new Impl(*src.p_impl)) {}
 
-ReldepList::ReldepList(ReldepList && src) noexcept : pImpl(std::move(src.pImpl)) {}
+ReldepList::ReldepList(ReldepList && src) noexcept : p_impl(std::move(src.p_impl)) {}
 
-ReldepList::ReldepList(SolvSack * sack) : pImpl(new Impl(sack)) {}
+ReldepList::ReldepList(SolvSack * sack) : p_impl(new Impl(sack)) {}
 
 ReldepList::~ReldepList() = default;
 
 ReldepId ReldepList::get_id(int index) const noexcept {
-    return ReldepId(pImpl->queue[index]);
+    return ReldepId(p_impl->queue[index]);
 }
 
 ReldepList & ReldepList::operator=(ReldepList && src) noexcept {
-    pImpl.swap(src.pImpl);
+    p_impl.swap(src.p_impl);
     return *this;
 }
 
@@ -55,8 +55,8 @@ bool ReldepList::operator!=(const ReldepList & other) const noexcept {
     return !(*this == other);
 }
 bool ReldepList::operator==(const ReldepList & other) const noexcept {
-    auto & this_queue = pImpl->queue;
-    auto & other_queue = other.pImpl->queue;
+    auto & this_queue = p_impl->queue;
+    auto & other_queue = other.p_impl->queue;
     auto this_count = this_queue.size();
     if (this_count != other_queue.size())
         return false;
@@ -67,21 +67,21 @@ bool ReldepList::operator==(const ReldepList & other) const noexcept {
         }
     }
 
-    return pImpl->sack->pImpl->pool == other.pImpl->sack->pImpl->pool;
+    return p_impl->sack->p_impl->pool == other.p_impl->sack->p_impl->pool;
 }
 
 ReldepList & ReldepList::operator=(const ReldepList & src) {
-    pImpl->queue = src.pImpl->queue;
-    pImpl->sack = src.pImpl->sack;
+    p_impl->queue = src.p_impl->queue;
+    p_impl->sack = src.p_impl->sack;
     return *this;
 }
 
 void ReldepList::add(Reldep & reldep) {
-    pImpl->queue.push_back(reldep.id.id);
+    p_impl->queue.push_back(reldep.id.id);
 }
 
 void ReldepList::add(ReldepId id) {
-    pImpl->queue.push_back(id.id);
+    p_impl->queue.push_back(id.id);
 }
 
 bool ReldepList::add_reldep_with_glob(const std::string & reldep_str) {
@@ -89,8 +89,8 @@ bool ReldepList::add_reldep_with_glob(const std::string & reldep_str) {
     if (!dep_splitter.parse(reldep_str))
         return false;
 
-    auto * sack = pImpl->sack.get();
-    Pool * pool = sack->pImpl->pool;
+    auto * sack = p_impl->sack.get();
+    Pool * pool = sack->p_impl->pool;
 
     Dataiterator di;
     dataiterator_init(&di, pool, 0, 0, 0, dep_splitter.get_name_cstr(), SEARCH_STRING | SEARCH_GLOB);
@@ -119,7 +119,7 @@ bool ReldepList::add_reldep_with_glob(const std::string & reldep_str) {
 
 bool ReldepList::add_reldep(const std::string & reldep_str) {
     try {
-        ReldepId id = Reldep::get_reldep_id(pImpl->sack.get(), reldep_str);
+        ReldepId id = Reldep::get_reldep_id(p_impl->sack.get(), reldep_str);
         add(id);
         return true;
         // TODO(jmracek) Make catch error more specific
@@ -129,16 +129,16 @@ bool ReldepList::add_reldep(const std::string & reldep_str) {
 }
 
 void ReldepList::append(ReldepList & source) {
-    pImpl->queue.append(source.pImpl->queue);
+    p_impl->queue.append(source.p_impl->queue);
 }
 
 Reldep ReldepList::get(int index) const noexcept {
-    ReldepId id(pImpl->queue[index]);
-    return Reldep(pImpl->sack.get(), id);
+    ReldepId id(p_impl->queue[index]);
+    return Reldep(p_impl->sack.get(), id);
 }
 
 int ReldepList::size() const noexcept {
-    return pImpl->queue.size();
+    return p_impl->queue.size();
 }
 
 ReldepList::iterator ReldepList::begin() const {
@@ -153,7 +153,7 @@ ReldepList::iterator ReldepList::end() const {
 }
 
 SolvSack * ReldepList::get_sack() const {
-    return pImpl->get_sack();
+    return p_impl->get_sack();
 }
 
 }  // namespace libdnf::rpm

--- a/libdnf/rpm/reldep_list_iterator.cpp
+++ b/libdnf/rpm/reldep_list_iterator.cpp
@@ -24,47 +24,47 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::rpm {
 
 
-ReldepListIterator::ReldepListIterator(const ReldepList & reldep_list) : pImpl(new Impl(reldep_list)) {}
+ReldepListIterator::ReldepListIterator(const ReldepList & reldep_list) : p_impl(new Impl(reldep_list)) {}
 
-ReldepListIterator::ReldepListIterator(const ReldepListIterator & other) : pImpl(new Impl(*other.pImpl)) {}
+ReldepListIterator::ReldepListIterator(const ReldepListIterator & other) : p_impl(new Impl(*other.p_impl)) {}
 
 ReldepListIterator::~ReldepListIterator() {}
 
 void ReldepListIterator::begin() {
-    pImpl->begin();
+    p_impl->begin();
 }
 
 
 void ReldepListIterator::end() {
-    pImpl->end();
+    p_impl->end();
 }
 
 
 Reldep ReldepListIterator::operator*() {
-    return {pImpl->reldep_list.get_sack(), ReldepId(**pImpl)};
+    return {p_impl->reldep_list.get_sack(), ReldepId(**p_impl)};
 }
 
 
 ReldepListIterator & ReldepListIterator::operator++() {
-    ++*pImpl;
+    ++*p_impl;
     return *this;
 }
 
 
 ReldepListIterator ReldepListIterator::operator++(int) {
     ReldepListIterator it(*this);
-    ++*pImpl;
+    ++*p_impl;
     return it;
 }
 
 
 bool ReldepListIterator::operator==(const ReldepListIterator & other) const {
-    return *pImpl == *other.pImpl;
+    return *p_impl == *other.p_impl;
 }
 
 
 bool ReldepListIterator::operator!=(const ReldepListIterator & other) const {
-    return *pImpl != *other.pImpl;
+    return *p_impl != *other.p_impl;
 }
 
 

--- a/libdnf/rpm/reldep_list_iterator_impl.hpp
+++ b/libdnf/rpm/reldep_list_iterator_impl.hpp
@@ -43,7 +43,7 @@ private:
 
 
 inline ReldepListIterator::Impl::Impl(const ReldepList & reldep_list)
-    : solv::IdQueue::iterator(&(reldep_list.pImpl->get_idqueue().get_queue()))
+    : solv::IdQueue::iterator(&(reldep_list.p_impl->get_idqueue().get_queue()))
     , reldep_list{reldep_list} {}
 
 inline ReldepListIterator::Impl & ReldepListIterator::Impl::operator++() {

--- a/libdnf/rpm/solv/goal_private.cpp
+++ b/libdnf/rpm/solv/goal_private.cpp
@@ -223,9 +223,9 @@ void GoalPrivate::write_debugdata(const std::string & dir) {
 // PackageSet
 // Goal::listUnneeded()
 // {
-//     PackageSet pset(pImpl->sack);
+//     PackageSet pset(p_impl->sack);
 //     IdQueue queue;
-//     Solver *solv = pImpl->solv;
+//     Solver *solv = p_impl->solv;
 //
 //     solver_get_unneeded(solv, queue.getQueue(), 0);
 //     queue2pset(queue, &pset);
@@ -235,9 +235,9 @@ void GoalPrivate::write_debugdata(const std::string & dir) {
 // PackageSet
 // Goal::listSuggested()
 // {
-//     PackageSet pset(pImpl->sack);
+//     PackageSet pset(p_impl->sack);
 //     IdQueue queue;
-//     Solver *solv = pImpl->solv;
+//     Solver *solv = p_impl->solv;
 //
 //     solver_get_recommendations(solv, NULL, queue.getQueue(), 0);
 //     queue2pset(queue, &pset);

--- a/libdnf/rpm/solv/solv_map.hpp
+++ b/libdnf/rpm/solv/solv_map.hpp
@@ -72,16 +72,16 @@ public:
     /// Return the underlying libsolv Map
     ///
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.getMap()
-    const Map * get_map() const;
+    const Map * get_map() const noexcept;
 
     /// Return the number of solvables in the SolvMap (number of 1s in the bitmap).
     ///
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.size()
     std::size_t size() const noexcept;
 
-    bool empty() const;
+    bool empty() const noexcept;
 
-    void clear();
+    void clear() noexcept;
 
     // ITEM OPERATIONS
 
@@ -89,50 +89,52 @@ public:
     void add(PackageId package_id);
 
     /// Faster, but unsafe version of add() method that is doesn't check bitmap range
-    void add_unsafe(PackageId package_id);
+    void add_unsafe(PackageId package_id) noexcept;
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.has(Id id)
-    bool contains(PackageId package_id) const;
+    bool contains(PackageId package_id) const noexcept;
 
     /// Faster, but unsafe version of contains() method that is doesn't check bitmap range
-    bool contains_unsafe(PackageId package_id) const;
+    bool contains_unsafe(PackageId package_id) const noexcept;
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.remove(Id id)
     void remove(PackageId package_id);
 
     /// Faster, but unsafe version of remove() method that is doesn't check bitmap range
-    void remove_unsafe(PackageId package_id);
+    void remove_unsafe(PackageId package_id) noexcept;
 
     // SET OPERATIONS - Map
 
     /// Union operator
     ///
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.operator+=(const Map * other)
-    SolvMap & operator|=(const Map * other);
+    SolvMap & operator|=(const Map * other) noexcept;
 
     /// Difference operator
     ///
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.operator-=(const Map * other)
-    SolvMap & operator-=(const Map * other);
+    SolvMap & operator-=(const Map * other) noexcept;
 
     /// Intersection operator
     ///
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.operator/=(const Map * other)
-    SolvMap & operator&=(const Map * other);
+    SolvMap & operator&=(const Map * other) noexcept;
 
     // SET OPERATIONS - SolvMap
 
     /// Union operator
-    SolvMap & operator|=(const SolvMap & other);
+    SolvMap & operator|=(const SolvMap & other) noexcept;
 
     /// Difference operator
-    SolvMap & operator-=(const SolvMap & other);
+    SolvMap & operator-=(const SolvMap & other) noexcept;
 
     /// Intersection operator
-    SolvMap & operator&=(const SolvMap & other);
+    SolvMap & operator&=(const SolvMap & other) noexcept;
 
-    SolvMap & operator=(const SolvMap & other);
+    SolvMap & operator=(const SolvMap & other) noexcept;
     SolvMap & operator=(SolvMap && other) noexcept;
+
+    void swap(SolvMap & other) noexcept;
 
 protected:
     /// Check if `id` is in bitmap range.
@@ -196,7 +198,7 @@ inline void SolvMap::add(PackageId package_id) {
 }
 
 
-inline bool SolvMap::contains(PackageId package_id) const {
+inline bool SolvMap::contains(PackageId package_id) const noexcept {
     if (package_id.id < 0 || package_id.id >= (map.size << 3)) {
         // if Id is outside bitmap range, then bitmap doesn't contain it
         return false;
@@ -211,7 +213,7 @@ inline void SolvMap::remove(PackageId package_id) {
 }
 
 
-inline void SolvMap::add_unsafe(PackageId package_id) {
+inline void SolvMap::add_unsafe(PackageId package_id) noexcept {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
     MAPSET(&map, package_id.id);
@@ -219,12 +221,12 @@ inline void SolvMap::add_unsafe(PackageId package_id) {
 }
 
 
-inline bool SolvMap::contains_unsafe(PackageId package_id) const {
+inline bool SolvMap::contains_unsafe(PackageId package_id) const noexcept {
     return MAPTST(&map, package_id.id);
 }
 
 
-inline void SolvMap::remove_unsafe(PackageId package_id) {
+inline void SolvMap::remove_unsafe(PackageId package_id) noexcept {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
     MAPCLR(&map, package_id.id);
@@ -232,12 +234,12 @@ inline void SolvMap::remove_unsafe(PackageId package_id) {
 }
 
 
-inline const Map * SolvMap::get_map() const {
+inline const Map * SolvMap::get_map() const noexcept {
     return &map;
 }
 
 
-inline bool SolvMap::empty() const {
+inline bool SolvMap::empty() const noexcept {
     const unsigned char * byte = map.map;
     const unsigned char * end = byte + map.size;
 
@@ -267,47 +269,47 @@ inline std::size_t SolvMap::size() const noexcept {
 }
 
 
-inline void SolvMap::clear() {
+inline void SolvMap::clear() noexcept {
     map_empty(&map);
 }
 
 
-inline SolvMap & SolvMap::operator|=(const Map * other) {
+inline SolvMap & SolvMap::operator|=(const Map * other) noexcept {
     map_or(&map, const_cast<Map *>(other));
     return *this;
 }
 
 
-inline SolvMap & SolvMap::operator|=(const SolvMap & other) {
+inline SolvMap & SolvMap::operator|=(const SolvMap & other) noexcept {
     *this |= other.get_map();
     return *this;
 }
 
 
-inline SolvMap & SolvMap::operator-=(const Map * other) {
+inline SolvMap & SolvMap::operator-=(const Map * other) noexcept {
     map_subtract(&map, const_cast<Map *>(other));
     return *this;
 }
 
 
-inline SolvMap & SolvMap::operator-=(const SolvMap & other) {
+inline SolvMap & SolvMap::operator-=(const SolvMap & other) noexcept {
     *this -= other.get_map();
     return *this;
 }
 
 
-inline SolvMap & SolvMap::operator&=(const Map * other) {
+inline SolvMap & SolvMap::operator&=(const Map * other) noexcept {
     map_and(&map, other);
     return *this;
 }
 
 
-inline SolvMap & SolvMap::operator&=(const SolvMap & other) {
+inline SolvMap & SolvMap::operator&=(const SolvMap & other) noexcept {
     *this &= other.get_map();
     return *this;
 }
 
-inline SolvMap & SolvMap::operator=(const SolvMap & other) {
+inline SolvMap & SolvMap::operator=(const SolvMap & other) noexcept {
     map_free(&map);
     map_init_clone(&map, &other.map);
     return *this;
@@ -317,6 +319,11 @@ inline SolvMap & SolvMap::operator=(SolvMap && other) noexcept {
     std::swap(map, other.map);
     return *this;
 }
+
+inline void SolvMap::swap(SolvMap & other) noexcept {
+    std::swap(map, other.map);
+}
+
 
 }  // namespace libdnf::rpm::solv
 

--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -205,7 +205,7 @@ inline bool name_compare_icase_lower_id(const std::pair<Id, Solvable *> first, I
 }  //  namespace
 
 
-SolvQuery::SolvQuery(SolvSack * sack, InitFlags flags) : PackageSet(sack) {
+SolvQuery::SolvQuery(SolvSack * sack, InitFlags flags) : PackageSet(sack), init_flags(flags) {
     switch (flags) {
         case InitFlags::EMPTY:
             break;

--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -246,14 +246,6 @@ SolvQuery & SolvQuery::operator-=(const SolvQuery & other) {
     return *this;
 }
 
-PackageSet & SolvQuery::get_package_set() {
-    return *this;
-}
-
-const PackageSet & SolvQuery::get_package_set() const {
-    return *this;
-}
-
 template <const char * (*c_string_getter_fnc)(Pool * pool, libdnf::rpm::PackageId)>
 inline static void filter_glob_internal(
     Pool * pool,

--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -214,7 +214,7 @@ SolvQuery::SolvQuery(SolvSack * sack, InitFlags flags) : PackageSet(sack), init_
         case InitFlags::APPLY_EXCLUDES:
         case InitFlags::IGNORE_MODULAR_EXCLUDES:
         case InitFlags::IGNORE_REGULAR_EXCLUDES:
-            *pImpl |= sack->pImpl->get_solvables();
+            *p_impl |= sack->p_impl->get_solvables();
             break;
     }
 }
@@ -236,9 +236,9 @@ inline static void filter_glob_internal(
 
 SolvQuery & SolvQuery::ifilter_name(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {
     SolvSack * sack = get_sack();
-    Pool * pool = sack->pImpl->get_pool();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    auto & sorted_solvables = sack->pImpl->get_sorted_solvables();
+    Pool * pool = sack->p_impl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    auto & sorted_solvables = sack->p_impl->get_sorted_solvables();
 
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
@@ -270,7 +270,7 @@ SolvQuery & SolvQuery::ifilter_name(libdnf::sack::QueryCmp cmp_type, const std::
                 }
             } break;
             case libdnf::sack::QueryCmp::IEXACT: {
-                auto & sorted_icase_solvables = sack->pImpl->get_sorted_icase_solvables();
+                auto & sorted_icase_solvables = sack->p_impl->get_sorted_icase_solvables();
                 Id icase_name = libdnf::utils::id_to_lowercase_id(pool, pattern.c_str(), 0);
                 if (icase_name == 0) {
                     continue;
@@ -286,7 +286,7 @@ SolvQuery & SolvQuery::ifilter_name(libdnf::sack::QueryCmp cmp_type, const std::
                 }
             } break;
             case libdnf::sack::QueryCmp::ICONTAINS: {
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     const char * name = solv::get_name(pool, candidate_id);
                     if (strcasestr(name, c_pattern) != nullptr) {
                         filter_result.add_unsafe(candidate_id);
@@ -294,10 +294,10 @@ SolvQuery & SolvQuery::ifilter_name(libdnf::sack::QueryCmp cmp_type, const std::
                 }
             } break;
             case libdnf::sack::QueryCmp::IGLOB:
-                filter_glob_internal<solv::get_name>(pool, c_pattern, *pImpl, filter_result, FNM_CASEFOLD);
+                filter_glob_internal<solv::get_name>(pool, c_pattern, *p_impl, filter_result, FNM_CASEFOLD);
                 break;
             case libdnf::sack::QueryCmp::CONTAINS: {
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     const char * name = solv::get_name(pool, candidate_id);
                     if (strstr(name, c_pattern) != nullptr) {
                         filter_result.add_unsafe(candidate_id);
@@ -305,7 +305,7 @@ SolvQuery & SolvQuery::ifilter_name(libdnf::sack::QueryCmp cmp_type, const std::
                 }
             } break;
             case libdnf::sack::QueryCmp::GLOB:
-                filter_glob_internal<solv::get_name>(pool, c_pattern, *pImpl, filter_result, 0);
+                filter_glob_internal<solv::get_name>(pool, c_pattern, *p_impl, filter_result, 0);
                 break;
             default:
                 throw SolvQuery::NotSupportedCmpType("Used unsupported CmpType");
@@ -314,9 +314,9 @@ SolvQuery & SolvQuery::ifilter_name(libdnf::sack::QueryCmp cmp_type, const std::
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
     return *this;
 }
@@ -360,22 +360,22 @@ inline static void filter_evr_internal(
 }
 
 SolvQuery & SolvQuery::ifilter_evr(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {
-    Pool * pool = pImpl->sack->pImpl->get_pool();
+    Pool * pool = p_impl->sack->p_impl->get_pool();
     switch (cmp_type) {
         case libdnf::sack::QueryCmp::GT:
-            filter_evr_internal<cmp_gt>(patterns, pool, *pImpl);
+            filter_evr_internal<cmp_gt>(patterns, pool, *p_impl);
             break;
         case libdnf::sack::QueryCmp::LT:
-            filter_evr_internal<cmp_lt>(patterns, pool, *pImpl);
+            filter_evr_internal<cmp_lt>(patterns, pool, *p_impl);
             break;
         case libdnf::sack::QueryCmp::GTE:
-            filter_evr_internal<cmp_gte>(patterns, pool, *pImpl);
+            filter_evr_internal<cmp_gte>(patterns, pool, *p_impl);
             break;
         case libdnf::sack::QueryCmp::LTE:
-            filter_evr_internal<cmp_lte>(patterns, pool, *pImpl);
+            filter_evr_internal<cmp_lte>(patterns, pool, *p_impl);
             break;
         case libdnf::sack::QueryCmp::EQ:
-            filter_evr_internal<cmp_eq>(patterns, pool, *pImpl);
+            filter_evr_internal<cmp_eq>(patterns, pool, *p_impl);
             break;
         default:
             throw NotSupportedCmpType("Used unsupported CmpType");
@@ -385,8 +385,8 @@ SolvQuery & SolvQuery::ifilter_evr(libdnf::sack::QueryCmp cmp_type, const std::v
 
 SolvQuery & SolvQuery::ifilter_arch(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {
     SolvSack * sack = get_sack();
-    Pool * pool = sack->pImpl->get_pool();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -409,7 +409,7 @@ SolvQuery & SolvQuery::ifilter_arch(libdnf::sack::QueryCmp cmp_type, const std::
                 if (match_arch_id == 0) {
                     continue;
                 }
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     Solvable * solvable = solv::get_solvable(pool, candidate_id);
                     if (solvable->arch == match_arch_id) {
                         filter_result.add_unsafe(candidate_id);
@@ -417,7 +417,7 @@ SolvQuery & SolvQuery::ifilter_arch(libdnf::sack::QueryCmp cmp_type, const std::
                 }
             } break;
             case libdnf::sack::QueryCmp::GLOB:
-                filter_glob_internal<solv::get_arch>(pool, c_pattern, *pImpl, filter_result, 0);
+                filter_glob_internal<solv::get_arch>(pool, c_pattern, *p_impl, filter_result, 0);
                 break;
             default:
                 throw NotSupportedCmpType("Unsupported CmpType");
@@ -426,9 +426,9 @@ SolvQuery & SolvQuery::ifilter_arch(libdnf::sack::QueryCmp cmp_type, const std::
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -560,9 +560,9 @@ SolvQuery & SolvQuery::ifilter_nevra(libdnf::sack::QueryCmp cmp_type, const std:
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
 
-    auto & sorted_solvables = sack->pImpl->get_sorted_solvables();
+    auto & sorted_solvables = sack->p_impl->get_sorted_solvables();
 
     for (auto & pattern : patterns) {
         Impl::filter_nevra(*this, sorted_solvables, pattern, cmp_glob, cmp_type, filter_result);
@@ -570,9 +570,9 @@ SolvQuery & SolvQuery::ifilter_nevra(libdnf::sack::QueryCmp cmp_type, const std:
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -587,15 +587,15 @@ SolvQuery & SolvQuery::ifilter_nevra(libdnf::sack::QueryCmp cmp_type, const libd
 
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
 
-    solv::SolvMap filter_result(get_sack()->pImpl->get_nsolvables());
+    solv::SolvMap filter_result(get_sack()->p_impl->get_nsolvables());
 
     Impl::filter_nevra(*this, pattern, cmp_glob, cmp_type, filter_result, true);
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -624,8 +624,8 @@ SolvQuery & SolvQuery::ifilter_version(libdnf::sack::QueryCmp cmp_type, const st
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
 
     for (auto & pattern : patterns) {
@@ -637,22 +637,22 @@ SolvQuery & SolvQuery::ifilter_version(libdnf::sack::QueryCmp cmp_type, const st
         }
         switch (tmp_cmp_type) {
             case libdnf::sack::QueryCmp::EQ:
-                filter_version_internal<cmp_eq>(pool, c_pattern, *pImpl, filter_result);
+                filter_version_internal<cmp_eq>(pool, c_pattern, *p_impl, filter_result);
                 break;
             case libdnf::sack::QueryCmp::GLOB:
-                filter_glob_internal<solv::get_version>(pool, c_pattern, *pImpl, filter_result, 0);
+                filter_glob_internal<solv::get_version>(pool, c_pattern, *p_impl, filter_result, 0);
                 break;
             case libdnf::sack::QueryCmp::GT:
-                filter_version_internal<cmp_gt>(pool, c_pattern, *pImpl, filter_result);
+                filter_version_internal<cmp_gt>(pool, c_pattern, *p_impl, filter_result);
                 break;
             case libdnf::sack::QueryCmp::LT:
-                filter_version_internal<cmp_lt>(pool, c_pattern, *pImpl, filter_result);
+                filter_version_internal<cmp_lt>(pool, c_pattern, *p_impl, filter_result);
                 break;
             case libdnf::sack::QueryCmp::GTE:
-                filter_version_internal<cmp_gte>(pool, c_pattern, *pImpl, filter_result);
+                filter_version_internal<cmp_gte>(pool, c_pattern, *p_impl, filter_result);
                 break;
             case libdnf::sack::QueryCmp::LTE:
-                filter_version_internal<cmp_lte>(pool, c_pattern, *pImpl, filter_result);
+                filter_version_internal<cmp_lte>(pool, c_pattern, *p_impl, filter_result);
                 break;
             default:
                 throw NotSupportedCmpType("Used unsupported CmpType");
@@ -661,9 +661,9 @@ SolvQuery & SolvQuery::ifilter_version(libdnf::sack::QueryCmp cmp_type, const st
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -692,8 +692,8 @@ SolvQuery & SolvQuery::ifilter_release(libdnf::sack::QueryCmp cmp_type, const st
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
 
     for (auto & pattern : patterns) {
@@ -705,22 +705,22 @@ SolvQuery & SolvQuery::ifilter_release(libdnf::sack::QueryCmp cmp_type, const st
         }
         switch (tmp_cmp_type) {
             case libdnf::sack::QueryCmp::EQ:
-                filter_release_internal<cmp_eq>(pool, c_pattern, *pImpl, filter_result);
+                filter_release_internal<cmp_eq>(pool, c_pattern, *p_impl, filter_result);
                 break;
             case libdnf::sack::QueryCmp::GLOB:
-                filter_glob_internal<solv::get_release>(pool, c_pattern, *pImpl, filter_result, 0);
+                filter_glob_internal<solv::get_release>(pool, c_pattern, *p_impl, filter_result, 0);
                 break;
             case libdnf::sack::QueryCmp::GT:
-                filter_release_internal<cmp_gt>(pool, c_pattern, *pImpl, filter_result);
+                filter_release_internal<cmp_gt>(pool, c_pattern, *p_impl, filter_result);
                 break;
             case libdnf::sack::QueryCmp::LT:
-                filter_release_internal<cmp_lt>(pool, c_pattern, *pImpl, filter_result);
+                filter_release_internal<cmp_lt>(pool, c_pattern, *p_impl, filter_result);
                 break;
             case libdnf::sack::QueryCmp::GTE:
-                filter_release_internal<cmp_gte>(pool, c_pattern, *pImpl, filter_result);
+                filter_release_internal<cmp_gte>(pool, c_pattern, *p_impl, filter_result);
                 break;
             case libdnf::sack::QueryCmp::LTE:
-                filter_release_internal<cmp_lte>(pool, c_pattern, *pImpl, filter_result);
+                filter_release_internal<cmp_lte>(pool, c_pattern, *p_impl, filter_result);
                 break;
             default:
                 throw NotSupportedCmpType("Used unsupported CmpType");
@@ -729,9 +729,9 @@ SolvQuery & SolvQuery::ifilter_release(libdnf::sack::QueryCmp cmp_type, const st
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -745,8 +745,8 @@ SolvQuery & SolvQuery::ifilter_repoid(libdnf::sack::QueryCmp cmp_type, const std
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
 
     Id repo_id;
@@ -783,7 +783,7 @@ SolvQuery & SolvQuery::ifilter_repoid(libdnf::sack::QueryCmp cmp_type, const std
                 throw NotSupportedCmpType("Used unsupported CmpType");
         }
     }
-    for (PackageId candidate_id : *pImpl) {
+    for (PackageId candidate_id : *p_impl) {
         auto * solvable = solv::get_solvable(pool, candidate_id);
         if (solvable->repo && repo_ids[solvable->repo->repoid]) {
             filter_result.add_unsafe(candidate_id);
@@ -792,9 +792,9 @@ SolvQuery & SolvQuery::ifilter_repoid(libdnf::sack::QueryCmp cmp_type, const std
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -808,8 +808,8 @@ SolvQuery & SolvQuery::ifilter_sourcerpm(libdnf::sack::QueryCmp cmp_type, const 
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
 
     for (auto & pattern : patterns) {
@@ -821,7 +821,7 @@ SolvQuery & SolvQuery::ifilter_sourcerpm(libdnf::sack::QueryCmp cmp_type, const 
         }
         switch (tmp_cmp_type) {
             case libdnf::sack::QueryCmp::EQ:
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto * solvable = solv::get_solvable(pool, candidate_id);
                     const char * name = solvable_lookup_str(solvable, SOLVABLE_SOURCENAME);
                     if (name == nullptr) {
@@ -839,7 +839,7 @@ SolvQuery & SolvQuery::ifilter_sourcerpm(libdnf::sack::QueryCmp cmp_type, const 
                 }
                 break;
             case libdnf::sack::QueryCmp::GLOB:
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto * sourcerpm = solv::get_sourcerpm(pool, candidate_id);
                     if (sourcerpm && (fnmatch(c_pattern, sourcerpm, 0) == 0)) {
                         filter_result.add_unsafe(candidate_id);
@@ -853,9 +853,9 @@ SolvQuery & SolvQuery::ifilter_sourcerpm(libdnf::sack::QueryCmp cmp_type, const 
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -869,13 +869,13 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
 
     switch (cmp_type) {
         case libdnf::sack::QueryCmp::EQ:
             for (auto & pattern : patterns) {
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto candidate_epoch = solv::get_epoch(pool, candidate_id);
                     if (candidate_epoch == pattern) {
                         filter_result.add_unsafe(candidate_id);
@@ -885,7 +885,7 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
             break;
         case libdnf::sack::QueryCmp::GT:
             for (auto & pattern : patterns) {
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto candidate_epoch = solv::get_epoch(pool, candidate_id);
                     if (candidate_epoch > pattern) {
                         filter_result.add_unsafe(candidate_id);
@@ -895,7 +895,7 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
             break;
         case libdnf::sack::QueryCmp::LT:
             for (auto & pattern : patterns) {
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto candidate_epoch = solv::get_epoch(pool, candidate_id);
                     if (candidate_epoch < pattern) {
                         filter_result.add_unsafe(candidate_id);
@@ -905,7 +905,7 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
             break;
         case libdnf::sack::QueryCmp::GTE:
             for (auto & pattern : patterns) {
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto candidate_epoch = solv::get_epoch(pool, candidate_id);
                     if (candidate_epoch >= pattern) {
                         filter_result.add_unsafe(candidate_id);
@@ -915,7 +915,7 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
             break;
         case libdnf::sack::QueryCmp::LTE:
             for (auto & pattern : patterns) {
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto candidate_epoch = solv::get_epoch(pool, candidate_id);
                     if (candidate_epoch <= pattern) {
                         filter_result.add_unsafe(candidate_id);
@@ -929,9 +929,9 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -945,8 +945,8 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
 
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
 
@@ -960,7 +960,7 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
 
         switch (tmp_cmp_type) {
             case libdnf::sack::QueryCmp::EQ:
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto candidate_epoch = solv::get_epoch_cstring(pool, candidate_id);
                     if (strcmp(candidate_epoch, c_pattern) == 0) {
                         filter_result.add_unsafe(candidate_id);
@@ -968,7 +968,7 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
                 }
                 break;
             case libdnf::sack::QueryCmp::GLOB:
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     auto candidate_epoch = solv::get_epoch_cstring(pool, candidate_id);
                     if (fnmatch(c_pattern, candidate_epoch, 0) == 0) {
                         filter_result.add_unsafe(candidate_id);
@@ -982,9 +982,9 @@ SolvQuery & SolvQuery::ifilter_epoch(libdnf::sack::QueryCmp cmp_type, const std:
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -1068,33 +1068,33 @@ static void filter_dataiterator_internal(
 }
 
 SolvQuery & SolvQuery::ifilter_file(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {
-    Pool * pool = get_sack()->pImpl->get_pool();
+    Pool * pool = get_sack()->p_impl->get_pool();
 
-    filter_dataiterator_internal(pool, SOLVABLE_FILELIST, *pImpl, cmp_type, patterns);
+    filter_dataiterator_internal(pool, SOLVABLE_FILELIST, *p_impl, cmp_type, patterns);
 
     return *this;
 }
 
 SolvQuery & SolvQuery::ifilter_description(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {
-    Pool * pool = get_sack()->pImpl->get_pool();
+    Pool * pool = get_sack()->p_impl->get_pool();
 
-    filter_dataiterator_internal(pool, SOLVABLE_DESCRIPTION, *pImpl, cmp_type, patterns);
+    filter_dataiterator_internal(pool, SOLVABLE_DESCRIPTION, *p_impl, cmp_type, patterns);
 
     return *this;
 }
 
 SolvQuery & SolvQuery::ifilter_summary(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {
-    Pool * pool = get_sack()->pImpl->get_pool();
+    Pool * pool = get_sack()->p_impl->get_pool();
 
-    filter_dataiterator_internal(pool, SOLVABLE_SUMMARY, *pImpl, cmp_type, patterns);
+    filter_dataiterator_internal(pool, SOLVABLE_SUMMARY, *p_impl, cmp_type, patterns);
 
     return *this;
 }
 
 SolvQuery & SolvQuery::ifilter_url(libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns) {
-    Pool * pool = get_sack()->pImpl->get_pool();
+    Pool * pool = get_sack()->p_impl->get_pool();
 
-    filter_dataiterator_internal(pool, SOLVABLE_URL, *pImpl, cmp_type, patterns);
+    filter_dataiterator_internal(pool, SOLVABLE_URL, *p_impl, cmp_type, patterns);
 
     return *this;
 }
@@ -1107,14 +1107,14 @@ SolvQuery & SolvQuery::ifilter_location(libdnf::sack::QueryCmp cmp_type, const s
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
 
     switch (cmp_type) {
         case libdnf::sack::QueryCmp::EQ: {
             for (auto & pattern : patterns) {
                 const char * c_pattern = pattern.c_str();
-                for (PackageId candidate_id : *pImpl) {
+                for (PackageId candidate_id : *p_impl) {
                     Solvable * solvable = solv::get_solvable(pool, candidate_id);
                     const char * location = solvable_get_location(solvable, NULL);
                     if (location && strcmp(c_pattern, location) == 0) {
@@ -1129,9 +1129,9 @@ SolvQuery & SolvQuery::ifilter_location(libdnf::sack::QueryCmp cmp_type, const s
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -1145,17 +1145,17 @@ SolvQuery & SolvQuery::ifilter_provides(libdnf::sack::QueryCmp cmp_type, const R
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
 
-    sack->pImpl->make_provides_ready();
+    sack->p_impl->make_provides_ready();
     Impl::filter_provides(pool, cmp_type, reldep_list, filter_result);
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -1264,14 +1264,14 @@ void SolvQuery::Impl::filter_reldep(
 
     SolvSack * sack = pkg_set.get_sack();
 
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
 
-    sack->pImpl->make_provides_ready();
+    sack->p_impl->make_provides_ready();
 
     solv::IdQueue rco;
 
-    for (PackageId candidate_id : *pkg_set.pImpl) {
+    for (PackageId candidate_id : *pkg_set.p_impl) {
         Solvable * solvable = solv::get_solvable(pool, candidate_id);
         auto reldep_list_size = reldep_list.size();
         for (int index = 0; index < reldep_list_size; ++index) {
@@ -1293,9 +1293,9 @@ void SolvQuery::Impl::filter_reldep(
 
     // Apply filter results to query
     if (cmp_not) {
-        *pkg_set.pImpl -= filter_result;
+        *pkg_set.p_impl -= filter_result;
     } else {
-        *pkg_set.pImpl &= filter_result;
+        *pkg_set.p_impl &= filter_result;
     }
 }
 
@@ -1316,14 +1316,14 @@ void SolvQuery::Impl::filter_reldep(
 
     SolvSack * sack = pkg_set.get_sack();
 
-    sack->pImpl->make_provides_ready();
+    sack->p_impl->make_provides_ready();
 
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
 
     solv::IdQueue out;
 
-    for (auto package_id : *package_set.pImpl) {
+    for (auto package_id : *package_set.p_impl) {
         out.clear();
 
         // queue_push2 because we are creating a selection, which contains pairs
@@ -1346,9 +1346,9 @@ void SolvQuery::Impl::filter_reldep(
 
     // Apply filter results to query
     if (cmp_not) {
-        *pkg_set.pImpl -= filter_result;
+        *pkg_set.p_impl -= filter_result;
     } else {
-        *pkg_set.pImpl &= filter_result;
+        *pkg_set.p_impl &= filter_result;
     }
 }
 
@@ -1360,7 +1360,7 @@ void SolvQuery::Impl::filter_nevra(
     solv::SolvMap & filter_result,
     bool with_src) {
     SolvSack * sack = pkg_set.get_sack();
-    Pool * pool = sack->pImpl->get_pool();
+    Pool * pool = sack->p_impl->get_pool();
 
     auto & name = pattern.get_name();
     const char * name_c_pattern = name.c_str();
@@ -1394,7 +1394,7 @@ void SolvQuery::Impl::filter_nevra(
     Id src = with_src ? 0 : pool_str2id(pool, "src", 0);
 
     if (!name.empty()) {
-        auto & sorted_solvables = sack->pImpl->get_sorted_solvables();
+        auto & sorted_solvables = sack->p_impl->get_sorted_solvables();
 
         switch (name_cmp_type) {
             case libdnf::sack::QueryCmp::EQ: {
@@ -1430,7 +1430,7 @@ void SolvQuery::Impl::filter_nevra(
                 }
             } break;
             case libdnf::sack::QueryCmp::IEXACT: {
-                auto & sorted_icase_solvables = sack->pImpl->get_sorted_icase_solvables();
+                auto & sorted_icase_solvables = sack->p_impl->get_sorted_icase_solvables();
                 Id icase_name = libdnf::utils::id_to_lowercase_id(pool, name_c_pattern, 0);
                 if (icase_name == 0) {
                     break;
@@ -1468,7 +1468,7 @@ void SolvQuery::Impl::filter_nevra(
             case libdnf::sack::QueryCmp::GLOB:
             case libdnf::sack::QueryCmp::IGLOB: {
                 int fnmatch_flags = name_cmp_type == libdnf::sack::QueryCmp::IGLOB ? FNM_CASEFOLD : 0;
-                for (PackageId candidate_id : *pkg_set.pImpl) {
+                for (PackageId candidate_id : *pkg_set.p_impl) {
                     const char * candidate_name = solv::get_name(pool, candidate_id);
                     if (!all_names && fnmatch(name_c_pattern, candidate_name, fnmatch_flags) != 0) {
                         continue;
@@ -1499,7 +1499,7 @@ void SolvQuery::Impl::filter_nevra(
                 throw NotSupportedCmpType("Unsupported CmpType");
         }
     } else if (!epoch.empty() || !version.empty() || !release.empty() || !arch.empty()) {
-        for (PackageId candidate_id : *pkg_set.pImpl) {
+        for (PackageId candidate_id : *pkg_set.p_impl) {
             if (!is_valid_candidate(
                     pool,
                     candidate_id,
@@ -1537,7 +1537,7 @@ void SolvQuery::Impl::filter_nevra(
         tmp_cmp_type = (tmp_cmp_type - libdnf::sack::QueryCmp::GLOB) | libdnf::sack::QueryCmp::EQ;
     }
 
-    Pool * pool = pkg_set.get_sack()->pImpl->get_pool();
+    Pool * pool = pkg_set.get_sack()->p_impl->get_pool();
 
     switch (tmp_cmp_type) {
         case libdnf::sack::QueryCmp::EQ: {
@@ -1566,13 +1566,13 @@ void SolvQuery::Impl::filter_nevra(
             filter_nevra_internal<cmp_lte>(pool, c_pattern, sorted_solvables, filter_result);
             break;
         case libdnf::sack::QueryCmp::GLOB:
-            filter_glob_internal<solv::get_nevra>(pool, c_pattern, *pkg_set.pImpl, filter_result, 0);
+            filter_glob_internal<solv::get_nevra>(pool, c_pattern, *pkg_set.p_impl, filter_result, 0);
             break;
         case libdnf::sack::QueryCmp::IGLOB:
-            filter_glob_internal<solv::get_nevra>(pool, c_pattern, *pkg_set.pImpl, filter_result, FNM_CASEFOLD);
+            filter_glob_internal<solv::get_nevra>(pool, c_pattern, *pkg_set.p_impl, filter_result, FNM_CASEFOLD);
             break;
         case libdnf::sack::QueryCmp::IEXACT: {
-            for (PackageId candidate_id : *pkg_set.pImpl) {
+            for (PackageId candidate_id : *pkg_set.p_impl) {
                 const char * nevra = solv::get_nevra(pool, candidate_id);
                 if (strcasecmp(nevra, c_pattern) == 0) {
                     filter_result.add_unsafe(candidate_id);
@@ -1640,15 +1640,15 @@ SolvQuery & SolvQuery::ifilter_obsoletes(libdnf::sack::QueryCmp cmp_type, const 
     }
 
     SolvSack * sack = get_sack();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    Pool * pool = sack->pImpl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
 
-    sack->pImpl->make_provides_ready();
+    sack->p_impl->make_provides_ready();
 
     int obsprovides = pool_get_flag(pool, POOL_FLAG_OBSOLETEUSESPROVIDES);
 
-    auto & target = *package_set.pImpl;
-    for (auto package_id : *pImpl) {
+    auto & target = *package_set.p_impl;
+    for (auto package_id : *p_impl) {
         Solvable * solvable = solv::get_solvable(pool, package_id);
         if (!solvable->repo)
             continue;
@@ -1673,9 +1673,9 @@ SolvQuery & SolvQuery::ifilter_obsoletes(libdnf::sack::QueryCmp cmp_type, const 
 
     // Apply filter results to query
     if (cmp_not) {
-        *pImpl -= filter_result;
+        *p_impl -= filter_result;
     } else {
-        *pImpl &= filter_result;
+        *p_impl &= filter_result;
     }
 
     return *this;
@@ -1743,15 +1743,15 @@ SolvQuery & SolvQuery::ifilter_supplements(libdnf::sack::QueryCmp cmp_type, cons
 
 SolvQuery & SolvQuery::ifilter_installed() {
     SolvSack * sack = get_sack();
-    Pool * pool = sack->pImpl->get_pool();
+    Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
-        (*pImpl).clear();
+        (*p_impl).clear();
         return *this;
     }
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
-    auto it = pImpl->begin();
-    auto end = pImpl->end();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
+    auto it = p_impl->begin();
+    auto end = p_impl->end();
     for (it.jump(PackageId(installed_repo->start)); it != end; ++it) {
         Solvable * solvable = solv::get_solvable(pool, *it);
         if (solvable->repo == installed_repo) {
@@ -1763,23 +1763,23 @@ SolvQuery & SolvQuery::ifilter_installed() {
         }
     }
     // TODO(jrohel): The optimization replaces the original query_result buffer. Is it OK?
-    // Or we need to use a slower version "*pImpl &= filter_result;"
-    pImpl->swap(filter_result);
+    // Or we need to use a slower version "*p_impl &= filter_result;"
+    p_impl->swap(filter_result);
     return *this;
 }
 
 SolvQuery & SolvQuery::ifilter_available() {
-    Pool * pool = pImpl->sack->pImpl->get_pool();
+    Pool * pool = p_impl->sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
         return *this;
     }
-    auto it = pImpl->begin();
-    auto end = pImpl->end();
+    auto it = p_impl->begin();
+    auto end = p_impl->end();
     for (it.jump(PackageId(installed_repo->start)); it != end; ++it) {
         Solvable * solvable = solv::get_solvable(pool, *it);
         if (solvable->repo == installed_repo) {
-            pImpl->remove_unsafe(*it);
+            p_impl->remove_unsafe(*it);
             continue;
         }
         if ((*it).id >= installed_repo->end) {
@@ -1791,23 +1791,23 @@ SolvQuery & SolvQuery::ifilter_available() {
 
 SolvQuery & SolvQuery::ifilter_upgrades() {
     SolvSack * sack = get_sack();
-    Pool * pool = sack->pImpl->get_pool();
+    Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
         clear();
         return *this;
     }
 
-    sack->pImpl->make_provides_ready();
+    sack->p_impl->make_provides_ready();
 
-    for (PackageId candidate_id : *pImpl) {
+    for (PackageId candidate_id : *p_impl) {
         Solvable * solvable = solv::get_solvable(pool, candidate_id);
         if (solvable->repo == installed_repo) {
-            pImpl->remove_unsafe(candidate_id);
+            p_impl->remove_unsafe(candidate_id);
             continue;
         }
         if (what_upgrades(pool, solvable) <= 0) {
-            pImpl->remove_unsafe(candidate_id);
+            p_impl->remove_unsafe(candidate_id);
         }
     }
 
@@ -1816,7 +1816,7 @@ SolvQuery & SolvQuery::ifilter_upgrades() {
 
 SolvQuery & SolvQuery::ifilter_downgrades() {
     SolvSack * sack = get_sack();
-    Pool * pool = sack->pImpl->get_pool();
+    Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
 
     if (pool->installed == nullptr) {
@@ -1824,16 +1824,16 @@ SolvQuery & SolvQuery::ifilter_downgrades() {
         return *this;
     }
 
-    sack->pImpl->make_provides_ready();
+    sack->p_impl->make_provides_ready();
 
-    for (PackageId candidate_id : *pImpl) {
+    for (PackageId candidate_id : *p_impl) {
         Solvable * solvable = solv::get_solvable(pool, candidate_id);
         if (solvable->repo == installed_repo) {
-            pImpl->remove_unsafe(candidate_id);
+            p_impl->remove_unsafe(candidate_id);
             continue;
         }
         if (what_downgrades(pool, solvable) <= 0) {
-            pImpl->remove_unsafe(candidate_id);
+            p_impl->remove_unsafe(candidate_id);
         }
     }
 
@@ -1842,7 +1842,7 @@ SolvQuery & SolvQuery::ifilter_downgrades() {
 
 SolvQuery & SolvQuery::ifilter_upgradable() {
     SolvSack * sack = get_sack();
-    Pool * pool = sack->pImpl->get_pool();
+    Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
 
     if (pool->installed == nullptr) {
@@ -1850,10 +1850,10 @@ SolvQuery & SolvQuery::ifilter_upgradable() {
         return *this;
     }
 
-    sack->pImpl->make_provides_ready();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
+    sack->p_impl->make_provides_ready();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
 
-    for (auto pkg_id : sack->pImpl->get_solvables()) {
+    for (auto pkg_id : sack->p_impl->get_solvables()) {
         // if (flags == Query::ExcludeFlags::APPLY_EXCLUDES) {
         //     if (pool->considered && !map_tst(pool->considered, p))
         //         continue;
@@ -1874,14 +1874,14 @@ SolvQuery & SolvQuery::ifilter_upgradable() {
             filter_result.add_unsafe(PackageId(what));
         }
     }
-    *pImpl &= filter_result;
+    *p_impl &= filter_result;
 
     return *this;
 }
 
 SolvQuery & SolvQuery::ifilter_downgradable() {
     SolvSack * sack = get_sack();
-    Pool * pool = sack->pImpl->get_pool();
+    Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
 
     if (pool->installed == nullptr) {
@@ -1889,10 +1889,10 @@ SolvQuery & SolvQuery::ifilter_downgradable() {
         return *this;
     }
 
-    sack->pImpl->make_provides_ready();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
+    sack->p_impl->make_provides_ready();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
 
-    for (auto pkg_id : sack->pImpl->get_solvables()) {
+    for (auto pkg_id : sack->p_impl->get_solvables()) {
         //  if (flags == Query::ExcludeFlags::APPLY_EXCLUDES) {
         //      if (pool->considered && !map_tst(pool->considered, p))
         //          continue;
@@ -1913,7 +1913,7 @@ SolvQuery & SolvQuery::ifilter_downgradable() {
             filter_result.add_unsafe(PackageId(what));
         }
     }
-    *pImpl &= filter_result;
+    *p_impl &= filter_result;
 
     return *this;
 }
@@ -1927,8 +1927,8 @@ std::pair<bool, libdnf::rpm::Nevra> SolvQuery::resolve_pkg_spec(
     bool with_src,
     const std::vector<libdnf::rpm::Nevra::Form> & forms) {
     SolvSack * sack = get_sack();
-    Pool * pool = sack->pImpl->get_pool();
-    solv::SolvMap filter_result(sack->pImpl->get_nsolvables());
+    Pool * pool = sack->p_impl->get_pool();
+    solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     if (with_nevra) {
         const std::vector<Nevra::Form> & test_forms = forms.empty() ? Nevra::PKG_SPEC_FORMS : forms;
         Nevra nevra_obj;
@@ -1941,16 +1941,16 @@ std::pair<bool, libdnf::rpm::Nevra> SolvQuery::resolve_pkg_spec(
                     icase ? libdnf::sack::QueryCmp::IGLOB : libdnf::sack::QueryCmp::GLOB,
                     filter_result,
                     with_src);
-                filter_result &= *pImpl;
+                filter_result &= *p_impl;
                 if (!filter_result.empty()) {
                     // Apply filter results to query
-                    *pImpl &= filter_result;
+                    *p_impl &= filter_result;
                     return {true, libdnf::rpm::Nevra(std::move(nevra_obj))};
                 }
             }
         }
         if (forms.empty()) {
-            auto & sorted_solvables = get_sack()->pImpl->get_sorted_solvables();
+            auto & sorted_solvables = get_sack()->p_impl->get_sorted_solvables();
             Impl::filter_nevra(
                 *this,
                 sorted_solvables,
@@ -1958,9 +1958,9 @@ std::pair<bool, libdnf::rpm::Nevra> SolvQuery::resolve_pkg_spec(
                 true,
                 icase ? libdnf::sack::QueryCmp::IGLOB : libdnf::sack::QueryCmp::GLOB,
                 filter_result);
-            filter_result &= *pImpl;
+            filter_result &= *p_impl;
             if (!filter_result.empty()) {
-                *pImpl &= filter_result;
+                *p_impl &= filter_result;
                 return {true, libdnf::rpm::Nevra()};
             }
         }
@@ -1968,11 +1968,11 @@ std::pair<bool, libdnf::rpm::Nevra> SolvQuery::resolve_pkg_spec(
     if (with_provides) {
         ReldepList reldep_list(sack);
         str2reldep_internal(reldep_list, libdnf::sack::QueryCmp::GLOB, true, pkg_spec);
-        sack->pImpl->make_provides_ready();
+        sack->p_impl->make_provides_ready();
         Impl::filter_provides(pool, libdnf::sack::QueryCmp::EQ, reldep_list, filter_result);
-        filter_result &= *pImpl;
+        filter_result &= *p_impl;
         if (!filter_result.empty()) {
-            *pImpl &= filter_result;
+            *p_impl &= filter_result;
             return {true, libdnf::rpm::Nevra()};
         }
     }
@@ -1981,11 +1981,11 @@ std::pair<bool, libdnf::rpm::Nevra> SolvQuery::resolve_pkg_spec(
             pool,
             SOLVABLE_FILELIST,
             SEARCH_FILES | SEARCH_COMPLETE_FILELIST | SEARCH_GLOB,
-            *pImpl,
+            *p_impl,
             filter_result,
             pkg_spec.c_str());
         if (!filter_result.empty()) {
-            *pImpl &= filter_result;
+            *p_impl &= filter_result;
             return {true, libdnf::rpm::Nevra()};
         }
     }
@@ -1994,7 +1994,7 @@ std::pair<bool, libdnf::rpm::Nevra> SolvQuery::resolve_pkg_spec(
 }
 
 void SolvQuery::swap(SolvQuery & other) noexcept {
-    pImpl->swap(*other.pImpl);
+    p_impl->swap(*other.p_impl);
 }
 
 }  //  namespace libdnf::rpm

--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -219,33 +219,6 @@ SolvQuery::SolvQuery(SolvSack * sack, InitFlags flags) : PackageSet(sack) {
     }
 }
 
-SolvQuery & SolvQuery::operator|=(const SolvQuery & other) {
-    if (pImpl->sack != other.pImpl->sack) {
-        throw UsedDifferentSack(
-            "Cannot perform the action with SolvQuery instances initialized with different SolvSacks");
-    }
-    *pImpl |= *other.pImpl;
-    return *this;
-}
-
-SolvQuery & SolvQuery::operator&=(const SolvQuery & other) {
-    if (pImpl->sack != other.pImpl->sack) {
-        throw UsedDifferentSack(
-            "Cannot perform the action with SolvQuery instances initialized with different SolvSacks");
-    }
-    *pImpl &= *other.pImpl;
-    return *this;
-}
-
-SolvQuery & SolvQuery::operator-=(const SolvQuery & other) {
-    if (pImpl->sack != other.pImpl->sack) {
-        throw UsedDifferentSack(
-            "Cannot perform the action with SolvQuery instances initialized with different SolvSacks");
-    }
-    *pImpl -= *other.pImpl;
-    return *this;
-}
-
 template <const char * (*c_string_getter_fnc)(Pool * pool, libdnf::rpm::PackageId)>
 inline static void filter_glob_internal(
     Pool * pool,

--- a/libdnf/rpm/solv_query_impl.hpp
+++ b/libdnf/rpm/solv_query_impl.hpp
@@ -25,12 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "solv/solv_map.hpp"
 
 extern "C" {
-#include <solv/chksum.h>
-#include <solv/evr.h>
-#include <solv/repo.h>
-#include <solv/selection.h>
 #include <solv/solvable.h>
-#include <solv/solver.h>
 }
 
 namespace libdnf::rpm {
@@ -38,40 +33,33 @@ namespace libdnf::rpm {
 
 class SolvQuery::Impl {
 public:
-    Impl(SolvSack * sack, InitFlags flags);
-    Impl(const SolvQuery::Impl & src) = default;
-    Impl(const SolvQuery::Impl && src) = delete;
-    ~Impl() = default;
-
-    SolvQuery::Impl & operator=(const SolvQuery::Impl & src);
-    SolvQuery::Impl & operator=(SolvQuery::Impl && src) noexcept;
-
-    void filter_provides(
+    static void filter_provides(
         Pool * pool, libdnf::sack::QueryCmp cmp_type, const ReldepList & reldep_list, solv::SolvMap & filter_result);
-    void filter_reldep(Id libsolv_key, libdnf::sack::QueryCmp cmp_type, const std::vector<std::string> & patterns);
-    void filter_reldep(Id libsolv_key, libdnf::sack::QueryCmp cmp_type, const ReldepList & reldep_list);
-    void filter_reldep(Id libsolv_key, libdnf::sack::QueryCmp cmp_type, const PackageSet & package_set);
+    static void filter_reldep(
+        PackageSet & pkg_set,
+        Id libsolv_key,
+        libdnf::sack::QueryCmp cmp_type,
+        const std::vector<std::string> & patterns);
+    static void filter_reldep(
+        PackageSet & pkg_set, Id libsolv_key, libdnf::sack::QueryCmp cmp_type, const ReldepList & reldep_list);
+    static void filter_reldep(
+        PackageSet & pkg_set, Id libsolv_key, libdnf::sack::QueryCmp cmp_type, const PackageSet & package_set);
 
     /// @param cmp_glob performance optimization - it must be in synchronization with cmp_type
-    void filter_nevra(
+    static void filter_nevra(
+        PackageSet & pkg_set,
         const Nevra & pattern,
         bool cmp_glob,
         libdnf::sack::QueryCmp cmp_type,
         solv::SolvMap & filter_result,
         bool with_src);
-    void filter_nevra(
-        Pool * pool,
-        const std::vector<Solvable *> sorted_solvables,
+    static void filter_nevra(
+        PackageSet & pkg_set,
+        const std::vector<Solvable *> & sorted_solvables,
         const std::string & pattern,
         bool cmp_glob,
         libdnf::sack::QueryCmp cmp_type,
         solv::SolvMap & filter_result);
-
-private:
-    friend class SolvQuery;
-    friend libdnf::Goal;
-    SolvSackWeakPtr sack;
-    solv::SolvMap query_result;
 };
 
 

--- a/libdnf/rpm/solv_sack.cpp
+++ b/libdnf/rpm/solv_sack.cpp
@@ -561,16 +561,16 @@ void SolvSack::load_repo(Repo & repo, LoadRepoFlags flags) {
     if (repo_impl->type != Repo::Type::AVAILABLE) {
         throw LogicError("SolvSack::load_repo(): User can load only \"available\" repository");
     }
-    pImpl->load_available_repo(repo, flags);
+    p_impl->load_available_repo(repo, flags);
 }
 
 void SolvSack::create_system_repo(bool build_cache) {
-    if (pImpl->system_repo) {
+    if (p_impl->system_repo) {
         throw LogicError("SolvSack::create_system_repo(): System repo already exists");
     }
-    pImpl->system_repo = std::make_unique<Repo>(SYSTEM_REPO_NAME, *pImpl->base, Repo::Type::SYSTEM);
-    pImpl->system_repo->get_config().build_cache().set(libdnf::Option::Priority::RUNTIME, build_cache);
-    pImpl->load_system_repo();
+    p_impl->system_repo = std::make_unique<Repo>(SYSTEM_REPO_NAME, *p_impl->base, Repo::Type::SYSTEM);
+    p_impl->system_repo->get_config().build_cache().set(libdnf::Option::Priority::RUNTIME, build_cache);
+    p_impl->load_system_repo();
 }
 
 Repo & SolvSack::Impl::get_cmdline_repo() {
@@ -587,11 +587,11 @@ Repo & SolvSack::Impl::get_cmdline_repo() {
 }
 
 Package SolvSack::add_cmdline_package(const std::string & fn, bool add_with_hdrid) {
-    auto & repo = pImpl->get_cmdline_repo();
+    auto & repo = p_impl->get_cmdline_repo();
     auto new_id = repo.p_impl->add_rpm_package(fn, add_with_hdrid);
 
-    pImpl->provides_ready = false;
-    pImpl->considered_uptodate = false;
+    p_impl->provides_ready = false;
+    p_impl->considered_uptodate = false;
     return Package(this, PackageId(new_id));
 }
 
@@ -611,16 +611,16 @@ Repo & SolvSack::Impl::get_system_repo(bool build_cache) {
 }
 
 Package SolvSack::add_system_package(const std::string & fn, bool add_with_hdrid, bool build_cache) {
-    auto & repo = pImpl->get_system_repo(build_cache);
+    auto & repo = p_impl->get_system_repo(build_cache);
     auto new_id = repo.p_impl->add_rpm_package(fn, add_with_hdrid);
 
-    pImpl->provides_ready = false;
-    pImpl->considered_uptodate = false;
+    p_impl->provides_ready = false;
+    p_impl->considered_uptodate = false;
     return Package(this, PackageId(new_id));
 }
 
 void SolvSack::dump_debugdata(const std::string & dir) {
-    Solver * solver = solver_create(pImpl->pool);
+    Solver * solver = solver_create(p_impl->pool);
 
     try {
         std::filesystem::create_directory(dir);
@@ -637,11 +637,11 @@ void SolvSack::dump_debugdata(const std::string & dir) {
 }
 
 SolvSackWeakPtr SolvSack::get_weak_ptr() {
-    return SolvSackWeakPtr(this, &pImpl->data_guard);
+    return SolvSackWeakPtr(this, &p_impl->data_guard);
 }
 
 int SolvSack::get_nsolvables() const noexcept {
-    return pImpl->get_nsolvables();
+    return p_impl->get_nsolvables();
 };
 
 // TODO(jrohel): we want to change directory for solv(x) cache (into repo metadata directory?)
@@ -657,7 +657,7 @@ std::string SolvSack::Impl::give_repo_solv_cache_fn(const std::string & repoid, 
     return fn;
 }
 
-SolvSack::SolvSack(Base & base) : pImpl{new Impl(base)} {}
+SolvSack::SolvSack(Base & base) : p_impl{new Impl(base)} {}
 
 SolvSack::~SolvSack() = default;
 

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -83,7 +83,7 @@ void CmdDownload::run(Context & ctx) {
         libdnf::rpm::SolvQuery solv_query(full_solv_query);
         solv_query.resolve_pkg_spec(
             dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value(), true, true, true, true, true, {});
-        result_pset |= solv_query.get_package_set();
+        result_pset |= solv_query;
     }
 
     std::vector<libdnf::rpm::Package> download_pkgs;

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -86,7 +86,7 @@ void CmdReinstall::run(Context & ctx) {
     for (auto & pattern : *patterns_to_reinstall_options) {
         libdnf::rpm::SolvQuery solv_query(full_solv_query);
         solv_query.resolve_pkg_spec(dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value(), true, true, true, true, true, {});
-        result_pset |= solv_query.get_package_set();
+        result_pset |= solv_query;
     }
 
     std::vector<libdnf::rpm::Package> download_pkgs;

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -135,7 +135,7 @@ void CmdRepoquery::run(Context & ctx) {
     for (auto & pattern : *patterns_to_show_options) {
         libdnf::rpm::SolvQuery solv_query(full_solv_query);
         solv_query.resolve_pkg_spec(dynamic_cast<libdnf::OptionString *>(pattern.get())->get_value(), true, true, true, true, true, {});
-        result_pset |= solv_query.get_package_set();
+        result_pset |= solv_query;
     }
 
     if (info_option->get_value()) {

--- a/test/libdnf/rpm/test_package.cpp
+++ b/test/libdnf/rpm/test_package.cpp
@@ -45,7 +45,7 @@ libdnf::rpm::Package RpmPackageTest::get_pkg(const std::string &nevra) {
         1lu,
         query.size()
     );
-    return *query.get_package_set().begin();
+    return *query.begin();
 }
 
 

--- a/test/libdnf/rpm/test_solv_query.cpp
+++ b/test/libdnf/rpm/test_solv_query.cpp
@@ -62,8 +62,7 @@ void RpmSolvQueryTest::test_ifilter_name() {
     std::vector<std::string> names{"CQRlib"};
     query.ifilter_name(libdnf::sack::QueryCmp::EQ, names);
     CPPUNIT_ASSERT_EQUAL(2lu, query.size());
-    auto pset = query.get_package_set();
-    for (auto pkg : pset) {
+    for (auto pkg : query) {
         CPPUNIT_ASSERT(nevras.find(pkg.get_nevra()) != nevras.end());
     }
 
@@ -72,8 +71,7 @@ void RpmSolvQueryTest::test_ifilter_name() {
     std::vector<std::string> names2{"CQ?lib"};
     query2.ifilter_name(libdnf::sack::QueryCmp::GLOB, names2);
     CPPUNIT_ASSERT_EQUAL(2lu, query2.size());
-    auto pset2 = query2.get_package_set();
-    for (auto pkg : pset2) {
+    for (auto pkg : query2) {
         CPPUNIT_ASSERT(nevras.find(pkg.get_nevra()) != nevras.end());
     }
 
@@ -82,8 +80,7 @@ void RpmSolvQueryTest::test_ifilter_name() {
     libdnf::rpm::SolvQuery query3(sack);
     query3.ifilter_name(libdnf::sack::QueryCmp::EQ, names).ifilter_arch(libdnf::sack::QueryCmp::EQ, arches);
     CPPUNIT_ASSERT_EQUAL(1lu, query3.size());
-    auto pset3 = query3.get_package_set();
-    for (auto pkg : pset3) {
+    for (auto pkg : query3) {
         CPPUNIT_ASSERT(pkg.get_nevra() == "CQRlib-1.1.1-4.fc29.src");
     }
 
@@ -97,8 +94,7 @@ void RpmSolvQueryTest::test_ifilter_name() {
     std::vector<std::string> names_icase{"cqrlib"};
     query5.ifilter_name(libdnf::sack::QueryCmp::IEXACT, names_icase);
     CPPUNIT_ASSERT_EQUAL(2lu, query5.size());
-    auto pset4 = query5.get_package_set();
-    for (auto pkg : pset4) {
+    for (auto pkg : query5) {
         CPPUNIT_ASSERT(nevras.find(pkg.get_nevra()) != nevras.end());
     }
     query5.ifilter_name(libdnf::sack::QueryCmp::EQ, names_icase);
@@ -109,8 +105,7 @@ void RpmSolvQueryTest::test_ifilter_name() {
     std::vector<std::string> names_glob_icase{"cq?lib"};
     query6.ifilter_name(libdnf::sack::QueryCmp::IGLOB, names_glob_icase);
     CPPUNIT_ASSERT_EQUAL(2lu, query6.size());
-    auto pset5 = query6.get_package_set();
-    for (auto pkg : pset5) {
+    for (auto pkg : query6) {
         CPPUNIT_ASSERT(nevras.find(pkg.get_nevra()) != nevras.end());
     }
     query6.ifilter_name(libdnf::sack::QueryCmp::GLOB, names_glob_icase);
@@ -121,8 +116,7 @@ void RpmSolvQueryTest::test_ifilter_name() {
     std::vector<std::string> names_contains{"QRli"};
     query7.ifilter_name(libdnf::sack::QueryCmp::CONTAINS, names_contains);
     CPPUNIT_ASSERT_EQUAL(4lu, query7.size());
-    auto pset6 = query7.get_package_set();
-    for (auto pkg : pset6) {
+    for (auto pkg : query7) {
         CPPUNIT_ASSERT(nevras_contains.find(pkg.get_nevra()) != nevras_contains.end());
     }
 
@@ -131,8 +125,7 @@ void RpmSolvQueryTest::test_ifilter_name() {
     std::vector<std::string> names_icontains{"qRli"};
     query8.ifilter_name(libdnf::sack::QueryCmp::ICONTAINS, names_icontains);
     CPPUNIT_ASSERT_EQUAL(4lu, query8.size());
-    auto pset7 = query8.get_package_set();
-    for (auto pkg : pset7) {
+    for (auto pkg : query8) {
         CPPUNIT_ASSERT(nevras_contains.find(pkg.get_nevra()) != nevras_contains.end());
     }
     query8.ifilter_name(libdnf::sack::QueryCmp::CONTAINS, names_icontains);
@@ -147,8 +140,7 @@ void RpmSolvQueryTest::test_ifilter_name() {
     std::vector<std::string> names3{"CQRlib", "nodejs"};
     query9.ifilter_name(libdnf::sack::QueryCmp::EQ, names3);
     CPPUNIT_ASSERT_EQUAL(4lu, query9.size());
-    auto pset8 = query9.get_package_set();
-    for (auto pkg : pset8) {
+    for (auto pkg : query9) {
         CPPUNIT_ASSERT(full_nevras.find(pkg.get_full_nevra()) != full_nevras.end());
     }
 }
@@ -162,8 +154,7 @@ void RpmSolvQueryTest::test_ifilter_nevra() {
         std::vector<std::string> nevras_without_0_epoch{"CQRlib-1.1.1-4.fc29.src", "CQRlib-1.1.1-4.fc29.x86_64"};
         query.ifilter_nevra(libdnf::sack::QueryCmp::EQ, nevras_without_0_epoch);
         CPPUNIT_ASSERT_EQUAL(2lu, query.size());
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
         }
     }
@@ -174,8 +165,7 @@ void RpmSolvQueryTest::test_ifilter_nevra() {
         std::vector<std::string> nevras_with_0_epoch{"CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64"};
         query.ifilter_nevra(libdnf::sack::QueryCmp::EQ, nevras_with_0_epoch);
         CPPUNIT_ASSERT_EQUAL(2lu, query.size());
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
         }
     }
@@ -186,8 +176,7 @@ void RpmSolvQueryTest::test_ifilter_nevra() {
         std::vector<std::string> nevras_without_0_epoch{"CQRlib-1.1.1-4.fc29.src"};
         query.ifilter_nevra(libdnf::sack::QueryCmp::EQ, nevras_without_0_epoch);
         CPPUNIT_ASSERT_EQUAL(1lu, query.size());
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT(pkg.get_full_nevra() == "CQRlib-0:1.1.1-4.fc29.src");
         }
     }
@@ -198,8 +187,7 @@ void RpmSolvQueryTest::test_ifilter_nevra() {
         std::vector<std::string> nevras_with_0_epoch{"CQRlib-0:1.1.1-4.fc29.src"};
         query.ifilter_nevra(libdnf::sack::QueryCmp::EQ, nevras_with_0_epoch);
         CPPUNIT_ASSERT_EQUAL(1lu, query.size());
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT(pkg.get_full_nevra() == "CQRlib-0:1.1.1-4.fc29.src");
         }
     }
@@ -238,8 +226,7 @@ void RpmSolvQueryTest::test_ifilter_version() {
         std::vector<std::string> version{"1.1.1"};
         query.ifilter_version(libdnf::sack::QueryCmp::EQ, version);
         CPPUNIT_ASSERT(query.size() == 2);
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
         }
     }
@@ -254,8 +241,7 @@ void RpmSolvQueryTest::test_ifilter_release() {
         std::vector<std::string> release{"4.fc29"};
         query.ifilter_release(libdnf::sack::QueryCmp::EQ, release);
         CPPUNIT_ASSERT(query.size() == 5);
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
         }
     }
@@ -268,8 +254,7 @@ void RpmSolvQueryTest::test_ifilter_provides() {
         std::vector<std::string> provides{"glibc-langpack-hr"};
         query.ifilter_provides(libdnf::sack::QueryCmp::EQ, provides);
         CPPUNIT_ASSERT_EQUAL(1lu, query.size());
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT(pkg.get_full_nevra() == "glibc-langpack-hr-0:2.28-9.fc29.x86_64");
         }
     }
@@ -290,8 +275,7 @@ void RpmSolvQueryTest::test_ifilter_requires() {
         std::vector<std::string> requires {"wget"};
         query.ifilter_requires(libdnf::sack::QueryCmp::EQ, requires);
         CPPUNIT_ASSERT_EQUAL(1lu, query.size());
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT(pkg.get_full_nevra() == "abcde-0:2.9.2-1.fc29.noarch");
         }
     }
@@ -312,8 +296,7 @@ void RpmSolvQueryTest::test_resolve_pkg_spec() {
         auto return_value = query.resolve_pkg_spec("wget.x86_64", false, true, false, false, true, {});
         CPPUNIT_ASSERT_EQUAL(query.size(), 1lu);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT_EQUAL(pkg.get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
         }
     }
@@ -324,8 +307,7 @@ void RpmSolvQueryTest::test_resolve_pkg_spec() {
         auto return_value = query.resolve_pkg_spec("Wget.x86_64", true, true, false, false, true, {});
         CPPUNIT_ASSERT_EQUAL(query.size(), 1lu);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT_EQUAL(pkg.get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
         }
     }
@@ -336,8 +318,7 @@ void RpmSolvQueryTest::test_resolve_pkg_spec() {
         auto return_value = query.resolve_pkg_spec("wget > 1", false, true, true, false, true, {});
         CPPUNIT_ASSERT_EQUAL(query.size(), 1lu);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT_EQUAL(pkg.get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
         }
     }
@@ -347,8 +328,7 @@ void RpmSolvQueryTest::test_resolve_pkg_spec() {
         auto return_value = query.resolve_pkg_spec("wge?-?:1.1?.5-?.fc29.x8?_64", false, true, false, false, true, {});
         CPPUNIT_ASSERT_EQUAL(query.size(), 1lu);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT_EQUAL(pkg.get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
         }
     }
@@ -364,8 +344,7 @@ void RpmSolvQueryTest::test_resolve_pkg_spec() {
         auto return_value = query.resolve_pkg_spec("wGe?-?:1.1?.5-?.fc29.x8?_64", true, true, false, false, true, {});
         CPPUNIT_ASSERT_EQUAL(query.size(), 1lu);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT_EQUAL(pkg.get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
         }
     }
@@ -375,8 +354,7 @@ void RpmSolvQueryTest::test_resolve_pkg_spec() {
         auto return_value = query.resolve_pkg_spec("wgeT-0:1.19.5-5.Fc29.X86_64", true, true, false, false, true, {});
         CPPUNIT_ASSERT_EQUAL(query.size(), 1lu);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        auto pset = query.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query) {
             CPPUNIT_ASSERT_EQUAL(pkg.get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
         }
     }
@@ -400,8 +378,7 @@ void RpmSolvQueryTest::test_update() {
         query1.update(query2);
 
         CPPUNIT_ASSERT_EQUAL(4lu, query1.size());
-        auto pset = query1.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query1) {
             CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
         }
     }
@@ -424,8 +401,7 @@ void RpmSolvQueryTest::test_intersection() {
         query1.intersection(query2);
 
         CPPUNIT_ASSERT_EQUAL(2lu, query1.size());
-        auto pset = query1.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query1) {
             CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
         }
     }
@@ -448,8 +424,7 @@ void RpmSolvQueryTest::test_difference() {
         query1.difference(query2);
 
         CPPUNIT_ASSERT_EQUAL(3lu, query1.size());
-        auto pset = query1.get_package_set();
-        for (auto pkg : pset) {
+        for (auto pkg : query1) {
             CPPUNIT_ASSERT(nevras.find(pkg.get_full_nevra()) != nevras.end());
         }
     }

--- a/test/perl5/libdnf/rpm/test_solv_query.t
+++ b/test/perl5/libdnf/rpm/test_solv_query.t
@@ -66,10 +66,8 @@ my @full_nevras = ("CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64",
     my $names = ["CQRlib"];
     $query->ifilter_name($libdnf::common::QueryCmp_EQ, $names);
     is($query->size(), 2);
-    my $pset = $query->get_package_set();
-    is($pset->size(), 2);
-    my $it = $pset->begin();
-    my $e = $pset->end();
+    my $it = $query->begin();
+    my $e = $query->end();
     my %nevras_map = map { $_ => 1 } @nevras;
     while ($it != $e) {
         ok(exists($nevras_map{$it->value()->get_nevra()}));
@@ -83,9 +81,8 @@ my @full_nevras = ("CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64",
     my $names2 = ["CQ?lib"];
     $query2->ifilter_name($libdnf::common::QueryCmp_GLOB, $names2);
     is($query2->size(), 2);
-    my $pset2 = $query2->get_package_set();
-    my $it = $pset2->begin();
-    my $e = $pset2->end();
+    my $it = $query2->begin();
+    my $e = $query2->end();
     my %nevras_map = map { $_ => 1 } @nevras;
     while ($it != $e) {
         ok(exists($nevras_map{$it->value()->get_nevra()}));

--- a/test/python3/libdnf/rpm/test_solv_query.py
+++ b/test/python3/libdnf/rpm/test_solv_query.py
@@ -51,13 +51,12 @@ class TestSolvQuery(unittest.TestCase):
         query = libdnf.rpm.SolvQuery(self.sack)
         self.assertEqual(query.size(), 291)
 
-    def test_iterate_packageset(self):
+    def test_iterate_solv_query(self):
         query = libdnf.rpm.SolvQuery(self.sack)
 
-        # Iterates over helping reference "pset".
-        pset = query.get_package_set()
+        # Iterates over reference "query".
         prev_id = 0
-        for pkg in pset:
+        for pkg in query:
             id = pkg.get_id().id
             self.assertGreater(id, prev_id)
             prev_id = id
@@ -65,11 +64,11 @@ class TestSolvQuery(unittest.TestCase):
         self.assertGreaterEqual(prev_id, query.size())
 
         # Similar to above, but longer notation.
-        pset_iterator = iter(pset)
+        query_iterator = iter(query)
         prev_id = 0
         while True:
             try:
-                pkg = next(pset_iterator)
+                pkg = next(query_iterator)
                 id = pkg.get_id().id
                 self.assertGreater(id, prev_id)
                 prev_id = id
@@ -78,37 +77,35 @@ class TestSolvQuery(unittest.TestCase):
         self.assertLess(prev_id, self.sack.get_nsolvables())
         self.assertGreaterEqual(prev_id, query.size())
 
-    def test_iterate_packageset2(self):
-        # Tests the iteration of an unreferenced PackageSet object. The iterator must hold a reference
+    def test_iterate_solv_query2(self):
+        # Tests the iteration of an unreferenced SolvQuery object. The iterator must hold a reference
         # to the iterated object, otherwise the gargabe collector can remove the object.
 
-        query = libdnf.rpm.SolvQuery(self.sack)
-
-        # Iterates directly over "get_package_set()" result. No helping reference.
+        # Iterates directly over "libdnf.rpm.SolvQuery(self.sack)" result. No helping reference.
         prev_id = 0
-        for pkg in query.get_package_set():
+        for pkg in libdnf.rpm.SolvQuery(self.sack):
             id = pkg.get_id().id
             self.assertGreater(id, prev_id)
             prev_id = id
         self.assertLess(prev_id, self.sack.get_nsolvables())
-        self.assertGreaterEqual(prev_id, query.size())
+        self.assertGreaterEqual(prev_id, libdnf.rpm.SolvQuery(self.sack).size())
 
-        # Another test. The iterator is created from the "pset" reference, but the reference
+        # Another test. The iterator is created from the "query" reference, but the reference
         # is removed (set to "None") before starting the iteration.
-        pset = query.get_package_set()
-        pset_iterator = iter(pset)
-        pset = None
+        query = libdnf.rpm.SolvQuery(self.sack)
+        query_iterator = iter(query)
+        query = None
         prev_id = 0
         while True:
             try:
-                pkg = next(pset_iterator)
+                pkg = next(query_iterator)
                 id = pkg.get_id().id
                 self.assertGreater(id, prev_id)
                 prev_id = id
             except StopIteration:
                 break
         self.assertLess(prev_id, self.sack.get_nsolvables())
-        self.assertGreaterEqual(prev_id, query.size())
+        self.assertGreaterEqual(prev_id, libdnf.rpm.SolvQuery(self.sack).size())
 
     def test_ifilter_name(self):
 
@@ -123,9 +120,7 @@ class TestSolvQuery(unittest.TestCase):
         names = ["CQRlib"]
         query.ifilter_name(libdnf.common.QueryCmp_EQ, names)
         self.assertEqual(query.size(), 2)
-        pset = query.get_package_set()
-        self.assertEqual(pset.size(), 2)
-        for pkg in pset:
+        for pkg in query:
             self.assertTrue(pkg.get_nevra() in nevras)
 
         # Test QueryCmp::GLOB
@@ -133,5 +128,5 @@ class TestSolvQuery(unittest.TestCase):
         names2 = ["CQ?lib"]
         query2.ifilter_name(libdnf.common.QueryCmp_GLOB, names2)
         self.assertEqual(query2.size(), 2)
-        for pkg in query2.get_package_set():
+        for pkg in query2:
             self.assertTrue(pkg.get_nevra() in nevras)

--- a/test/ruby/libdnf/rpm/test_solv_query.rb
+++ b/test/ruby/libdnf/rpm/test_solv_query.rb
@@ -69,10 +69,8 @@ class TestSimpleNumber < Test::Unit::TestCase
         names = ["CQRlib"]
         query.ifilter_name(Common::QueryCmp_EQ, names)
         assert_equal(query.size(), 2)
-        pset = query.get_package_set()
-        assert_equal(pset.size(), 2)
-        it = pset.begin()
-        e = pset.end()
+        it = query.begin()
+        e = query.end()
         while it != e
             assert(nevras.include?(it.value.get_nevra))
             it.next()
@@ -83,9 +81,8 @@ class TestSimpleNumber < Test::Unit::TestCase
         names2 = ["CQ?lib"]
         query2.ifilter_name(Common::QueryCmp_GLOB, names2)
         assert_equal(query2.size(), 2)
-        pset2 = query2.get_package_set()
-        it = pset2.begin()
-        e = pset2.end()
+        it = query2.begin()
+        e = query2.end()
         while it != e
             assert(nevras.include?(it.value.get_nevra))
             it.next()


### PR DESCRIPTION
Improved rpm :: sol :: SolvMap and rpm :: PackageSet:
- added swap() method
- fixed and optimized the copy assignment operator and the move assignment operator

Reorganized `rpm::SolvQuery`. It now inherits `rpm::PackageSet`. It support iteration. Iterators are inherited from `rpm::PackageSet`.

Unit tests and applications use `rpm::SolvQuery` directly instead of `rpm::PackageSet` helping object .