### PR TITLE
[dnf5] libdnf: Ensure library is correctly linked with libdl

### DIFF
--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(libdnf SHARED ${LIBDNF_SOURCES})
 set(DNF_SO_VERSION 3)
 set_target_properties(libdnf PROPERTIES OUTPUT_NAME "dnf")
 set_target_properties(libdnf PROPERTIES SOVERSION ${DNF_SO_VERSION})
+# required to have dlopen symbol
+target_link_libraries(libdnf ${CMAKE_DL_LIBS})
 # required by clang
 target_link_libraries(libdnf stdc++)
 


### PR DESCRIPTION
Without this fix, libdnf fails to link with the following error:

```
/usr/bin/ld: CMakeFiles/libdnf.dir/utils/library.cpp.o: in function `libdnf::utils::Library::Library(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/builddir/build/BUILD/libdnf-968ccb38d686f56b539f0fb8d4b4e51c888260fa/libdnf/utils/library.cpp:28: undefined reference to `dlopen'
/usr/bin/ld: /builddir/build/BUILD/libdnf-968ccb38d686f56b539f0fb8d4b4e51c888260fa/libdnf/utils/library.cpp:30: undefined reference to `dlerror'
/usr/bin/ld: CMakeFiles/libdnf.dir/utils/library.cpp.o: in function `libdnf::utils::Library::~Library()':
/builddir/build/BUILD/libdnf-968ccb38d686f56b539f0fb8d4b4e51c888260fa/libdnf/utils/library.cpp:36: undefined reference to `dlclose'
/usr/bin/ld: CMakeFiles/libdnf.dir/utils/library.cpp.o: in function `libdnf::utils::Library::get_address(char const*) const':
/builddir/build/BUILD/libdnf-968ccb38d686f56b539f0fb8d4b4e51c888260fa/libdnf/utils/library.cpp:40: undefined reference to `dlerror'
/usr/bin/ld: /builddir/build/BUILD/libdnf-968ccb38d686f56b539f0fb8d4b4e51c888260fa/libdnf/utils/library.cpp:41: undefined reference to `dlsym'
/usr/bin/ld: /builddir/build/BUILD/libdnf-968ccb38d686f56b539f0fb8d4b4e51c888260fa/libdnf/utils/library.cpp:44: undefined reference to `dlerror'
collect2: error: ld returned 1 exit status
```

This already existed in dnf-4 libdnf, but wasn't carried over to this.