### PR TITLE
build-sys: Clean up message about Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,9 @@ if(WITH_BINDINGS)
         message(FATAL_ERROR "Invalid PYTHON_DESIRED value: " ${PYTHON_DESIRED})
     endif()
     find_package(PythonLibs REQUIRED)
+    message(STATUS "Building for python${PYTHON_VERSION_MAJOR}")
+else()
+    message(STATUS "Not building language bindings")
 endif()
 
 

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -137,8 +137,6 @@ set(LIBDNF_headers
     libdnf.h
 )
 
-message(STATUS "Building for python${PYTHON_VERSION_MAJOR}")
-
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libdnf.pc
     DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig
 )


### PR DESCRIPTION
We still printed a message about Python even if not
building the bindings.  Move the print into the binding
conditional, and for clarity also log when the bindings
are not built.