### PR TITLE
Add a const char * constructor to exception classes

### DIFF
--- a/libdnf/error.hpp
+++ b/libdnf/error.hpp
@@ -13,7 +13,7 @@ namespace libdnf {
  */
 class Error : public std::runtime_error {
 public:
-    Error(const std::string & what) : runtime_error(what) {}
+    using runtime_error::runtime_error;
 };
 
 /**
@@ -33,7 +33,7 @@ public:
  */
 class Exception : public std::runtime_error {
 public:
-    Exception(const std::string & what) : runtime_error(what) {}
+    using runtime_error::runtime_error;
 };
 
 } // namespace libdnf


### PR DESCRIPTION
It should be there, seems it doesn't compile without it under certain
circumstances.

fixes #1197
fixes #1038 