### PR TITLE
DnfContext: make dnf_context_module_install like `dnf module install`

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -3160,7 +3160,7 @@ static std::map<std::string, std::map<std::string, std::vector<libdnf::ModulePac
 static std::vector<std::tuple<libdnf::ModulePackageContainer::ModuleErrorType, std::string, std::string>> modify_module_dict_and_enable_stream(std::map<std::string, std::map<std::string, std::vector<libdnf::ModulePackage *>>> & module_dict, libdnf::ModulePackageContainer & container, bool enable)
 {
     std::vector<std::tuple<libdnf::ModulePackageContainer::ModuleErrorType, std::string, std::string>> messages;
-    for (auto module_dict_iter : module_dict) {
+    for (auto & module_dict_iter : module_dict) {
         auto & name = module_dict_iter.first;
         auto & stream_dict = module_dict_iter.second;
         auto moduleState = container.getModuleState(name);

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -3142,7 +3142,7 @@ dnf_context_reset_all_modules(DnfContext * context, DnfSack * sack, GError ** er
     return recompute_modular_filtering(context, sack, error);
 } CATCH_TO_GERROR(FALSE)
 
-/// module dict { name : {stream : [modules] }
+/// module dict { name : {stream : [module packages] }
 static std::map<std::string, std::map<std::string, std::vector<libdnf::ModulePackage *>>> create_module_dict(
     const std::vector<libdnf::ModulePackage *> & modules)
 {
@@ -3155,6 +3155,8 @@ static std::map<std::string, std::map<std::string, std::vector<libdnf::ModulePac
 
 /// Modify module_dict => Keep only single relevant stream
 /// If more streams it keeps enabled or default stream
+/// If `enable` is true, also marks the selected stream as enabled.
+///  Returns errors found as: vec<(error type, error msg, module name)>
 static std::vector<std::tuple<libdnf::ModulePackageContainer::ModuleErrorType, std::string, std::string>> modify_module_dict_and_enable_stream(std::map<std::string, std::map<std::string, std::vector<libdnf::ModulePackage *>>> & module_dict, libdnf::ModulePackageContainer & container, bool enable)
 {
     std::vector<std::tuple<libdnf::ModulePackageContainer::ModuleErrorType, std::string, std::string>> messages;
@@ -3215,6 +3217,8 @@ static std::vector<std::tuple<libdnf::ModulePackageContainer::ModuleErrorType, s
     return messages;
 }
 
+// Attempts to parse the module spec and returns the parsed Nsvcap with the list
+// of module packages which matched.
 static std::pair<std::unique_ptr<libdnf::Nsvcap>, std::vector< libdnf::ModulePackage*>> resolve_module_spec(const std::string & module_spec, libdnf::ModulePackageContainer & container)
 {
     std::unique_ptr<libdnf::Nsvcap> nsvcapObj(new libdnf::Nsvcap);

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -315,7 +315,7 @@ gboolean         dnf_context_module_enable              (DnfContext * context,
  *
  * Since: 0.63.0
  **/
-gboolean         dnf_context_module_install              (DnfContext * context,
+gboolean           dnf_context_module_install            (DnfContext * context,
                                                           const char ** module_specs,
                                                           GError ** error);
 

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -851,6 +851,24 @@ ModulePackageContainer::getModuleState(const std::string& name)
     }
 }
 
+ModulePackage * ModulePackageContainer::getLatestModule(std::vector<ModulePackage *> modulePackages, bool activeOnly)
+{
+    ModulePackage * latest = nullptr;
+    for (ModulePackage * module: modulePackages) {
+        if (!activeOnly || isModuleActive(module->getId())) {
+            if (!latest) {
+                latest = module;
+            } else {
+                if (module->getVersion() > latest->getVersion()) {
+                    latest = module;
+                }
+            }
+        }
+    }
+
+    return latest;
+}
+
 std::set<std::string> ModulePackageContainer::getInstalledPkgNames()
 {
     pImpl->addVersion2Modules();
@@ -869,28 +887,9 @@ std::set<std::string> ModulePackageContainer::getInstalledPkgNames()
         nameStream += ":";
         nameStream += stream;
         auto modules = query(nameStream);
-        const ModulePackage * latest = nullptr;
-        for (const ModulePackage * module: modules) {
-            if (isModuleActive(module->getId())) {
-                if (!latest) {
-                    latest = module;
-                } else {
-                    if (module->getVersion() > latest->getVersion()) {
-                        latest = module;
-                    }
-                }
-            }
-        }
+        const ModulePackage * latest = getLatestModule(modules, true);
         if (!latest) {
-            for (auto module: modules) {
-                if (!latest) {
-                    latest = module;
-                } else {
-                    if (module->getVersion() > latest->getVersion()) {
-                        latest = module;
-                    }
-                }
-            }
+            latest = getLatestModule(modules, false);
         }
         if (!latest) {
             continue;

--- a/libdnf/module/ModulePackageContainer.hpp
+++ b/libdnf/module/ModulePackageContainer.hpp
@@ -134,6 +134,7 @@ public:
     std::vector<ModulePackage *> getModulePackages();
     std::vector<std::vector<std::vector<ModulePackage *>>> getLatestModulesPerRepo(
         ModuleState moduleFilter, std::vector<ModulePackage *> modulePackages);
+    ModulePackage * getLatestModule(std::vector<ModulePackage *> modulePackages, bool activeOnly);
 
     std::vector<ModulePackage *> requiresModuleEnablement(const libdnf::PackageSet & packages);
 


### PR DESCRIPTION
This significantly revamps `dnf_context_module_install`. It fixes some
issues noticed during review, but also aligns the logic closer to what
`dnf module install` does.