### PR TITLE
Add darwin compatibility fixes.

### DIFF
--- a/libdnf/config.h
+++ b/libdnf/config.h
@@ -18,7 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef __APPLE__
+#include <stdint.h>
+#else
 #include <bits/wordsize.h>
+#endif
 
 #if __WORDSIZE == 32
 #include "config-32.h"

--- a/libdnf/hy-iutil.cpp
+++ b/libdnf/hy-iutil.cpp
@@ -22,7 +22,11 @@
 #include <errno.h>
 #include <dirent.h>
 #include <fcntl.h>
+#ifdef __APPLE__
+#include <limits.h>
+#else
 #include <linux/limits.h>
+#endif
 #include <pwd.h>
 #include <unistd.h>
 #include <stdio.h>

--- a/libdnf/hy-util.cpp
+++ b/libdnf/hy-util.cpp
@@ -24,7 +24,23 @@
 #include <ctype.h>
 #include <sys/utsname.h>
 #include <sys/stat.h>
+
+#ifdef __APPLE__
+typedef int auxv_t;
+#ifndef AT_HWCAP2
+#define AT_HWCAP2 26
+#endif
+#ifndef AT_HWCAP
+#define AT_HWCAP 16
+#endif
+static unsigned long getauxval(unsigned long type)
+{
+  unsigned long ret = 0;
+  return ret;
+}
+#else
 #include <sys/auxv.h>
+#endif
 
 // hawkey
 #include "dnf-types.h"


### PR DESCRIPTION
These patches are the ones we use over in nix to get this to compile on darwin: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/package-management/libdnf/darwin.patch

I am not the most prolific C developer, so any comments about how to improve this would be welcome.
At this point, it's compiles fine on darwin and is functional. It allows us to use microdnf on macOS.