### PR TITLE
tests: Squash unused variable warnings

### DIFF
--- a/tests/hawkey/test_subject.cpp
+++ b/tests/hawkey/test_subject.cpp
@@ -42,7 +42,6 @@ const char inp_fof_na[] = "four-of-fish-3.6.9.i686";
 /* with profile */
 const char module_nsvcap[] = "module-name:stream:1:b86c854:x86_64/profile";
 const char module_nsvap[] = "module-name:stream:1::x86_64/profile";
-const char module_nsvcp[] = "module-name:stream:1:b86c854/profile";
 const char module_nsvp[] = "module-name:stream:1/profile";
 const char module_nsap[] = "module-name:stream::x86_64/profile";
 const char module_nsp[] = "module-name:stream/profile";

--- a/tests/libdnf/transaction/RpmItemTest.cpp
+++ b/tests/libdnf/transaction/RpmItemTest.cpp
@@ -112,7 +112,9 @@ RpmItemTest::testGetTransactionItems()
     std::chrono::duration< double > read_duration = read_finish - read_start;
 
     auto createMs = std::chrono::duration_cast< std::chrono::milliseconds >(create_duration);
+    (void)createMs;
     auto readMs = std::chrono::duration_cast< std::chrono::milliseconds >(read_duration);
+    (void)readMs;
 
     //CPPUNIT_ASSERT(createMs.count() == 0);
     //CPPUNIT_ASSERT(readMs.count() == 0);


### PR DESCRIPTION
I'd like to build rpm-ostree with `-Werror=unused-variable`.