### PR TITLE
[dnf5] "installroot" support

### DIFF
--- a/libdnf/rpm/solv_sack.cpp
+++ b/libdnf/rpm/solv_sack.cpp
@@ -451,6 +451,8 @@ bool SolvSack::Impl::load_system_repo() {
     std::unique_ptr<LibsolvRepo, decltype(&libsolv_repo_free)> libsolv_repo(repo_create(pool, id), &libsolv_repo_free);
 
     logger.debug("load_system_repo(): fetching rpmdb");
+    // TODO(jrohel): Lock "installroot" after read its value
+    pool_set_rootdir(pool, base->get_config().installroot().get_value().c_str());
     int flagsrpm = REPO_REUSE_REPODATA | RPM_ADD_WITH_HDRID | REPO_USE_ROOTDIR;
     int rc = repo_add_rpmdb(libsolv_repo.get(), nullptr, flagsrpm);
     if (rc != 0) {

--- a/libdnf/rpm/solv_sack_impl.hpp
+++ b/libdnf/rpm/solv_sack_impl.hpp
@@ -168,7 +168,6 @@ private:
 
 inline SolvSack::Impl::Impl(Base & base) : base(&base) {
     pool = pool_create();
-    pool_set_rootdir(pool, base.get_config().installroot().get_value().c_str());
 }
 
 

--- a/libdnf/transaction/db/db.cpp
+++ b/libdnf/transaction/db/db.cpp
@@ -77,8 +77,12 @@ std::unique_ptr<libdnf::utils::SQLite3> transaction_db_connect(libdnf::Base & ba
     std::string db_path;
 
     // use db_path based on persistdir
-    auto persistdir = base.get_config().persistdir().get_value();
-    std::filesystem::path path(persistdir);
+    auto & config = base.get_config();
+    // TODO(jrohel): Lock "installroot" after read its value
+    std::filesystem::path path(config.installroot().get_value());
+    std::filesystem::path persistdir(config.persistdir().get_value());
+    path /= persistdir.relative_path();
+    std::filesystem::create_directories(path);
     path /= "history.sqlite";
     db_path = path.native();
 

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -150,6 +150,27 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
         });
     microdnf->register_named_arg(comment);
 
+    auto installroot = ctx.arg_parser.add_new_named_arg("installroot");
+    installroot->set_long_name("installroot");
+    installroot->set_has_value(true);
+    installroot->set_arg_value_help("ABSOLUTE_PATH");
+    installroot->set_short_description("set install root");
+    installroot->link_value(&config.installroot());
+    microdnf->register_named_arg(installroot);
+
+    auto releasever = ctx.arg_parser.add_new_named_arg("releasever");
+    releasever->set_long_name("releasever");
+    releasever->set_has_value(true);
+    releasever->set_arg_value_help("RELEASEVER");
+    releasever->set_short_description("override the value of $releasever in config and repo files");
+    releasever->set_parse_hook_func(
+        [&ctx](
+            [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            ctx.base.get_vars().set("releasever", value);
+            return true;
+        });
+    microdnf->register_named_arg(releasever);
+
     ctx.arg_parser.set_root_command(microdnf);
 
     for (auto & command : ctx.commands) {


### PR DESCRIPTION
- Fixes SolvSack installroot support.
- Adds installroot to SWDB

Test with microdnf, install "bash" to new "installroot":
`microdnf --installroot=<absolute_path_to_installroot> --releasever=<releasever> install bash`

Requires https://github.com/rpm-software-management/libdnf/pull/1194