### PR TITLE
[dnf5] Tests for bindings use tmpdir for cache and solv files

### DIFF
--- a/test/perl5/libdnf/rpm/test_solv_query.t
+++ b/test/perl5/libdnf/rpm/test_solv_query.t
@@ -21,6 +21,7 @@ no if $] >= 5.010, warnings => qw(experimental::smartmatch);
 
 use Test::More;
 use Cwd qw(cwd);
+use File::Temp qw(tempdir);
 use File::Spec::Functions 'catfile';
 
 
@@ -29,8 +30,8 @@ use libdnf::base;
 my $base = new libdnf::base::Base();
 
 # Sets path to cache directory.
-my $cwd = cwd;
-$base->get_config()->cachedir()->set($libdnf::conf::Option::Priority_RUNTIME, $cwd);
+my $tmpdir = tempdir("libdnf-perl5-XXXX", TMPDIR => 1, CLEANUP => 1);
+$base->get_config()->cachedir()->set($libdnf::conf::Option::Priority_RUNTIME, $tmpdir);
 
 my $repo_sack = new libdnf::rpm::RepoSack($base);
 my $sack = new libdnf::rpm::SolvSack($base);

--- a/test/python3/libdnf/rpm/test_reldep_list.py
+++ b/test/python3/libdnf/rpm/test_reldep_list.py
@@ -16,6 +16,8 @@
 # along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 import unittest
+import tempfile
+import shutil
 import os
 
 import libdnf
@@ -26,8 +28,8 @@ class TestReldepList(unittest.TestCase):
         self.base = libdnf.base.Base()
 
         # Sets path to cache directory.
-        cwd = os.getcwd()
-        self.base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, cwd)
+        self.tmpdir = tempfile.mkdtemp(prefix="libdnf-python3-")
+        self.base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, self.tmpdir)
 
         self.repo_sack = libdnf.rpm.RepoSack(self.base)
         self.sack = libdnf.rpm.SolvSack(self.base)
@@ -36,7 +38,7 @@ class TestReldepList(unittest.TestCase):
         repo = self.repo_sack.new_repo("repomd-repo1")
 
         # Tunes repository configuration (baseurl is mandatory)
-        repo_path = os.path.join(cwd, "../../../test/data/repos-repomd/repomd-repo1/")
+        repo_path = os.path.join(os.getcwd(), "../../../test/data/repos-repomd/repomd-repo1/")
         baseurl = "file://" + repo_path
         repo_cfg = repo.get_config()
         repo_cfg.baseurl().set(libdnf.conf.Option.Priority_RUNTIME, baseurl)
@@ -50,6 +52,10 @@ class TestReldepList(unittest.TestCase):
                             libdnf.rpm.SolvSack.LoadRepoFlags_USE_OTHER |
                             libdnf.rpm.SolvSack.LoadRepoFlags_USE_PRESTO |
                             libdnf.rpm.SolvSack.LoadRepoFlags_USE_UPDATEINFO)
+
+    def tearDown(self):
+        # Remove the cache directory.
+        shutil.rmtree(self.tmpdir)
 
     def test_add(self):
         a = libdnf.rpm.Reldep(self.sack, "python3-labirinto = 4.2.0")

--- a/test/python3/libdnf/rpm/test_repo.py
+++ b/test/python3/libdnf/rpm/test_repo.py
@@ -16,11 +16,12 @@
 # along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 import unittest
+import tempfile
+import shutil
+import os
 
 import libdnf.base
 import libdnf.logger
-
-import os
 
 
 class TestRepo(unittest.TestCase):
@@ -28,8 +29,8 @@ class TestRepo(unittest.TestCase):
         base = libdnf.base.Base()
 
         # Sets path to cache directory.
-        cwd = os.getcwd()
-        base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, cwd)
+        tmpdir = tempfile.mkdtemp(prefix="libdnf-python3-")
+        base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, tmpdir)
 
         repo_sack = libdnf.rpm.RepoSack(base)
         solv_sack = libdnf.rpm.SolvSack(base)
@@ -41,7 +42,7 @@ class TestRepo(unittest.TestCase):
         repo = repo_sack.new_repo("repomd-repo1")
 
         # Tunes repository configuration (baseurl is mandatory)
-        repo_path = os.path.join(cwd, "../../../test/data/repos-repomd/repomd-repo1/")
+        repo_path = os.path.join(os.getcwd(), "../../../test/data/repos-repomd/repomd-repo1/")
         baseurl = "file://" + repo_path
         repo_cfg = repo.get_config()
         repo_cfg.baseurl().set(libdnf.conf.Option.Priority_RUNTIME, baseurl)
@@ -53,3 +54,6 @@ class TestRepo(unittest.TestCase):
         SolvSack = libdnf.rpm.SolvSack
         solv_sack.load_repo(repo.get(), SolvSack.LoadRepoFlags_USE_PRESTO | SolvSack.LoadRepoFlags_USE_UPDATEINFO |
                             SolvSack.LoadRepoFlags_USE_OTHER)
+
+        # Remove the cache directory.
+        shutil.rmtree(tmpdir)

--- a/test/python3/libdnf/rpm/test_solv_query.py
+++ b/test/python3/libdnf/rpm/test_solv_query.py
@@ -16,6 +16,8 @@
 # along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 import unittest
+import tempfile
+import shutil
 import os
 
 import libdnf
@@ -26,8 +28,8 @@ class TestSolvQuery(unittest.TestCase):
         self.base = libdnf.base.Base()
 
         # Sets path to cache directory.
-        cwd = os.getcwd()
-        self.base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, cwd)
+        self.tmpdir = tempfile.mkdtemp(prefix="libdnf-python3-")
+        self.base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, self.tmpdir)
 
         self.repo_sack = libdnf.rpm.RepoSack(self.base)
         self.sack = libdnf.rpm.SolvSack(self.base)
@@ -36,7 +38,7 @@ class TestSolvQuery(unittest.TestCase):
         repo = self.repo_sack.new_repo("repomd-repo1")
 
         # Tunes repository configuration (baseurl is mandatory)
-        repo_path = os.path.join(cwd, "../../../test/data/repos-repomd/repomd-repo1/")
+        repo_path = os.path.join(os.getcwd(), "../../../test/data/repos-repomd/repomd-repo1/")
         baseurl = "file://" + repo_path
         repo_cfg = repo.get_config()
         repo_cfg.baseurl().set(libdnf.conf.Option.Priority_RUNTIME, baseurl)
@@ -46,6 +48,10 @@ class TestSolvQuery(unittest.TestCase):
 
         # Loads rpm::Repo into rpm::SolvSack
         self.sack.load_repo(repo.get(), libdnf.rpm.SolvSack.LoadRepoFlags_NONE)
+
+    def tearDown(self):
+        # Remove the cache directory.
+        shutil.rmtree(self.tmpdir)
 
     def test_size(self):
         query = libdnf.rpm.SolvQuery(self.sack)

--- a/test/ruby/libdnf/rpm/test_repo.rb
+++ b/test/ruby/libdnf/rpm/test_repo.rb
@@ -16,6 +16,7 @@
 # along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 require 'test/unit'
+require 'tmpdir'
 include Test::Unit::Assertions
 
 require 'libdnf/base'
@@ -25,8 +26,8 @@ class TestRepo < Test::Unit::TestCase
         base = Base::Base.new()
 
         # Sets path to cache directory.
-        cwd = Dir.getwd()
-        base.get_config().cachedir().set(Conf::Option::Priority_RUNTIME, cwd)
+        tmpdir = Dir.mktmpdir("libdnf-ruby-")
+        base.get_config().cachedir().set(Conf::Option::Priority_RUNTIME, tmpdir)
 
         repo_sack = Rpm::RepoSack.new(base)
         solv_sack = Rpm::SolvSack.new(base)
@@ -38,7 +39,7 @@ class TestRepo < Test::Unit::TestCase
         repo = repo_sack.new_repo("repomd-repo1")
 
         # Tunes repository configuration (baseurl is mandatory)
-        repo_path = File.join(cwd, '../../../test/data/repos-repomd/repomd-repo1/')
+        repo_path = File.join(Dir.getwd(), '../../../test/data/repos-repomd/repomd-repo1/')
         baseurl = 'file://' + repo_path
         repo_cfg = repo.get_config()
         repo_cfg.baseurl().set(Conf::Option::Priority_RUNTIME, baseurl)
@@ -49,5 +50,8 @@ class TestRepo < Test::Unit::TestCase
         # Loads rpm::Repo into rpm::SolvSack
         solv_sack.load_repo(repo.get(), Rpm::SolvSack::LoadRepoFlags_USE_PRESTO |
                             Rpm::SolvSack::LoadRepoFlags_USE_UPDATEINFO | Rpm::SolvSack::LoadRepoFlags_USE_OTHER)
+
+        # Remove the cache directory.
+        FileUtils.remove_entry(tmpdir)
     end
 end

--- a/test/ruby/libdnf/rpm/test_solv_query.rb
+++ b/test/ruby/libdnf/rpm/test_solv_query.rb
@@ -16,6 +16,7 @@
 # along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 require 'test/unit'
+require 'tmpdir'
 include Test::Unit::Assertions
 
 require 'libdnf/base'
@@ -26,8 +27,8 @@ class TestSimpleNumber < Test::Unit::TestCase
         @base = Base::Base.new()
 
         # Sets path to cache directory.
-        cwd = Dir.getwd()
-        @base.get_config().cachedir().set(Conf::Option::Priority_RUNTIME, cwd)
+        @tmpdir = Dir.mktmpdir("libdnf-ruby-")
+        @base.get_config().cachedir().set(Conf::Option::Priority_RUNTIME, @tmpdir)
 
         @repo_sack = Rpm::RepoSack.new(@base)
         @sack = Rpm::SolvSack.new(@base)
@@ -36,7 +37,7 @@ class TestSimpleNumber < Test::Unit::TestCase
         @repo = @repo_sack.new_repo('repomd-repo1')
 
         # Tunes repository configuration (baseurl is mandatory)
-        repo_path = File.join(cwd, '../../../test/data/repos-repomd/repomd-repo1/')
+        repo_path = File.join(Dir.getwd(), '../../../test/data/repos-repomd/repomd-repo1/')
         baseurl = 'file://' + repo_path
         repo_cfg = @repo.get_config()
         repo_cfg.baseurl().set(Conf::Option::Priority_RUNTIME, baseurl)
@@ -49,7 +50,8 @@ class TestSimpleNumber < Test::Unit::TestCase
     end
 
     def teardown()
-        ## Nothing really
+        # Remove the cache directory.
+        FileUtils.remove_entry(@tmpdir)
     end
 
     def test_size()


### PR DESCRIPTION
This prevents creation of cache and solv files in the repo every time
the tests are run.