### PR TITLE
[context] Support config file option "proxy_auth_method", set default to "any"

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1090,6 +1090,11 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, gboolean reloadFromGKeyFile, GError **e
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_PROXY, tmp_cstr))
         return FALSE;
 
+    // setup proxy authorization method
+    auto proxyAuthMethods = libdnf::Repo::Impl::stringToProxyAuthMethods(conf->proxy_auth_method().getValue());
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_PROXYAUTHMETHODS, static_cast<long>(proxyAuthMethods)))
+        return FALSE;
+
     // setup proxy username and password
     tmp_cstr = NULL;
     if (!conf->proxy_username().empty()) {

--- a/libdnf/repo/Repo-private.hpp
+++ b/libdnf/repo/Repo-private.hpp
@@ -134,6 +134,9 @@ public:
     void attachLibsolvRepo(LibsolvRepo * libsolvRepo);
     void detachLibsolvRepo();
 
+    // Converts configuration string of proxy authorization methods to librepo enum.
+    static LrAuth stringToProxyAuthMethods(const std::string & proxy_auth_method) noexcept;
+
     std::string id;
     Type type;
     std::unique_ptr<ConfigRepo> conf;

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -608,15 +608,8 @@ std::unique_ptr<LrHandle> Repo::Impl::lrHandleInitRemote(const char *destdir)
         handleSetOpt(h.get(), LRO_PROXY, conf->proxy().getValue().c_str());
 
     //set proxy authorization method
-    auto proxyAuthMethodStr = conf->proxy_auth_method().getValue();
-    auto proxyAuthMethod = LR_AUTH_ANY;
-    for (auto & auth : PROXYAUTHMETHODS) {
-        if (proxyAuthMethodStr == auth.name) {
-            proxyAuthMethod = auth.code;
-            break;
-        }
-    }
-    handleSetOpt(h.get(), LRO_PROXYAUTHMETHODS, static_cast<long>(proxyAuthMethod));
+    auto proxyAuthMethods = stringToProxyAuthMethods(conf->proxy_auth_method().getValue());
+    handleSetOpt(h.get(), LRO_PROXYAUTHMETHODS, static_cast<long>(proxyAuthMethods));
 
     if (!conf->proxy_username().empty()) {
         userpwd = conf->proxy_username().getValue();
@@ -1531,6 +1524,18 @@ void Repo::Impl::detachLibsolvRepo()
         attachLibsolvMutex.unlock();
 }
 
+LrAuth Repo::Impl::stringToProxyAuthMethods(const std::string & proxyAuthMethodStr) noexcept
+{
+    auto proxyAuthMethods = LR_AUTH_ANY;
+    for (auto & auth : PROXYAUTHMETHODS) {
+        if (proxyAuthMethodStr == auth.name) {
+            proxyAuthMethods = auth.code;
+            break;
+        }
+    }
+    return proxyAuthMethods;
+}
+
 void Repo::setMaxMirrorTries(int maxMirrorTries)
 {
     pImpl->maxMirrorTries = maxMirrorTries;
@@ -1710,15 +1715,8 @@ static LrHandle * newHandle(ConfigMain * conf)
             handleSetOpt(h, LRO_PROXY, conf->proxy().getValue().c_str());
 
         //set proxy authorization method
-        auto proxyAuthMethodStr = conf->proxy_auth_method().getValue();
-        auto proxyAuthMethod = LR_AUTH_ANY;
-        for (auto & auth : PROXYAUTHMETHODS) {
-            if (proxyAuthMethodStr == auth.name) {
-                proxyAuthMethod = auth.code;
-                break;
-            }
-        }
-        handleSetOpt(h, LRO_PROXYAUTHMETHODS, static_cast<long>(proxyAuthMethod));
+        auto proxyAuthMethods = Repo::Impl::stringToProxyAuthMethods(conf->proxy_auth_method().getValue());
+        handleSetOpt(h, LRO_PROXYAUTHMETHODS, static_cast<long>(proxyAuthMethods));
 
         if (!conf->proxy_username().empty()) {
             auto userpwd = conf->proxy_username().getValue();


### PR DESCRIPTION
Adds support for the "proxy_auth_method" configuration file option.
The default value is set to "any". Before that, the default librepo/libcurl value "basic" was used.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1924001

Support for "proxy_username" and "proxy_password" was added in PR https://github.com/rpm-software-management/libdnf/pull/1103 . However, without "proxy_auth_method", usage is very limited.
