### PR TITLE
[dnf5] Vars source/priority support, microdnf "--setvars" command line arg support

### DIFF
--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -246,7 +246,8 @@ libdnf::transaction::TransactionWeakPtr new_db_transaction(libdnf::Base * base, 
     if (!comment.empty()) {
         transaction->set_comment(comment);
     }
-    transaction->set_releasever(base->get_vars().get_values().at("releasever"));
+    // TODO(jrohel): What if the "releasever" variable is not set?
+    transaction->set_releasever(base->get_vars().get_value("releasever"));
 
     // TODO (mblaha): command line for the transaction?
     //transaction->set_cmdline(cmd_line);

--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -156,7 +156,7 @@ Session::Session(sdbus::IConnection & connection, dnfdaemon::KeyValueMap session
     );
     if (session_configuration.find("releasever") != session_configuration.end()) {
         auto releasever = session_configuration_value<std::string>("releasever");
-        base->get_vars().set_value("releasever", releasever);
+        base->get_vars().set("releasever", releasever);
     }
 
     // load repo configuration

--- a/include/libdnf/conf/vars.hpp
+++ b/include/libdnf/conf/vars.hpp
@@ -34,19 +34,51 @@ namespace libdnf {
 /// of directories.
 struct Vars {
 public:
+    enum class Priority {
+        DEFAULT = 10,
+        AUTO = 20,
+        VARSDIR = 30,
+        PLUGIN = 40,
+        ENVIRONMENT = 50,
+        COMMANDLINE = 60,
+        RUNTIME = 70
+    };
+
+    struct Variable {
+        std::string value;
+        Priority priority;
+    };
+
     /// @brief Substitute DNF vars in the input text.
     ///
     /// @param text The text for substitution
     /// @return The substituted text
     std::string substitute(const std::string & text) const;
 
-    const std::map<std::string, std::string> & get_values() const { return values; }
+    const std::map<std::string, Variable> & get_variables() const { return variables; }
 
     /// @brief Set particular variable to a value
     ///
     /// @param name Name of the variable
     /// @param value Value to be stored in variable
-    void set_value(const std::string & name, const std::string & value) { values[name] = value; }
+    /// @param prio Source/Priority of the value
+    void set(const std::string & name, const std::string & value, Priority prio = Priority::RUNTIME);
+
+    /// @brief Checks if there is an variable with name equivalent to name in the container.
+    ///
+    /// @param name Name of the variable
+    /// @return true if there is such an element, otherwise false
+    bool contains(const std::string & name) const { return variables.find(name) != variables.end(); }
+
+    /// @brief Get value of particular variable.
+    ///
+    /// @param name Name of the variable
+    const std::string & get_value(const std::string & name) const { return variables.at(name).value; }
+
+    /// @brief Get particular variable.
+    ///
+    /// @param name Name of the variable
+    const Variable & get(const std::string & name) const { return variables.at(name); }
 
     /// @brief Loads DNF vars from the environment and the passed directories.
     ///
@@ -79,8 +111,9 @@ private:
     /// "DNF_VAR_[A-Za-z0-9_]+" patterns. The "DNF_VAR_" prefix is cut off.
     void load_from_env();
 
-    std::map<std::string, std::string> values;
+    std::map<std::string, Variable> variables;
 };
+
 
 }  // namespace libdnf
 

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -675,7 +675,7 @@ libdnf::transaction::TransactionWeakPtr new_db_transaction(Context & ctx) {
     if (auto comment = ctx.get_comment()) {
         transaction->set_comment(comment);
     }
-    transaction->set_releasever(ctx.base.get_vars().get_values().at("releasever"));
+    transaction->set_releasever(ctx.base.get_vars().get_value("releasever"));
     auto arguments = ctx.get_prg_arguments();
     std::string cmd_line;
     for (size_t i = 0; i < arguments.size(); ++i) {

--- a/test/libdnf/conf/test_vars.cpp
+++ b/test/libdnf/conf/test_vars.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -42,16 +42,28 @@ void VarsTest::test_vars_multiple_dirs() {
 }
 
 void VarsTest::test_vars_env() {
+    // Setting environment variables.
+    // Environment variables have higher priority than variables from files.
     setenv("DNF0", "foo0", 1);
     setenv("DNF1", "foo1", 1);
     setenv("DNF9", "foo9", 1);
     setenv("DNF_VAR_var1", "testvar1", 1);
     setenv("DNF_VAR_var41", "testvar2", 1);
 
+    // Load all variables.
     vars.load("/", {PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
 
+    // Cleaning up environment variables (necessary in case other tests share the environment)
+    unsetenv("DNF0");
+    unsetenv("DNF1");
+    unsetenv("DNF9");
+    unsetenv("DNF_VAR_var1");
+    unsetenv("DNF_VAR_var41");
+
+    // The variables var1 and var2 are defined in the files.
+    // However, var1 was also an environment variable. The environment has a higher priority.
     CPPUNIT_ASSERT_EQUAL(
-        std::string("foo0-foo1-foo9-value123-testvar2"),
-        vars.substitute("${DNF0}-${DNF1}-${DNF9}-${var1}-${var41}")
+        std::string("foo0-foo1-foo9-testvar1-testvar2-456"),
+        vars.substitute("${DNF0}-${DNF1}-${DNF9}-${var1}-${var41}-${var2}")
     );
 }


### PR DESCRIPTION
- Vars source/priority support
    - each variable remembers its source
    - sources have priority: DEFAULT, AUTO (eg from "detect_arch"), VARSDIR, PLUGIN, ENVIRONMENT, COMMANDLINE, RUNTIME
    - a lower priority source cannot overwrite a value from a higher priority source
    
- microdnf "--setvars" command line argument support
  The "--setvar" command line argument allows to set a new/existing libdnf variable.
  Format: `--setvar=<name>=<value>`
  Example: `--setvar=releasever=24`
