### PR TITLE
MultiProgressBar does not take over ownership of its ProgressBars

### DIFF
--- a/include/libdnf-cli/progressbar/multi_progress_bar.hpp
+++ b/include/libdnf-cli/progressbar/multi_progress_bar.hpp
@@ -26,7 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "progress_bar.hpp"
 
 #include <iostream>
-#include <mutex>
 #include <vector>
 
 
@@ -49,7 +48,6 @@ private:
     std::vector<ProgressBar *> bars_done;
     DownloadProgressBar total;
     std::size_t printed_lines = 0;
-    std::mutex mtx;
 };
 
 

--- a/libdnf-cli/progressbar/multi_progress_bar.cpp
+++ b/libdnf-cli/progressbar/multi_progress_bar.cpp
@@ -43,10 +43,6 @@ MultiProgressBar::MultiProgressBar() : total(0, "Total") {
 
 
 MultiProgressBar::~MultiProgressBar() {
-    std::lock_guard<std::mutex> lck(mtx);
-    for (auto & i : bars_all) {
-        delete i;
-    }
     if (tty::is_interactive()) {
         std::cout << tty::cursor_show;
     }


### PR DESCRIPTION
The lifecycle of progress bars created in microdnf / dnfdaemon-client is
cleaner this way.