### PR TITLE
Fix repo.fresh() implementation

### DIFF
--- a/libdnf/repo/Repo-private.hpp
+++ b/libdnf/repo/Repo-private.hpp
@@ -144,6 +144,7 @@ public:
     int timestamp;
     int maxTimestamp{0};
     bool preserveRemoteTime{false};
+    bool fresh{false};
     std::string repomdFn;
     std::set<std::string> additionalMetadata;
     std::string revision;

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -1326,6 +1326,7 @@ bool Repo::Impl::load()
         fetch(cacheDir, lrHandleInitRemote(nullptr));
         timestamp = -1;
         loadCache(true);
+        fresh = true;
     } catch (const LrExceptionWithSourceUrl & e) {
         auto msg = tfm::format(_("Failed to download metadata for repo '%s': %s"), id, e.what());
         throw RepoError(msg);
@@ -1455,7 +1456,7 @@ const char * const * Repo::Impl::getHttpHeaders() const
 
 bool Repo::fresh()
 {
-    return pImpl->timestamp >= 0;
+    return pImpl->fresh;
 }
 
 void Repo::Impl::resetMetadataExpired()

--- a/libdnf/repo/Repo.hpp
+++ b/libdnf/repo/Repo.hpp
@@ -244,7 +244,14 @@ public:
     * @return Seconds to expiration
     */
     int getExpiresIn() const;
+
+    /**
+    * @brief Returns whether the metadata was loaded from the origin, not from cache
+    *
+    * @return bool
+    */
     bool fresh();
+
     void setMaxMirrorTries(int maxMirrorTries);
     int getTimestamp() const;
     int getMaxTimestamp();


### PR DESCRIPTION
Without the patch Repo.fresh() relies on the value of timestamp
attribute. timestamp is set to -1 in the end of Repo.load() method, but
subsequently called Repo.loadCache() method immediately resets timestamp
to actual timestamp of the downloaded primary metadata file.

Related: https://github.com/rpm-software-management/dnf-plugins-core/pull/418