### PR TITLE
[dnf5] Exception::what() full message, SystemError: remove "path", format() nested

### DIFF
--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -91,6 +91,7 @@ public:
             str_what = get_description();
             str_what += ": [Errno ";
             str_what += std::to_string(get_error_code());
+            str_what += "] ";
 
             // example: "Operation not permitted"
             str_what += std::system_category().default_error_condition(error_code).message();

--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -86,6 +86,10 @@ private:
     mutable std::string description;
 };
 
+/// Formats the explanatory string of an exception.
+/// If the exception is nested, recurses to format the explanatory of the exception it holds.
+std::string format(const std::exception & e, std::size_t level = 0);
+
 }  // namespace libdnf
 
 #endif

--- a/libdnf-cli/CMakeLists.txt
+++ b/libdnf-cli/CMakeLists.txt
@@ -26,6 +26,8 @@ install(TARGETS libdnf-cli LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 
 # link libraries and set pkg-config requires
 
+target_link_libraries(libdnf-cli libdnf)
+
 pkg_check_modules(LIBFMT REQUIRED fmt)
 list(APPEND LIBDNF_CLI_PC_REQUIRES "${LIBFMT_MODULE_NAME}")
 target_link_libraries(libdnf-cli ${LIBFMT_LIBRARIES})

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -120,6 +120,7 @@ Package management library
 %package -n libdnf-cli
 Summary:        Library for working with a terminal in a command-line package manager
 BuildRequires:  pkgconfig(smartcols)
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description -n libdnf-cli
 Library for working with a terminal in a command-line package manager.

--- a/libdnf/common/exception.cpp
+++ b/libdnf/common/exception.cpp
@@ -65,5 +65,16 @@ const char * SystemError::get_description() const noexcept {
     return description.c_str();
 }
 
+std::string format(const std::exception & e, std::size_t level) {
+    std::string ret(std::string(level, ' ') + e.what() + '\n');
+    try {
+        std::rethrow_if_nested(e);
+    } catch (const std::exception & e) {
+        ret += format(e, level + 1);
+    } catch (...) {
+    }
+
+    return ret;
+}
 
 }  // namespace libdnf

--- a/libdnf/common/exception.cpp
+++ b/libdnf/common/exception.cpp
@@ -1,0 +1,69 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/common/exception.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <system_error>
+
+
+namespace libdnf {
+
+
+const char * Exception::what() const noexcept {
+    try {
+        str_what = std::string(get_domain_name()) + "::" + get_name() + ": " + get_description();
+
+        // related data, eg file name
+        const char * what = runtime_error::what();
+        if (what && what[0] != '\0') {
+            str_what += ": ";
+            str_what += what;
+        }
+
+        return str_what.c_str();
+    } catch (...) {
+        return runtime_error::what();
+    }
+}
+
+SystemError::SystemError(int error_code, const std::string & what) : RuntimeError(what), error_code{error_code} {
+    char * it = std::copy_n(NAME_PREFIX, NAME_PREFIX_LEN, name);
+    auto res = std::to_chars(it, name + sizeof(name) - 1, get_error_code());
+    *res.ptr = '\0';
+}
+
+SystemError::SystemError(int error_code, const char * what) : RuntimeError(what), error_code{error_code} {
+    char * it = std::copy_n(NAME_PREFIX, NAME_PREFIX_LEN, name);
+    auto res = std::to_chars(it, name + sizeof(name) - 1, get_error_code());
+    *res.ptr = '\0';
+}
+
+const char * SystemError::get_description() const noexcept {
+    try {
+        description = std::system_category().default_error_condition(error_code).message();
+    } catch (...) {
+        return "Unknown error";
+    }
+    return description.c_str();
+}
+
+
+}  // namespace libdnf

--- a/libdnf/rpm/repo_sack.cpp
+++ b/libdnf/rpm/repo_sack.cpp
@@ -59,7 +59,11 @@ static void libsolv_repo_free(LibsolvRepo * libsolv_repo) {
 RepoWeakPtr RepoSack::new_repo_from_libsolv_testcase(const std::string & repoid, const std::string & path) {
     std::unique_ptr<std::FILE, decltype(&std::fclose)> testcase_file(solv_xfopen(path.c_str(), "r"), &std::fclose);
     if (!testcase_file) {
-        throw SystemError(EIO, "Unable to open libsolv testcase file", path);
+        try {
+            throw SystemError(errno ? errno : EIO, path);
+        } catch (...) {
+            std::throw_with_nested(RuntimeError("Unable to open libsolv testcase file"));
+        }
     }
 
     auto repo = new_repo(repoid);


### PR DESCRIPTION
* Removed `path` from `SystemError`. User can use `what`. And nesting exceptions.

* Multi-line code moved from header file "exception.hpp" to "exception.cpp".

* `Exception::what()` returns full explanatory message: `<domain_name>::<name>: <description>: <message>`
  
  Example:
  `throw RuntimeError("Test failed")` -> `what()` returns:
  ```
  libdnf::RuntimeError: General RuntimeError exception: Test failed
  ```

* `SystemError::what()` returns: `system::Errno_<code>: <String describing error code>: <user message>`

  Example:
  `throw SystemError(ENOENT, "nonexistent.file")` -> `what()` returns:
  ```
  SystemError::Errno_2: No such file or directory: nonexistent.file
  ```



* New format() function. 
  Formats the explanatory string of an exception. If the exception is nested, recurses to format the explanatory of the exception it holds. Strings from nested exceptions are indented by spaces.
  
  Example output:
```
  libdnf::RuntimeError: General RuntimeError exception: open_file2() failed
   SystemError::Errno_2: No such file or directory: my.txt
```