### PR TITLE
[dnfdaemon] Repoconf service uses session configuration

### DIFF
--- a/dnfdaemon-server/services/repoconf/configuration.cpp
+++ b/dnfdaemon-server/services/repoconf/configuration.cpp
@@ -26,38 +26,32 @@
 #include <filesystem>
 #include <iostream>
 
-Configuration::Configuration(Session & session) : cfg_main(new libdnf::ConfigMain), session(session) {
-    install_root = session.session_configuration_value<std::string>("installroot", "/");
-}
+Configuration::Configuration(Session & session) : session(session) {}
 
 void Configuration::read_configuration() {
     read_main_config();
     read_repo_configs();
 }
 
-std::string Configuration::prepend_install_root(const std::string & path) {
-    auto fs_path = std::filesystem::path(path);
-    return (std::filesystem::path(install_root) / fs_path.relative_path()).string();
-}
-
 void Configuration::read_main_config() {
     auto & logger = session.get_base()->get_logger();
-    auto main_config_path = prepend_install_root(cfg_main->config_file_path().get_value());
     auto base = session.get_base();
+    auto & cfg_main = base->get_config();
+    auto main_config_path = cfg_main.config_file_path().get_value();
 
     try {
         // create new main config parser and read the config file
         std::unique_ptr<libdnf::ConfigParser> main_parser(new libdnf::ConfigParser);
 
         main_parser->read(main_config_path);
-        cfg_main->load_from_parser(
+        cfg_main.load_from_parser(
             *main_parser,
             "main",
             base->get_vars(),
             base->get_logger()
         );
 
-        base->get_vars().load(cfg_main->installroot().get_value(), cfg_main->varsdir().get_value());
+        base->get_vars().load(cfg_main.installroot().get_value(), cfg_main.varsdir().get_value());
 
         // read repos possibly configured in the main config file
         read_repos(main_parser.get(), main_config_path);
@@ -70,17 +64,19 @@ void Configuration::read_main_config() {
 
 void Configuration::read_repos(const libdnf::ConfigParser * repo_parser, const std::string & file_path) {
     const auto & cfg_parser_data = repo_parser->get_data();
+    auto base = session.get_base();
+    auto & cfg_main = base->get_config();
     for (const auto & cfg_parser_data_iter : cfg_parser_data) {
         if (cfg_parser_data_iter.first != "main") {
             // each section other than [main] is considered a repository
             auto section = cfg_parser_data_iter.first;
-            std::unique_ptr<libdnf::rpm::ConfigRepo> cfg_repo(new libdnf::rpm::ConfigRepo(*cfg_main));
+            std::unique_ptr<libdnf::rpm::ConfigRepo> cfg_repo(new libdnf::rpm::ConfigRepo(cfg_main));
 
             cfg_repo->load_from_parser(
                 *repo_parser,
                 section,
-                session.get_base()->get_vars(),
-                session.get_base()->get_logger()
+                base->get_vars(),
+                base->get_logger()
             );
             // save configured repo
             std::unique_ptr<RepoInfo> repoinfo(new RepoInfo());
@@ -92,12 +88,14 @@ void Configuration::read_repos(const libdnf::ConfigParser * repo_parser, const s
 }
 
 void Configuration::read_repo_configs() {
-    auto & logger = session.get_base()->get_logger();
-    for (const auto & repos_dir : cfg_main->reposdir().get_value()) {
+    auto base = session.get_base();
+    auto & logger = base->get_logger();
+    auto & cfg_main = base->get_config();
+    for (const auto & repos_dir : cfg_main.reposdir().get_value()) {
         // use canonical to resolve symlinks in repos_dir
         std::string pattern;
         try {
-            pattern = std::filesystem::canonical(prepend_install_root(repos_dir)).string() + "/*.repo";
+            pattern = std::filesystem::canonical(repos_dir).string() + "/*.repo";
         } catch (std::filesystem::filesystem_error & e) {
             logger.debug(
                 fmt::format("Error reading repository configuration directory \"{}\": {}", repos_dir, e.what()));

--- a/dnfdaemon-server/services/repoconf/configuration.hpp
+++ b/dnfdaemon-server/services/repoconf/configuration.hpp
@@ -47,19 +47,16 @@ public:
     libdnf::ConfigParser * find_parser(const std::string & file_path);
 
 private:
-    std::unique_ptr<libdnf::ConfigMain> cfg_main;
     // repoid: repoinfo
     std::map<std::string, std::unique_ptr<RepoInfo>> repos;
     // repo_config_file_path: parser
     std::map<std::string, std::unique_ptr<libdnf::ConfigParser>> config_parsers;
     std::map<std::string, std::string> substitutions;
-    std::string install_root;
     Session & session;
 
     void read_repos(const libdnf::ConfigParser * repo_parser, const std::string & file_path);
     void read_main_config();
     void read_repo_configs();
-    std::string prepend_install_root(const std::string & path);
 };
 
 

--- a/test/dnfdaemon-server/test_repoconf.py
+++ b/test/dnfdaemon-server/test_repoconf.py
@@ -43,15 +43,21 @@ class RepoConfTest(unittest.TestCase):
     def setUp(self):
         # prepare install root with repository configuration
         self.installroot = tempfile.mkdtemp(prefix="dnfdaemon-test-")
-        configure_repo(os.path.join(self.installroot, 'etc/dnf/dnf.conf'), 'main_repo')
-        configure_repo(os.path.join(self.installroot, 'etc/yum.repos.d/repo1.repo'), 'repo1')
-        configure_repo(os.path.join(self.installroot, 'etc/yum.repos.d/repo2.repo'), 'repo2')
+        config_file_path = os.path.join(self.installroot, 'etc/dnf/dnf.conf')
+        reposdir = os.path.join(self.installroot, 'etc/yum.repos.d')
+        configure_repo(config_file_path, 'main_repo')
+        configure_repo(os.path.join(reposdir, 'repo1.repo'), 'repo1')
+        configure_repo(os.path.join(reposdir, 'repo2.repo'), 'repo2')
         # get the session for the installroot
         self.bus = dbus.SystemBus()
         self.iface_session = dbus.Interface(
             self.bus.get_object(support.DNFDAEMON_BUS_NAME, support.DNFDAEMON_OBJECT_PATH),
             dbus_interface=support.IFACE_SESSION_MANAGER)
-        self.session = self.iface_session.open_session({"installroot": self.installroot})
+        self.session = self.iface_session.open_session({
+            "installroot": self.installroot,
+            "config_file_path": config_file_path,
+            "reposdir": reposdir,
+            })
         self.iface_repoconf = dbus.Interface(
             self.bus.get_object(support.DNFDAEMON_BUS_NAME, self.session),
             dbus_interface=IFACE_REPOCONF)


### PR DESCRIPTION
Remove special handling of installroot in repoconf. Now settings are
handled on session level.