### PR TITLE
[dnf5][dnfdaemon] Unify repo list API with rpm list

### DIFF
--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -32,6 +32,164 @@ along with dnfdaemon-server.  If not, see <https://www.gnu.org/licenses/>.
 #include <iostream>
 #include <string>
 
+// repository attributes available to be retrieved
+// based on `dnf repolist` command
+enum class RepoAttribute {
+    // from repo configuration
+    id,
+    name,
+    enabled,
+    baseurl,
+    metalink,
+    mirrorlist,
+    metadata_expire,
+    excludepkgs,
+    includepkgs,
+    repofile,
+
+    // require metadata loading
+    revision,
+    content_tags,
+    distro_tags,
+    updated,
+    pkgs,
+    available_pkgs, // number of not excluded packages
+    size
+};
+
+std::vector<RepoAttribute> metadata_required_attributes {
+    RepoAttribute::revision,
+    RepoAttribute::content_tags,
+    RepoAttribute::distro_tags,
+    RepoAttribute::updated,
+    RepoAttribute::pkgs,
+    RepoAttribute::available_pkgs,
+    RepoAttribute::size
+};
+
+// map string package attribute name to actual attribute
+const static std::map<std::string, RepoAttribute> repo_attributes {
+    {"id", RepoAttribute::id},
+    {"name", RepoAttribute::name},
+    {"enabled", RepoAttribute::enabled},
+    {"baseurl", RepoAttribute::baseurl},
+    {"metalink", RepoAttribute::metalink},
+    {"mirrorlist", RepoAttribute::mirrorlist},
+    {"metadata_expire", RepoAttribute::metadata_expire},
+    {"excludepkgs", RepoAttribute::excludepkgs},
+    {"includepkgs", RepoAttribute::includepkgs},
+    {"repofile", RepoAttribute::repofile},
+    {"revision", RepoAttribute::revision},
+    {"content_tags", RepoAttribute::content_tags},
+    {"distro_tags", RepoAttribute::distro_tags},
+    {"updated", RepoAttribute::updated},
+    {"pkgs", RepoAttribute::pkgs},
+    {"available_pkgs", RepoAttribute::available_pkgs},
+    {"size", RepoAttribute::size}
+};
+
+// converts Repo object to dbus map
+dnfdaemon::KeyValueMap repo_to_map(libdnf::Base & base, const libdnf::WeakPtr<libdnf::rpm::Repo, false> libdnf_repo, std::vector<std::string> & attributes) {
+    dnfdaemon::KeyValueMap dbus_repo;
+    // attributes required by client
+    for (auto & attr : attributes) {
+        switch (repo_attributes.at(attr)) {
+            case RepoAttribute::id:
+                dbus_repo.emplace(attr, libdnf_repo->get_id());
+                break;
+            case RepoAttribute::name:
+                dbus_repo.emplace(attr, libdnf_repo->get_config().name().get_value());
+                break;
+            case RepoAttribute::enabled:
+                dbus_repo.emplace(attr, libdnf_repo->is_enabled());
+                break;
+            case RepoAttribute::size:
+                {
+                    auto & solv_sack = base.get_rpm_solv_sack();
+                    uint64_t size = 0;
+                    libdnf::rpm::SolvQuery query(&solv_sack);
+                    std::vector<std::string> reponames = {libdnf_repo->get_id()};
+                    query.ifilter_repoid(libdnf::sack::QueryCmp::EQ, reponames);
+                    for (auto pkg : query) {
+                        size += pkg.get_download_size();
+                    }
+                    dbus_repo.emplace(attr, size);
+                }
+                break;
+            case RepoAttribute::revision:
+                dbus_repo.emplace(attr, libdnf_repo->get_revision());
+                break;
+            case RepoAttribute::content_tags:
+                dbus_repo.emplace(attr, libdnf_repo->get_content_tags());
+                break;
+            case RepoAttribute::distro_tags:
+                {
+                    // sdbus::Variant cannot accomodate a std::pair
+                    std::vector<std::string> distro_tags {};
+                    for (auto & dt: libdnf_repo->get_distro_tags()) {
+                        distro_tags.emplace_back(dt.first);
+                        distro_tags.emplace_back(dt.second);
+                    }
+                    dbus_repo.emplace(attr, distro_tags);
+                }
+                break;
+            case RepoAttribute::updated:
+                dbus_repo.emplace(attr, libdnf_repo->get_max_timestamp());
+                break;
+            case RepoAttribute::pkgs:
+                {
+                    auto & solv_sack = base.get_rpm_solv_sack();
+                    libdnf::rpm::SolvQuery query(&solv_sack, libdnf::rpm::SolvQuery::InitFlags::IGNORE_EXCLUDES);
+                    std::vector<std::string> reponames = {libdnf_repo->get_id()};
+                    query.ifilter_repoid(libdnf::sack::QueryCmp::EQ, reponames);
+                    dbus_repo.emplace(attr, query.size());
+                }
+                break;
+            case RepoAttribute::available_pkgs:
+                {
+                    auto & solv_sack = base.get_rpm_solv_sack();
+                    libdnf::rpm::SolvQuery query(&solv_sack);
+                    std::vector<std::string> reponames = {libdnf_repo->get_id()};
+                    query.ifilter_repoid(libdnf::sack::QueryCmp::EQ, reponames);
+                    dbus_repo.emplace(attr, query.size());
+                }
+                break;
+            case RepoAttribute::metalink:
+                {
+                    auto opt = libdnf_repo->get_config().metalink();
+                    dbus_repo.emplace(attr, (opt.empty() || opt.get_value().empty()) ? "" : opt.get_value());
+                }
+                break;
+            case RepoAttribute::mirrorlist:
+                {
+                    auto opt = libdnf_repo->get_config().mirrorlist();
+                    dbus_repo.emplace(attr, (opt.empty() || opt.get_value().empty()) ? "" : opt.get_value());
+                }
+                break;
+            case RepoAttribute::baseurl:
+                dbus_repo.emplace(attr, libdnf_repo->get_config().baseurl().get_value());
+                break;
+            case RepoAttribute::metadata_expire:
+                dbus_repo.emplace(attr, libdnf_repo->get_config().metadata_expire().get_value());
+                break;
+            case RepoAttribute::excludepkgs:
+                dbus_repo.emplace(attr, libdnf_repo->get_config().excludepkgs().get_value());
+                break;
+            case RepoAttribute::includepkgs:
+                dbus_repo.emplace(attr, libdnf_repo->get_config().includepkgs().get_value());
+                break;
+            case RepoAttribute::repofile:
+                dbus_repo.emplace(attr, libdnf_repo->get_repo_file_path());
+                break;
+        }
+    }
+    return dbus_repo;
+}
+
+bool keyval_repo_compare(const dnfdaemon::KeyValueMap & first, const dnfdaemon::KeyValueMap & second) {
+    return key_value_map_get<std::string>(first, "id") < key_value_map_get<std::string>(second, "id");
+}
+
 void Repo::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
@@ -40,39 +198,36 @@ void Repo::dbus_register() {
         });
 }
 
-uint64_t repo_size(libdnf::rpm::SolvSack & sack, const libdnf::WeakPtr<libdnf::rpm::Repo, false> & repo) {
-    uint64_t size = 0;
-    libdnf::rpm::SolvQuery query(&sack);
-    std::vector<std::string> reponames = {repo->get_id()};
-    query.ifilter_repoid(libdnf::sack::QueryCmp::EQ, reponames);
-    for (auto pkg : query) {
-        size += pkg.get_download_size();
-    }
-    return size;
-}
-
-bool keyval_repo_compare(const dnfdaemon::KeyValueMap & first, const dnfdaemon::KeyValueMap & second) {
-    return key_value_map_get<std::string>(first, "id") < key_value_map_get<std::string>(second, "id");
-}
-
 void Repo::list(sdbus::MethodCall call) {
     dnfdaemon::KeyValueMap options;
     call >> options;
     auto worker = std::thread([this, options = std::move(options), call = std::move(call)]() {
         try {
+            const std::vector<std::string> empty_list {};
+
             // read options from dbus call
             std::string enable_disable = key_value_map_get<std::string>(options, "enable_disable", "enabled");
-            std::vector<std::string> default_patterns{};
             std::vector<std::string> patterns =
-                key_value_map_get<std::vector<std::string>>(options, "patterns", std::move(default_patterns));
-            std::string command = key_value_map_get<std::string>(options, "command", "repolist");
-
-            // repoinfo command needs repositories loaded into sack
-            // TODO(mblaha): check that repos are loaded
+                key_value_map_get<std::vector<std::string>>(options, "patterns", empty_list);
+            // check demanded attributes
+            std::vector<std::string> repo_attrs = key_value_map_get<std::vector<std::string>>(options, "repo_attrs", empty_list);
+            bool fill_sack_needed = false;
+            for (auto & attr_str : repo_attrs) {
+                if (repo_attributes.count(attr_str) == 0) {
+                    throw std::runtime_error(fmt::format("Repo attribute '{}' not supported", attr_str));
+                }
+                if (!fill_sack_needed) {
+                    fill_sack_needed = std::find(metadata_required_attributes.begin(), metadata_required_attributes.end(), repo_attributes.at(attr_str)) != metadata_required_attributes.end();
+                }
+            }
+            // always return repoid
+            repo_attrs.push_back("id");
+            if (fill_sack_needed) {
+                session.fill_sack();
+            }
 
             // prepare repository query filtered by options
             auto base = session.get_base();
-            auto & solv_sack = base->get_rpm_solv_sack();
             auto & rpm_repo_sack = base->get_rpm_repo_sack();
             auto repos_query = rpm_repo_sack.new_query();
 
@@ -90,16 +245,9 @@ void Repo::list(sdbus::MethodCall call) {
 
             // create reply from the query
             dnfdaemon::KeyValueMapList out_repositories;
+
             for (auto & repo : repos_query.get_data()) {
-                dnfdaemon::KeyValueMap out_repo;
-                out_repo.emplace(std::make_pair("id", repo->get_id()));
-                out_repo.emplace(std::make_pair("name", repo->get_config().name().get_value()));
-                out_repo.emplace(std::make_pair("enabled", repo->is_enabled()));
-                // TODO(mblaha): add all other repository attributes
-                if (command == "repoinfo") {
-                    out_repo.emplace(std::make_pair("repo_size", repo_size(solv_sack, repo)));
-                }
-                out_repositories.push_back(std::move(out_repo));
+                out_repositories.push_back(repo_to_map(*base, repo, repo_attrs));
             }
 
             std::sort(out_repositories.begin(), out_repositories.end(), keyval_repo_compare);

--- a/test/dnfdaemon-server/test_repolist.py
+++ b/test/dnfdaemon-server/test_repolist.py
@@ -49,17 +49,17 @@ class RepoTest(unittest.TestCase):
     def test_list_repos(self):
         # get list of all repositories
         self.assertEqual(
-            self.iface_repo.list({}),
+            self.iface_repo.list({"repo_attrs": ["name", "enabled"]}),
             dbus.Array([
                 dbus.Dictionary({
                     dbus.String('name'): dbus.String('Repository 1', variant_level=1),
                     dbus.String('enabled'): dbus.Boolean(True, variant_level=1),
-                    dbus.String('id'): dbus.String('repo1', variant_level=1)},
+                    dbus.String('id'): dbus.String('rpm-repo1', variant_level=1)},
                     signature=dbus.Signature('sv')),
                 dbus.Dictionary({
                     dbus.String('name'): dbus.String('Repository 2', variant_level=1),
                     dbus.String('enabled'): dbus.Boolean(True, variant_level=1),
-                    dbus.String('id'): dbus.String('repo2', variant_level=1)},
+                    dbus.String('id'): dbus.String('rpm-repo2', variant_level=1)},
                     signature=dbus.Signature('sv')),
                 ],
                 signature=dbus.Signature('a{sv}'))
@@ -69,12 +69,13 @@ class RepoTest(unittest.TestCase):
     def test_list_repos_spec(self):
         # get list of specified repositories
         self.assertEqual(
-            self.iface_repo.list({"patterns": ['repo1']}),
+            self.iface_repo.list(
+                    {"repo_attrs": ["name", "enabled"], "patterns": ['rpm-repo1']}),
             dbus.Array([
                 dbus.Dictionary({
                     dbus.String('name'): dbus.String('Repository 1', variant_level=1),
                     dbus.String('enabled'): dbus.Boolean(True, variant_level=1),
-                    dbus.String('id'): dbus.String('repo1', variant_level=1)},
+                    dbus.String('id'): dbus.String('rpm-repo1', variant_level=1)},
                     signature=dbus.Signature('sv')),
                 ],
                 signature=dbus.Signature('a{sv}'))

--- a/test/dnfdaemon-server/test_repoquery.py
+++ b/test/dnfdaemon-server/test_repoquery.py
@@ -61,19 +61,19 @@ class RepoTest(unittest.TestCase):
             dbus.Array([
                 dbus.Dictionary({
                     dbus.String('full_nevra'): dbus.String('one-0:1-1.noarch', variant_level=1),
-                    dbus.String('repo'): dbus.String('repo1', variant_level=1)},
+                    dbus.String('repo'): dbus.String('rpm-repo1', variant_level=1)},
                     signature=dbus.Signature('sv')),
                 dbus.Dictionary({
                     dbus.String('full_nevra'): dbus.String('one-0:1-1.src', variant_level=1),
-                    dbus.String('repo'): dbus.String('repo1', variant_level=1)},
+                    dbus.String('repo'): dbus.String('rpm-repo1', variant_level=1)},
                     signature=dbus.Signature('sv')),
                 dbus.Dictionary({
                     dbus.String('full_nevra'): dbus.String('two-0:2-2.noarch', variant_level=1),
-                    dbus.String('repo'): dbus.String('repo2', variant_level=1)},
+                    dbus.String('repo'): dbus.String('rpm-repo2', variant_level=1)},
                     signature=dbus.Signature('sv')),
                 dbus.Dictionary({
                     dbus.String('full_nevra'): dbus.String('two-0:2-2.src', variant_level=1),
-                    dbus.String('repo'): dbus.String('repo2', variant_level=1)},
+                    dbus.String('repo'): dbus.String('rpm-repo2', variant_level=1)},
                     signature=dbus.Signature('sv')),
                 ],
                 signature=dbus.Signature('a{sv}'))
@@ -94,11 +94,11 @@ class RepoTest(unittest.TestCase):
             dbus.Array([
                 dbus.Dictionary({
                     dbus.String('full_nevra'): dbus.String('one-0:1-1.noarch', variant_level=1),
-                    dbus.String('repo'): dbus.String('repo1', variant_level=1)},
+                    dbus.String('repo'): dbus.String('rpm-repo1', variant_level=1)},
                     signature=dbus.Signature('sv')),
                 dbus.Dictionary({
                     dbus.String('full_nevra'): dbus.String('one-0:1-1.src', variant_level=1),
-                    dbus.String('repo'): dbus.String('repo1', variant_level=1)},
+                    dbus.String('repo'): dbus.String('rpm-repo1', variant_level=1)},
                     signature=dbus.Signature('sv')),
             ],
             signature=dbus.Signature('a{sv}'))


### PR DESCRIPTION
- it is client responsibility to ask for each repo attribute it wants to
  use
- sack is filled automatically when attribute that needs it is required
- all needed repository parameters now could be retrieved using
  InterfaceRepo.list() dbus call.