### PR TITLE
[context] Use global ConfigMain::keepcache(), use value from config file

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -160,7 +160,6 @@ typedef struct
     gboolean         check_transaction;
     gboolean         only_trusted;
     gboolean         enable_filelists;
-    gboolean         keep_cache;
     gboolean         enrollment_valid;
     gboolean         write_history;
     DnfLock         *lock;
@@ -1000,8 +999,8 @@ dnf_context_get_check_transaction(DnfContext *context)
 gboolean
 dnf_context_get_keep_cache(DnfContext *context)
 {
-    DnfContextPrivate *priv = GET_PRIVATE(context);
-    return priv->keep_cache;
+    auto & mainConf = libdnf::getGlobalMainConfig();
+    return mainConf.keepcache().getValue();
 }
 
 /**
@@ -1503,8 +1502,8 @@ dnf_context_set_check_transaction(DnfContext *context, gboolean check_transactio
 void
 dnf_context_set_keep_cache(DnfContext *context, gboolean keep_cache)
 {
-    DnfContextPrivate *priv = GET_PRIVATE(context);
-    priv->keep_cache = keep_cache;
+    auto & mainConf = libdnf::getGlobalMainConfig();
+    mainConf.keepcache().set(libdnf::Option::Priority::RUNTIME, keep_cache);
 }
 
 /**

--- a/libdnf/dnf-context.hpp
+++ b/libdnf/dnf-context.hpp
@@ -44,7 +44,7 @@ struct Setopt {
 std::map<std::string, std::string> & dnf_context_get_vars(DnfContext * context);
 bool dnf_context_get_vars_cached(DnfContext * context);
 void dnf_context_load_vars(DnfContext * context);
-ConfigMain & getGlobalMainConfig();
+ConfigMain & getGlobalMainConfig(bool canReadConfigFile = true);
 bool addSetopt(const char * key, Option::Priority priority, const char * value, GError ** error);
 const std::vector<Setopt> & getGlobalSetopts();
 

--- a/tests/libdnf/dnf-self-test.c
+++ b/tests/libdnf/dnf-self-test.c
@@ -885,6 +885,7 @@ dnf_context_func(void)
     g_assert_cmpstr(dnf_context_get_solv_dir(ctx), ==, "/tmp/hawkey");
     g_assert(dnf_context_get_check_disk_space(ctx));
     g_assert(dnf_context_get_check_transaction(ctx));
+    dnf_context_set_keep_cache(ctx, FALSE);
     g_assert(!dnf_context_get_keep_cache(ctx));
 
     dnf_context_set_cache_dir(ctx, "/var");


### PR DESCRIPTION
Previously, "keep_cache" was part of the DnfContextPrivate structure. And its default value was "false". The value in the configuration file was ignored.
After the fix, the value from the configuration file is used.
As a side effect, the current "keepcache" value is now shared between contexts.