### PR TITLE
Change order of TransactionItemReason (RhBug:1921063)

### DIFF
--- a/libdnf/transaction/TransactionItemReason.hpp
+++ b/libdnf/transaction/TransactionItemReason.hpp
@@ -48,10 +48,10 @@ inline bool operator<(TransactionItemReason lhs, TransactionItemReason rhs)
         return false;
     }
     TransactionItemReason order[] = {
-        TransactionItemReason::UNKNOWN,
         TransactionItemReason::CLEAN,
         TransactionItemReason::WEAK_DEPENDENCY,
         TransactionItemReason::DEPENDENCY,
+        TransactionItemReason::UNKNOWN,
         TransactionItemReason::GROUP,
         TransactionItemReason::USER,
     };

--- a/tests/libdnf/transaction/TransactionItemReasonTest.cpp
+++ b/tests/libdnf/transaction/TransactionItemReasonTest.cpp
@@ -339,6 +339,14 @@ TransactionItemReasonTest::testCompareReasons()
     CPPUNIT_ASSERT(TransactionItemReason::GROUP != TransactionItemReason::USER);
     CPPUNIT_ASSERT(TransactionItemReason::GROUP < TransactionItemReason::USER);
     CPPUNIT_ASSERT(TransactionItemReason::GROUP <= TransactionItemReason::USER);
+
+    CPPUNIT_ASSERT(TransactionItemReason::UNKNOWN < TransactionItemReason::USER);
+    CPPUNIT_ASSERT(TransactionItemReason::GROUP > TransactionItemReason::UNKNOWN);
+    CPPUNIT_ASSERT(TransactionItemReason::DEPENDENCY < TransactionItemReason::UNKNOWN);
+    CPPUNIT_ASSERT(TransactionItemReason::WEAK_DEPENDENCY < TransactionItemReason::UNKNOWN);
+    CPPUNIT_ASSERT(TransactionItemReason::CLEAN < TransactionItemReason::UNKNOWN);
+    CPPUNIT_ASSERT(TransactionItemReason::WEAK_DEPENDENCY < TransactionItemReason::DEPENDENCY);
+    CPPUNIT_ASSERT(TransactionItemReason::CLEAN < TransactionItemReason::WEAK_DEPENDENCY);
 }
 
 void


### PR DESCRIPTION
TransactionItemReason::UNKNOWN will have higher value than
TransactionItemReason::DEPENDENCY. It resolves the problem when kernel
with reason UNKNOWN is changed to DEPENDENCY after upgrade.

https://bugzilla.redhat.com/show_bug.cgi?id=1921063

Requires: https://github.com/rpm-software-management/dnf/pull/1728

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/958