### PR TITLE
[dnf5] Fix check whether the subkey can be used for signing

### DIFF
--- a/libdnf/rpm/repo.cpp
+++ b/libdnf/rpm/repo.cpp
@@ -812,7 +812,7 @@ static std::vector<Key> rawkey2infos(int fd, Logger & logger) {
 
         // _extract_signing_subkey
         auto subkey = key->subkeys;
-        while (subkey && !key->subkeys->can_sign) {
+        while (subkey && !subkey->can_sign) {
             subkey = subkey->next;
         }
         if (subkey)


### PR DESCRIPTION
This is 26bc12b16e4e951bf896e4827702283999e49de8 from dnf-4-master.