### PR TITLE
Add the libdnf::system::State class

### DIFF
--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -133,6 +133,10 @@ public:
     // @replaces libdnf:libdnf/hy-package.h:function:dnf_package_get_nevra(DnfPackage * pkg)
     std::string get_full_nevra() const;
 
+    /// @return RPM package NA (Name.Arch).
+    /// @since 5.0
+    std::string get_na() const;
+
     /// @return RPM package Group (`RPMTAG_GROUP`).
     /// @since 5.0
     //

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -436,9 +436,7 @@ public:
     //
     // TODO(dmach): return actual value from data in PackageSack
     // TODO(dmach): throw an exception when getting a reason for an available package (it should work only for installed)
-    libdnf::transaction::TransactionItemReason get_reason() const {
-        return libdnf::transaction::TransactionItemReason::UNKNOWN;
-    }
+    libdnf::transaction::TransactionItemReason get_reason() const;
 
 protected:
     // @replaces libdnf:libdnf/dnf-package.h:function:dnf_package_new(DnfSack *sack, Id id)

--- a/include/libdnf/rpm/package_sack.hpp
+++ b/include/libdnf/rpm/package_sack.hpp
@@ -28,6 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/exception.hpp"
 #include "libdnf/common/weak_ptr.hpp"
+#include "libdnf/system/state.hpp"
 #include "libdnf/transaction/transaction_item_reason.hpp"
 
 #include <map>
@@ -157,13 +158,9 @@ public:
     /// Returns number of solvables in pool.
     int get_nsolvables() const noexcept;
 
-    /// @return Map of resolved reasons why packages were installed: ``{(name, arch) -> reason}``.
-    ///         A package can be installed due to multiple reasons, only the most significant is returned.
+    /// @return The system state object.
     /// @since 5.0
-    const std::map<std::pair<std::string, std::string>, libdnf::transaction::TransactionItemReason> & get_reasons()
-        const {
-        return reasons;
-    }
+    libdnf::system::State & get_system_state() { return system_state; }
 
 private:
     friend libdnf::Goal;
@@ -184,9 +181,11 @@ private:
     friend libdnf::advisory::AdvisoryModule;
     friend libdnf::advisory::AdvisoryReference;
     friend libdnf::base::Transaction;
+
     class Impl;
     std::unique_ptr<Impl> p_impl;
-    std::map<std::pair<std::string, std::string>, libdnf::transaction::TransactionItemReason> reasons;
+
+    libdnf::system::State system_state;
 };
 
 inline constexpr PackageSack::LoadRepoFlags operator|(PackageSack::LoadRepoFlags lhs, PackageSack::LoadRepoFlags rhs) {

--- a/include/libdnf/system/state.hpp
+++ b/include/libdnf/system/state.hpp
@@ -1,0 +1,81 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_SYSTEM_STATE_HPP
+#define LIBDNF_SYSTEM_STATE_HPP
+
+#include "libdnf/common/exception.hpp"
+#include "libdnf/transaction/transaction_item_reason.hpp"
+
+#include <filesystem>
+#include <string>
+#include <map>
+
+
+namespace libdnf::system {
+
+/// A class providing information and allowing modification of the DNF system
+/// state. The state consists of a list of userinstalled packages, installed
+/// groups and their packages etc.
+// TODO(lukash) make parts of the api (creating the class, saving reasons)
+// private or remove the class from the interface altogether
+class State {
+public:
+    /// Creates an instance of `State`, optionally specifying the directory
+    /// where the state is stored.
+    /// @param dir_path The directory where the state is stored.
+    /// @since 5.0
+    State(const std::filesystem::path & installroot, const std::filesystem::path & dir_path = "/var/lib/dnf/state");
+
+    /// @return The reason for a package NA (Name.Arch).
+    /// @param na The NA to get the reason for.
+    /// @since 5.0
+    libdnf::transaction::TransactionItemReason get_reason(const std::string & na);
+
+    /// Sets the reason for a package NA (Name.Arch).
+    /// @param na The NA to set the reason for.
+    /// @param reason The reason to set.
+    /// @since 5.0
+    void set_reason(const std::string & na, libdnf::transaction::TransactionItemReason reason);
+
+    /// Saves the system state to the filesystem path specified in constructor.
+    /// @since 5.0
+    void save();
+
+private:
+    /// Loads the system state from the filesystem path given in constructor.
+    /// @since 5.0
+    void load();
+
+    /// @return The path to the toml file containing the list of userinstalled packages.
+    /// @since 5.0
+    std::filesystem::path get_userinstalled_path();
+
+    std::filesystem::path path;
+
+    /// The map of the reasons. Only explicitly userinstalled or
+    /// group-installed packages are stored here, if a package is installed and
+    /// doesn't have a reason in this map, it is implicitly a dependency (or a
+    /// package that can be auto-cleaned).
+    std::map<std::string, libdnf::transaction::TransactionItemReason> reasons;
+};
+
+}  // namespace libdnf::system
+
+#endif

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -62,6 +62,7 @@ BuildRequires:  clang
 BuildRequires:  gcc-c++
 %endif
 
+BuildRequires:  toml11-devel
 BuildRequires:  pkgconfig(check)
 %if %{with tests}
 BuildRequires:  pkgconfig(cppunit)

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -30,6 +30,8 @@ install(TARGETS libdnf LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 
 # link libraries and set pkg-config requires
 
+find_package(toml11 REQUIRED)
+
 pkg_check_modules(LIBFMT REQUIRED fmt)
 list(APPEND LIBDNF_PC_REQUIRES "${LIBFMT_MODULE_NAME}")
 target_link_libraries(libdnf ${LIBFMT_LIBRARIES})

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -289,6 +289,15 @@ std::string Package::get_repo_id() const {
     return get_pool(base).get_repo(id.id)->get_id();
 }
 
+libdnf::transaction::TransactionItemReason Package::get_reason() const {
+    if (!is_installed()) {
+        // TODO(lukash) Right now this breaks getting reasons in Transaction::Impl::set_transaction
+        //throw LogicError("Package " + get_nevra() + " is not installed.");
+    }
+
+    return base->get_rpm_package_sack()->get_system_state().get_reason(get_na());
+}
+
 Checksum Package::get_checksum() const {
     Solvable * solvable = get_pool(base).id2solvable(id.id);
     int type;

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -91,6 +91,13 @@ std::string Package::get_full_nevra() const {
     return get_pool(base).get_full_nevra(id.id);
 }
 
+std::string Package::get_na() const {
+    std::string res = get_name();
+    res.append(".");
+    res.append(get_arch());
+    return res;
+}
+
 std::string Package::get_group() const {
     return cstring2string(lookup_cstring(get_pool(base).id2solvable(id.id), SOLVABLE_GROUP));
 }

--- a/libdnf/rpm/package_sack.cpp
+++ b/libdnf/rpm/package_sack.cpp
@@ -710,7 +710,10 @@ std::string PackageSack::Impl::give_repo_solv_cache_fn(const std::string & repoi
     return fn;
 }
 
-PackageSack::PackageSack(const BaseWeakPtr & base) : p_impl{new Impl(base)} {}
+PackageSack::PackageSack(const BaseWeakPtr & base)
+  : p_impl{new Impl(base)},
+    system_state(base->get_config().installroot().get_value())
+{}
 
 PackageSack::PackageSack(libdnf::Base & base) : PackageSack(base.get_weak_ptr()) {}
 

--- a/libdnf/system/state.cpp
+++ b/libdnf/system/state.cpp
@@ -1,0 +1,93 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/system/state.hpp"
+
+#include "libdnf/utils/fs.hpp"
+
+#include <toml.hpp>
+#include <fstream>
+
+namespace libdnf::system {
+
+State::State(
+    const std::filesystem::path & installroot,
+    const std::filesystem::path & dir_path)
+    : path(installroot / dir_path) {
+    load();
+}
+
+
+libdnf::transaction::TransactionItemReason State::get_reason(const std::string & na) {
+    auto it = reasons.find(na);
+    if (it == reasons.end()) {
+        return libdnf::transaction::TransactionItemReason::DEPENDENCY;
+    }
+
+    return it->second;
+}
+
+
+void State::set_reason(const std::string & na, libdnf::transaction::TransactionItemReason reason) {
+    if (reason == libdnf::transaction::TransactionItemReason::DEPENDENCY) {
+        reasons.erase(na);
+    } else {
+        reasons[na] = reason;
+    }
+}
+
+
+void State::save() {
+    std::filesystem::path path = get_userinstalled_path();
+    utils::fs::makedirs_for_file(path);
+
+    std::vector<std::string> userinstalled;
+
+    for (auto & na_reason : reasons) {
+        if (na_reason.second == libdnf::transaction::TransactionItemReason::USER) {
+            userinstalled.push_back(na_reason.first);
+        }
+    }
+    std::sort(userinstalled.begin(), userinstalled.end());
+
+    std::ofstream toml(path);
+    toml << toml::value({{"userinstalled", userinstalled}});
+    toml.close();
+}
+
+
+void State::load() {
+    std::filesystem::path path = get_userinstalled_path();
+
+    if (!std::filesystem::exists(path)) {
+        return;
+    }
+
+    // TODO(lukash) throws std::runtime_error with no error description in case opening the file fails
+    for (auto & na : toml::find<std::vector<std::string>>(toml::parse(path), "userinstalled")) {
+        reasons[na] = libdnf::transaction::TransactionItemReason::USER;
+    }
+}
+
+
+std::filesystem::path State::get_userinstalled_path() {
+    return path / "userinstalled.toml";
+}
+
+}  // namespace libdnf::system

--- a/microdnf/commands/downgrade/downgrade.cpp
+++ b/microdnf/commands/downgrade/downgrade.cpp
@@ -108,26 +108,7 @@ void DowngradeCommand::run() {
         return;
     }
 
-    download_packages(transaction, nullptr);
-
-    std::cout << std::endl;
-
-    libdnf::rpm::Transaction rpm_transaction(ctx.base);
-    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
-    rpm_transaction.fill_transaction<RpmTransactionItem>(transaction.get_packages(), transaction_items);
-
-    auto db_transaction = new_db_transaction(ctx);
-    db_transaction->fill_transaction_packages(transaction.get_packages());
-
-    auto time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->start();
-
-    run_transaction(rpm_transaction);
-
-    time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_end(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->finish(libdnf::transaction::TransactionState::DONE);
+    ctx.download_and_run(transaction);
 }
 
 

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -108,26 +108,7 @@ void InstallCommand::run() {
         return;
     }
 
-    download_packages(transaction, nullptr);
-
-    std::cout << std::endl;
-
-    libdnf::rpm::Transaction rpm_transaction(ctx.base);
-    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
-    rpm_transaction.fill_transaction<RpmTransactionItem>(transaction.get_packages(), transaction_items);
-
-    auto db_transaction = new_db_transaction(ctx);
-    db_transaction->fill_transaction_packages(transaction.get_packages());
-
-    auto time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->start();
-
-    run_transaction(rpm_transaction);
-
-    time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_end(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->finish(libdnf::transaction::TransactionState::DONE);
+    ctx.download_and_run(transaction);
 }
 
 

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -107,24 +107,7 @@ void ReinstallCommand::run() {
         return;
     }
 
-    download_packages(transaction, nullptr);
-
-    libdnf::rpm::Transaction rpm_transaction(ctx.base);
-    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
-    rpm_transaction.fill_transaction<RpmTransactionItem>(transaction.get_packages(), transaction_items);
-
-    auto db_transaction = new_db_transaction(ctx);
-    db_transaction->fill_transaction_packages(transaction.get_packages());
-
-    auto time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->start();
-
-    run_transaction(rpm_transaction);
-
-    time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_end(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->finish(libdnf::transaction::TransactionState::DONE);
+    ctx.download_and_run(transaction);
 }
 
 

--- a/microdnf/commands/remove/remove.cpp
+++ b/microdnf/commands/remove/remove.cpp
@@ -106,22 +106,7 @@ void RemoveCommand::run() {
         return;
     }
 
-    libdnf::rpm::Transaction rpm_transaction(ctx.base);
-    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
-    rpm_transaction.fill_transaction<RpmTransactionItem>(transaction.get_packages(), transaction_items);
-
-    auto db_transaction = new_db_transaction(ctx);
-    db_transaction->fill_transaction_packages(transaction.get_packages());
-
-    auto time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->start();
-
-    run_transaction(rpm_transaction);
-
-    time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_end(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->finish(libdnf::transaction::TransactionState::DONE);
+    ctx.download_and_run(transaction);
 }
 
 

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -113,26 +113,7 @@ void UpgradeCommand::run() {
         return;
     }
 
-    download_packages(transaction, nullptr);
-
-    std::cout << std::endl;
-
-    libdnf::rpm::Transaction rpm_transaction(ctx.base);
-    std::vector<std::unique_ptr<RpmTransactionItem>> transaction_items;
-    rpm_transaction.fill_transaction<RpmTransactionItem>(transaction.get_packages(), transaction_items);
-
-    auto db_transaction = new_db_transaction(ctx);
-    db_transaction->fill_transaction_packages(transaction.get_packages());
-
-    auto time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->start();
-
-    run_transaction(rpm_transaction);
-
-    time = std::chrono::system_clock::now().time_since_epoch();
-    db_transaction->set_dt_end(std::chrono::duration_cast<std::chrono::seconds>(time).count());
-    db_transaction->finish(libdnf::transaction::TransactionState::DONE);
+    ctx.download_and_run(transaction);
 }
 
 

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -329,6 +329,13 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
 
     run_transaction(rpm_transaction);
 
+    auto & system_state = base.get_rpm_package_sack()->get_system_state();
+    for (const auto & tspkg : transaction.get_packages()) {
+        system_state.set_reason(tspkg.get_package().get_na(), tspkg.get_reason());
+    }
+
+    system_state.save();
+
     time = std::chrono::system_clock::now().time_since_epoch();
     db_transaction->set_dt_end(std::chrono::duration_cast<std::chrono::seconds>(time).count());
     db_transaction->finish(libdnf::transaction::TransactionState::DONE);

--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -57,9 +57,16 @@ public:
     /// Stores pointer to user comment.
     void set_comment(const char * comment) noexcept { this->comment = comment; }
 
+    /// Downloads transaction packages, creates the history DB transaction and
+    /// rpm transaction and runs it.
+    void download_and_run(libdnf::base::Transaction & transaction);
+
 private:
     /// Updates the repository metadata cache and load it into rpm::RepoSack.
     void load_rpm_repo(libdnf::repo::Repo & repo);
+
+    /// Creates, initializes and returns new database transaction.
+    libdnf::transaction::TransactionWeakPtr new_db_transaction();
 
     /// Refers to program arguments.
     libdnf::Span<const char * const> prg_args;
@@ -87,9 +94,6 @@ void download_packages(const std::vector<libdnf::rpm::Package> & packages, const
 void download_packages(libdnf::base::Transaction & transaction, const char * dest_dir);
 
 void run_transaction(libdnf::rpm::Transaction & transaction);
-
-/// Creates, initializes and returns new database transaction.
-libdnf::transaction::TransactionWeakPtr new_db_transaction(Context & ctx);
 
 
 }  // namespace microdnf

--- a/test/data/repos-solv/solv-distrosync.repo
+++ b/test/data/repos-solv/solv-distrosync.repo
@@ -1,6 +1,6 @@
 =Ver: 3.0
 
-=Pkg: cmdline 1.2 1 src
+=Pkg: one 1 1 src
 
-=Pkg: cmdline 1.2 1 noarch
-=Prv: cmdline = 1.2-1
+=Pkg: one 1 1 noarch
+=Prv: one = 1-1

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -140,7 +140,7 @@ void BaseGoalTest::test_install_multilib_all() {
 
 void BaseGoalTest::test_reinstall() {
     add_repo_rpm("rpm-repo1");
-    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::Goal goal(base);
     goal.add_rpm_reinstall("one");
@@ -151,13 +151,39 @@ void BaseGoalTest::test_reinstall() {
         TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::REINSTALL,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REINSTALLED,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
+            TransactionItemState::UNKNOWN
+        )
+    };
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+}
+
+void BaseGoalTest::test_reinstall_user() {
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::USER);
+
+    libdnf::Goal goal(base);
+    goal.add_rpm_reinstall("one");
+
+    auto transaction = goal.resolve(false);
+
+    std::vector<libdnf::base::TransactionPackage> expected = {
+        TransactionPackage(
+            get_pkg("one-0:1-1.noarch"),
+            TransactionItemAction::REINSTALL,
+            TransactionItemReason::USER,
+            TransactionItemState::UNKNOWN
+        ),
+        TransactionPackage(
+            get_pkg("one-0:1-1.noarch", true),
+            TransactionItemAction::REINSTALLED,
+            TransactionItemReason::USER,
             TransactionItemState::UNKNOWN
         )
     };
@@ -166,7 +192,7 @@ void BaseGoalTest::test_reinstall() {
 
 void BaseGoalTest::test_remove() {
     add_repo_rpm("rpm-repo1");
-    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::Goal goal(base);
     goal.add_rpm_remove("one");
@@ -205,7 +231,7 @@ void BaseGoalTest::test_remove_not_installed() {
 
 void BaseGoalTest::test_install_installed_pkg() {
     add_repo_rpm("rpm-repo1");
-    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::rpm::PackageQuery query(base);
     query.filter_available().filter_nevra({"one-0:1-1.noarch"});
@@ -223,7 +249,7 @@ void BaseGoalTest::test_install_installed_pkg() {
 
 void BaseGoalTest::test_upgrade() {
     add_repo_rpm("rpm-repo1");
-    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::rpm::PackageQuery query(base);
 
@@ -236,13 +262,13 @@ void BaseGoalTest::test_upgrade() {
         TransactionPackage(
             get_pkg("one-0:2-1.noarch"),
             TransactionItemAction::UPGRADE,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::UPGRADED,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         )
     };
@@ -275,7 +301,7 @@ void BaseGoalTest::test_upgrade_not_available() {
 
 void BaseGoalTest::test_upgrade_all() {
     add_repo_rpm("rpm-repo1");
-    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::rpm::PackageQuery query(base);
 
@@ -288,13 +314,41 @@ void BaseGoalTest::test_upgrade_all() {
         TransactionPackage(
             get_pkg("one-0:2-1.noarch"),
             TransactionItemAction::UPGRADE,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::UPGRADED,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
+            TransactionItemState::UNKNOWN
+        )
+    };
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+}
+
+void BaseGoalTest::test_upgrade_user() {
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::USER);
+
+    libdnf::rpm::PackageQuery query(base);
+
+    libdnf::Goal goal(base);
+    goal.add_rpm_upgrade("one");
+
+    auto transaction = goal.resolve(false);
+
+    std::vector<libdnf::base::TransactionPackage> expected = {
+        TransactionPackage(
+            get_pkg("one-0:2-1.noarch"),
+            TransactionItemAction::UPGRADE,
+            TransactionItemReason::USER,
+            TransactionItemState::UNKNOWN
+        ),
+        TransactionPackage(
+            get_pkg("one-0:1-1.noarch", true),
+            TransactionItemAction::UPGRADED,
+            TransactionItemReason::USER,
             TransactionItemState::UNKNOWN
         )
     };
@@ -303,7 +357,7 @@ void BaseGoalTest::test_upgrade_all() {
 
 void BaseGoalTest::test_downgrade() {
     add_repo_rpm("rpm-repo1");
-    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::rpm::PackageQuery query(base);
 
@@ -316,13 +370,41 @@ void BaseGoalTest::test_downgrade() {
         TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
             get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::DOWNGRADED,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
+            TransactionItemState::UNKNOWN
+        )
+    };
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+}
+
+void BaseGoalTest::test_downgrade_user() {
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm", TransactionItemReason::USER);
+
+    libdnf::rpm::PackageQuery query(base);
+
+    libdnf::Goal goal(base);
+    goal.add_rpm_downgrade("one");
+
+    auto transaction = goal.resolve(false);
+
+    std::vector<libdnf::base::TransactionPackage> expected = {
+        TransactionPackage(
+            get_pkg("one-0:1-1.noarch"),
+            TransactionItemAction::DOWNGRADE,
+            TransactionItemReason::USER,
+            TransactionItemState::UNKNOWN
+        ),
+        TransactionPackage(
+            get_pkg("one-0:2-1.noarch", true),
+            TransactionItemAction::DOWNGRADED,
+            TransactionItemReason::USER,
             TransactionItemState::UNKNOWN
         )
     };
@@ -331,7 +413,7 @@ void BaseGoalTest::test_downgrade() {
 
 void BaseGoalTest::test_distrosync() {
     add_repo_solv("solv-distrosync");
-    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::rpm::PackageQuery query(base);
 
@@ -344,13 +426,13 @@ void BaseGoalTest::test_distrosync() {
         TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
             get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::DOWNGRADED,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         )
     };
@@ -359,7 +441,7 @@ void BaseGoalTest::test_distrosync() {
 
 void BaseGoalTest::test_distrosync_all() {
     add_repo_solv("solv-distrosync");
-    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::rpm::PackageQuery query(base);
 
@@ -372,13 +454,13 @@ void BaseGoalTest::test_distrosync_all() {
         TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
             get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::DOWNGRADED,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         )
     };
@@ -387,7 +469,7 @@ void BaseGoalTest::test_distrosync_all() {
 
 void BaseGoalTest::test_install_or_reinstall() {
     add_repo_rpm("rpm-repo1");
-    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::Goal goal(base);
     libdnf::rpm::PackageQuery query(base);
@@ -400,13 +482,13 @@ void BaseGoalTest::test_install_or_reinstall() {
         TransactionPackage(
             get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::REINSTALL,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
             get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REINSTALLED,
-            TransactionItemReason::UNKNOWN,
+            TransactionItemReason::DEPENDENCY,
             TransactionItemState::UNKNOWN
         )
     };

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -92,24 +92,13 @@ void BaseGoalTest::test_install_not_available() {
 }
 
 void BaseGoalTest::test_install_from_cmdline() {
-    // this test covers an old dnf bug described in the following steps:
-    // * specify a commandline package to install
-    // * the specified package has the same NEVRA as an available package in a repo
-    // * the package query uses NEVRA instead of id and is resolved into the available rather than the specified package
-    // * -> an unexpected package is installed
-
-    // add a repo with package 'one-0:1-1.noarch'
+    // Tests installing a cmdline package when there is a package with the same NEVRA available in a repo
     add_repo_rpm("rpm-repo1");
+    auto cmdline_pkg = add_cmdline_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
 
-    // add 'one-0:1-1.noarch' package from the command-line
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/repos-rpm/rpm-repo1/one-1-1.noarch.rpm";
-    auto cmdline_pkg = sack->add_cmdline_package(rpm_path, false);
-
-    // install the command-line package
     libdnf::Goal goal(base);
     goal.add_rpm_install(cmdline_pkg);
 
-    // resolve the goal and read results
     auto transaction = goal.resolve(false);
 
     std::vector<libdnf::base::TransactionPackage> expected = {
@@ -127,11 +116,9 @@ void BaseGoalTest::test_install_multilib_all() {
     add_repo_solv("solv-multilib");
     base.get_config().multilib_policy().set(libdnf::Option::Priority::RUNTIME, "all");
 
-    // install the command-line package
     libdnf::Goal goal(base);
     goal.add_rpm_install("multilib");
 
-    // resolve the goal and read results
     auto transaction = goal.resolve(false);
 
     std::vector<libdnf::base::TransactionPackage> expected = {
@@ -152,30 +139,23 @@ void BaseGoalTest::test_install_multilib_all() {
 }
 
 void BaseGoalTest::test_reinstall() {
-    add_repo_repomd("repomd-repo1");
-
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears as installed
-    sack->add_system_package(rpm_path, false, false);
-
-    // also add it to the @Commandline repo to make it available for reinstall
-    sack->add_cmdline_package(rpm_path, false);
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
 
     libdnf::Goal goal(base);
-    goal.add_rpm_reinstall("cmdline");
+    goal.add_rpm_reinstall("one");
 
     auto transaction = goal.resolve(false);
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch"),
+            get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::REINSTALL,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch", true),
+            get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REINSTALLED,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
@@ -185,17 +165,16 @@ void BaseGoalTest::test_reinstall() {
 }
 
 void BaseGoalTest::test_remove() {
-    add_repo_repomd("repomd-repo1");
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
 
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-    sack->add_system_package(rpm_path, false, false);
     libdnf::Goal goal(base);
-    goal.add_rpm_remove("cmdline");
+    goal.add_rpm_remove("one");
     auto transaction = goal.resolve(false);
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch", true),
+            get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REMOVE,
             TransactionItemReason::USER,
             TransactionItemState::UNKNOWN
@@ -205,11 +184,8 @@ void BaseGoalTest::test_remove() {
 }
 
 void BaseGoalTest::test_remove_not_installed() {
-    add_repo_repomd("repomd-repo1");
-
     base.get_config().clean_requirements_on_remove().set(libdnf::Option::Priority::RUNTIME, true);
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-    sack->add_system_package(rpm_path, false, false);
+
     libdnf::Goal goal(base);
     goal.add_rpm_remove("not_installed");
     auto transaction = goal.resolve(false);
@@ -228,18 +204,13 @@ void BaseGoalTest::test_remove_not_installed() {
 }
 
 void BaseGoalTest::test_install_installed_pkg() {
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears installed
-    sack->add_system_package(rpm_path, false, false);
-
-    // also add it to the @Commandline repo to make it available for install
-    sack->add_cmdline_package(rpm_path, false);
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
 
     libdnf::rpm::PackageQuery query(base);
-    query.filter_available().filter_nevra({"cmdline-0:1.2-3.noarch"});
+    query.filter_available().filter_nevra({"one-0:1-1.noarch"});
 
-    std::vector<std::string> expected = {"cmdline-0:1.2-3.noarch"};
+    std::vector<std::string> expected = {"one-0:1-1.noarch"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
 
     libdnf::Goal goal(base);
@@ -251,31 +222,25 @@ void BaseGoalTest::test_install_installed_pkg() {
 }
 
 void BaseGoalTest::test_upgrade() {
-    add_repo_repomd("repomd-repo1");
-
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears installed
-    sack->add_system_package(rpm_path, false, false);
-
-    add_repo_solv("solv-upgrade");
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
 
     libdnf::rpm::PackageQuery query(base);
 
     libdnf::Goal goal(base);
-    goal.add_rpm_upgrade("cmdline");
+    goal.add_rpm_upgrade("one");
 
     auto transaction = goal.resolve(false);
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-4.noarch"),
+            get_pkg("one-0:2-1.noarch"),
             TransactionItemAction::UPGRADE,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch", true),
+            get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::UPGRADED,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
@@ -285,16 +250,8 @@ void BaseGoalTest::test_upgrade() {
 }
 
 void BaseGoalTest::test_upgrade_not_available() {
-    add_repo_repomd("repomd-repo1");
-
     base.get_config().best().set(libdnf::Option::Priority::RUNTIME, true);
     base.get_config().clean_requirements_on_remove().set(libdnf::Option::Priority::RUNTIME, true);
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears installed
-    sack->add_system_package(rpm_path, false, false);
-
-    add_repo_solv("solv-upgrade");
 
     libdnf::rpm::PackageQuery query(base);
 
@@ -317,12 +274,8 @@ void BaseGoalTest::test_upgrade_not_available() {
 }
 
 void BaseGoalTest::test_upgrade_all() {
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears installed
-    sack->add_system_package(rpm_path, false, false);
-
-    add_repo_solv("solv-upgrade");
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
 
     libdnf::rpm::PackageQuery query(base);
 
@@ -333,13 +286,13 @@ void BaseGoalTest::test_upgrade_all() {
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-4.noarch"),
+            get_pkg("one-0:2-1.noarch"),
             TransactionItemAction::UPGRADE,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch", true),
+            get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::UPGRADED,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
@@ -349,29 +302,25 @@ void BaseGoalTest::test_upgrade_all() {
 }
 
 void BaseGoalTest::test_downgrade() {
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears installed
-    sack->add_system_package(rpm_path, false, false);
-
-    add_repo_solv("solv-downgrade");
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm");
 
     libdnf::rpm::PackageQuery query(base);
 
     libdnf::Goal goal(base);
-    goal.add_rpm_downgrade("cmdline");
+    goal.add_rpm_downgrade("one");
 
     auto transaction = goal.resolve(false);
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-1.noarch"),
+            get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch", true),
+            get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::DOWNGRADED,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
@@ -381,29 +330,25 @@ void BaseGoalTest::test_downgrade() {
 }
 
 void BaseGoalTest::test_distrosync() {
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears installed
-    sack->add_system_package(rpm_path, false, false);
-
     add_repo_solv("solv-distrosync");
+    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm");
 
     libdnf::rpm::PackageQuery query(base);
 
     libdnf::Goal goal(base);
-    goal.add_rpm_distro_sync("cmdline");
+    goal.add_rpm_distro_sync("one");
 
     auto transaction = goal.resolve(false);
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-1.noarch"),
+            get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch", true),
+            get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::DOWNGRADED,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
@@ -413,12 +358,8 @@ void BaseGoalTest::test_distrosync() {
 }
 
 void BaseGoalTest::test_distrosync_all() {
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears installed
-    sack->add_system_package(rpm_path, false, false);
-
     add_repo_solv("solv-distrosync");
+    add_system_pkg("repos-rpm/rpm-repo1/one-2-1.noarch.rpm");
 
     libdnf::rpm::PackageQuery query(base);
 
@@ -429,13 +370,13 @@ void BaseGoalTest::test_distrosync_all() {
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-1.noarch"),
+            get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::DOWNGRADE,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch", true),
+            get_pkg("one-0:2-1.noarch", true),
             TransactionItemAction::DOWNGRADED,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
@@ -445,30 +386,25 @@ void BaseGoalTest::test_distrosync_all() {
 }
 
 void BaseGoalTest::test_install_or_reinstall() {
-    std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
-
-    // add the package to the @System repo so it appears installed
-    sack->add_system_package(rpm_path, false, false);
-
-    // also add it to the @Commandline repo to make it available for reinstall
-    sack->add_cmdline_package(rpm_path, false);
+    add_repo_rpm("rpm-repo1");
+    add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm");
 
     libdnf::Goal goal(base);
     libdnf::rpm::PackageQuery query(base);
-    query.filter_available().filter_nevra({"cmdline-0:1.2-3.noarch"});
+    query.filter_available().filter_nevra({"one-0:1-1.noarch"});
     CPPUNIT_ASSERT_EQUAL(1lu, query.size());
     goal.add_rpm_install_or_reinstall(query);
     auto transaction = goal.resolve(false);
 
     std::vector<libdnf::base::TransactionPackage> expected = {
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch"),
+            get_pkg("one-0:1-1.noarch"),
             TransactionItemAction::REINSTALL,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN
         ),
         TransactionPackage(
-            get_pkg("cmdline-0:1.2-3.noarch", true),
+            get_pkg("one-0:1-1.noarch", true),
             TransactionItemAction::REINSTALLED,
             TransactionItemReason::UNKNOWN,
             TransactionItemState::UNKNOWN

--- a/test/libdnf/base/test_goal.hpp
+++ b/test/libdnf/base/test_goal.hpp
@@ -38,12 +38,15 @@ class BaseGoalTest : public LibdnfTestCase {
     CPPUNIT_TEST(test_install_or_reinstall);
     CPPUNIT_TEST(test_install_from_cmdline);
     CPPUNIT_TEST(test_reinstall);
+    CPPUNIT_TEST(test_reinstall_user);
     CPPUNIT_TEST(test_remove);
     CPPUNIT_TEST(test_remove_not_installed);
     CPPUNIT_TEST(test_upgrade);
     CPPUNIT_TEST(test_upgrade_not_available);
     CPPUNIT_TEST(test_upgrade_all);
+    CPPUNIT_TEST(test_upgrade_user);
     CPPUNIT_TEST(test_downgrade);
+    CPPUNIT_TEST(test_downgrade_user);
     CPPUNIT_TEST(test_distrosync);
     CPPUNIT_TEST(test_distrosync_all);
 #endif
@@ -63,12 +66,15 @@ public:
     void test_install_or_reinstall();
     void test_install_from_cmdline();
     void test_reinstall();
+    void test_reinstall_user();
     void test_remove();
     void test_remove_not_installed();
     void test_upgrade();
     void test_upgrade_not_available();
     void test_upgrade_all();
+    void test_upgrade_user();
     void test_downgrade();
+    void test_downgrade_user();
     void test_distrosync();
     void test_distrosync_all();
 };

--- a/test/libdnf/support.cpp
+++ b/test/libdnf/support.cpp
@@ -93,6 +93,16 @@ libdnf::rpm::Package LibdnfTestCase::get_pkg(const std::string & nevra, const ch
 }
 
 
+libdnf::rpm::Package LibdnfTestCase::add_system_pkg(const std::string & relative_path) {
+    return sack->add_system_package(PROJECT_BINARY_DIR "/test/data/" + relative_path, false, false);
+}
+
+
+libdnf::rpm::Package LibdnfTestCase::add_cmdline_pkg(const std::string & relative_path) {
+    return sack->add_cmdline_package(PROJECT_BINARY_DIR "/test/data/" + relative_path, false);
+}
+
+
 libdnf::rpm::Package LibdnfTestCase::first_query_pkg(libdnf::rpm::PackageQuery & query, const std::string & what) {
     if (query.empty()) {
         CPPUNIT_FAIL("No package \"" + what + "\" found. All sack packages:" + \

--- a/test/libdnf/support.hpp
+++ b/test/libdnf/support.hpp
@@ -58,7 +58,11 @@ protected:
         return get_pkg(nevra, repo.c_str());
     }
 
+    libdnf::rpm::Package add_system_pkg(const std::string & relative_path);
+    libdnf::rpm::Package add_cmdline_pkg(const std::string & relative_path);
+
     libdnf::Base base;
+
     libdnf::repo::RepoSackWeakPtr repo_sack;
     libdnf::rpm::PackageSackWeakPtr sack;
     std::unique_ptr<libdnf::utils::TempDir> temp;

--- a/test/libdnf/support.hpp
+++ b/test/libdnf/support.hpp
@@ -58,7 +58,9 @@ protected:
         return get_pkg(nevra, repo.c_str());
     }
 
-    libdnf::rpm::Package add_system_pkg(const std::string & relative_path);
+    libdnf::rpm::Package add_system_pkg(
+        const std::string & relative_path,
+        libdnf::transaction::TransactionItemReason reason = libdnf::transaction::TransactionItemReason::UNKNOWN);
     libdnf::rpm::Package add_cmdline_pkg(const std::string & relative_path);
 
     libdnf::Base base;

--- a/test/libdnf/system/test_state.cpp
+++ b/test/libdnf/system/test_state.cpp
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_state.hpp"
+
+#include "../utils.hpp"
+
+#include <iostream>
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(StateTest);
+
+using namespace libdnf;
+
+void StateTest::setUp() {
+    LibdnfTestCase::setUp();
+    add_repo_repomd("repomd-repo1");
+
+    temp_dir = std::make_unique<libdnf::utils::TempDir>("libdnf_test_state_");
+
+    std::ofstream toml(temp_dir->get_path() / "userinstalled.toml");
+    toml << "userinstalled = [\n"
+    "\"pkg.x86_64\",\n"
+    "\"cmdline.noarch\",\n"
+    "]\n";
+    toml.close();
+}
+
+void StateTest::tearDown() {
+    temp_dir.reset();
+
+    LibdnfTestCase::tearDown();
+}
+
+void StateTest::test_state_read() {
+    libdnf::system::State state("/", temp_dir->get_path());
+
+    CPPUNIT_ASSERT_EQUAL(libdnf::transaction::TransactionItemReason::USER, state.get_reason("pkg.x86_64"));
+    CPPUNIT_ASSERT_EQUAL(libdnf::transaction::TransactionItemReason::DEPENDENCY, state.get_reason("pkg-libs.x86_64"));
+}
+
+void StateTest::test_state_write() {
+    const auto path = temp_dir->get_path() / "write_test";
+    libdnf::system::State state("/", path);
+
+    state.set_reason("pkg.x86_64", libdnf::transaction::TransactionItemReason::USER);
+    state.set_reason("pkg-libs.x86_64", libdnf::transaction::TransactionItemReason::USER);
+    state.set_reason("unresolvable.noarch", libdnf::transaction::TransactionItemReason::USER);
+    state.set_reason("unresolvable.noarch", libdnf::transaction::TransactionItemReason::DEPENDENCY);
+
+    state.save();
+
+    std::ifstream toml(path / "userinstalled.toml");
+    std::string contents;
+    contents.assign(std::istreambuf_iterator<char>(toml), std::istreambuf_iterator<char>());
+
+    std::string expected = "userinstalled = [\n"
+    "\"pkg-libs.x86_64\",\n"
+    "\"pkg.x86_64\",\n"
+    "]\n";
+    CPPUNIT_ASSERT_EQUAL(expected, contents);
+}

--- a/test/libdnf/system/test_state.hpp
+++ b/test/libdnf/system/test_state.hpp
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF_SYSTEM_STATE_HPP
+#define TEST_LIBDNF_SYSTEM_STATE_HPP
+
+
+#include "../support.hpp"
+
+#include "libdnf/system/state.hpp"
+
+#include "libdnf/utils/temp.hpp"
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <memory>
+
+
+class StateTest : public LibdnfTestCase {
+    CPPUNIT_TEST_SUITE(StateTest);
+    CPPUNIT_TEST(test_state_read);
+    CPPUNIT_TEST(test_state_write);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp() override;
+    void tearDown() override;
+
+    void test_state_read();
+    void test_state_write();
+
+    std::unique_ptr<libdnf::utils::TempDir> temp_dir;
+};
+
+
+#endif


### PR DESCRIPTION
The class reads and writes a .toml file and allows to store and retrieve
a list of userinstalled packages.

Adds a dependency on toml11-devel, a header-only C++ library that isn't
packaged in Fedora atm.

The package can be temporarily found at:
https://copr.fedorainfracloud.org/coprs/lhrazky/toml11/

This is very basic right now and up for comments to adjust the interface, make it default to read from e.g. `/etc/dnf/system/state.toml` or whichever location we'll decide on.

The toml11 library is very nice, but we'd obviously need to get it packaged.