### PR TITLE
[dnf-5] Add goal.install_or_reinstall()

### DIFF
--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -36,7 +36,7 @@ class Goal {
 public:
     /// NOT_FOUND - _('No match for argument: %s')
     enum class Problem { NOT_FOUND, EXCLUDED, ONLY_SRC, NOT_FOUND_IN_REPOSITORIES };
-    enum class Action { INSTALL, UPGRADE, REMOVE };
+    enum class Action { INSTALL, INSTALL_OR_REINSTALL, UPGRADE, REMOVE };
 
     explicit Goal(Base * base);
     ~Goal();
@@ -46,8 +46,12 @@ public:
         const std::vector<std::string> & repo_ids,
         bool strict,
         const std::vector<libdnf::rpm::Nevra::Form> & forms);
+    /// Prevent reinstallation by adding of already installed packages with the same NEVRA
     void add_rpm_install(const libdnf::rpm::Package & rpm_package, bool strict);
+    /// Prevent reinstallation by adding of already installed packages with the same NEVRA
     void add_rpm_install(const libdnf::rpm::PackageSet & package_set, bool strict);
+    void add_rpm_install_or_reinstall(const libdnf::rpm::Package & rpm_package, bool strict);
+    void add_rpm_install_or_reinstall(const libdnf::rpm::PackageSet & package_set, bool strict);
     void add_rpm_remove(
         const std::string & spec, const std::string & repo_id, const std::vector<libdnf::rpm::Nevra::Form> & forms);
     void add_rpm_remove(const libdnf::rpm::Package & rpm_package);

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -34,6 +34,15 @@ namespace libdnf {
 
 class Goal {
 public:
+    struct UsedDifferentSack : public LogicError {
+        using LogicError::LogicError;
+        UsedDifferentSack() : LogicError(
+            "Cannot perform the action with Goal instances initialized with different SolvSacks") {};
+        const char * get_domain_name() const noexcept override { return "libdnf::Goal"; }
+        const char * get_name() const noexcept override { return "UsedDifferentSack"; }
+        const char * get_description() const noexcept override { return "Goal exception"; }
+    };
+
     /// NOT_FOUND - _('No match for argument: %s')
     enum class Problem { NOT_FOUND, EXCLUDED, ONLY_SRC, NOT_FOUND_IN_REPOSITORIES };
     enum class Action { INSTALL, INSTALL_OR_REINSTALL, UPGRADE, REMOVE };

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -97,12 +97,18 @@ void Goal::add_rpm_install(
 }
 
 void Goal::add_rpm_install(const libdnf::rpm::Package & rpm_package, bool strict) {
+    if (rpm_package.sack.get() != &p_impl->base->get_rpm_solv_sack()) {
+        throw UsedDifferentSack();
+    }
     libdnf::rpm::solv::IdQueue ids;
     ids.push_back(rpm_package.get_id().id);
     p_impl->rpm_ids.push_back(std::make_tuple(Action::INSTALL, std::move(ids), strict));
 }
 
 void Goal::add_rpm_install(const libdnf::rpm::PackageSet & package_set, bool strict) {
+    if (package_set.get_sack() != &p_impl->base->get_rpm_solv_sack()) {
+        throw UsedDifferentSack();
+    }
     libdnf::rpm::solv::IdQueue ids;
     for (auto package_id : *package_set.p_impl) {
         ids.push_back(package_id.id);
@@ -111,12 +117,18 @@ void Goal::add_rpm_install(const libdnf::rpm::PackageSet & package_set, bool str
 }
 
 void Goal::add_rpm_install_or_reinstall(const libdnf::rpm::Package & rpm_package, bool strict) {
+    if (rpm_package.sack.get() != &p_impl->base->get_rpm_solv_sack()) {
+        throw UsedDifferentSack();
+    }
     libdnf::rpm::solv::IdQueue ids;
     ids.push_back(rpm_package.get_id().id);
     p_impl->rpm_ids.push_back(std::make_tuple(Action::INSTALL_OR_REINSTALL, std::move(ids), strict));
 }
 
 void Goal::add_rpm_install_or_reinstall(const libdnf::rpm::PackageSet & package_set, bool strict) {
+    if (package_set.get_sack() != &p_impl->base->get_rpm_solv_sack()) {
+        throw UsedDifferentSack();
+    }
     libdnf::rpm::solv::IdQueue ids;
     for (auto package_id : *package_set.p_impl) {
         ids.push_back(package_id.id);
@@ -130,12 +142,18 @@ void Goal::add_rpm_remove(
 }
 
 void Goal::add_rpm_remove(const libdnf::rpm::Package & rpm_package) {
+    if (rpm_package.sack.get() != &p_impl->base->get_rpm_solv_sack()) {
+        throw UsedDifferentSack();
+    }
     libdnf::rpm::solv::IdQueue ids;
     ids.push_back(rpm_package.get_id().id);
     p_impl->rpm_ids.push_back(std::make_tuple(Action::REMOVE, std::move(ids), false));
 }
 
 void Goal::add_rpm_remove(const libdnf::rpm::PackageSet & package_set) {
+    if (package_set.get_sack() != &p_impl->base->get_rpm_solv_sack()) {
+        throw UsedDifferentSack();
+    }
     libdnf::rpm::solv::IdQueue ids;
     for (auto package_id : *package_set.p_impl) {
         ids.push_back(package_id.id);
@@ -148,12 +166,18 @@ void Goal::add_rpm_upgrade(const std::string & spec, const std::vector<std::stri
 }
 
 void Goal::add_rpm_upgrade(const libdnf::rpm::Package & rpm_package) {
+    if (rpm_package.sack.get() != &p_impl->base->get_rpm_solv_sack()) {
+        throw UsedDifferentSack();
+    }
     libdnf::rpm::solv::IdQueue ids;
     ids.push_back(rpm_package.get_id().id);
     p_impl->rpm_ids.push_back(std::make_tuple(Action::UPGRADE, std::move(ids), false));
 }
 
 void Goal::add_rpm_upgrade(const libdnf::rpm::PackageSet & package_set) {
+    if (package_set.get_sack() != &p_impl->base->get_rpm_solv_sack()) {
+        throw UsedDifferentSack();
+    }
     libdnf::rpm::solv::IdQueue ids;
     for (auto package_id : *package_set.p_impl) {
         ids.push_back(package_id.id);

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -95,3 +95,52 @@ void BaseGoalTest::test_remove() {
     CPPUNIT_ASSERT_EQUAL(remove_set[0].get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
     CPPUNIT_ASSERT_EQUAL(0lu, obsoleted_set.size());
 }
+
+void BaseGoalTest::test_install_pkg() {
+    std::filesystem::path rpm_path =
+        PROJECT_SOURCE_DIR "/test/libdnf/rpm/repos-data/dnf-ci-fedora/x86_64/wget-1.19.5-5.fc29.x86_64.rpm";
+    sack->add_system_package(rpm_path, false, false);
+    libdnf::Goal goal(base.get());
+    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    query.ifilter_available().ifilter_nevra(libdnf::sack::QueryCmp::EQ, {"wget-1.19.5-5.fc29.x86_64"});
+    CPPUNIT_ASSERT_EQUAL(1lu, query.size());
+    goal.add_rpm_install(query, true);
+    goal.resolve();
+    auto install_set = goal.list_rpm_installs();
+    auto reinstall_set = goal.list_rpm_reinstalls();
+    auto upgrade_set = goal.list_rpm_upgrades();
+    auto downgrade_set = goal.list_rpm_downgrades();
+    auto remove_set = goal.list_rpm_removes();
+    auto obsoleted_set = goal.list_rpm_obsoleted();
+    CPPUNIT_ASSERT_EQUAL(0lu, install_set.size());
+    CPPUNIT_ASSERT_EQUAL(0lu, reinstall_set.size());
+    CPPUNIT_ASSERT_EQUAL(0lu, upgrade_set.size());
+    CPPUNIT_ASSERT_EQUAL(0lu, downgrade_set.size());
+    CPPUNIT_ASSERT_EQUAL(0lu, remove_set.size());
+    CPPUNIT_ASSERT_EQUAL(0lu, obsoleted_set.size());
+}
+
+void BaseGoalTest::test_install_or_reinstall() {
+    std::filesystem::path rpm_path =
+        PROJECT_SOURCE_DIR "/test/libdnf/rpm/repos-data/dnf-ci-fedora/x86_64/wget-1.19.5-5.fc29.x86_64.rpm";
+    sack->add_system_package(rpm_path, false, false);
+    libdnf::Goal goal(base.get());
+    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    query.ifilter_available().ifilter_nevra(libdnf::sack::QueryCmp::EQ, {"wget-1.19.5-5.fc29.x86_64"});
+    CPPUNIT_ASSERT_EQUAL(1lu, query.size());
+    goal.add_rpm_install_or_reinstall(query, true);
+    goal.resolve();
+    auto install_set = goal.list_rpm_installs();
+    auto reinstall_set = goal.list_rpm_reinstalls();
+    auto upgrade_set = goal.list_rpm_upgrades();
+    auto downgrade_set = goal.list_rpm_downgrades();
+    auto remove_set = goal.list_rpm_removes();
+    auto obsoleted_set = goal.list_rpm_obsoleted();
+    CPPUNIT_ASSERT_EQUAL(0lu, install_set.size());
+    CPPUNIT_ASSERT_EQUAL(1lu, reinstall_set.size());
+    CPPUNIT_ASSERT_EQUAL(reinstall_set[0].get_full_nevra(), std::string("wget-0:1.19.5-5.fc29.x86_64"));
+    CPPUNIT_ASSERT_EQUAL(0lu, upgrade_set.size());
+    CPPUNIT_ASSERT_EQUAL(0lu, downgrade_set.size());
+    CPPUNIT_ASSERT_EQUAL(0lu, remove_set.size());
+    CPPUNIT_ASSERT_EQUAL(0lu, obsoleted_set.size());
+}

--- a/test/libdnf/base/test_goal.hpp
+++ b/test/libdnf/base/test_goal.hpp
@@ -32,6 +32,8 @@ class BaseGoalTest : public RepoFixture {
 
 #ifndef WITH_PERFORMANCE_TESTS
     CPPUNIT_TEST(test_install);
+    CPPUNIT_TEST(test_install_pkg);
+    CPPUNIT_TEST(test_install_or_reinstall);
     CPPUNIT_TEST(test_install_from_cmdline);
     CPPUNIT_TEST(test_remove);
 #endif
@@ -45,6 +47,8 @@ public:
     void setUp() override;
 
     void test_install();
+    void test_install_pkg();
+    void test_install_or_reinstall();
     void test_install_from_cmdline();
     void test_remove();
 };


### PR DESCRIPTION
It is an important part of functionality that was possible to emulate by
Hawkey goal. In DNF-5 the low level object will be not available
therefore we have to emulate it somewhere else.