### PR TITLE
build-sys: Add ENABLE_STATIC option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ message("Building ${PROJECT_NAME} version: ${LIBDNF_VERSION}")
 
 # build options
 option(WITH_BINDINGS "Enables python/SWIG bindings" ON)
+option(ENABLE_STATIC "Build a static library instead of shared" OFF)
 option(WITH_GTKDOC "Enables libdnf GTK-Doc HTML documentation" ON)
 option(WITH_HTML "Enables hawkey HTML generation" ON)
 option(WITH_MAN "Enables hawkey man page generation" ON)

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -55,7 +55,11 @@ set(LIBDNF_SRCS ${LIBDNF_SRCS} ${SACK_SOURCES})
 set(LIBDNF_SRCS ${LIBDNF_SRCS} ${REPO_SOURCES})
 set(LIBDNF_SRCS ${LIBDNF_SRCS} ${PLUGIN_SOURCES})
 
-add_library(libdnf SHARED ${LIBDNF_SRCS})
+if(ENABLE_STATIC)
+    add_library(libdnf STATIC ${LIBDNF_SRCS})
+else()
+    add_library(libdnf SHARED ${LIBDNF_SRCS})
+endif()
 target_link_libraries(libdnf
     ${CMAKE_DL_LIBS}
     ${REPO_LIBRARIES}


### PR DESCRIPTION

For rpm-ostree we're bundling libdnf because doesn't
have a stable API/ABI; more on that here:
https://github.com/coreos/rpm-ostree/blob/master/docs/HACKING.md#testing-with-a-custom-libdnf
Since forever we've been sticking it in `/usr/lib64/rpm-ostree/libdnf.so.2`,
but that means we need to set an `rpath` for it which is a bit obscure.
It's just way simpler if we link statically.

