### PR TITLE
Do not allow 1 as installonly_limit value (RhBug:1926261)

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -196,12 +196,18 @@ class ConfigMain::Impl {
         [](const std::string & value)->std::uint32_t{
             if (value == "<off>")
                 return 0;
+            std::int32_t value_i;
             try {
-                return std::stoul(value);
+                value_i = std::stol(value);
             }
             catch (...) {
-                return 0;
+                throw Option::InvalidValue(tfm::format(_("invalid value")));
             }
+            if (value_i == 1)
+                throw Option::InvalidValue(tfm::format(_("value 1 is not allowed")));
+            if (value_i < 0)
+                throw Option::InvalidValue(tfm::format(_("negative value is not allowed")));
+            return (std::uint32_t)value_i;
         }
     };
 


### PR DESCRIPTION
Value 1 is confusing for users and should not be allowed as installonly_limit value.
Also handling of negative values is fixed - std::stoul() does not fail on negative input in the string.

= changelog =
msg:           do not allow 1 as installonly_limit value
type:          enhancement
resolves:      https://bugzilla.redhat.com/show_bug.cgi?id=1926261

Requires: https://github.com/rpm-software-management/dnf/pull/1740