### PR TITLE
[context] improve retrieving repository configuration

### DIFF
--- a/libdnf/conf/Option.hpp
+++ b/libdnf/conf/Option.hpp
@@ -62,6 +62,8 @@ public:
     virtual void set(Priority priority, const std::string & value) = 0;
     virtual std::string getValueString() const = 0;
     virtual bool empty() const noexcept;
+    /// Resets the option to its initial state.
+    virtual void reset() = 0;
     virtual ~Option() = default;
 
 protected:

--- a/libdnf/conf/OptionBinds.cpp
+++ b/libdnf/conf/OptionBinds.cpp
@@ -66,6 +66,15 @@ bool OptionBinds::Item::getAddValue() const
     return addValue;
 }
 
+const Option & OptionBinds::Item::getOption() const
+{
+    return *option;
+}
+
+Option & OptionBinds::Item::getOption()
+{
+    return *option;
+}
 
 // =========== OptionBinds class ===============
 

--- a/libdnf/conf/OptionBinds.hpp
+++ b/libdnf/conf/OptionBinds.hpp
@@ -55,6 +55,8 @@ public:
         void newString(Option::Priority priority, const std::string & value);
         std::string getValueString() const;
         bool getAddValue() const;
+        const Option & getOption() const;
+        Option & getOption();
 
     private:
         friend class OptionBinds;

--- a/libdnf/conf/OptionBool.hpp
+++ b/libdnf/conf/OptionBool.hpp
@@ -47,6 +47,7 @@ public:
     std::string getValueString() const override;
     const char * const * getTrueValues() const noexcept;
     const char * const * getFalseValues() const noexcept;
+    void reset() override;
 
 protected:
     const char * const * const trueValues;
@@ -84,7 +85,13 @@ inline const char * const * OptionBool::getTrueValues() const noexcept
 
 inline const char * const * OptionBool::getFalseValues() const noexcept
 {
-    return falseValues ? falseValues : defFalseValues; 
+    return falseValues ? falseValues : defFalseValues;
+}
+
+inline void OptionBool::reset()
+{
+    value = defaultValue;
+    priority = Priority::DEFAULT;
 }
 
 }

--- a/libdnf/conf/OptionChild.hpp
+++ b/libdnf/conf/OptionChild.hpp
@@ -39,6 +39,7 @@ public:
     const typename ParentOptionType::ValueType getDefaultValue() const;
     std::string getValueString() const override;
     bool empty() const noexcept override;
+    void reset() override;
 
 private:
     const ParentOptionType * parent;
@@ -56,6 +57,7 @@ public:
     const std::string & getDefaultValue() const;
     std::string getValueString() const override;
     bool empty() const noexcept override;
+    void reset() override;
 
 private:
     const ParentOptionType * parent;
@@ -119,6 +121,12 @@ inline bool OptionChild<ParentOptionType, Enable>::empty() const noexcept
     return priority == Priority::EMPTY && parent->empty();
 }
 
+template <class ParentOptionType, class Enable>
+inline void OptionChild<ParentOptionType, Enable>::reset()
+{
+    priority = Priority::EMPTY;
+}
+
 template <class ParentOptionType>
 inline OptionChild<ParentOptionType, typename std::enable_if<std::is_same<typename ParentOptionType::ValueType, std::string>::value>::type>::OptionChild(const ParentOptionType & parent)
 : parent(&parent) {}
@@ -169,6 +177,12 @@ template <class ParentOptionType>
 inline bool OptionChild<ParentOptionType, typename std::enable_if<std::is_same<typename ParentOptionType::ValueType, std::string>::value>::type>::empty() const noexcept
 {
     return priority == Priority::EMPTY && parent->empty();
+}
+
+template <class ParentOptionType>
+inline void OptionChild<ParentOptionType, typename std::enable_if<std::is_same<typename ParentOptionType::ValueType, std::string>::value>::type>::reset()
+{
+    priority = Priority::EMPTY;
 }
 
 }

--- a/libdnf/conf/OptionEnum.hpp
+++ b/libdnf/conf/OptionEnum.hpp
@@ -49,6 +49,7 @@ public:
     T getDefaultValue() const;
     std::string toString(ValueType value) const;
     std::string getValueString() const override;
+    void reset() override;
 
 protected:
     FromStringFunc fromStringUser;
@@ -74,6 +75,7 @@ public:
     const std::string & getValue() const;
     const std::string & getDefaultValue() const;
     std::string getValueString() const override;
+    void reset() override;
 
 protected:
     FromStringFunc fromStringUser;
@@ -86,6 +88,13 @@ template <typename T>
 inline OptionEnum<T> * OptionEnum<T>::clone() const
 {
     return new OptionEnum<T>(*this);
+}
+
+template <typename T>
+inline void OptionEnum<T>::reset()
+{
+    value = defaultValue;
+    priority = Priority::DEFAULT;
 }
 
 inline OptionEnum<std::string> * OptionEnum<std::string>::clone() const
@@ -106,6 +115,12 @@ inline const std::string & OptionEnum<std::string>::getDefaultValue() const
 inline std::string OptionEnum<std::string>::getValueString() const
 {
     return value;
+}
+
+inline void OptionEnum<std::string>::reset()
+{
+    value = defaultValue;
+    priority = Priority::DEFAULT;
 }
 
 }

--- a/libdnf/conf/OptionNumber.hpp
+++ b/libdnf/conf/OptionNumber.hpp
@@ -50,6 +50,7 @@ public:
     T getDefaultValue() const;
     std::string toString(ValueType value) const;
     std::string getValueString() const override;
+    void reset() override;
 
 protected:
     FromStringFunc fromStringUser;
@@ -80,7 +81,14 @@ inline T OptionNumber<T>::getDefaultValue() const
 template <typename T>
 inline std::string OptionNumber<T>::getValueString() const
 {
-    return toString(value); 
+    return toString(value);
+}
+
+template <typename T>
+inline void OptionNumber<T>::reset()
+{
+    value = defaultValue;
+    priority = Priority::DEFAULT;
 }
 
 extern template class OptionNumber<std::int32_t>;

--- a/libdnf/conf/OptionString.cpp
+++ b/libdnf/conf/OptionString.cpp
@@ -27,18 +27,21 @@
 namespace libdnf {
 
 OptionString::OptionString(const std::string & defaultValue)
-: Option(Priority::DEFAULT), defaultValue(defaultValue), value(defaultValue) {}
+: Option(Priority::DEFAULT), initPriority(Priority::DEFAULT), defaultValue(defaultValue), value(defaultValue) {}
 
 OptionString::OptionString(const char * defaultValue)
 {
     if (defaultValue) {
         this->value = this->defaultValue = defaultValue;
-        this->priority = Priority::DEFAULT;
+        this->initPriority = this->priority = Priority::DEFAULT;
+    } else {
+        this->initPriority = Priority::EMPTY;
     }
 }
 
 OptionString::OptionString(const std::string & defaultValue, const std::string & regex, bool icase)
-: Option(Priority::DEFAULT), regex(regex), icase(icase), defaultValue(defaultValue), value(defaultValue) { test(defaultValue); }
+: Option(Priority::DEFAULT), initPriority(Priority::DEFAULT), regex(regex), icase(icase)
+, defaultValue(defaultValue), value(defaultValue) { test(defaultValue); }
 
 OptionString::OptionString(const char * defaultValue, const std::string & regex, bool icase)
 : regex(regex), icase(icase)
@@ -48,6 +51,8 @@ OptionString::OptionString(const char * defaultValue, const std::string & regex,
         test(this->defaultValue);
         this->value = this->defaultValue;
         this->priority = Priority::DEFAULT;
+    } else {
+        this->initPriority = Priority::EMPTY;
     }
 }
 

--- a/libdnf/conf/OptionString.hpp
+++ b/libdnf/conf/OptionString.hpp
@@ -42,8 +42,10 @@ public:
     const std::string & getValue() const;
     const std::string & getDefaultValue() const noexcept;
     std::string getValueString() const override;
+    void reset() override;
 
 protected:
+    Priority initPriority;
     std::string regex;
     bool icase;
     std::string defaultValue;
@@ -68,6 +70,12 @@ inline std::string OptionString::getValueString() const
 inline std::string OptionString::fromString(const std::string & value) const
 {
     return value;
+}
+
+inline void OptionString::reset()
+{
+    value = defaultValue;
+    priority = initPriority;
 }
 
 }

--- a/libdnf/conf/OptionStringList.hpp
+++ b/libdnf/conf/OptionStringList.hpp
@@ -45,6 +45,7 @@ public:
     const ValueType & getDefaultValue() const;
     std::string toString(const ValueType & value) const;
     std::string getValueString() const override;
+    void reset() override;
 
 protected:
     std::string regex;
@@ -70,7 +71,13 @@ inline const OptionStringList::ValueType & OptionStringList::getDefaultValue() c
 
 inline std::string OptionStringList::getValueString() const
 {
-    return toString(value); 
+    return toString(value);
+}
+
+inline void OptionStringList::reset()
+{
+    value = defaultValue;
+    priority = Priority::DEFAULT;
 }
 
 }


### PR DESCRIPTION
Better repository configuration support for context libdnf clients (`microdnf`, `PackageKit`, ...).

- Fixes `cost` and  `metadata_expire` repository options. The options priority is set to the REPOCONFIG value (wrong value RUNTIME before).
- Fixes options `username`, `password`, `proxy`, `proxy_username`, `proxy_password`:
    - Uses global configuration options when they are not defined in the repository configuration.
    - `proxy_username` and `proxy_password` is urlEncoded before passing to librepo.
- Adds support for options `minrate`, `throttle`, `bandwidth`, `timeout`.
- Optimizations

Support for `minrate` and `timeout` was requested in https://bugzilla.redhat.com/show_bug.cgi?id=1889525