### PR TITLE
hy-util: support missing outvars in hy_split_nevra and add hy_parse_module_spec

### DIFF
--- a/libdnf/hy-util.cpp
+++ b/libdnf/hy-util.cpp
@@ -160,13 +160,19 @@ hy_split_nevra(const char *nevra, char **name, int *epoch,
         return DNF_ERROR_INTERNAL_ERROR;
     libdnf::Nevra nevraObj;
     if (nevraObj.parse(nevra, HY_FORM_NEVRA)) {
-        *arch = g_strdup(nevraObj.getArch().c_str());
-        *name = g_strdup(nevraObj.getName().c_str());
-        *release = g_strdup(nevraObj.getRelease().c_str());
-        *version = g_strdup(nevraObj.getVersion().c_str());
-        *epoch = nevraObj.getEpoch();
-        if (*epoch == -1)
-            *epoch = 0;
+        if (arch)
+            *arch = g_strdup(nevraObj.getArch().c_str());
+        if (name)
+            *name = g_strdup(nevraObj.getName().c_str());
+        if (release)
+            *release = g_strdup(nevraObj.getRelease().c_str());
+        if (version)
+            *version = g_strdup(nevraObj.getVersion().c_str());
+        if (epoch) {
+            *epoch = nevraObj.getEpoch();
+            if (*epoch == -1)
+                *epoch = 0;
+        }
         return 0;
     }
     return DNF_ERROR_INTERNAL_ERROR;

--- a/libdnf/hy-util.h
+++ b/libdnf/hy-util.h
@@ -36,6 +36,8 @@ int hy_detect_arch(char **arch);
 
 int hy_split_nevra(const char *nevra, char **name, int *epoch,
                    char **version, char **release, char **arch);
+int hy_parse_module_spec(const char *spec, char **name, char **stream,
+                         char **version, char **context, char **arch, char **profile);
 
 G_END_DECLS
 


### PR DESCRIPTION
```
commit f814dda7b87201800e0ffa8abd4fdd4c9f021697
Date:   Fri Apr 23 12:08:34 2021 -0400

    hy-util: support missing outvars in hy_split_nevra

    Often, the client-side is only interested in e.g. extracting the package
    name, or the NVR, from a NEVRA. Let's make that easier by not requiring
    them to specify output variables for the components they're not
    interested in.

    = changelog =
    msg: Allow omitting some output variables when calling hy_split_nevra()
    type: enhancement
```
```
commit 2dd667f1ba0ffccc3c14f8c7fbe7aee27ad9e1b9
Date:   Fri Apr 23 12:10:24 2021 -0400

    hy-util: add hy_parse_module_spec

    This is a simple wrapper around libdnf::Nsvcap's `parse()` function.
    Support missing output variables, just like `hy_split_nevra`.

    = changelog =
    msg: Add new API hy_parse_module_spec()
    type: enhancement
```