### PR TITLE
Fix: Goal - translation of messages in global maps 

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -1003,12 +1003,6 @@ Goal::describeProblemRules(unsigned i, bool pkgs)
     IdQueue rq;
     // this libsolv interface indexes from 1 (we do from 0), so:
     solver_findallproblemrules(solv, i+1, pq.getQueue());
-    std::map<int, const char *> problemDict;
-    if (pkgs) {
-        problemDict = PKG_PROBLEMS_DICT;
-    } else {
-        problemDict = MODULE_PROBLEMS_DICT;
-    }
     std::unique_ptr<libdnf::PackageSet> modularExcludes(dnf_sack_get_module_excludes(pImpl->sack));
     for (j = 0; j < pq.size(); j++) {
         rid = pq[j];

--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -87,57 +87,57 @@ enum {RULE_DISTUPGRADE=1, RULE_INFARCH, RULE_UPDATE, RULE_JOB, RULE_JOB_UNSUPPOR
 };
 
 static const std::map<int, const char *> PKG_PROBLEMS_DICT = {
-    {RULE_DISTUPGRADE, _(" does not belong to a distupgrade repository")},
-    {RULE_INFARCH, _(" has inferior architecture")},
-    {RULE_UPDATE, _("problem with installed package ")},
-    {RULE_JOB, _("conflicting requests")},
-    {RULE_JOB_UNSUPPORTED, _("unsupported request")},
-    {RULE_JOB_NOTHING_PROVIDES_DEP, _("nothing provides requested ")},
-    {RULE_JOB_UNKNOWN_PACKAGE, _("package %s does not exist")},
-    {RULE_JOB_PROVIDED_BY_SYSTEM, _(" is provided by the system")},
-    {RULE_PKG, _("some dependency problem")},
-    {RULE_BEST_1, _("cannot install the best update candidate for package ")},
-    {RULE_BEST_2, _("cannot install the best candidate for the job")},
-    {RULE_PKG_NOT_INSTALLABLE_1, _("package %s is filtered out by modular filtering")},
-    {RULE_PKG_NOT_INSTALLABLE_2, _("package %s does not have a compatible architecture")},
-    {RULE_PKG_NOT_INSTALLABLE_3, _("package %s is not installable")},
-    {RULE_PKG_NOT_INSTALLABLE_4, _("package %s is filtered out by exclude filtering")},
-    {RULE_PKG_NOTHING_PROVIDES_DEP, _("nothing provides %s needed by %s")},
-    {RULE_PKG_SAME_NAME, _("cannot install both %s and %s")},
-    {RULE_PKG_CONFLICTS, _("package %s conflicts with %s provided by %s")},
-    {RULE_PKG_OBSOLETES, _("package %s obsoletes %s provided by %s")},
-    {RULE_PKG_INSTALLED_OBSOLETES, _("installed package %s obsoletes %s provided by %s")},
-    {RULE_PKG_IMPLICIT_OBSOLETES, _("package %s implicitly obsoletes %s provided by %s")},
-    {RULE_PKG_REQUIRES, _("package %s requires %s, but none of the providers can be installed")},
-    {RULE_PKG_SELF_CONFLICT, _("package %s conflicts with %s provided by itself")},
-    {RULE_YUMOBS, _("both package %s and %s obsolete %s")}
+    {RULE_DISTUPGRADE, M_(" does not belong to a distupgrade repository")},
+    {RULE_INFARCH, M_(" has inferior architecture")},
+    {RULE_UPDATE, M_("problem with installed package ")},
+    {RULE_JOB, M_("conflicting requests")},
+    {RULE_JOB_UNSUPPORTED, M_("unsupported request")},
+    {RULE_JOB_NOTHING_PROVIDES_DEP, M_("nothing provides requested ")},
+    {RULE_JOB_UNKNOWN_PACKAGE, M_("package %s does not exist")},
+    {RULE_JOB_PROVIDED_BY_SYSTEM, M_(" is provided by the system")},
+    {RULE_PKG, M_("some dependency problem")},
+    {RULE_BEST_1, M_("cannot install the best update candidate for package ")},
+    {RULE_BEST_2, M_("cannot install the best candidate for the job")},
+    {RULE_PKG_NOT_INSTALLABLE_1, M_("package %s is filtered out by modular filtering")},
+    {RULE_PKG_NOT_INSTALLABLE_2, M_("package %s does not have a compatible architecture")},
+    {RULE_PKG_NOT_INSTALLABLE_3, M_("package %s is not installable")},
+    {RULE_PKG_NOT_INSTALLABLE_4, M_("package %s is filtered out by exclude filtering")},
+    {RULE_PKG_NOTHING_PROVIDES_DEP, M_("nothing provides %s needed by %s")},
+    {RULE_PKG_SAME_NAME, M_("cannot install both %s and %s")},
+    {RULE_PKG_CONFLICTS, M_("package %s conflicts with %s provided by %s")},
+    {RULE_PKG_OBSOLETES, M_("package %s obsoletes %s provided by %s")},
+    {RULE_PKG_INSTALLED_OBSOLETES, M_("installed package %s obsoletes %s provided by %s")},
+    {RULE_PKG_IMPLICIT_OBSOLETES, M_("package %s implicitly obsoletes %s provided by %s")},
+    {RULE_PKG_REQUIRES, M_("package %s requires %s, but none of the providers can be installed")},
+    {RULE_PKG_SELF_CONFLICT, M_("package %s conflicts with %s provided by itself")},
+    {RULE_YUMOBS, M_("both package %s and %s obsolete %s")}
 };
 
 static const std::map<int, const char *> MODULE_PROBLEMS_DICT = {
-    {RULE_DISTUPGRADE, _(" does not belong to a distupgrade repository")},
-    {RULE_INFARCH, _(" has inferior architecture")},
-    {RULE_UPDATE, _("problem with installed module ")},
-    {RULE_JOB, _("conflicting requests")},
-    {RULE_JOB_UNSUPPORTED, _("unsupported request")},
-    {RULE_JOB_NOTHING_PROVIDES_DEP, _("nothing provides requested ")},
-    {RULE_JOB_UNKNOWN_PACKAGE, _("module %s does not exist")},
-    {RULE_JOB_PROVIDED_BY_SYSTEM, _(" is provided by the system")},
-    {RULE_PKG, _("some dependency problem")},
-    {RULE_BEST_1, _("cannot install the best update candidate for module ")},
-    {RULE_BEST_2, _("cannot install the best candidate for the job")},
-    {RULE_PKG_NOT_INSTALLABLE_1, _("module %s is disabled")},
-    {RULE_PKG_NOT_INSTALLABLE_2, _("module %s does not have a compatible architecture")},
-    {RULE_PKG_NOT_INSTALLABLE_3, _("module %s is not installable")},
-    {RULE_PKG_NOT_INSTALLABLE_4, _("module %s is disabled")},
-    {RULE_PKG_NOTHING_PROVIDES_DEP, _("nothing provides %s needed by module %s")},
-    {RULE_PKG_SAME_NAME, _("cannot install both modules %s and %s")},
-    {RULE_PKG_CONFLICTS, _("module %s conflicts with %s provided by %s")},
-    {RULE_PKG_OBSOLETES, _("module %s obsoletes %s provided by %s")},
-    {RULE_PKG_INSTALLED_OBSOLETES, _("installed module %s obsoletes %s provided by %s")},
-    {RULE_PKG_IMPLICIT_OBSOLETES, _("module %s implicitly obsoletes %s provided by %s")},
-    {RULE_PKG_REQUIRES, _("module %s requires %s, but none of the providers can be installed")},
-    {RULE_PKG_SELF_CONFLICT, _("module %s conflicts with %s provided by itself")},
-    {RULE_YUMOBS, _("both module %s and %s obsolete %s")}
+    {RULE_DISTUPGRADE, M_(" does not belong to a distupgrade repository")},
+    {RULE_INFARCH, M_(" has inferior architecture")},
+    {RULE_UPDATE, M_("problem with installed module ")},
+    {RULE_JOB, M_("conflicting requests")},
+    {RULE_JOB_UNSUPPORTED, M_("unsupported request")},
+    {RULE_JOB_NOTHING_PROVIDES_DEP, M_("nothing provides requested ")},
+    {RULE_JOB_UNKNOWN_PACKAGE, M_("module %s does not exist")},
+    {RULE_JOB_PROVIDED_BY_SYSTEM, M_(" is provided by the system")},
+    {RULE_PKG, M_("some dependency problem")},
+    {RULE_BEST_1, M_("cannot install the best update candidate for module ")},
+    {RULE_BEST_2, M_("cannot install the best candidate for the job")},
+    {RULE_PKG_NOT_INSTALLABLE_1, M_("module %s is disabled")},
+    {RULE_PKG_NOT_INSTALLABLE_2, M_("module %s does not have a compatible architecture")},
+    {RULE_PKG_NOT_INSTALLABLE_3, M_("module %s is not installable")},
+    {RULE_PKG_NOT_INSTALLABLE_4, M_("module %s is disabled")},
+    {RULE_PKG_NOTHING_PROVIDES_DEP, M_("nothing provides %s needed by module %s")},
+    {RULE_PKG_SAME_NAME, M_("cannot install both modules %s and %s")},
+    {RULE_PKG_CONFLICTS, M_("module %s conflicts with %s provided by %s")},
+    {RULE_PKG_OBSOLETES, M_("module %s obsoletes %s provided by %s")},
+    {RULE_PKG_INSTALLED_OBSOLETES, M_("installed module %s obsoletes %s provided by %s")},
+    {RULE_PKG_IMPLICIT_OBSOLETES, M_("module %s implicitly obsoletes %s provided by %s")},
+    {RULE_PKG_REQUIRES, M_("module %s requires %s, but none of the providers can be installed")},
+    {RULE_PKG_SELF_CONFLICT, M_("module %s conflicts with %s provided by itself")},
+    {RULE_YUMOBS, M_("both module %s and %s obsolete %s")}
 };
 
 static std::string
@@ -158,69 +158,68 @@ libdnf_problemruleinfo2str(libdnf::PackageSet * modularExclude, Solver *solv, So
     Solvable *ss;
     switch (type) {
         case SOLVER_RULE_DISTUPGRADE:
-            return solvid2str(pool, source) + problemDict[RULE_DISTUPGRADE];
+            return solvid2str(pool, source) + TM_(problemDict[RULE_DISTUPGRADE], 1);
         case SOLVER_RULE_INFARCH:
-            return solvid2str(pool, source) + problemDict[RULE_INFARCH];
+            return solvid2str(pool, source) + TM_(problemDict[RULE_INFARCH], 1);
         case SOLVER_RULE_UPDATE:
-            return std::string(problemDict[RULE_UPDATE]) + solvid2str(pool, source);
+            return std::string(TM_(problemDict[RULE_UPDATE], 1)) + solvid2str(pool, source);
         case SOLVER_RULE_JOB:
-            return std::string(problemDict[RULE_JOB]);
+            return std::string(TM_(problemDict[RULE_JOB], 1));
         case SOLVER_RULE_JOB_UNSUPPORTED:
-            return std::string(problemDict[RULE_JOB_UNSUPPORTED]);
+            return std::string(TM_(problemDict[RULE_JOB_UNSUPPORTED], 1));
         case SOLVER_RULE_JOB_NOTHING_PROVIDES_DEP:
-            return std::string(problemDict[RULE_JOB_NOTHING_PROVIDES_DEP]) + pool_dep2str(pool,
-                                                                                          dep);
+            return std::string(TM_(problemDict[RULE_JOB_NOTHING_PROVIDES_DEP], 1)) + pool_dep2str(pool, dep);
         case SOLVER_RULE_JOB_UNKNOWN_PACKAGE:
-            return tfm::format(problemDict[RULE_JOB_UNKNOWN_PACKAGE], pool_dep2str(pool, dep));
+            return tfm::format(TM_(problemDict[RULE_JOB_UNKNOWN_PACKAGE], 1), pool_dep2str(pool, dep));
         case SOLVER_RULE_JOB_PROVIDED_BY_SYSTEM:
-            return std::string(pool_dep2str(pool, dep)) + problemDict[RULE_JOB_PROVIDED_BY_SYSTEM]; 
+            return std::string(pool_dep2str(pool, dep)) + TM_(problemDict[RULE_JOB_PROVIDED_BY_SYSTEM], 1);
         case SOLVER_RULE_PKG:
-            return std::string(problemDict[RULE_PKG]);
+            return std::string(TM_(problemDict[RULE_PKG], 1));
         case SOLVER_RULE_BEST:
             if (source > 0)
-                return std::string(problemDict[RULE_BEST_1]) + solvid2str(pool, source);
-            return std::string(problemDict[RULE_BEST_2]);
+                return std::string(TM_(problemDict[RULE_BEST_1], 1)) + solvid2str(pool, source);
+            return std::string(TM_(problemDict[RULE_BEST_2], 1));
         case SOLVER_RULE_PKG_NOT_INSTALLABLE:
             ss = pool->solvables + source;
             if (pool_disabled_solvable(pool, ss)) {
                 if (modularExclude && modularExclude->has(source)) {
-                    return tfm::format(problemDict[RULE_PKG_NOT_INSTALLABLE_1], solvid2str(pool, source).c_str());
+                    return tfm::format(TM_(problemDict[RULE_PKG_NOT_INSTALLABLE_1], 1), solvid2str(pool, source).c_str());
                 } else {
-                    return tfm::format(problemDict[RULE_PKG_NOT_INSTALLABLE_4], solvid2str(pool, source).c_str());
+                    return tfm::format(TM_(problemDict[RULE_PKG_NOT_INSTALLABLE_4], 1), solvid2str(pool, source).c_str());
                 }
             }
             if (ss->arch && ss->arch != ARCH_SRC && ss->arch != ARCH_NOSRC &&
                 pool->id2arch && (ss->arch > pool->lastarch || !pool->id2arch[ss->arch]))
-                return tfm::format(problemDict[RULE_PKG_NOT_INSTALLABLE_2], solvid2str(pool, source).c_str());
-            return tfm::format(problemDict[RULE_PKG_NOT_INSTALLABLE_3], solvid2str(pool, source).c_str());
+                return tfm::format(TM_(problemDict[RULE_PKG_NOT_INSTALLABLE_2], 1), solvid2str(pool, source).c_str());
+            return tfm::format(TM_(problemDict[RULE_PKG_NOT_INSTALLABLE_3], 1), solvid2str(pool, source).c_str());
         case SOLVER_RULE_PKG_NOTHING_PROVIDES_DEP:
-            return tfm::format(problemDict[RULE_PKG_NOTHING_PROVIDES_DEP], pool_dep2str(pool, dep),
+            return tfm::format(TM_(problemDict[RULE_PKG_NOTHING_PROVIDES_DEP], 1), pool_dep2str(pool, dep),
                                solvid2str(pool, source).c_str());
         case SOLVER_RULE_PKG_SAME_NAME:
-            return tfm::format(problemDict[RULE_PKG_SAME_NAME], solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict[RULE_PKG_SAME_NAME], 1), solvid2str(pool, source).c_str(),
                                solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_CONFLICTS:
-            return tfm::format(problemDict[RULE_PKG_CONFLICTS], solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict[RULE_PKG_CONFLICTS], 1), solvid2str(pool, source).c_str(),
                                pool_dep2str(pool, dep), solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_OBSOLETES:
-            return tfm::format(problemDict[RULE_PKG_OBSOLETES], solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict[RULE_PKG_OBSOLETES], 1), solvid2str(pool, source).c_str(),
                                pool_dep2str(pool, dep), solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_INSTALLED_OBSOLETES:
-            return tfm::format(problemDict[RULE_PKG_INSTALLED_OBSOLETES],
+            return tfm::format(TM_(problemDict[RULE_PKG_INSTALLED_OBSOLETES], 1),
                                solvid2str(pool, source).c_str(), pool_dep2str(pool, dep),
                                solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_IMPLICIT_OBSOLETES:
-            return tfm::format(problemDict[RULE_PKG_IMPLICIT_OBSOLETES],
+            return tfm::format(TM_(problemDict[RULE_PKG_IMPLICIT_OBSOLETES], 1),
                                solvid2str(pool, source).c_str(), pool_dep2str(pool, dep),
                                solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_REQUIRES:
-            return tfm::format(problemDict[RULE_PKG_REQUIRES], solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict[RULE_PKG_REQUIRES], 1), solvid2str(pool, source).c_str(),
                                pool_dep2str(pool, dep));
         case SOLVER_RULE_PKG_SELF_CONFLICT:
-            return tfm::format(problemDict[RULE_PKG_SELF_CONFLICT], solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict[RULE_PKG_SELF_CONFLICT], 1), solvid2str(pool, source).c_str(),
                                pool_dep2str(pool, dep));
         case SOLVER_RULE_YUMOBS:
-            return tfm::format(problemDict[RULE_YUMOBS], solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict[RULE_YUMOBS], 1), solvid2str(pool, source).c_str(),
                                solvid2str(pool, target).c_str(), pool_dep2str(pool, dep));
         default:
             return solver_problemruleinfo2str(solv, type, source, target, dep);

--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -144,82 +144,75 @@ static std::string
 libdnf_problemruleinfo2str(libdnf::PackageSet * modularExclude, Solver *solv, SolverRuleinfo type, Id source, Id target,
     Id dep, bool pkgs)
 {
-    std::map<int, const char *> problemDict;
-    std::function<std::string(Pool *, Id)> solvid2str;
-    if (pkgs) {
-        problemDict = PKG_PROBLEMS_DICT;
-        solvid2str = pkgSolvid2str;
-    } else {
-        problemDict = MODULE_PROBLEMS_DICT;
-        solvid2str = moduleSolvid2str;
-    }
+    const std::map<int, const char *> & problemDict = pkgs ? PKG_PROBLEMS_DICT : MODULE_PROBLEMS_DICT;
+    const auto solvid2str = pkgs ? pkgSolvid2str : moduleSolvid2str;
 
-    Pool *pool = solv->pool;
+    Pool * const pool = solv->pool;
     Solvable *ss;
     switch (type) {
         case SOLVER_RULE_DISTUPGRADE:
-            return solvid2str(pool, source) + TM_(problemDict[RULE_DISTUPGRADE], 1);
+            return solvid2str(pool, source) + TM_(problemDict.at(RULE_DISTUPGRADE), 1);
         case SOLVER_RULE_INFARCH:
-            return solvid2str(pool, source) + TM_(problemDict[RULE_INFARCH], 1);
+            return solvid2str(pool, source) + TM_(problemDict.at(RULE_INFARCH), 1);
         case SOLVER_RULE_UPDATE:
-            return std::string(TM_(problemDict[RULE_UPDATE], 1)) + solvid2str(pool, source);
+            return std::string(TM_(problemDict.at(RULE_UPDATE), 1)) + solvid2str(pool, source);
         case SOLVER_RULE_JOB:
-            return std::string(TM_(problemDict[RULE_JOB], 1));
+            return std::string(TM_(problemDict.at(RULE_JOB), 1));
         case SOLVER_RULE_JOB_UNSUPPORTED:
-            return std::string(TM_(problemDict[RULE_JOB_UNSUPPORTED], 1));
+            return std::string(TM_(problemDict.at(RULE_JOB_UNSUPPORTED), 1));
         case SOLVER_RULE_JOB_NOTHING_PROVIDES_DEP:
-            return std::string(TM_(problemDict[RULE_JOB_NOTHING_PROVIDES_DEP], 1)) + pool_dep2str(pool, dep);
+            return std::string(TM_(problemDict.at(RULE_JOB_NOTHING_PROVIDES_DEP), 1)) + pool_dep2str(pool, dep);
         case SOLVER_RULE_JOB_UNKNOWN_PACKAGE:
-            return tfm::format(TM_(problemDict[RULE_JOB_UNKNOWN_PACKAGE], 1), pool_dep2str(pool, dep));
+            return tfm::format(TM_(problemDict.at(RULE_JOB_UNKNOWN_PACKAGE), 1), pool_dep2str(pool, dep));
         case SOLVER_RULE_JOB_PROVIDED_BY_SYSTEM:
-            return std::string(pool_dep2str(pool, dep)) + TM_(problemDict[RULE_JOB_PROVIDED_BY_SYSTEM], 1);
+            return std::string(pool_dep2str(pool, dep)) + TM_(problemDict.at(RULE_JOB_PROVIDED_BY_SYSTEM), 1);
         case SOLVER_RULE_PKG:
-            return std::string(TM_(problemDict[RULE_PKG], 1));
+            return std::string(TM_(problemDict.at(RULE_PKG), 1));
         case SOLVER_RULE_BEST:
             if (source > 0)
-                return std::string(TM_(problemDict[RULE_BEST_1], 1)) + solvid2str(pool, source);
-            return std::string(TM_(problemDict[RULE_BEST_2], 1));
+                return std::string(TM_(problemDict.at(RULE_BEST_1), 1)) + solvid2str(pool, source);
+            return std::string(TM_(problemDict.at(RULE_BEST_2), 1));
         case SOLVER_RULE_PKG_NOT_INSTALLABLE:
             ss = pool->solvables + source;
             if (pool_disabled_solvable(pool, ss)) {
                 if (modularExclude && modularExclude->has(source)) {
-                    return tfm::format(TM_(problemDict[RULE_PKG_NOT_INSTALLABLE_1], 1), solvid2str(pool, source).c_str());
+                    return tfm::format(TM_(problemDict.at(RULE_PKG_NOT_INSTALLABLE_1), 1), solvid2str(pool, source).c_str());
                 } else {
-                    return tfm::format(TM_(problemDict[RULE_PKG_NOT_INSTALLABLE_4], 1), solvid2str(pool, source).c_str());
+                    return tfm::format(TM_(problemDict.at(RULE_PKG_NOT_INSTALLABLE_4), 1), solvid2str(pool, source).c_str());
                 }
             }
             if (ss->arch && ss->arch != ARCH_SRC && ss->arch != ARCH_NOSRC &&
                 pool->id2arch && (ss->arch > pool->lastarch || !pool->id2arch[ss->arch]))
-                return tfm::format(TM_(problemDict[RULE_PKG_NOT_INSTALLABLE_2], 1), solvid2str(pool, source).c_str());
-            return tfm::format(TM_(problemDict[RULE_PKG_NOT_INSTALLABLE_3], 1), solvid2str(pool, source).c_str());
+                return tfm::format(TM_(problemDict.at(RULE_PKG_NOT_INSTALLABLE_2), 1), solvid2str(pool, source).c_str());
+            return tfm::format(TM_(problemDict.at(RULE_PKG_NOT_INSTALLABLE_3), 1), solvid2str(pool, source).c_str());
         case SOLVER_RULE_PKG_NOTHING_PROVIDES_DEP:
-            return tfm::format(TM_(problemDict[RULE_PKG_NOTHING_PROVIDES_DEP], 1), pool_dep2str(pool, dep),
+            return tfm::format(TM_(problemDict.at(RULE_PKG_NOTHING_PROVIDES_DEP), 1), pool_dep2str(pool, dep),
                                solvid2str(pool, source).c_str());
         case SOLVER_RULE_PKG_SAME_NAME:
-            return tfm::format(TM_(problemDict[RULE_PKG_SAME_NAME], 1), solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict.at(RULE_PKG_SAME_NAME), 1), solvid2str(pool, source).c_str(),
                                solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_CONFLICTS:
-            return tfm::format(TM_(problemDict[RULE_PKG_CONFLICTS], 1), solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict.at(RULE_PKG_CONFLICTS), 1), solvid2str(pool, source).c_str(),
                                pool_dep2str(pool, dep), solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_OBSOLETES:
-            return tfm::format(TM_(problemDict[RULE_PKG_OBSOLETES], 1), solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict.at(RULE_PKG_OBSOLETES), 1), solvid2str(pool, source).c_str(),
                                pool_dep2str(pool, dep), solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_INSTALLED_OBSOLETES:
-            return tfm::format(TM_(problemDict[RULE_PKG_INSTALLED_OBSOLETES], 1),
+            return tfm::format(TM_(problemDict.at(RULE_PKG_INSTALLED_OBSOLETES), 1),
                                solvid2str(pool, source).c_str(), pool_dep2str(pool, dep),
                                solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_IMPLICIT_OBSOLETES:
-            return tfm::format(TM_(problemDict[RULE_PKG_IMPLICIT_OBSOLETES], 1),
+            return tfm::format(TM_(problemDict.at(RULE_PKG_IMPLICIT_OBSOLETES), 1),
                                solvid2str(pool, source).c_str(), pool_dep2str(pool, dep),
                                solvid2str(pool, target).c_str());
         case SOLVER_RULE_PKG_REQUIRES:
-            return tfm::format(TM_(problemDict[RULE_PKG_REQUIRES], 1), solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict.at(RULE_PKG_REQUIRES), 1), solvid2str(pool, source).c_str(),
                                pool_dep2str(pool, dep));
         case SOLVER_RULE_PKG_SELF_CONFLICT:
-            return tfm::format(TM_(problemDict[RULE_PKG_SELF_CONFLICT], 1), solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict.at(RULE_PKG_SELF_CONFLICT), 1), solvid2str(pool, source).c_str(),
                                pool_dep2str(pool, dep));
         case SOLVER_RULE_YUMOBS:
-            return tfm::format(TM_(problemDict[RULE_YUMOBS], 1), solvid2str(pool, source).c_str(),
+            return tfm::format(TM_(problemDict.at(RULE_YUMOBS), 1), solvid2str(pool, source).c_str(),
                                solvid2str(pool, target).c_str(), pool_dep2str(pool, dep));
         default:
             return solver_problemruleinfo2str(solv, type, source, target, dep);


### PR DESCRIPTION
Global (static global) variables were initialized before the locale is set. Translation will not work at this time. Instead of translation, we mark and encode the text for later translation.
So, `_()` is replaced by `M_()` and encoded text is translated later by `TM_()`.

Optimizations - removes unnecessary code, uses reference instead of copying entire maps.