### PR TITLE
libdnf.h: Remove overall extern "C"

### DIFF
--- a/libdnf/libdnf.h
+++ b/libdnf/libdnf.h
@@ -22,10 +22,6 @@
 #ifndef __LIBDNF_H
 #define __LIBDNF_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define __LIBDNF_H_INSIDE__
 
 #include <libdnf/dnf-advisory.h>
@@ -62,9 +58,5 @@ extern "C" {
 #include <libdnf/hy-util.h>
 
 #undef __LIBDNF_H_INSIDE__
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* __LIBDNF_H */


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1935

The individual header files already do this, which is
the right thing to do.  Otherwise we force on C linkage
even for external header files like the ones from GLib,
but they may want to use C++ features if they detect
they're being used in C++.

(In fact GLib offers `G_BEGIN_DECLS/G_END_DECLS`
 which is a nice macro wrapper for this, but we can switch
 to that later)