### PR TITLE
Add ASAN_OPTIONS for test_libdnf_main

### DIFF
--- a/tests/libdnf/CMakeLists.txt
+++ b/tests/libdnf/CMakeLists.txt
@@ -15,4 +15,12 @@ target_link_libraries(test_libdnf_main
 )
 
 add_test(test_libdnf_main test_libdnf_main)
-set_property(TEST test_libdnf_main PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/libdnf")
+
+# ASAN_OPTIONS fix the "ASan runtime does not come first in initial library
+# list" message. Note the better solution should be to use LD_PRELOAD=`ls
+# /lib64/libasan.so.?`. With the solution used here the sanitizer library is
+# loaded when the DSO linked against it is loaded. For any calls up to that
+# point the sanitizers aren't active. While hackish, this is convenient because
+# e.g. python is causing some leaks during module loading which this works
+# around.
+set_property(TEST test_libdnf_main PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/libdnf;ASAN_OPTIONS=verify_asan_link_order=0")


### PR DESCRIPTION
The test only seems to fail on this in COPR.