### PR TITLE
[dnf5] New options for working with certificates used with proxy and fully set ssl in newHandle function

### DIFF
--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -246,6 +246,14 @@ public:
     const OptionString & sslclientcert() const;
     OptionString & sslclientkey();
     const OptionString & sslclientkey() const;
+    OptionString & proxy_sslcacert();
+    const OptionString & proxy_sslcacert() const;
+    OptionBool & proxy_sslverify();
+    const OptionBool & proxy_sslverify() const;
+    OptionString & proxy_sslclientcert();
+    const OptionString & proxy_sslclientcert() const;
+    OptionString & proxy_sslclientkey();
+    const OptionString & proxy_sslclientkey() const;
     OptionBool & deltarpm();
     const OptionBool & deltarpm() const;
     OptionNumber<std::uint32_t> & deltarpm_percentage();

--- a/include/libdnf/rpm/config_repo.hpp
+++ b/include/libdnf/rpm/config_repo.hpp
@@ -111,6 +111,14 @@ public:
     const OptionChild<OptionString> & sslclientcert() const;
     OptionChild<OptionString> & sslclientkey();
     const OptionChild<OptionString> & sslclientkey() const;
+    OptionChild<OptionString> & proxy_sslcacert();
+    const OptionChild<OptionString> & proxy_sslcacert() const;
+    OptionChild<OptionBool> & proxy_sslverify();
+    const OptionChild<OptionBool> & proxy_sslverify() const;
+    OptionChild<OptionString> & proxy_sslclientcert();
+    const OptionChild<OptionString> & proxy_sslclientcert() const;
+    OptionChild<OptionString> & proxy_sslclientkey();
+    const OptionChild<OptionString> & proxy_sslclientkey() const;
     OptionChild<OptionBool> & deltarpm();
     const OptionChild<OptionBool> & deltarpm() const;
     OptionChild<OptionNumber<std::uint32_t>> & deltarpm_percentage();

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -37,7 +37,7 @@ Source0:        %{url}/archive/%{version}/libdnf-%{version}.tar.gz
 # ========== versions of dependencies ==========
 
 %global libmodulemd_version 2.5.0
-%global librepo_version 1.11.0
+%global librepo_version 1.13.0
 %global libsolv_version 0.7.7
 %global swig_version 3.0.12
 %global zchunk_version 0.9.11

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -64,7 +64,7 @@ PKG_CHECK_MODULES(GPGME gpgme REQUIRED)
 list(APPEND LIBDNF_PC_REQUIRES "${LIBREPO_MODULE_NAME}")
 target_link_libraries(libdnf ${GPGME_LIBRARIES})
 
-pkg_check_modules(LIBREPO REQUIRED librepo)
+pkg_check_modules(LIBREPO REQUIRED librepo>=1.13.0)
 list(APPEND LIBDNF_PC_REQUIRES "${LIBREPO_MODULE_NAME}")
 target_link_libraries(libdnf ${LIBREPO_LIBRARIES})
 

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -340,6 +340,10 @@ class ConfigMain::Impl {
     OptionBool sslverify{true};
     OptionString sslclientcert{""};
     OptionString sslclientkey{""};
+    OptionString proxy_sslcacert{""};
+    OptionBool proxy_sslverify{true};
+    OptionString proxy_sslclientcert{""};
+    OptionString proxy_sslclientkey{""};
     OptionBool deltarpm{true};
     OptionNumber<std::uint32_t> deltarpm_percentage{75};
     OptionBool skip_if_unavailable{false};
@@ -498,6 +502,10 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("sslverify", sslverify);
     owner.opt_binds().add("sslclientcert", sslclientcert);
     owner.opt_binds().add("sslclientkey", sslclientkey);
+    owner.opt_binds().add("proxy_sslcacert", proxy_sslcacert);
+    owner.opt_binds().add("proxy_sslverify", proxy_sslverify);
+    owner.opt_binds().add("proxy_sslclientcert", proxy_sslclientcert);
+    owner.opt_binds().add("proxy_sslclientkey", proxy_sslclientkey);
     owner.opt_binds().add("deltarpm", deltarpm);
     owner.opt_binds().add("deltarpm_percentage", deltarpm_percentage);
     owner.opt_binds().add("skip_if_unavailable", skip_if_unavailable);
@@ -1193,6 +1201,38 @@ OptionString & ConfigMain::sslclientkey() {
 }
 const OptionString & ConfigMain::sslclientkey() const {
     return p_impl->sslclientkey;
+}
+
+OptionString & ConfigMain::proxy_sslcacert() {
+    return p_impl->proxy_sslcacert;
+}
+
+const OptionString & ConfigMain::proxy_sslcacert() const {
+    return p_impl->proxy_sslcacert;
+}
+
+OptionBool & ConfigMain::proxy_sslverify() {
+    return p_impl->proxy_sslverify;
+}
+
+const OptionBool & ConfigMain::proxy_sslverify() const {
+    return p_impl->proxy_sslverify;
+}
+
+OptionString & ConfigMain::proxy_sslclientcert() {
+    return p_impl->proxy_sslclientcert;
+}
+
+const OptionString & ConfigMain::proxy_sslclientcert() const {
+    return p_impl->proxy_sslclientcert;
+}
+
+OptionString & ConfigMain::proxy_sslclientkey() {
+    return p_impl->proxy_sslclientkey;
+}
+
+const OptionString & ConfigMain::proxy_sslclientkey() const {
+    return p_impl->proxy_sslclientkey;
 }
 
 OptionBool & ConfigMain::deltarpm() {

--- a/libdnf/rpm/config_repo.cpp
+++ b/libdnf/rpm/config_repo.cpp
@@ -70,6 +70,10 @@ class ConfigRepo::Impl {
     OptionChild<OptionBool> sslverify{main_config.sslverify()};
     OptionChild<OptionString> sslclientcert{main_config.sslclientcert()};
     OptionChild<OptionString> sslclientkey{main_config.sslclientkey()};
+    OptionChild<OptionString> proxy_sslcacert{main_config.proxy_sslcacert()};
+    OptionChild<OptionBool> proxy_sslverify{main_config.proxy_sslverify()};
+    OptionChild<OptionString> proxy_sslclientcert{main_config.proxy_sslclientcert()};
+    OptionChild<OptionString> proxy_sslclientkey{main_config.proxy_sslclientkey()};
     OptionChild<OptionBool> deltarpm{main_config.deltarpm()};
     OptionChild<OptionNumber<std::uint32_t>> deltarpm_percentage{main_config.deltarpm_percentage()};
     OptionChild<OptionBool> skip_if_unavailable{main_config.skip_if_unavailable()};
@@ -161,6 +165,10 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config) : owner(owner),
     owner.opt_binds().add("sslverify", sslverify);
     owner.opt_binds().add("sslclientcert", sslclientcert);
     owner.opt_binds().add("sslclientkey", sslclientkey);
+    owner.opt_binds().add("proxy_sslcacert", proxy_sslcacert);
+    owner.opt_binds().add("proxy_sslverify", proxy_sslverify);
+    owner.opt_binds().add("proxy_sslclientcert", proxy_sslclientcert);
+    owner.opt_binds().add("proxy_sslclientkey", proxy_sslclientkey);
     owner.opt_binds().add("deltarpm", deltarpm);
     owner.opt_binds().add("deltarpm_percentage", deltarpm_percentage);
     owner.opt_binds().add("skip_if_unavailable", skip_if_unavailable);
@@ -437,6 +445,38 @@ OptionChild<OptionString> & ConfigRepo::sslclientkey() {
 }
 const OptionChild<OptionString> & ConfigRepo::sslclientkey() const {
     return p_impl->sslclientkey;
+}
+
+OptionChild<OptionString> & ConfigRepo::proxy_sslcacert() {
+    return p_impl->proxy_sslcacert;
+}
+
+const OptionChild<OptionString> & ConfigRepo::proxy_sslcacert() const {
+    return p_impl->proxy_sslcacert;
+}
+
+OptionChild<OptionBool> & ConfigRepo::proxy_sslverify() {
+    return p_impl->proxy_sslverify;
+}
+
+const OptionChild<OptionBool> & ConfigRepo::proxy_sslverify() const {
+    return p_impl->proxy_sslverify;
+}
+
+OptionChild<OptionString> & ConfigRepo::proxy_sslclientcert() {
+    return p_impl->proxy_sslclientcert;
+}
+
+const OptionChild<OptionString> & ConfigRepo::proxy_sslclientcert() const {
+    return p_impl->proxy_sslclientcert;
+}
+
+OptionChild<OptionString> & ConfigRepo::proxy_sslclientkey() {
+    return p_impl->proxy_sslclientkey;
+}
+
+const OptionChild<OptionString> & ConfigRepo::proxy_sslclientkey() const {
+    return p_impl->proxy_sslclientkey;
 }
 
 OptionChild<OptionBool> & ConfigRepo::deltarpm() {

--- a/libdnf/rpm/repo.cpp
+++ b/libdnf/rpm/repo.cpp
@@ -1760,6 +1760,17 @@ static LrHandle * new_handle(ConfigMain * config) {
             }
         }
 
+        // setup ssl stuff
+        if (!config->sslcacert().get_value().empty()) {
+            handle_set_opt(h, LRO_SSLCACERT, config->sslcacert().get_value().c_str());
+        }
+        if (!config->sslclientcert().get_value().empty()) {
+            handle_set_opt(h, LRO_SSLCLIENTCERT, config->sslclientcert().get_value().c_str());
+        }
+        if (!config->sslclientkey().get_value().empty()) {
+            handle_set_opt(h, LRO_SSLCLIENTKEY, config->sslclientkey().get_value().c_str());
+        }
+
         auto sslverify = config->sslverify().get_value() ? 1L : 0L;
         handle_set_opt(h, LRO_SSLVERIFYHOST, sslverify);
         handle_set_opt(h, LRO_SSLVERIFYPEER, sslverify);

--- a/libdnf/rpm/repo.cpp
+++ b/libdnf/rpm/repo.cpp
@@ -697,6 +697,20 @@ std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_remote(const char * destdir
     handle_set_opt(h.get(), LRO_SSLVERIFYHOST, sslverify);
     handle_set_opt(h.get(), LRO_SSLVERIFYPEER, sslverify);
 
+    // setup proxy ssl stuff
+    if (!config.proxy_sslcacert().get_value().empty()) {
+        handle_set_opt(h.get(), LRO_PROXY_SSLCACERT, config.proxy_sslcacert().get_value().c_str());
+    }
+    if (!config.proxy_sslclientcert().get_value().empty()) {
+        handle_set_opt(h.get(), LRO_PROXY_SSLCLIENTCERT, config.proxy_sslclientcert().get_value().c_str());
+    }
+    if (!config.proxy_sslclientkey().get_value().empty()) {
+        handle_set_opt(h.get(), LRO_PROXY_SSLCLIENTKEY, config.proxy_sslclientkey().get_value().c_str());
+    }
+    long proxy_sslverify = config.proxy_sslverify().get_value() ? 1L : 0L;
+    handle_set_opt(h.get(), LRO_PROXY_SSLVERIFYHOST, proxy_sslverify);
+    handle_set_opt(h.get(), LRO_PROXY_SSLVERIFYPEER, proxy_sslverify);
+
     return h;
 }
 
@@ -1774,6 +1788,20 @@ static LrHandle * new_handle(ConfigMain * config) {
         auto sslverify = config->sslverify().get_value() ? 1L : 0L;
         handle_set_opt(h, LRO_SSLVERIFYHOST, sslverify);
         handle_set_opt(h, LRO_SSLVERIFYPEER, sslverify);
+
+        // setup proxy ssl stuff
+        if (!config->proxy_sslcacert().get_value().empty()) {
+            handle_set_opt(h, LRO_PROXY_SSLCACERT, config->proxy_sslcacert().get_value().c_str());
+        }
+        if (!config->proxy_sslclientcert().get_value().empty()) {
+            handle_set_opt(h, LRO_PROXY_SSLCLIENTCERT, config->proxy_sslclientcert().get_value().c_str());
+        }
+        if (!config->proxy_sslclientkey().get_value().empty()) {
+            handle_set_opt(h, LRO_PROXY_SSLCLIENTKEY, config->proxy_sslclientkey().get_value().c_str());
+        }
+        long proxy_sslverify = config->proxy_sslverify().get_value() ? 1L : 0L;
+        handle_set_opt(h, LRO_PROXY_SSLVERIFYHOST, proxy_sslverify);
+        handle_set_opt(h, LRO_PROXY_SSLVERIFYPEER, proxy_sslverify);
     }
     handle_set_opt(h, LRO_USERAGENT, user_agent);
     return h;


### PR DESCRIPTION
Port of PR from DNF4 branch https://github.com/rpm-software-management/libdnf/pull/1128

Added options: proxy_sslcacert, proxy_sslverify, proxy_sslclientcert, proxy_sslclientkey.
Options were added to both (main and repository) configuration.
The meaning of the options is the same as for the options used with server certificates.

Fix: Fully set ssl in newHandle function. The sslverify option was applied, but other ssl options were ignored (sslcacert, sslclientcert, sslclientkey). All ssl options are now applied. Note: Multiple non ssl options are ignored in the newHandle function. Need to consider which options should be applied.

Requires "librepo >= 1.13.0".
rpm-software-management/librepo#227