### PR TITLE
[dnf5] Build with clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ jobs:
     name: Package Build
     runs-on: ubuntu-latest
     container: ghcr.io/rpm-software-management/dnf-ci-host
+    strategy:
+      fail-fast: false  # don't fail all matrix jobs if one of them fails
+      matrix:
+        compiler: ['', clang]  # gcc is the default
     steps:
       - name: Check out ci-dnf-stack
         uses: actions/checkout@v2
@@ -40,4 +44,7 @@ jobs:
         run: |
           CHROOTS="fedora-33-x86_64, fedora-34-x86_64, fedora-rawhide-x86_64"
           PROJECT_NAME="CI-libdnf5-pr${{github.event.pull_request.number}}"
-          rpm-gitoverlay --gitdir=gits build-overlay -s overlays/dnf5-unstable rpm copr --owner "${{steps.setup-ci.outputs.copr-user}}" --project "$PROJECT_NAME" --chroots "$CHROOTS" --delete-project-after-days=7
+          if [[ -n "${{matrix.compiler}}" ]]; then
+            PROJECT_NAME+="-${{matrix.compiler}}"
+          fi
+          rpm-gitoverlay --gitdir=gits build-overlay -s overlays/dnf5-unstable rpm --with "${{matrix.compiler}}" copr --owner "${{steps.setup-ci.outputs.copr-user}}" --project "$PROJECT_NAME" --chroots "$CHROOTS" --delete-project-after-days=7

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -25,17 +25,20 @@ set(SWIG_COMPILE_OPTIONS
     -Wno-conversion
     -Wno-deprecated-copy
     -Wno-deprecated-declarations
-    -Wno-maybe-uninitialized
     -Wno-missing-declarations
     -Wno-missing-field-initializers
     -Wno-sign-compare
+    -Wno-sometimes-uninitialized
     -Wno-strict-aliasing
     -Wno-unused-function
     -Wno-unused-parameter
 )
 
 if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS} -Wno-catch-value)
+    set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
+        -Wno-catch-value
+        -Wno-maybe-uninitialized
+    )
 endif()
 
 

--- a/bindings/perl5/CMakeLists.txt
+++ b/bindings/perl5/CMakeLists.txt
@@ -18,6 +18,8 @@ separate_arguments(PERL_CFLAGS)
 
 # remove options unused by clang
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    list(REMOVE_ITEM PERL_CFLAGS -flto=auto)
+    list(REMOVE_ITEM PERL_CFLAGS -ffat-lto-objects)
     list(REMOVE_ITEM PERL_CFLAGS -fstack-clash-protection)
     list(REMOVE_ITEM PERL_CFLAGS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1)
     list(REMOVE_ITEM PERL_CFLAGS -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1)

--- a/dnfdaemon-client/commands/install/install.cpp
+++ b/dnfdaemon-client/commands/install/install.cpp
@@ -98,7 +98,7 @@ void CmdInstall::run(Context & ctx) {
 
     ctx.session_proxy->callMethod("install")
         .onInterface(dnfdaemon::INTERFACE_RPM)
-        .withTimeout(-1)
+        .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(patterns, options);
 
     // resolve the transaction
@@ -107,7 +107,7 @@ void CmdInstall::run(Context & ctx) {
     std::vector<dnfdaemon::DbusTransactionItem> transaction;
     ctx.session_proxy->callMethod("resolve")
         .onInterface(dnfdaemon::INTERFACE_RPM)
-        .withTimeout(-1)
+        .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(options)
         .storeResultsTo(transaction);
     if (transaction.empty()) {
@@ -136,7 +136,7 @@ void CmdInstall::run(Context & ctx) {
     options.clear();
     ctx.session_proxy->callMethod("do_transaction")
         .onInterface(dnfdaemon::INTERFACE_RPM)
-        .withTimeout(-1)
+        .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(options);
 }
 

--- a/dnfdaemon-client/commands/install/install.hpp
+++ b/dnfdaemon-client/commands/install/install.hpp
@@ -35,7 +35,6 @@ public:
 private:
     libdnf::OptionBool * strict_option{nullptr};
     libdnf::OptionBool * allow_erasing_option{nullptr};
-    std::vector<std::unique_ptr<libdnf::Option>> * repo_ids_options{nullptr};
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 

--- a/dnfdaemon-client/commands/repoquery/repoquery.cpp
+++ b/dnfdaemon-client/commands/repoquery/repoquery.cpp
@@ -150,7 +150,7 @@ void CmdRepoquery::run(Context & ctx) {
     dnfdaemon::KeyValueMapList packages;
     ctx.session_proxy->callMethod("list")
         .onInterface(dnfdaemon::INTERFACE_RPM)
-        .withTimeout(-1)
+        .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(options)
         .storeResultsTo(packages);
 

--- a/dnfdaemon-client/commands/repoquery/repoquery.hpp
+++ b/dnfdaemon-client/commands/repoquery/repoquery.hpp
@@ -39,7 +39,6 @@ private:
     libdnf::OptionBool * available_option{nullptr};
     libdnf::OptionBool * installed_option{nullptr};
     libdnf::OptionBool * info_option{nullptr};
-    libdnf::OptionBool * nevra_option{nullptr};
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 

--- a/dnfdaemon-client/context.cpp
+++ b/dnfdaemon-client/context.cpp
@@ -137,7 +137,10 @@ dnfdaemon::RepoStatus Context::wait_for_repos() {
             }
         };
         repositories_status = dnfdaemon::RepoStatus::PENDING;
-        session_proxy->callMethodAsync("read_all_repos").onInterface(dnfdaemon::INTERFACE_BASE).withTimeout(-1).uponReplyInvoke(callback);
+        session_proxy->callMethodAsync("read_all_repos")
+            .onInterface(dnfdaemon::INTERFACE_BASE)
+            .withTimeout(static_cast<uint64_t>(-1))
+            .uponReplyInvoke(callback);
     }
     while (repositories_status == dnfdaemon::RepoStatus::PENDING) {
         sleep(1);

--- a/include/libdnf/rpm/repo.hpp
+++ b/include/libdnf/rpm/repo.hpp
@@ -114,9 +114,9 @@ public:
 
     /// Verify repo ID
     /// @param id repo ID to verify
-    /// @return   index of the first invalid character in the repo ID (if present) or -1
+    /// @return   index of the first invalid character in the repo ID (if present) or std::string::npos
     /// @replaces libdnf:repo/Repo.hpp:method:Repo.verifyId(const std::string & id)
-    static int verify_id(const std::string & repo_id);
+    static std::string::size_type verify_id(const std::string & repo_id);
 
     /// Construct the Repo object
     /// @param id     repo ID to use

--- a/include/libdnf/utils/utils.hpp
+++ b/include/libdnf/utils/utils.hpp
@@ -126,51 +126,39 @@ inline GoalProblem operator&(GoalProblem lhs, GoalProblem rhs) {
 }
 
 inline bool GoalJobSettings::get_strict(const libdnf::ConfigMain & cfg_main) const {
-    bool ret;
     switch (strict) {
         case GoalSetting::AUTO:
-            ret = cfg_main.strict().get_value();
-            break;
+            return cfg_main.strict().get_value();
         case GoalSetting::SET_TRUE:
-            ret = true;
-            break;
+            return true;
         case GoalSetting::SET_FALSE:
-            ret = false;
-            break;
+        default:
+            return false;
     }
-    return ret;
 }
 
 inline bool GoalJobSettings::get_best(const libdnf::ConfigMain & cfg_main) const {
-    bool ret;
     switch (best) {
         case GoalSetting::AUTO:
-            ret = cfg_main.best().get_value();
-            break;
+            return cfg_main.best().get_value();
         case GoalSetting::SET_TRUE:
-            ret = true;
-            break;
+            return true;
         case GoalSetting::SET_FALSE:
-            ret = false;
-            break;
+        default:
+            return false;
     }
-    return ret;
 }
 
 inline bool GoalJobSettings::get_clean_requirements_on_remove(const libdnf::ConfigMain & cfg_main) const {
-    bool ret;
     switch (clean_requirements_on_remove) {
         case GoalSetting::AUTO:
-            ret = cfg_main.clean_requirements_on_remove().get_value();
-            break;
+            return cfg_main.clean_requirements_on_remove().get_value();
         case GoalSetting::SET_TRUE:
-            ret = true;
-            break;
+            return true;
         case GoalSetting::SET_FALSE:
-            ret = false;
-            break;
+        default:
+            return false;
     }
-    return ret;
 }
 
 

--- a/libdnf-cli/output/key_value_table.cpp
+++ b/libdnf-cli/output/key_value_table.cpp
@@ -69,10 +69,15 @@ void KeyValueTable::print() {
 }
 
 
-struct libscols_line * KeyValueTable::add_line(const char * key, const std::string & value, const char * color, struct libscols_line * parent) {
+struct libscols_line * KeyValueTable::add_line(
+    const char * key,
+    const char * value,
+    const char * color,
+    struct libscols_line * parent
+) {
     struct libscols_line * ln = scols_table_new_line(tb, parent);
     scols_line_set_data(ln, 0, key);
-    scols_line_set_data(ln, 1, value.c_str());
+    scols_line_set_data(ln, 1, value);
 
     if (color && strcmp(color, "") != 0) {
         auto cell_value = scols_line_get_cell(ln, 1);
@@ -83,12 +88,22 @@ struct libscols_line * KeyValueTable::add_line(const char * key, const std::stri
 }
 
 
-struct libscols_line * KeyValueTable::add_line(const char * key, int64_t value, const char * color, struct libscols_line * parent) {
-    return add_line(key, std::to_string(value), color, parent);
+struct libscols_line * KeyValueTable::add_line(
+    const char * key,
+    const std::string & value,
+    const char * color,
+    struct libscols_line * parent
+) {
+    return add_line(key, value.c_str(), color, parent);
 }
 
 
-struct libscols_line * KeyValueTable::add_line(const char * key, const std::vector<std::string> & value, const char * color, struct libscols_line * parent) {
+struct libscols_line * KeyValueTable::add_line(
+    const char * key,
+    const std::vector<std::string> & value,
+    const char * color,
+    struct libscols_line * parent
+) {
     return add_line(key, join(value, " "), color, parent);
 }
 

--- a/libdnf-cli/output/key_value_table.hpp
+++ b/libdnf-cli/output/key_value_table.hpp
@@ -37,9 +37,36 @@ public:
     void print();
 
 protected:
-    struct libscols_line * add_line(const char * key, const std::string & value, const char * color = nullptr, struct libscols_line * parent = nullptr);
-    struct libscols_line * add_line(const char * key, int64_t value, const char * color = nullptr, struct libscols_line * parent = nullptr);
-    struct libscols_line * add_line(const char * key, const std::vector<std::string> & value, const char * color = nullptr, struct libscols_line * parent = nullptr);
+    struct libscols_line * add_line(
+        const char * key,
+        const char * value,
+        const char * color = nullptr,
+        struct libscols_line * parent = nullptr
+    );
+
+    struct libscols_line * add_line(
+        const char * key,
+        const std::string & value,
+        const char * color = nullptr,
+        struct libscols_line * parent = nullptr
+    );
+
+    struct libscols_line * add_line(
+        const char * key,
+        const std::vector<std::string> & value,
+        const char * color = nullptr,
+        struct libscols_line * parent = nullptr
+    );
+
+    template<typename V>
+    struct libscols_line * add_line(
+        const char * key,
+        V value,
+        const char * color = nullptr,
+        struct libscols_line * parent = nullptr
+    ) {
+        return add_line(key, std::to_string(value), color, parent);
+    }
 
 private:
     struct libscols_table * tb = nullptr;

--- a/libdnf-cli/output/repo_info.hpp
+++ b/libdnf-cli/output/repo_info.hpp
@@ -107,7 +107,7 @@ void RepoInfo::add_repo(const Repo & repo, bool verbose, bool show_sack_data) {
         add_line("Available packages", repo.get_available_pkgs(), nullptr, group_repodata);
         add_line("Total packages", repo.get_pkgs(), nullptr, group_repodata);
 
-        std::string size = libdnf::cli::utils::units::format_size(repo.get_size());
+        std::string size = libdnf::cli::utils::units::format_size(static_cast<int64_t>(repo.get_size()));
         add_line("Size", size, nullptr, group_repodata);
 
         add_line("Content tags", repo.get_content_tags(), nullptr, group_repodata);

--- a/libdnf-cli/output/repolist.hpp
+++ b/libdnf-cli/output/repolist.hpp
@@ -58,7 +58,7 @@ static void add_line_into_repolist_table(
 }
 
 template <class Query>
-static void print_repolist_table(Query query, bool with_status, int c) {
+static void print_repolist_table(Query query, bool with_status, size_t sort_column) {
     auto table = create_repolist_table(with_status);
     for (auto & repo : query.get_data()) {
         add_line_into_repolist_table(
@@ -68,7 +68,7 @@ static void print_repolist_table(Query query, bool with_status, int c) {
             repo->get_name().c_str(), //repo->get_config().name().get_value().c_str(),
             repo->is_enabled());
     }
-    auto cl = scols_table_get_column(table, c);
+    auto cl = scols_table_get_column(table, sort_column);
     scols_sort_table(table, cl);
 
     scols_print_table(table);

--- a/libdnf-cli/utils/utf8.cpp
+++ b/libdnf-cli/utils/utf8.cpp
@@ -96,7 +96,8 @@ std::size_t width(const std::string & str) {
         }
 
         // increase string width
-        result += wcwidth(wide_char);
+        // TODO lukash: handle wcwidth returning -1: unprintable character?
+        result += static_cast<std::size_t>(wcwidth(wide_char));
 
         // move the input string pointer by number of bytes read into the wide_char
         ptr += bytes;
@@ -141,7 +142,7 @@ std::string substr_length(const std::string & str, std::string::size_type pos, s
             continue;
         }
 
-        result.append(ptr, bytes);
+        result.append(ptr, static_cast<std::size_t>(bytes));
 
         // move the input string pointer by number of bytes read into the wide_char
         ptr += bytes;
@@ -195,13 +196,14 @@ std::string substr_width(const std::string & str, std::string::size_type pos, st
 
         // increase string width
         if (wid != std::string::npos) {
-            std::size_t char_width = wcwidth(wide_char);
+            // TODO lukash: handle wcwidth returning -1: unprintable character?
+            std::size_t char_width = static_cast<std::size_t>(wcwidth(wide_char));
             if (char_width > wid) {
                 break;
             }
             wid -= char_width;
         }
-        result.append(ptr, bytes);
+        result.append(ptr, static_cast<std::size_t>(bytes));
 
         // move the input string pointer by number of bytes read into the wide_char
         ptr += bytes;

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -28,11 +28,15 @@ Source0:        %{url}/archive/%{version}/libdnf-%{version}.tar.gz
 %bcond_without python3
 %bcond_without ruby
 
+%bcond_with    clang
 %bcond_with    sanitizers
 %bcond_without tests
 %bcond_with    performance_tests
 %bcond_with    dnfdaemon_tests
 
+%if %{with clang}
+    %global toolchain clang
+%endif
 
 # ========== versions of dependencies ==========
 
@@ -47,8 +51,12 @@ Source0:        %{url}/archive/%{version}/libdnf-%{version}.tar.gz
 
 BuildRequires:  cmake
 BuildRequires:  doxygen
-BuildRequires:  gcc-c++
 BuildRequires:  gettext
+%if %{with clang}
+BuildRequires:  clang
+%else
+BuildRequires:  gcc-c++
+%endif
 
 BuildRequires:  pkgconfig(check)
 %if ! %{with tests_disabled}

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -131,10 +131,6 @@ bool is_unique(
     return true;
 }
 
-inline static std::string cstring2string(const char * input) {
-    return input ? std::string(input) : std::string();
-}
-
 std::string string_join(
     const std::vector<std::pair<ProblemRules, std::vector<std::string>>> & src, const std::string & delim) {
     if (src.empty()) {

--- a/libdnf/conf/vars.cpp
+++ b/libdnf/conf/vars.cpp
@@ -180,11 +180,11 @@ std::string Vars::substitute(const std::string & text) const {
             bracket = false;
         }
         auto it = std::find_if_not(
-            res.begin() + variable, res.end(), [](char c) { return std::isalnum(c) != 0 || c == '_'; });
+            res.begin() + static_cast<long>(variable), res.end(), [](char c) { return std::isalnum(c) != 0 || c == '_'; });
         if (bracket && it == res.end()) {
             break;
         }
-        auto past_variable = std::distance(res.begin(), it);
+        auto past_variable = static_cast<unsigned long>(std::distance(res.begin(), it));
         if (bracket && *it != '}') {
             start = res.find_first_of('$', past_variable);
             continue;

--- a/libdnf/rpm/config_repo.cpp
+++ b/libdnf/rpm/config_repo.cpp
@@ -30,7 +30,6 @@ class ConfigRepo::Impl {
 
     Impl(Config & owner, ConfigMain & main_config);
 
-    Config & owner;
     ConfigMain & main_config;
 
     OptionString name{""};
@@ -84,7 +83,7 @@ class ConfigRepo::Impl {
     OptionBool build_cache{true};
 };
 
-ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config) : owner(owner), main_config(main_config) {
+ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config) : main_config(main_config) {
     owner.opt_binds().add("name", name);
     owner.opt_binds().add("enabled", enabled);
     owner.opt_binds().add("cachedir", basecachedir);

--- a/libdnf/rpm/repo.cpp
+++ b/libdnf/rpm/repo.cpp
@@ -385,7 +385,7 @@ Repo::Impl::~Impl() {
 Repo::Repo(const std::string & id, Base & base, Repo::Type type) {
     if (type == Type::AVAILABLE) {
         auto idx = verify_id(id);
-        if (idx >= 0) {
+        if (idx != std::string::npos) {
             std::string msg = fmt::format(_("Bad id for repo: {}, byte = {} {}"), id, id[idx], idx);
             throw RuntimeError(msg);
         }
@@ -399,9 +399,8 @@ void Repo::set_callbacks(std::unique_ptr<RepoCB> && callbacks) {
     p_impl->callbacks = std::move(callbacks);
 }
 
-int Repo::verify_id(const std::string & repo_id) {
-    auto idx = repo_id.find_first_not_of(REPOID_CHARS);
-    return idx == repo_id.npos ? -1 : static_cast<int>(idx);
+std::string::size_type Repo::verify_id(const std::string & repo_id) {
+    return repo_id.find_first_not_of(REPOID_CHARS);
 }
 
 void Repo::verify() const {

--- a/libdnf/rpm/repo.cpp
+++ b/libdnf/rpm/repo.cpp
@@ -1190,11 +1190,11 @@ void Repo::Impl::add_countme_flag(LrHandle * handle) {
         int64_t step = (win - epoch) / COUNTME_WINDOW;
 
         // Compute the bucket we are in
-        unsigned int i;
+        uint32_t i;
         for (i = 0; i < COUNTME_BUCKETS.size(); ++i)
             if (step < COUNTME_BUCKETS[i])
                 break;
-        int bucket = i + 1;  // Buckets are indexed from 1
+        uint32_t bucket = i + 1;  // Buckets are indexed from 1
 
         // Set the flag
         std::string flag = "countme=" + std::to_string(bucket);

--- a/libdnf/rpm/repo_sack.cpp
+++ b/libdnf/rpm/repo_sack.cpp
@@ -91,7 +91,7 @@ void RepoSack::new_repos_from_file(const std::string & path) {
             section));
 
         auto bad_char_idx = Repo::verify_id(repo_id);
-        if (bad_char_idx >= 0) {
+        if (bad_char_idx != std::string::npos) {
             auto msg = fmt::format(
                 R"**(Bad id for repo "{}" section "{}", char = {} at pos {})**",
                 repo_id,

--- a/libdnf/rpm/solv/package_private.hpp
+++ b/libdnf/rpm/solv/package_private.hpp
@@ -101,12 +101,12 @@ inline void pool_split_evr(Pool * pool, const char * evr_c, char ** epoch, char 
     *release = r;
 }
 
-static inline unsigned long long lookup_num(Solvable * solvable, unsigned type) {
+static inline unsigned long long lookup_num(Solvable * solvable, Id type) {
     SolvPrivate::internalize_libsolv_repo(solvable->repo);
     return solvable_lookup_num(solvable, type, 0);
 }
 
-static inline const char * lookup_cstring(Solvable * solvable, unsigned type) {
+static inline const char * lookup_cstring(Solvable * solvable, Id type) {
     SolvPrivate::internalize_libsolv_repo(solvable->repo);
     return solvable_lookup_str(solvable, type);
 }

--- a/libdnf/rpm/solv_sack.cpp
+++ b/libdnf/rpm/solv_sack.cpp
@@ -53,7 +53,8 @@ namespace {
 // Names of special repositories
 constexpr const char * SYSTEM_REPO_NAME = "@System";
 constexpr const char * CMDLINE_REPO_NAME = "@commandline";
-constexpr const char * MODULE_FAIL_SAFE_REPO_NAME = "@modulefailsafe";
+// TODO lukash: unused, remove?
+//constexpr const char * MODULE_FAIL_SAFE_REPO_NAME = "@modulefailsafe";
 
 // Extensions of solv file names
 constexpr const char * SOLV_EXT_FILENAMES = "-filenames";

--- a/libdnf/rpm/solv_sack_impl.hpp
+++ b/libdnf/rpm/solv_sack_impl.hpp
@@ -225,7 +225,7 @@ inline solv::SolvMap & SolvSack::Impl::get_solvables() {
     }
     // map.size is in bytes, << 3 multiplies the number with 8 and gives size in bits
     if (static_cast<int>(nsolvables) > (cached_solvables.map.size << 3)) {
-        cached_solvables = std::move(solv::SolvMap(static_cast<int>(nsolvables)));
+        cached_solvables = solv::SolvMap(static_cast<int>(nsolvables));
     } else {
         cached_solvables.clear();
     }

--- a/libdnf/transaction/rpm_package.cpp
+++ b/libdnf/transaction/rpm_package.cpp
@@ -39,7 +39,7 @@ uint32_t Package::get_epoch_int() const {
     if (get_epoch().empty()) {
         return 0;
     }
-    return std::stoi(get_epoch());
+    return static_cast<uint32_t>(std::stoi(get_epoch()));
 }
 
 
@@ -126,10 +126,9 @@ TransactionItemReason Package::resolveTransactionItemReason(
 bool Package::operator<(const Package & other) const {
     // TODO(dmach): replace the whole function with a different implementation, preferably an existing code
     // compare epochs
-    int32_t epoch_diff = other.get_epoch_int() - get_epoch_int();
-    if (epoch_diff > 0) {
+    if (get_epoch_int() < other.get_epoch_int()) {
         return true;
-    } else if (epoch_diff < 0) {
+    } else if (get_epoch_int() > other.get_epoch_int()) {
         return false;
     }
 

--- a/libdnf/utils/sqlite3/sqlite3.hpp
+++ b/libdnf/utils/sqlite3/sqlite3.hpp
@@ -98,7 +98,10 @@ public:
         }
 
         void bind(int pos, std::uint32_t val) {
-            auto result = sqlite3_bind_int(stmt, pos, val);
+            // SQLite doesn't support storing unsigned ints, for 32 bit unsigned bind,
+            // we can just use the 64 bit version, it all converts to a single
+            // signed INTEGER type in the DB
+            auto result = sqlite3_bind_int64(stmt, pos, static_cast<int64_t>(val));
             if (result != SQLITE_OK)
                 throw Error(*this, result, "Unsigned integer bind failed");
         }
@@ -225,7 +228,9 @@ public:
 
         int get(int idx, Identity<int> /*unused*/) { return sqlite3_column_int(stmt, idx); }
 
-        uint32_t get(int idx, Identity<uint32_t> /*unused*/) { return sqlite3_column_int(stmt, idx); }
+        uint32_t get(int idx, Identity<uint32_t> /*unused*/) {
+            return static_cast<uint32_t>(sqlite3_column_int64(stmt, idx));
+        }
 
         int64_t get(int idx, Identity<int64_t> /*unused*/) { return sqlite3_column_int64(stmt, idx); }
 

--- a/test/libdnf/CMakeLists.txt
+++ b/test/libdnf/CMakeLists.txt
@@ -7,9 +7,11 @@ file(GLOB_RECURSE TEST_LIBDNF_SOURCES *.cpp)
 
 add_executable(run_tests ${TEST_LIBDNF_SOURCES})
 
-# unused comparisons and values are frequently used in CPPUNIT_ASSERT_THROW
+# Disable warnings for operations used intentionally to test how the case is handled
 target_compile_options(run_tests PRIVATE "-Wno-unused-comparison")
 target_compile_options(run_tests PRIVATE "-Wno-unused-value")
+target_compile_options(run_tests PRIVATE "-Wno-self-assign-overloaded")
+target_compile_options(run_tests PRIVATE "-Wno-self-move")
 
 target_link_directories(run_tests PUBLIC ${CMAKE_BINARY_DIR}/libdnf)
 target_link_libraries(run_tests stdc++ libdnf cppunit)


### PR DESCRIPTION
Adds support to the build system to build with clang and fixes all the warnings clang produces (mainly about implicit type conversions).

There's also a WIP commit adding a `--with clang` switch to the .spec file, but there's an issue with `rpmbuild` setting compiler flags which clang doesn't support through env variables. I'm not sure what is the proper solution here. @Conan-Kudo would you perhaps have any suggestions how to solve this?