### PR TITLE
[dnf5][microdnf] Fix error if there is no argument "--comment"

### DIFF
--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -670,7 +670,9 @@ libdnf::transaction::TransactionWeakPtr new_db_transaction(Context & ctx) {
     auto & transaction_sack = ctx.base.get_transaction_sack();
     auto transaction = transaction_sack.new_transaction();
     transaction->set_user_id(get_login_uid());
-    transaction->set_comment(ctx.get_comment());
+    if (auto comment = ctx.get_comment()) {
+        transaction->set_comment(comment);
+    }
     transaction->set_releasever(ctx.base.get_vars().get_values().at("releasever"));
     auto arguments = ctx.get_prg_arguments();
     std::string cmd_line;


### PR DESCRIPTION
Without the `--comment` argument, microdnf ended up with a message in the log during database transaction preparation:
`ERROR Command returned error: basic_string::_M_construct null not valid`