### PR TITLE
[dnf5] fix new_handle function and code deduplication

### DIFF
--- a/libdnf/rpm/repo.cpp
+++ b/libdnf/rpm/repo.cpp
@@ -569,6 +569,32 @@ std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_local() {
 
 template<typename ConfigT>
 static void set_handle(LrHandle * h, ConfigT & config) {
+    auto & ip_resolve = config.ip_resolve().get_value();
+    if (ip_resolve == "ipv4") {
+        handle_set_opt(h, LRO_IPRESOLVE, LR_IPRESOLVE_V4);
+    } else if (ip_resolve == "ipv6") {
+        handle_set_opt(h, LRO_IPRESOLVE, LR_IPRESOLVE_V6);
+    }
+
+    // setup username/password if needed
+    auto userpwd = config.username().get_value();
+    if (!userpwd.empty()) {
+        // TODO Use URL encoded form, needs support in librepo
+        userpwd = format_user_pass_string(userpwd, config.password().get_value(), false);
+        handle_set_opt(h, LRO_USERPWD, userpwd.c_str());
+    }
+
+    // setup ssl stuff
+    if (!config.sslcacert().get_value().empty()) {
+        handle_set_opt(h, LRO_SSLCACERT, config.sslcacert().get_value().c_str());
+    }
+    if (!config.sslclientcert().get_value().empty()) {
+        handle_set_opt(h, LRO_SSLCLIENTCERT, config.sslclientcert().get_value().c_str());
+    }
+    if (!config.sslclientkey().get_value().empty()) {
+        handle_set_opt(h, LRO_SSLCLIENTKEY, config.sslclientkey().get_value().c_str());
+    }
+
     auto minrate = config.minrate().get_value();
     handle_set_opt(h, LRO_LOWSPEEDLIMIT, static_cast<long>(minrate));
 
@@ -581,6 +607,15 @@ static void set_handle(LrHandle * h, ConfigT & config) {
             _("Maximum download speed is lower than minimum. "
                 "Please change configuration of minrate or throttle"));
     handle_set_opt(h, LRO_MAXSPEED, static_cast<int64_t>(maxspeed));
+
+    long timeout = config.timeout().get_value();
+    if (timeout > 0) {
+        handle_set_opt(h, LRO_CONNECTTIMEOUT, timeout);
+        handle_set_opt(h, LRO_LOWSPEEDTIME, timeout);
+    } else {
+        handle_set_opt(h, LRO_CONNECTTIMEOUT, LRO_CONNECTTIMEOUT_DEFAULT);
+        handle_set_opt(h, LRO_LOWSPEEDTIME, LRO_LOWSPEEDTIME_DEFAULT);
+    }
 
     if (!config.proxy().empty() && !config.proxy().get_value().empty())
         handle_set_opt(h, LRO_PROXY, config.proxy().get_value().c_str());
@@ -597,7 +632,7 @@ static void set_handle(LrHandle * h, ConfigT & config) {
         }
     }
 
-    auto sslverify = config.sslverify().get_value() ? 1L : 0L;
+    long sslverify = config.sslverify().get_value() ? 1L : 0L;
     handle_set_opt(h, LRO_SSLVERIFYHOST, sslverify);
     handle_set_opt(h, LRO_SSLVERIFYPEER, sslverify);
 }
@@ -613,13 +648,6 @@ std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_remote(const char * destdir
     handle_set_opt(h.get(), LRO_VARSUB, vars);
 
     handle_set_opt(h.get(), LRO_DESTDIR, destdir);
-
-    auto & ip_resolve = config.ip_resolve().get_value();
-    if (ip_resolve == "ipv4") {
-        handle_set_opt(h.get(), LRO_IPRESOLVE, LR_IPRESOLVE_V4);
-    } else if (ip_resolve == "ipv6") {
-        handle_set_opt(h.get(), LRO_IPRESOLVE, LR_IPRESOLVE_V6);
-    }
 
     enum class Source { NONE, METALINK, MIRRORLIST } source{Source::NONE};
     std::string tmp;
@@ -665,25 +693,6 @@ std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_remote(const char * destdir
         throw RuntimeError(fmt::format(_("Cannot find a valid baseurl for repo: {}"), id));
     }
 
-    // setup username/password if needed
-    auto userpwd = config.username().get_value();
-    if (!userpwd.empty()) {
-        // TODO Use URL encoded form, needs support in librepo
-        userpwd = format_user_pass_string(userpwd, config.password().get_value(), false);
-        handle_set_opt(h.get(), LRO_USERPWD, userpwd.c_str());
-    }
-
-    // setup ssl stuff
-    if (!config.sslcacert().get_value().empty()) {
-        handle_set_opt(h.get(), LRO_SSLCACERT, config.sslcacert().get_value().c_str());
-    }
-    if (!config.sslclientcert().get_value().empty()) {
-        handle_set_opt(h.get(), LRO_SSLCLIENTCERT, config.sslclientcert().get_value().c_str());
-    }
-    if (!config.sslclientkey().get_value().empty()) {
-        handle_set_opt(h.get(), LRO_SSLCLIENTKEY, config.sslclientkey().get_value().c_str());
-    }
-
     handle_set_opt(h.get(), LRO_PROGRESSCB, static_cast<LrProgressCb>(progress_cb));
     handle_set_opt(h.get(), LRO_PROGRESSDATA, callbacks.get());
     handle_set_opt(h.get(), LRO_FASTESTMIRRORCB, static_cast<LrFastestMirrorCb>(fastest_mirror_cb));
@@ -697,15 +706,6 @@ std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_remote(const char * destdir
 #endif
 
     set_handle(h.get(), config);
-
-    long timeout = config.timeout().get_value();
-    if (timeout > 0) {
-        handle_set_opt(h.get(), LRO_CONNECTTIMEOUT, timeout);
-        handle_set_opt(h.get(), LRO_LOWSPEEDTIME, timeout);
-    } else {
-        handle_set_opt(h.get(), LRO_CONNECTTIMEOUT, LRO_CONNECTTIMEOUT_DEFAULT);
-        handle_set_opt(h.get(), LRO_LOWSPEEDTIME, LRO_LOWSPEEDTIME_DEFAULT);
-    }
 
     return h;
 }

--- a/libdnf/rpm/repo.cpp
+++ b/libdnf/rpm/repo.cpp
@@ -567,6 +567,41 @@ std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_local() {
     return h;
 }
 
+template<typename ConfigT>
+static void set_handle(LrHandle * h, ConfigT & config) {
+    auto minrate = config.minrate().get_value();
+    handle_set_opt(h, LRO_LOWSPEEDLIMIT, static_cast<long>(minrate));
+
+    auto maxspeed = config.throttle().get_value();
+    if (maxspeed > 0 && maxspeed <= 1) {
+        maxspeed *= static_cast<float>(config.bandwidth().get_value());
+    }
+    if (maxspeed != 0 && maxspeed < static_cast<float>(minrate))
+        throw RuntimeError(
+            _("Maximum download speed is lower than minimum. "
+                "Please change configuration of minrate or throttle"));
+    handle_set_opt(h, LRO_MAXSPEED, static_cast<int64_t>(maxspeed));
+
+    if (!config.proxy().empty() && !config.proxy().get_value().empty())
+        handle_set_opt(h, LRO_PROXY, config.proxy().get_value().c_str());
+
+    // set proxy authorization methods
+    auto proxy_auth_methods = string_to_proxy_auth_methods(config.proxy_auth_method().get_value());
+    handle_set_opt(h, LRO_PROXYAUTHMETHODS, static_cast<long>(proxy_auth_methods));
+
+    if (!config.proxy_username().empty()) {
+        auto userpwd = config.proxy_username().get_value();
+        if (!userpwd.empty()) {
+            userpwd = format_user_pass_string(userpwd, config.proxy_password().get_value(), true);
+            handle_set_opt(h, LRO_PROXYUSERPWD, userpwd.c_str());
+        }
+    }
+
+    auto sslverify = config.sslverify().get_value() ? 1L : 0L;
+    handle_set_opt(h, LRO_SSLVERIFYHOST, sslverify);
+    handle_set_opt(h, LRO_SSLVERIFYPEER, sslverify);
+}
+
 std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_remote(const char * destdir, bool mirror_setup) {
     std::unique_ptr<LrHandle> h(lr_handle_init_base());
     handle_set_opt(h.get(), LRO_HTTPHEADER, http_headers.get());
@@ -661,19 +696,7 @@ std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_remote(const char * destdir
     }
 #endif
 
-    auto minrate = config.minrate().get_value();
-    handle_set_opt(h.get(), LRO_LOWSPEEDLIMIT, static_cast<long>(minrate));
-
-    auto maxspeed = config.throttle().get_value();
-    if (maxspeed > 0 && maxspeed <= 1) {
-        maxspeed *= static_cast<float>(config.bandwidth().get_value());
-    }
-    if (maxspeed != 0 && maxspeed < static_cast<float>(minrate)) {
-        throw RuntimeError(
-            _("Maximum download speed is lower than minimum. "
-              "Please change configuration of minrate or throttle"));
-    }
-    handle_set_opt(h.get(), LRO_MAXSPEED, static_cast<int64_t>(maxspeed));
+    set_handle(h.get(), config);
 
     long timeout = config.timeout().get_value();
     if (timeout > 0) {
@@ -683,26 +706,6 @@ std::unique_ptr<LrHandle> Repo::Impl::lr_handle_init_remote(const char * destdir
         handle_set_opt(h.get(), LRO_CONNECTTIMEOUT, LRO_CONNECTTIMEOUT_DEFAULT);
         handle_set_opt(h.get(), LRO_LOWSPEEDTIME, LRO_LOWSPEEDTIME_DEFAULT);
     }
-
-    if (!config.proxy().empty() && !config.proxy().get_value().empty()) {
-        handle_set_opt(h.get(), LRO_PROXY, config.proxy().get_value().c_str());
-    }
-
-    // set proxy authorization methods
-    auto proxy_auth_methods = string_to_proxy_auth_methods(config.proxy_auth_method().get_value());
-    handle_set_opt(h.get(), LRO_PROXYAUTHMETHODS, static_cast<long>(proxy_auth_methods));
-
-    if (!config.proxy_username().empty()) {
-        userpwd = config.proxy_username().get_value();
-        if (!userpwd.empty()) {
-            userpwd = format_user_pass_string(userpwd, config.proxy_password().get_value(), true);
-            handle_set_opt(h.get(), LRO_PROXYUSERPWD, userpwd.c_str());
-        }
-    }
-
-    auto sslverify = config.sslverify().get_value() ? 1L : 0L;
-    handle_set_opt(h.get(), LRO_SSLVERIFYHOST, sslverify);
-    handle_set_opt(h.get(), LRO_SSLVERIFYPEER, sslverify);
 
     return h;
 }
@@ -1732,37 +1735,7 @@ static LrHandle * new_handle(ConfigMain * config) {
     // see dnf.repo.Repo._handle_new_remote() how to pass
     if (config) {
         user_agent = config->user_agent().get_value().c_str();
-        auto minrate = config->minrate().get_value();
-        handle_set_opt(h, LRO_LOWSPEEDLIMIT, static_cast<long>(minrate));
-
-        auto maxspeed = config->throttle().get_value();
-        if (maxspeed > 0 && maxspeed <= 1) {
-            maxspeed *= static_cast<float>(config->bandwidth().get_value());
-        }
-        if (maxspeed != 0 && maxspeed < static_cast<float>(minrate))
-            throw RuntimeError(
-                _("Maximum download speed is lower than minimum. "
-                  "Please change configuration of minrate or throttle"));
-        handle_set_opt(h, LRO_MAXSPEED, static_cast<int64_t>(maxspeed));
-
-        if (!config->proxy().empty() && !config->proxy().get_value().empty())
-            handle_set_opt(h, LRO_PROXY, config->proxy().get_value().c_str());
-
-        // set proxy authorization methods
-        auto proxy_auth_methods = string_to_proxy_auth_methods(config->proxy_auth_method().get_value());
-        handle_set_opt(h, LRO_PROXYAUTHMETHODS, static_cast<long>(proxy_auth_methods));
-
-        if (!config->proxy_username().empty()) {
-            auto userpwd = config->proxy_username().get_value();
-            if (!userpwd.empty()) {
-                userpwd = format_user_pass_string(userpwd, config->proxy_password().get_value(), true);
-                handle_set_opt(h, LRO_PROXYUSERPWD, userpwd.c_str());
-            }
-        }
-
-        auto sslverify = config->sslverify().get_value() ? 1L : 0L;
-        handle_set_opt(h, LRO_SSLVERIFYHOST, sslverify);
-        handle_set_opt(h, LRO_SSLVERIFYPEER, sslverify);
+        set_handle(h, *config);
     }
     handle_set_opt(h, LRO_USERAGENT, user_agent);
     return h;


### PR DESCRIPTION
Added support for "ip_resolve", "username", "password", "sslcacert", "sslclientcert", "ssclientkey", "timeout" options.

Fixed by moving code from the `Repo::Impl::lr_handle_init_remote` method to the `set_handle` shared template.