### PR TITLE
[dnf5] Plugins architecture for libdnf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ endif()
 option(WITH_DNFDAEMON_CLIENT "Build command-line interface for dnfdaemon" ON)
 option(WITH_DNFDAEMON_SERVER "Build package management service with a DBus interface" ON)
 option(WITH_LIBDNF_CLI "Build library for working with a terminal in a command-line package manager" ON)
-option(WITH_LIBDNF_PLUGINS "Build libdnf plugins" ON)
 option(WITH_MICRODNF "Build microdnf command-line package manager" ON)
+option(WITH_PYTHON_PLUGINS_LOADER "Build a special libdnf plugin that loads Python plugins. Requires WITH_PYTHON3=ON." ON)
 
 # build options - features
 option(WITH_COMPS "Build with comps groups and environments support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 option(WITH_DNFDAEMON_CLIENT "Build command-line interface for dnfdaemon" ON)
 option(WITH_DNFDAEMON_SERVER "Build package management service with a DBus interface" ON)
 option(WITH_LIBDNF_CLI "Build library for working with a terminal in a command-line package manager" ON)
+option(WITH_LIBDNF_PLUGINS "Build libdnf plugins" ON)
 option(WITH_MICRODNF "Build microdnf command-line package manager" ON)
 
 # build options - features
@@ -95,6 +96,7 @@ include_directories("${PROJECT_SOURCE_DIR}")
 add_subdirectory("include")
 add_subdirectory("libdnf")
 add_subdirectory("libdnf-cli")
+add_subdirectory("libdnf-plugins")
 add_subdirectory("doc")
 add_subdirectory("bindings")
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 
 # list of all modules that will be included in libdnf bindings
-list(APPEND SWIG_LIBDNF_MODULES base common conf logger rpm transaction)
+list(APPEND SWIG_LIBDNF_MODULES base common conf logger rpm transaction plugin)
 
 
 # list of all modules that will be included in libdnf-cli bindings

--- a/bindings/libdnf/base.i
+++ b/bindings/libdnf/base.i
@@ -11,6 +11,7 @@
 
 %import "common.i"
 %import "conf.i"
+%import "plugin.i"
 %import "logger.i"
 %import "rpm.i"
 %import "transaction.i"

--- a/bindings/libdnf/plugin.i
+++ b/bindings/libdnf/plugin.i
@@ -1,0 +1,35 @@
+#if defined(SWIGPYTHON)
+%module(package="libdnf", directors="1") plugin
+#elif defined(SWIGPERL)
+%module "libdnf::plugin"
+#elif defined(SWIGRUBY)
+%module "libdnf/plugin"
+#endif
+
+%include <exception.i>
+%include <stdint.i>
+%include <std_common.i>
+
+%{
+    #include "libdnf/plugin/iplugin.hpp"
+    #include "libdnf/plugin/plugins.hpp"
+%}
+
+#define CV __perl_CV
+
+%ignore libdnf_plugin_get_api_version;
+%ignore libdnf_plugin_get_name;
+%ignore libdnf_plugin_get_version;
+%ignore libdnf_plugin_new_instance;
+%ignore libdnf_plugin_delete_instance;
+%feature("director") IPlugin;
+%include "libdnf/plugin/iplugin.hpp"
+
+%extend libdnf::plugin::Version {
+    Version(std::uint16_t major, std::uint16_t minor, std::uint16_t micro) {
+        libdnf::plugin::Version * ver = new libdnf::plugin::Version({major, minor, micro});
+        return ver;
+    }
+}
+
+%include "libdnf/plugin/plugins.hpp"

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -37,6 +37,17 @@ namespace libdnf {
 /// :class:`.Base` instances are stateful objects owning various data.
 class Base {
 public:
+    /// Sets the pointer to the locked instance "Base" to "this" instance. Blocks if the pointer is already set.
+    /// Pointer to a locked "Base" instance can be obtained using "get_locked_base()".
+    void lock();
+
+    /// Resets the pointer to a locked "Base" instance to "nullptr".
+    /// Throws an exception if another or no instance is locked.
+    void unlock();
+
+    /// Returns a pointer to a locked "Base" instance or "nullptr" if no instance is locked.
+    static Base * get_locked_base() noexcept;
+
     /// Loads main configuration from file defined by the current configuration.
     void load_config_from_file();
 

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/rpm/solv_sack.hpp"
 #include "libdnf/conf/vars.hpp"
 #include "libdnf/transaction/sack.hpp"
+#include "libdnf/plugin/plugins.hpp"
 
 #include <map>
 
@@ -60,6 +61,10 @@ public:
     /// Gets base variables. They can be used in configuration files. Syntax in the config - ${var_name} or $var_name.
     Vars & get_vars() { return vars; }
 
+    void add_plugin(plugin::IPlugin & iplugin_instance);
+    void load_plugins();
+    plugin::Plugins & get_plugins() { return plugins; }
+
 private:
     //TODO(jrohel): Make public?
     /// Loads main configuration from file defined by path.
@@ -81,8 +86,8 @@ private:
     rpm::SolvSack rpm_solv_sack{*this};
     transaction::TransactionSack transaction_sack{*this};
     Vars vars;
+    plugin::Plugins plugins{*this};
 };
-
 
 }  // namespace libdnf
 

--- a/include/libdnf/plugin/iplugin.hpp
+++ b/include/libdnf/plugin/iplugin.hpp
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_PLUGIN_IPLUGIN_HPP
+#define LIBDNF_PLUGIN_IPLUGIN_HPP
+
+#include <cstdint>
+
+namespace libdnf {
+
+class Base;
+
+}  // namespace libdnf
+
+namespace libdnf::plugin {
+
+/// Enum of all plugin hooks
+enum class HookId { LOAD_CONFIG_FROM_FILE };
+
+struct Version {
+    std::uint16_t major;
+    std::uint16_t minor;
+    std::uint16_t micro;
+};
+
+static constexpr Version PLUGIN_API_VERSION{.major = 0, .minor = 1, .micro = 0};
+
+class IPlugin {
+public:
+    IPlugin() = default;
+    virtual ~IPlugin() = default;
+
+    IPlugin(const IPlugin &) = delete;
+    IPlugin(IPlugin &&) = delete;
+    IPlugin & operator=(const IPlugin &) = delete;
+    IPlugin & operator=(IPlugin &&) = delete;
+
+    /// Returns the version of the API supported by the plugin. It can be called at any time.
+    virtual Version get_api_version() const noexcept = 0;
+
+    /// Returns the name of the plugin. It can be called at any time.
+    virtual const char * get_name() const noexcept = 0;
+
+    /// Gets the plugin version. It can be called at any time.
+    virtual Version get_version() const noexcept = 0;
+
+    /// Gets the value of the attribute from the plugin. Returns nullptr if the attribute does not exist.
+    /// It can be called at any time.
+    virtual const char * get_attribute(const char * name) const noexcept = 0;
+
+    /// The plugin can load additional plugins. E.g. C++ plugin for loading Python plugins.
+    /// Called before init.
+    virtual void load_plugins(Base * /*base*/) {}
+
+    /// Plugin initialization.
+    virtual void init(Base * base) = 0;
+
+    /// It is called when a hook is reached. The argument describes what happened.
+    virtual bool hook(HookId hook_id) = 0;
+
+    /// Finish the plugin and release all resources obtained by the init method and in hooks.
+    virtual void finish() noexcept = 0;
+};
+
+}  // namespace libdnf::plugin
+
+
+extern "C" {
+
+/// Returns the version of the API supported by the plugin.
+/// Same result as IPlugin::get_api_version(), but can be called without creating an IPlugin instance.
+libdnf::plugin::Version libdnf_plugin_get_api_version(void);
+
+/// Returns the name of the plugin. It can be called at any time.
+/// Same result as IPlugin::get_name(), but can be called without creating an IPlugin instance.
+const char * libdnf_plugin_get_name(void);
+
+/// Returns the version of the plugin. It can be called at any time.
+/// Same result as IPlugin::get_version(), but can be called without creating an IPlugin instance.
+libdnf::plugin::Version libdnf_plugin_get_version(void);
+
+/// Creates a new plugin instance. Passes the API version to the plugin.
+libdnf::plugin::IPlugin * libdnf_plugin_new_instance(libdnf::plugin::Version api_version);
+
+/// Deletes plugin instance.
+void libdnf_plugin_delete_instance(libdnf::plugin::IPlugin * plugin_instance);
+}
+
+#endif

--- a/include/libdnf/plugin/plugins.hpp
+++ b/include/libdnf/plugin/plugins.hpp
@@ -1,0 +1,157 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_PLUGIN_PLUGINS_HPP
+#define LIBDNF_PLUGIN_PLUGINS_HPP
+
+#include "iplugin.hpp"
+
+#include "libdnf/utils/library.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace libdnf::plugin {
+
+class Plugin {
+public:
+    explicit Plugin(IPlugin & iplugin_instance);
+    virtual ~Plugin();
+
+    Plugin(const Plugin &) = delete;
+    Plugin(Plugin &&) = delete;
+    Plugin & operator=(const Plugin &) = delete;
+    Plugin & operator=(Plugin &&) = delete;
+
+    IPlugin * get_iplugin() const noexcept;
+
+    void set_enabled(bool enabled) noexcept;
+    bool get_enabled() const noexcept;
+
+    void init(Base * base);
+    bool hook(HookId hook_id);
+    void finish() noexcept;
+
+protected:
+    Plugin() = default;
+    IPlugin * iplugin_instance{nullptr};
+    bool enabled{true};
+};
+
+
+class PluginLibrary : public Plugin {
+public:
+    explicit PluginLibrary(const std::string & library_path);
+    ~PluginLibrary();
+
+private:
+    using TGetApiVersionFunc = decltype(&libdnf_plugin_get_api_version);
+    using TGetNameFunc = decltype(&libdnf_plugin_get_name);
+    using TGetVersionFunc = decltype(&libdnf_plugin_get_version);
+    using TNewInstanceFunc = decltype(&libdnf_plugin_new_instance);
+    using TDeleteInstanceFunc = decltype(&libdnf_plugin_delete_instance);
+    TGetApiVersionFunc get_api_version{nullptr};
+    TGetNameFunc get_name{nullptr};
+    TGetVersionFunc get_version{nullptr};
+    TNewInstanceFunc new_instance{nullptr};
+    TDeleteInstanceFunc delete_instance{nullptr};
+    utils::Library library;
+};
+
+
+/// Plugin manager
+class Plugins {
+public:
+    Plugins(Base & base);
+    ~Plugins();
+
+    /// Registers the plugin passed by the argument.
+    void register_plugin(std::unique_ptr<Plugin> && plugin);
+
+    /// Loads the plugin from the library defined by the file path.
+    void load_plugin(const std::string & file_path);
+
+    /// Loads plugins from libraries in the directory.
+    void load_plugins(const std::string & dir_path);
+
+    /// Returns the number of registered plugins.
+    size_t count() const noexcept;
+
+    /// Call init of all allowed plugins.
+    bool init();
+
+    /// Call hook of all allowed plugins.
+    bool hook(HookId id);
+
+    /// Call finish of all allowed plugins in reverse order.
+    void finish() noexcept;
+
+private:
+    Base * base;
+    std::vector<std::unique_ptr<Plugin>> plugins;
+};
+
+
+inline Plugin::Plugin(IPlugin & iplugin_instance) : iplugin_instance{&iplugin_instance} {}
+
+inline Plugin::~Plugin() {
+    finish();
+}
+
+inline IPlugin * Plugin::get_iplugin() const noexcept {
+    return iplugin_instance;
+}
+
+inline void Plugin::set_enabled(bool enabled) noexcept {
+    this->enabled = enabled;
+}
+
+inline bool Plugin::get_enabled() const noexcept {
+    return enabled;
+}
+
+inline void Plugin::init(Base * base) {
+    if (iplugin_instance) {
+        iplugin_instance->init(base);
+    }
+}
+
+inline bool Plugin::hook(HookId hook_id) {
+    if (iplugin_instance) {
+        return iplugin_instance->hook(hook_id);
+    }
+    return true;
+}
+
+inline void Plugin::finish() noexcept {
+    if (iplugin_instance) {
+        iplugin_instance->finish();
+    }
+}
+
+inline Plugins::Plugins(Base & base) : base(&base) {}
+
+inline size_t Plugins::count() const noexcept {
+    return plugins.size();
+}
+
+}  // namespace libdnf::plugin
+
+#endif

--- a/include/libdnf/plugin/plugins.hpp
+++ b/include/libdnf/plugin/plugins.hpp
@@ -61,6 +61,7 @@ public:
     explicit PluginLibrary(const std::string & library_path);
     ~PluginLibrary();
 
+#ifndef SWIG
 private:
     using TGetApiVersionFunc = decltype(&libdnf_plugin_get_api_version);
     using TGetNameFunc = decltype(&libdnf_plugin_get_name);
@@ -73,6 +74,7 @@ private:
     TNewInstanceFunc new_instance{nullptr};
     TDeleteInstanceFunc delete_instance{nullptr};
     utils::Library library;
+#endif
 };
 
 

--- a/libdnf-plugins/CMakeLists.txt
+++ b/libdnf-plugins/CMakeLists.txt
@@ -1,5 +1,1 @@
-if(NOT WITH_LIBDNF_PLUGINS)
-    return()
-endif()
-
 add_subdirectory("python_plugins_loader")

--- a/libdnf-plugins/CMakeLists.txt
+++ b/libdnf-plugins/CMakeLists.txt
@@ -1,3 +1,5 @@
 if(NOT WITH_LIBDNF_PLUGINS)
     return()
 endif()
+
+add_subdirectory("python_plugins_loader")

--- a/libdnf-plugins/CMakeLists.txt
+++ b/libdnf-plugins/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(NOT WITH_LIBDNF_PLUGINS)
+    return()
+endif()

--- a/libdnf-plugins/python_plugins_loader/CMakeLists.txt
+++ b/libdnf-plugins/python_plugins_loader/CMakeLists.txt
@@ -2,10 +2,19 @@ if(NOT WITH_PYTHON3)
     return()
 endif()
 
+if(NOT WITH_PYTHON_PLUGINS_LOADER)
+    return()
+endif()
+
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 include_directories(${Python3_INCLUDE_DIRS})
 
 add_library(python_plugins_loader MODULE python_plugins_loader.cpp)
+# disable the 'lib' prefix in order to create python_plugins_loader.so
+set_target_properties(python_plugins_loader PROPERTIES PREFIX "")
 
 target_link_libraries(python_plugins_loader PUBLIC libdnf libdnf-cli)
-target_link_libraries(python_plugins_loader PUBLIC ${PYTHON_LIBRARY})
+target_link_libraries(python_plugins_loader PUBLIC ${Python3_LIBRARIES})
+
+install(TARGETS python_plugins_loader LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/libdnf-plugins/)
+install(FILES "README" DESTINATION ${Python3_SITELIB}/libdnf_plugins/)

--- a/libdnf-plugins/python_plugins_loader/CMakeLists.txt
+++ b/libdnf-plugins/python_plugins_loader/CMakeLists.txt
@@ -1,0 +1,11 @@
+if(NOT WITH_PYTHON3)
+    return()
+endif()
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+include_directories(${Python3_INCLUDE_DIRS})
+
+add_library(python_plugins_loader MODULE python_plugins_loader.cpp)
+
+target_link_libraries(python_plugins_loader PUBLIC libdnf libdnf-cli)
+target_link_libraries(python_plugins_loader PUBLIC ${PYTHON_LIBRARY})

--- a/libdnf-plugins/python_plugins_loader/README
+++ b/libdnf-plugins/python_plugins_loader/README
@@ -1,0 +1,1 @@
+A drop-in directory for libdnf Python plugins.

--- a/libdnf-plugins/python_plugins_loader/plugin.py
+++ b/libdnf-plugins/python_plugins_loader/plugin.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import libdnf
+
+
+class Plugin(libdnf.plugin.IPlugin):
+    def __init__(self):
+        super(Plugin, self).__init__()
+        self.base = None
+
+    @staticmethod
+    def get_api_version():
+        return libdnf.plugin.Version(0, 1, 0)
+
+    @staticmethod
+    def get_name():
+        return 'python_test_plugin'
+
+    @staticmethod
+    def get_version():
+        return libdnf.plugin.Version(0, 1, 0)
+
+    def get_attribute(self, name):
+        attributes = {'author_name': 'Jaroslav Rohel',
+                      'author_email': 'jrohel@redhat.com',
+                      'description': 'Libdnf plugin written in Python. Processes the LOAD_CONFIG_FROM_FILE hook '
+                                     'and writes the current value of the "skip_if_unavailable" option to the log.'}
+        return attributes.get(name, None)
+
+    def init(self, base):
+        self.base = base
+
+    def hook(self, plugin_hook_id):
+        if plugin_hook_id == libdnf.plugin.HookId_LOAD_CONFIG_FROM_FILE:
+            logger = self.base.get_logger()
+            config = self.base.get_config()
+            logger.info(self.get_name() + ' - skip_if_unavailable = ' + str(config.skip_if_unavailable().get_value()))
+        return True
+
+    def finish(self):
+        pass

--- a/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -1,0 +1,346 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <Python.h>
+#include <fmt/format.h>
+#include <libdnf/base/base.hpp>
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <mutex>
+
+using namespace libdnf::plugin;
+namespace fs = std::filesystem;
+
+constexpr const char * PLUGIN_NAME = "python_plugin_loader";
+constexpr Version PLUGIN_VERSION{0, 1, 0};
+constexpr const char * PLUGIN_DESCRIPTION = "Plugin for loading Python plugins.";
+constexpr const char * PLUGIN_AUTHOR_NAME = "Jaroslav Rohel";
+constexpr const char * PLUGIN_AUTHOR_EMAIL = "jrohel@redhat.com";
+
+
+class PythonPluginLoader : public IPlugin {
+public:
+    PythonPluginLoader() = default;
+    virtual ~PythonPluginLoader();
+
+    Version get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
+
+    const char * get_name() const noexcept override { return PLUGIN_NAME; }
+
+    Version get_version() const noexcept override { return PLUGIN_VERSION; }
+
+    const char * get_attribute(const char * attribute) const noexcept override {
+        if (std::strcmp(attribute, "author_name") == 0)
+            return PLUGIN_AUTHOR_NAME;
+        if (std::strcmp(attribute, "author_email") == 0)
+            return PLUGIN_AUTHOR_EMAIL;
+        if (std::strcmp(attribute, "description") == 0)
+            return PLUGIN_DESCRIPTION;
+        return nullptr;
+    }
+
+    void load_plugins(libdnf::Base * base) override;
+
+    void init(libdnf::Base *) override {}
+
+    bool hook(HookId) override { return true; }
+
+    void finish() noexcept override {}
+
+private:
+    void load_plugin_file(const fs::path & file);
+    void load_plugins_from_dir(const fs::path & dir_path);
+
+    static int python_ref_counter;
+    bool active{false};
+    libdnf::Base * base{nullptr};
+};
+
+int PythonPluginLoader::python_ref_counter{0};
+
+
+/// Smart pointer to PyObject
+///
+/// Owns and manages PyObject. Decrements the reference count for the PyObject
+/// (calls Py_XDECREF on it) when  UniquePtrPyObject goes out of scope.
+///
+/// Implements subset of standard std::unique_ptr methods.
+///
+class UniquePtrPyObject {
+public:
+    constexpr UniquePtrPyObject() noexcept : py_obj(NULL) {}
+    explicit UniquePtrPyObject(PyObject * pyObj) noexcept : py_obj(pyObj) {}
+    UniquePtrPyObject(UniquePtrPyObject && src) noexcept : py_obj(src.py_obj) { src.py_obj = NULL; }
+    UniquePtrPyObject & operator=(UniquePtrPyObject && src) noexcept;
+    explicit operator bool() const noexcept { return py_obj != NULL; }
+    PyObject * get() const noexcept { return py_obj; }
+    PyObject * release() noexcept;
+    void reset(PyObject * pyObj = NULL) noexcept;
+    ~UniquePtrPyObject() { Py_XDECREF(py_obj); }
+
+private:
+    PyObject * py_obj;
+};
+
+inline PyObject * UniquePtrPyObject::release() noexcept {
+    auto tmpObj = py_obj;
+    py_obj = NULL;
+    return tmpObj;
+}
+
+inline UniquePtrPyObject & UniquePtrPyObject::operator=(UniquePtrPyObject && src) noexcept {
+    if (this == &src)
+        return *this;
+    Py_XDECREF(py_obj);
+    py_obj = src.py_obj;
+    src.py_obj = NULL;
+    return *this;
+}
+
+inline void UniquePtrPyObject::reset(PyObject * pyObj) noexcept {
+    Py_XDECREF(this->py_obj);
+    this->py_obj = pyObj;
+}
+
+
+/// bytes or unicode string in Python 3 to c string converter
+class PycompString {
+public:
+    PycompString() = default;
+    explicit PycompString(PyObject * str);
+    const std::string & get_string() const noexcept { return cpp_string; }
+    const char * get_cstring() const noexcept { return is_null ? nullptr : cpp_string.c_str(); }
+
+private:
+    bool is_null{true};
+    std::string cpp_string;
+};
+
+PycompString::PycompString(PyObject * str) {
+    if (PyUnicode_Check(str)) {
+        UniquePtrPyObject py_string(PyUnicode_AsEncodedString(str, "utf-8", "replace"));
+        if (py_string) {
+            // The c_string refers to the internal buffer of py_string
+            char * c_string = PyBytes_AsString(py_string.get());
+            if (c_string) {
+                cpp_string = c_string;
+                is_null = false;
+            }
+        }
+    } else if (PyBytes_Check(str)) {
+        auto c_string = PyBytes_AsString(str);
+        if (c_string) {
+            cpp_string = c_string;
+            is_null = false;
+        }
+    } else {
+        throw std::runtime_error("Expected a string or a unicode object");
+    }
+}
+
+PythonPluginLoader::~PythonPluginLoader() {
+    if (active) {
+        std::lock_guard<libdnf::Base> guard(*base);
+        if (--python_ref_counter == 0) {
+            Py_Finalize();
+        }
+    }
+}
+
+/// Fetch Python error (if exist) and throw C++ exception
+static void fetch_python_error_to_exception(const char * msg) {
+    if (!PyErr_Occurred()) {
+        return;
+    }
+    PyObject *type, *value, *traceback;
+    PyErr_Fetch(&type, &value, &traceback);
+    UniquePtrPyObject objectsRepresentation(PyObject_Repr(value));
+    auto pycomp_str = PycompString(objectsRepresentation.get());
+    throw std::runtime_error(msg + pycomp_str.get_string());
+}
+
+/// Load Python plugin from path
+void PythonPluginLoader::load_plugin_file(const fs::path & file_path) {
+    // Very High Level Embedding
+    // std::string python_code = "import " + file_path.stem().string() +";";
+    // python_code += "import libdnf;";
+    // python_code += "plug = " + file_path.stem().string() +".Plugin();";
+    // python_code += "locked_base = libdnf.base.Base.get_locked_base();";
+    // python_code += "locked_base.add_plugin(plug)";
+    // PyRun_SimpleString(python_code.c_str());
+
+    // Similar but Pure Embeding
+    auto * module_name = file_path.stem().c_str();
+    PyObject * plugin_module = PyImport_ImportModule(module_name);
+    if (!plugin_module) {
+        fetch_python_error_to_exception("PyImport_ImportModule(): ");
+    }
+    PyObject * plugin_module_dict = PyModule_GetDict(plugin_module);
+    if (!plugin_module_dict) {
+        fetch_python_error_to_exception("PyModule_GetDict(plugin_module): ");
+    }
+    PyObject * plugin_class = PyDict_GetItemString(plugin_module_dict, "Plugin");
+    if (!plugin_class) {
+        fetch_python_error_to_exception("PyDict_GetItemString(plugin_module_dict, \"Plugin\"): ");
+    }
+    PyObject * plugin_class_constructor = PyInstanceMethod_New(plugin_class);
+    if (!plugin_class_constructor) {
+        fetch_python_error_to_exception("PyInstanceMethod_New(plugin_class): ");
+    }
+    PyObject * plugin_instance = PyObject_CallObject(plugin_class_constructor, nullptr);
+    if (!plugin_instance) {
+        fetch_python_error_to_exception("PyObject_CallObject(plugin_class_constructor, nullptr): ");
+    }
+    PyObject * libdnf = PyDict_GetItemString(plugin_module_dict, "libdnf");
+    if (!libdnf) {
+        fetch_python_error_to_exception("PyDict_GetItemString(plugin_module_dict, \"libdnf\"): ");
+    }
+    PyObject * libdnf_dict = PyModule_GetDict(libdnf);
+    if (!libdnf_dict) {
+        fetch_python_error_to_exception("PyModule_GetDict(libdnf): ");
+    }
+    PyObject * base_module = PyDict_GetItemString(libdnf_dict, "base");
+    if (!base_module) {
+        fetch_python_error_to_exception("PyDict_GetItemString(plugin_module_dict, \"libdnf\"): ");
+    }
+    PyObject * base_module_dict = PyModule_GetDict(base_module);
+    if (!base_module_dict) {
+        fetch_python_error_to_exception("PyModule_GetDict(base_module): ");
+    }
+    PyObject * base_class = PyDict_GetItemString(base_module_dict, "Base");
+    if (!base_class) {
+        fetch_python_error_to_exception("PyDict_GetItemString(base_module_dict, \"Base\"): ");
+    }
+    UniquePtrPyObject locked_base(PyObject_CallMethod(base_class, "get_locked_base", NULL));
+    if (!locked_base) {
+        fetch_python_error_to_exception("PyDict_CallMethod(base_class, \"get_locked_base\", NULL): ");
+    }
+    UniquePtrPyObject add_plugin_string(PyUnicode_FromString("add_plugin"));
+    PyObject_CallMethodObjArgs(locked_base.get(), add_plugin_string.get(), plugin_instance, NULL);
+}
+
+
+void PythonPluginLoader::load_plugins_from_dir(const fs::path & dir_path) {
+    auto & logger = base->get_logger();
+
+    if (dir_path.empty())
+        throw std::runtime_error("PythonPluginLoader::load_from_dir() dir_path cannot be empty");
+
+    std::vector<fs::path> lib_names;
+    for (auto & p : std::filesystem::directory_iterator(dir_path)) {
+        if ((p.is_regular_file() || p.is_symlink()) && p.path().extension() == ".py") {
+            lib_names.emplace_back(p.path());
+        }
+    }
+    std::sort(lib_names.begin(), lib_names.end());
+
+    std::string error_msgs;
+    for (auto & p : lib_names) {
+        try {
+            load_plugin_file(p);
+        } catch (const std::exception & ex) {
+            std::string msg = fmt::format("Can't load plugin \"{}\": {}", p.string(), ex.what());
+            logger.error(msg);
+            error_msgs += msg + '\n';
+        }
+    }
+
+    if (!error_msgs.empty()) {
+        throw std::runtime_error(error_msgs);
+    }
+}
+
+void PythonPluginLoader::load_plugins(libdnf::Base * base) {
+    this->base = base;
+
+    const char * plugin_dir = std::getenv("LIBDNF_PYTHON_PLUGIN_DIR");
+    if (!plugin_dir) {
+        return;
+    }
+    const fs::path path(plugin_dir);
+
+    std::lock_guard<libdnf::Base> guard(*base);
+
+    if (python_ref_counter == 0) {
+        Py_InitializeEx(0);
+        if (!Py_IsInitialized()) {
+            return;
+        }
+    }
+    active = true;
+    ++python_ref_counter;
+
+    // PyRun_SimpleString("import sys");
+    PyObject * sys_module = PyImport_ImportModule("sys");
+    if (!sys_module) {
+        fetch_python_error_to_exception("PyImport_ImportModule(): ");
+    }
+
+    // PyRun_SimpleString(("sys.path.append('" + path.string() + "')").c_str());
+    PyObject * sys_dict = PyModule_GetDict(sys_module);
+    if (!sys_dict) {
+        fetch_python_error_to_exception("PyModule_GetDict(sys_module): ");
+    }
+    PyObject * path_object = PyDict_GetItemString(sys_dict, "path");
+    if (!path_object) {
+        fetch_python_error_to_exception("PyDict_GetItemString(sys_dict, \"path\"): ");
+    }
+    UniquePtrPyObject append(PyObject_CallMethod(path_object, "append", "(s)", path.c_str()));
+    if (!append) {
+        fetch_python_error_to_exception(("PyDict_CallMethod(path_object, \"append\", \"(s)\", " + path.string() + "): ").c_str());
+    }
+
+    load_plugins_from_dir(path);
+}
+
+
+Version libdnf_plugin_get_api_version(void) {
+    return PLUGIN_API_VERSION;
+}
+
+const char * libdnf_plugin_get_name(void) {
+    return PLUGIN_NAME;
+}
+
+Version libdnf_plugin_get_version(void) {
+    return PLUGIN_VERSION;
+}
+
+IPlugin * libdnf_plugin_new_instance(Version api_version) {
+    if (api_version.major != PLUGIN_API_VERSION.major || api_version.minor != PLUGIN_API_VERSION.minor) {
+        auto msg = fmt::format(
+            "Unsupported API combination. API version implemented by plugin = \"{}.{}.{}\"."
+            " API version in libdnf = \"{}.{}.{}\".",
+            PLUGIN_API_VERSION.major,
+            PLUGIN_API_VERSION.minor,
+            PLUGIN_API_VERSION.micro,
+            api_version.major,
+            api_version.minor,
+            api_version.micro);
+
+        throw std::runtime_error(msg);
+    }
+    return new PythonPluginLoader;
+}
+
+void libdnf_plugin_delete_instance(IPlugin * plugin_object) {
+    delete plugin_object;
+}

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -13,6 +13,7 @@ Source0:        %{url}/archive/%{version}/libdnf-%{version}.tar.gz
 %bcond_without dnfdaemon_server
 %bcond_without libdnf_cli
 %bcond_without microdnf
+%bcond_without python_plugins_loader
 
 %bcond_without comps
 %bcond_without modulemd
@@ -294,6 +295,25 @@ Ruby bindings for the libdnf-cli library.
 %endif
 
 
+# ========== libdnf-plugin-python-plugins-loader ==========
+
+%if %{with python_plugins_loader}
+%package -n python3-libdnf-python-plugins-loader
+Summary:        Libdnf plugin that allows loading Python plugins
+License:        LGPLv2.1+
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       python3-libdnf5%{?_isa} = %{version}-%{release}
+
+%description -n python3-libdnf-python-plugins-loader
+Libdnf plugin that allows loading Python plugins
+
+%files -n python3-libdnf-python-plugins-loader
+%{_libdir}/libdnf-plugins/python_plugins_loader.*
+%{python3_sitelib}/libdnf_plugins/
+%{python3_sitelib}/libdnf_plugins/README
+%endif
+
+
 # ========== dnfdaemon-client ==========
 
 %if %{with dnfdaemon_client}
@@ -384,6 +404,7 @@ It supports RPM packages, modulemd modules, and comps groups & environments.
     -DWITH_DNFDAEMON_SERVER=%{?with_dnfdaemon_server:ON}%{!?with_dnfdaemon_server:OFF} \
     -DWITH_LIBDNF_CLI=%{?with_libdnf_cli:ON}%{!?with_libdnf_cli:OFF} \
     -DWITH_MICRODNF=%{?with_microdnf:ON}%{!?with_microdnf:OFF} \
+    -DWITH_PYTHON_PLUGINS_LOADER=%{?with_python_plugins_loader:ON}%{!?with_python_plugins_loader:OFF} \
     \
     -DWITH_COMPS=%{?with_comps:ON}%{!?with_comps:OFF} \
     -DWITH_MODULEMD=%{?with_modulemd:ON}%{!?with_modulemd:OFF} \

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <atomic>
+#include <cstdlib>
 #include <filesystem>
 #include <mutex>
 #include <vector>
@@ -81,6 +82,16 @@ void Base::load_config_from_dir(const std::string & dir_path) {
 
 void Base::load_config_from_dir() {
     load_config_from_dir(libdnf::CONF_DIRECTORY);
+}
+
+void Base::add_plugin(plugin::IPlugin & iplugin_instance) {
+    plugins.register_plugin(std::make_unique<plugin::Plugin>(iplugin_instance));
+}
+
+void Base::load_plugins() {
+    if (const char * plugin_dir = std::getenv("LIBDNF_PLUGIN_DIR")) {
+        plugins.load_plugins(plugin_dir);
+    }
 }
 
 }  // namespace libdnf

--- a/libdnf/plugin/plugins.cpp
+++ b/libdnf/plugin/plugins.cpp
@@ -1,0 +1,140 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/plugin/plugins.hpp"
+
+#include "libdnf/base/base.hpp"
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
+#include <fmt/format.h>
+
+#include <filesystem>
+
+namespace libdnf::plugin {
+
+PluginLibrary::PluginLibrary(const std::string & library_path) : library(library_path) {
+    get_api_version = reinterpret_cast<TGetApiVersionFunc>(library.get_address("libdnf_plugin_get_api_version"));
+    get_name = reinterpret_cast<TGetNameFunc>(library.get_address("libdnf_plugin_get_name"));
+    get_version = reinterpret_cast<TGetVersionFunc>(library.get_address("libdnf_plugin_get_version"));
+    new_instance = reinterpret_cast<TNewInstanceFunc>(library.get_address("libdnf_plugin_new_instance"));
+    delete_instance = reinterpret_cast<TDeleteInstanceFunc>(library.get_address("libdnf_plugin_delete_instance"));
+    iplugin_instance = new_instance(PLUGIN_API_VERSION);
+}
+
+PluginLibrary::~PluginLibrary() {
+    finish();
+    delete_instance(iplugin_instance);
+    iplugin_instance = nullptr;
+}
+
+Plugins::~Plugins() {
+    finish();
+    for (auto plugin = plugins.rbegin(), stop = plugins.rend(); plugin != stop; ++plugin) {
+        (*plugin).reset();
+    }
+}
+
+void Plugins::register_plugin(std::unique_ptr<Plugin> && plugin) {
+    auto & logger = base->get_logger();
+    auto * iplugin = plugin->get_iplugin();
+    plugins.emplace_back(std::move(plugin));
+    auto name = iplugin->get_name();
+    auto version = iplugin->get_version();
+    logger.debug(fmt::format(
+        _("Added plugin name=\"{}\", version=\"{}.{}.{}\""), name, version.major, version.minor, version.micro));
+
+    logger.debug(fmt::format(_("Trying to load more plugins using the \"{}\" plugin."), name));
+    iplugin->load_plugins(base);
+    logger.debug(fmt::format(_("End of loading plugins using the \"{}\" plugin."), name));
+}
+
+void Plugins::load_plugin(const std::string & file_path) {
+    auto & logger = base->get_logger();
+    logger.debug(fmt::format(_("Loading plugin file=\"{}\""), file_path));
+    auto plugin = std::make_unique<PluginLibrary>(file_path);
+    auto * iplugin = plugin->get_iplugin();
+    plugins.emplace_back(std::move(plugin));
+    auto name = iplugin->get_name();
+    auto version = iplugin->get_version();
+    logger.debug(fmt::format(
+        _("Loaded plugin name=\"{}\", version=\"{}.{}.{}\""), name, version.major, version.minor, version.micro));
+
+    logger.debug(fmt::format(_("Trying to load more plugins using the \"{}\" plugin."), name));
+    iplugin->load_plugins(base);
+    logger.debug(fmt::format(_("End of loading plugins using the \"{}\" plugin."), name));
+}
+
+void Plugins::load_plugins(const std::string & dir_path) {
+    auto & logger = base->get_logger();
+    if (dir_path.empty())
+        throw std::runtime_error(_("Plugins::loadPlugins() dirPath cannot be empty"));
+
+    std::vector<std::filesystem::path> lib_names;
+    for (auto & p : std::filesystem::directory_iterator(dir_path)) {
+        if ((p.is_regular_file() || p.is_symlink()) && p.path().extension() == ".so") {
+            lib_names.emplace_back(p.path());
+        }
+    }
+    std::sort(lib_names.begin(), lib_names.end());
+
+    std::string error_msgs;
+    for (auto & p : lib_names) {
+        try {
+            load_plugin(p);
+        } catch (const std::exception & ex) {
+            std::string msg = fmt::format(_("Can't load plugin \"{}\": {}"), p.string(), ex.what());
+            logger.error(msg);
+            error_msgs += msg + '\n';
+        }
+    }
+
+    if (!error_msgs.empty()) {
+        throw std::runtime_error(error_msgs);
+    }
+}
+
+bool Plugins::init() {
+    for (auto & plugin : plugins) {
+        if (plugin->get_enabled()) {
+            plugin->init(base);
+        }
+    }
+    return true;
+}
+
+bool Plugins::hook(HookId id) {
+    for (auto & plugin : plugins) {
+        if (plugin->get_enabled()) {
+            if (!plugin->hook(id)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void Plugins::finish() noexcept {
+    for (auto plugin = plugins.rbegin(), stop = plugins.rend(); plugin != stop; ++plugin) {
+        if ((*plugin)->get_enabled()) {
+            (*plugin)->finish();
+        }
+    }
+}
+
+}  // namespace libdnf::plugin

--- a/libdnf/utils/library.cpp
+++ b/libdnf/utils/library.cpp
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "library.hpp"
+
+#include <dlfcn.h>
+
+namespace libdnf::utils {
+
+Library::Library(const std::string & path)
+: path(path) {
+    handle = dlopen(path.c_str(), RTLD_LAZY);
+    if (!handle) {
+        const char * err_msg = dlerror();
+        throw CantLoad(err_msg);
+    }
+}
+
+Library::~Library() {
+    dlclose(handle);
+}
+
+void * Library::get_address(const char * symbol) const {
+    dlerror();  // Clear any existing error
+    void * address  = dlsym(handle, symbol);
+    if (!address)
+    {
+        const char * err_msg = dlerror();
+        if (err_msg) {
+            throw NotFound(err_msg);
+        }
+    }
+    return address;
+}
+
+}  // namespace libdnf::utils

--- a/libdnf/utils/library.hpp
+++ b/libdnf/utils/library.hpp
@@ -1,0 +1,72 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef _LIBDNF_UTILS_LIBRARY_HPP
+#define _LIBDNF_UTILS_LIBRARY_HPP
+
+#include "libdnf/utils/exception.hpp"
+
+#include <string>
+
+namespace libdnf::utils {
+
+class Library {
+public:
+    /// Library exception
+    class Exception : public RuntimeError {
+    public:
+        using RuntimeError::RuntimeError;
+        const char * get_domain_name() const noexcept override { return "libdnf::Library"; }
+        const char * get_name() const noexcept override { return "Exception"; }
+        const char * get_description() const noexcept override { return "Library exception"; }
+    };
+
+    class CantLoad : public Exception {
+    public:
+        using Exception::Exception;
+        const char * get_name() const noexcept override { return "CantLoad"; }
+        const char * get_description() const noexcept override { return "Can't load shared library"; }
+    };
+
+    class NotFound : public Exception {
+    public:
+        using Exception::Exception;
+        const char * get_name() const noexcept override { return "NotFound"; }
+        const char * get_description() const noexcept override { return "Can't obtain address of symbol"; }
+    };
+
+    explicit Library(const std::string & path);
+    ~Library();
+
+    Library(const Library &) = delete;
+    Library(Library &&) = delete;
+    Library & operator =(const Library &) = delete;
+    Library & operator =(Library &&) = delete;
+
+    const std::string & get_path() const noexcept { return path; }
+    void * get_address(const char * symbol) const;
+
+private:
+    std::string path;
+    void * handle;
+};
+
+}  // namespace libdnf::utils
+
+#endif

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -163,6 +163,10 @@ int main(int argc, char * argv[]) {
 
     context.set_prg_arguments(static_cast<size_t>(argc), argv);
 
+    context.base.load_plugins();
+    auto & plugins = context.base.get_plugins();
+    plugins.init();
+
     // Register commands
     context.commands.push_back(std::make_unique<microdnf::CmdInstall>());
     context.commands.push_back(std::make_unique<microdnf::CmdDownload>());
@@ -257,6 +261,7 @@ int main(int argc, char * argv[]) {
 
     //configure_plugins
     //configure_from_options(context);
+    plugins.hook(libdnf::plugin::HookId::LOAD_CONFIG_FROM_FILE);
 
     // Configure selected command
     context.selected_command->configure(context);


### PR DESCRIPTION
I designed the plugin architecture for libdnf 5.
The architecture supports plugins written in C++. However, it also supports loading plugins using plagins. Even plugins in languages ​​other than C ++.

`Base::load_plugins()` - Loads plugins (".so" files) from the directory specified in the `LIBDNF_PLUGIN_DIR` environment variable. If the environment variable is not set, plugins will not be loaded.

PR also includes a C++ plugin that loads Python plugins - python_plugins_loader. And one sample Python plugin.
The path to the directory with Python plugins is retrieved from the `LIBDNF_PYTHON_PLUGIN_DIR` environment variable. If this variable is not set, plugins are not loaded.