### PR TITLE
[dnf5] Unit tests: New "TestCaseFixture" class: Restore "environ" after test case

### DIFF
--- a/test/libdnf/conf/test_conf.cpp
+++ b/test/libdnf/conf/test_conf.cpp
@@ -30,6 +30,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(ConfTest);
 using namespace libdnf;
 
 void ConfTest::setUp() {
+    TestCaseFixture::setUp();
     ConfigParser parser;
     parser.read(PROJECT_SOURCE_DIR "/test/libdnf/conf/data/main.conf");
     config.load_from_parser(parser, "main", vars, logger);

--- a/test/libdnf/conf/test_conf.hpp
+++ b/test/libdnf/conf/test_conf.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef TEST_LIBDNF_CONF_CONF_HPP
 #define TEST_LIBDNF_CONF_CONF_HPP
 
+#include "../testcase_fixture.hpp"
 
 #include "libdnf/conf/config_main.hpp"
 #include "libdnf/conf/vars.hpp"
@@ -29,7 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <cppunit/extensions/HelperMacros.h>
 
 
-class ConfTest : public CppUnit::TestCase {
+class ConfTest : public TestCaseFixture {
     CPPUNIT_TEST_SUITE(ConfTest);
     CPPUNIT_TEST(test_config_main);
     CPPUNIT_TEST(test_config_repo);

--- a/test/libdnf/conf/test_vars.cpp
+++ b/test/libdnf/conf/test_vars.cpp
@@ -53,13 +53,6 @@ void VarsTest::test_vars_env() {
     // Load all variables.
     vars.load("/", {PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
 
-    // Cleaning up environment variables (necessary in case other tests share the environment)
-    unsetenv("DNF0");
-    unsetenv("DNF1");
-    unsetenv("DNF9");
-    unsetenv("DNF_VAR_var1");
-    unsetenv("DNF_VAR_var41");
-
     // The variables var1 and var2 are defined in the files.
     // However, var1 was also an environment variable. The environment has a higher priority.
     CPPUNIT_ASSERT_EQUAL(

--- a/test/libdnf/conf/test_vars.hpp
+++ b/test/libdnf/conf/test_vars.hpp
@@ -21,13 +21,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef TEST_LIBDNF_CONF_VARS_HPP
 #define TEST_LIBDNF_CONF_VARS_HPP
 
+#include "../testcase_fixture.hpp"
 
 #include "libdnf/conf/vars.hpp"
 
 #include <cppunit/extensions/HelperMacros.h>
 
 
-class VarsTest : public CppUnit::TestCase {
+class VarsTest : public TestCaseFixture {
     CPPUNIT_TEST_SUITE(VarsTest);
     CPPUNIT_TEST(test_vars);
     CPPUNIT_TEST(test_vars_multiple_dirs);

--- a/test/libdnf/rpm/repo/test_repo.cpp
+++ b/test/libdnf/rpm/repo/test_repo.cpp
@@ -31,12 +31,14 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RepoTest);
 
 
 void RepoTest::setUp() {
+    TestCaseFixture::setUp();
     temp = new libdnf::utils::TempDir("libdnf_unittest_", {"installroot", "cache"});
 }
 
 
 void RepoTest::tearDown() {
     delete temp;
+    TestCaseFixture::tearDown();
 }
 
 

--- a/test/libdnf/rpm/repo/test_repo.hpp
+++ b/test/libdnf/rpm/repo/test_repo.hpp
@@ -20,14 +20,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_TEST_REPO_REPO_HPP
 #define LIBDNF_TEST_REPO_REPO_HPP
 
+#include "../../testcase_fixture.hpp"
 
 #include "libdnf/utils/temp.hpp"
 
-#include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
 
 
-class RepoTest : public CppUnit::TestCase {
+class RepoTest : public TestCaseFixture {
     CPPUNIT_TEST_SUITE(RepoTest);
     CPPUNIT_TEST(test_repo_basics);
     CPPUNIT_TEST_SUITE_END();

--- a/test/libdnf/rpm/repo_fixture.cpp
+++ b/test/libdnf/rpm/repo_fixture.cpp
@@ -79,6 +79,8 @@ void RepoFixture::add_repo_solv(const std::string & repoid) {
 
 
 void RepoFixture::setUp() {
+    TestCaseFixture::setUp();
+
     temp = std::make_unique<libdnf::utils::TempDir>(
         "libdnf_unittest_",
         std::vector<std::string>{"installroot"}

--- a/test/libdnf/rpm/repo_fixture.hpp
+++ b/test/libdnf/rpm/repo_fixture.hpp
@@ -21,18 +21,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef TEST_LIBDNF_REPO_FIXTURE_HPP
 #define TEST_LIBDNF_REPO_FIXTURE_HPP
 
+#include "../testcase_fixture.hpp"
 
 #include "libdnf/base/base.hpp"
 #include "libdnf/rpm/repo_sack.hpp"
 #include "libdnf/rpm/solv_sack.hpp"
 #include "libdnf/utils/temp.hpp"
 
-#include <cppunit/TestCase.h>
 
-
-class RepoFixture : public CppUnit::TestCase {
+class RepoFixture : public TestCaseFixture {
 public:
-    virtual void setUp() override;
+    void setUp() override;
 
     void dump_debugdata();
 

--- a/test/libdnf/testcase_fixture.cpp
+++ b/test/libdnf/testcase_fixture.cpp
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "testcase_fixture.hpp"
+
+#include <stdlib.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+extern char ** environ;
+
+static bool environ_backuped{false};
+static std::map<std::string, std::string> backup_environ;
+
+void TestCaseFixture::setUp() {
+    // Back up the current environment values.
+    // Optimization. Do this only if the backup was not there before.
+    std::string name;
+    if (!environ_backuped) {
+        for (char ** it = environ; *it; ++it) {
+            char * name_end = *it;
+            while (*name_end != '=' && *name_end != '\0') {
+                ++name_end;
+            }
+            name.assign(*it, name_end);
+            backup_environ[name] = getenv(name.c_str());
+        }
+        environ_backuped = true;
+    }
+}
+
+void TestCaseFixture::tearDown() {
+    // Remove extraneous variables from environment.
+    std::string name;
+    std::vector<std::string> vars_to_remove;
+    for (char ** it = environ; *it; ++it) {
+        char * name_end = *it;
+        while (*name_end != '=' && *name_end != '\0') {
+            ++name_end;
+        }
+        name.assign(*it, name_end);
+        auto backup_it = backup_environ.find(name);
+        if (backup_it == backup_environ.end()) {
+            vars_to_remove.emplace_back(name);
+        }
+    }
+    for (const auto & var : vars_to_remove) {
+        unsetenv(var.c_str());
+    }
+
+    // Add the missing and synchronize the value of the existing environment variables.
+    for (const auto & backup_var : backup_environ) {
+        const char * cbackup_name = backup_var.first.c_str();
+        const std::string & backup_value = backup_var.second;
+        const char * cvalue = getenv(cbackup_name);
+        if (!cvalue || cvalue != backup_value) {
+            setenv(cbackup_name, backup_value.c_str(), 1);
+        }
+    }
+}

--- a/test/libdnf/testcase_fixture.hpp
+++ b/test/libdnf/testcase_fixture.hpp
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF_TESTCASE_FIXTURE_HPP
+#define TEST_LIBDNF_TESTCASE_FIXTURE_HPP
+
+
+#include <cppunit/TestCase.h>
+
+class TestCaseFixture : public CppUnit::TestCase {
+public:
+    void setUp() override;
+    void tearDown() override;
+};
+
+
+#endif  // TEST_LIBDNF_TESTCASE_FIXTURE_HPP


### PR DESCRIPTION
The class implements the `setUp()` and `tearDown()` methods to prepare and clean up a test case. "environ" restoration is now implemented.
The class is used for tests that may depend on or change the environ.