### PR TITLE
lock: Add an assertion to quiet gcc -fanalyzer

### DIFF
--- a/libdnf/dnf-lock.cpp
+++ b/libdnf/dnf-lock.cpp
@@ -494,9 +494,9 @@ dnf_lock_release(DnfLock *lock, guint id, GError **error) try
     DnfLockPrivate *priv = GET_PRIVATE(lock);
     gboolean ret = FALSE;
 
-    g_return_val_if_fail(DNF_IS_LOCK(lock), FALSE);
-    g_return_val_if_fail(id != 0, FALSE);
-    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+    g_assert(DNF_IS_LOCK(lock));
+    g_assert(id != 0);
+    g_assert(error == NULL || *error == NULL);
 
     /* lock other threads */
     g_mutex_lock(&priv->mutex);


### PR DESCRIPTION
I saw https://developers.redhat.com/blog/2021/01/28/static-analysis-updates-in-gcc-11/
go by and tried it out on rpm-ostree.  The only error emitted was
this which about a possible `NULL` deref of `error`:

```
/var/srv/walters/src/github/coreos/rpm-ostree/libdnf/libdnf/dnf-lock.cpp: In function ‘void dnf_lock_release_noerror(DnfLock*, guint)’:
/usr/include/glib-2.0/glib/gmessages.h:338:31: warning: dereference of NULL ‘<unknown>’ [CWE-690] [-Wanalyzer-null-dereference]
```

because the inner function can return early if assertions trigger,
which shouldn't happen.

And actually IMO, `g_return_if_fail()` is basically an anti-pattern
that we only use in C GTK+ because it's annoying to return regular
errors there and one doesn't want to crash GUI apps usually.

Let's add an assertion to quiet the analyzer.