### PR TITLE
[dnfdaemon] Remove hard coded default option values

### DIFF
--- a/dnfdaemon-client/commands/command.cpp
+++ b/dnfdaemon-client/commands/command.cpp
@@ -37,7 +37,7 @@ void TransactionCommand::run_transaction(Context & ctx) {
     dnfdaemon::KeyValueMap options = {};
 
     // resolve the transaction
-    options["allow_erasing"] = ctx.allow_erasing->get_value();
+    options["allow_erasing"] = ctx.allow_erasing.get_value();
     std::vector<dnfdaemon::DbusTransactionItem> transaction;
     ctx.session_proxy->callMethod("resolve")
         .onInterface(dnfdaemon::INTERFACE_RPM)

--- a/dnfdaemon-client/commands/install/install.hpp
+++ b/dnfdaemon-client/commands/install/install.hpp
@@ -33,7 +33,7 @@ public:
     void run(Context & ctx) override;
 
 private:
-    libdnf::OptionBool * strict_option{nullptr};
+    libdnf::OptionBool strict_option{false};
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 

--- a/dnfdaemon-client/commands/remove/remove.cpp
+++ b/dnfdaemon-client/commands/remove/remove.cpp
@@ -56,6 +56,10 @@ void CmdRemove::set_argument_parser(Context & ctx) {
         patterns_options);
     keys->set_short_description("List of packages to remove");
     remove->register_positional_arg(keys);
+
+    // run remove command allways with allow_erasing on
+    ctx.allow_erasing->set(libdnf::Option::Priority::RUNTIME, true);
+
 }
 
 void CmdRemove::run(Context & ctx) {

--- a/dnfdaemon-client/commands/remove/remove.cpp
+++ b/dnfdaemon-client/commands/remove/remove.cpp
@@ -58,7 +58,7 @@ void CmdRemove::set_argument_parser(Context & ctx) {
     remove->register_positional_arg(keys);
 
     // run remove command allways with allow_erasing on
-    ctx.allow_erasing->set(libdnf::Option::Priority::RUNTIME, true);
+    ctx.allow_erasing.set(libdnf::Option::Priority::RUNTIME, true);
 
 }
 

--- a/dnfdaemon-client/commands/repolist/repolist.cpp
+++ b/dnfdaemon-client/commands/repolist/repolist.cpp
@@ -208,7 +208,7 @@ void CmdRepolist::run(Context & ctx) {
         for (auto & raw_repo : repositories) {
             RepoDbus repo(raw_repo);
             auto repo_info = libdnf::cli::output::RepoInfo();
-            repo_info.add_repo(repo, ctx.verbose->get_value(), ctx.verbose->get_value());
+            repo_info.add_repo(repo, ctx.verbose.get_value(), ctx.verbose.get_value());
             repo_info.print();
             std::cout << std::endl;
         }

--- a/dnfdaemon-client/context.cpp
+++ b/dnfdaemon-client/context.cpp
@@ -81,10 +81,10 @@ dnfdaemon::RepoStatus Context::wait_for_repos() {
 
 bool userconfirm(Context & ctx) {
     // "assumeno" takes precedence over "assumeyes"
-    if (ctx.assume_no->get_value()) {
+    if (ctx.assume_no.get_value()) {
         return false;
     }
-    if (ctx.assume_yes->get_value()) {
+    if (ctx.assume_yes.get_value()) {
         return true;
     }
     std::string msg = "Is this ok [y/N]: ";

--- a/dnfdaemon-client/context.hpp
+++ b/dnfdaemon-client/context.hpp
@@ -71,10 +71,10 @@ public:
     std::unique_ptr<sdbus::IProxy> session_proxy;
 
     // global command line arguments
-    std::unique_ptr<libdnf::OptionBool> verbose = std::make_unique<libdnf::OptionBool>(false);
-    std::unique_ptr<libdnf::OptionBool> assume_yes = std::make_unique<libdnf::OptionBool>(false);
-    std::unique_ptr<libdnf::OptionBool> assume_no = std::make_unique<libdnf::OptionBool>(false);
-    std::unique_ptr<libdnf::OptionBool> allow_erasing = std::make_unique<libdnf::OptionBool>(false);
+    libdnf::OptionBool verbose{false};
+    libdnf::OptionBool assume_yes{false};
+    libdnf::OptionBool assume_no{false};
+    libdnf::OptionBool allow_erasing{false};
 
 private:
     /// system d-bus connection

--- a/dnfdaemon-client/main.cpp
+++ b/dnfdaemon-client/main.cpp
@@ -18,10 +18,10 @@ along with dnfdaemon-client.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "commands/install/install.hpp"
+#include "commands/remove/remove.hpp"
 #include "commands/repolist/repolist.hpp"
 #include "commands/repoquery/repoquery.hpp"
 #include "commands/upgrade/upgrade.hpp"
-#include "commands/remove/remove.hpp"
 #include "context.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>

--- a/dnfdaemon-client/main.cpp
+++ b/dnfdaemon-client/main.cpp
@@ -68,7 +68,7 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
     verbose->set_long_name("verbose");
     verbose->set_short_description("increase output verbosity");
     verbose->set_const_value("true");
-    verbose->link_value(ctx.verbose.get());
+    verbose->link_value(&ctx.verbose);
     dnfdaemon_client->register_named_arg(verbose);
 
     auto assume_yes = ctx.arg_parser.add_new_named_arg("assumeyes");
@@ -76,21 +76,21 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
     assume_yes->set_short_name('y');
     assume_yes->set_short_description("automatically answer yes for all questions");
     assume_yes->set_const_value("true");
-    assume_yes->link_value(ctx.assume_yes.get());
+    assume_yes->link_value(&ctx.assume_yes);
     dnfdaemon_client->register_named_arg(assume_yes);
 
     auto assume_no = ctx.arg_parser.add_new_named_arg("assumeno");
     assume_no->set_long_name("assumeno");
     assume_no->set_short_description("automatically answer no for all questions");
     assume_no->set_const_value("true");
-    assume_no->link_value(ctx.assume_no.get());
+    assume_no->link_value(&ctx.assume_no);
     dnfdaemon_client->register_named_arg(assume_no);
 
     auto allow_erasing = ctx.arg_parser.add_new_named_arg("allow_erasing");
     allow_erasing->set_long_name("allowerasing");
     allow_erasing->set_short_description("installed package can be removed to resolve the transaction");
     allow_erasing->set_const_value("true");
-    allow_erasing->link_value(ctx.allow_erasing.get());
+    allow_erasing->link_value(&ctx.allow_erasing);
     dnfdaemon_client->register_named_arg(allow_erasing);
 
     auto setopt = ctx.arg_parser.add_new_named_arg("setopt");

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -38,13 +38,43 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
           <varlistentry>
             <term>patterns: list of strings</term>
             <listitem><para>
-              any package with nevra matching to any of patterns is returned
+              any package matching to any of patterns is returned
             </para></listitem>
           </varlistentry>
           <varlistentry>
             <term>package_attrs: list of strings</term>
             <listitem><para>
               list of package attributes that are returned
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>with_nevra: bool (default true)</term>
+            <listitem><para>
+              match patterns against available packages NEVRAs
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>with_provides: bool (default true)</term>
+            <listitem><para>
+              match patterns against available packages provides
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>with_filenames: bool (default true)</term>
+            <listitem><para>
+              match patterns against names of the files in available packages
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>with_src: bool (default true)</term>
+            <listitem><para>
+              include source rpms into the results
+            </para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>icase: bool (default true)</term>
+            <listitem><para>
+              ignore case while matching patterns
             </para></listitem>
           </varlistentry>
         </variablelist>

--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -144,13 +144,20 @@ void Rpm::list(sdbus::MethodCall && call) {
                 std::vector<std::string> default_patterns{};
                 std::vector<std::string> patterns =
                     key_value_map_get<std::vector<std::string>>(options, "patterns", std::move(default_patterns));
+                // packages matching flags
+                bool icase = key_value_map_get<bool>(options, "icase", true);
+                bool with_nevra = key_value_map_get<bool>(options, "with_nevra", true);
+                bool with_provides = key_value_map_get<bool>(options, "with_provides", true);
+                bool with_filenames = key_value_map_get<bool>(options, "with_filenames", true);
+                bool with_src = key_value_map_get<bool>(options, "with_src", true);
 
                 libdnf::rpm::PackageSet result_pset(&solv_sack);
                 libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
                 if (patterns.size() > 0) {
                     for (auto & pattern : patterns) {
                         libdnf::rpm::SolvQuery solv_query(full_solv_query);
-                        solv_query.resolve_pkg_spec(pattern, true, true, true, true, true, {});
+                        solv_query.resolve_pkg_spec(
+                            pattern, icase, with_nevra, with_provides, with_filenames, with_src, {});
                         result_pset |= solv_query;
                     }
                 } else {

--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -445,16 +445,21 @@ void Rpm::install(sdbus::MethodCall && call) {
                 // read options from dbus call
                 dnfdaemon::KeyValueMap options;
                 call >> options;
-                // TODO(jmracek) Set libdnf::GoalSetting::Auto when a specific setting is not requested by the client
-                bool strict = key_value_map_get<bool>(options, "strict", true);
-                auto strict_enum = strict ? libdnf::GoalSetting::SET_TRUE : libdnf::GoalSetting::SET_FALSE;
+
+                libdnf::GoalSetting strict;
+                if (options.find("strict") != options.end()) {
+                    strict = key_value_map_get<bool>(options, "strict") ? libdnf::GoalSetting::SET_TRUE
+                                                                        : libdnf::GoalSetting::SET_FALSE;
+                } else {
+                    strict = libdnf::GoalSetting::AUTO;
+                }
                 std::vector<std::string> repo_ids =
                     key_value_map_get<std::vector<std::string>>(options, "repo_ids", {});
 
                 // fill the goal
                 auto & goal = session.get_goal();
                 libdnf::GoalJobSettings setting;
-                setting.strict = strict_enum;
+                setting.strict = strict;
                 setting.to_repo_ids = repo_ids;
                 for (const auto & spec : specs) {
                     goal.add_rpm_install(spec, setting);


### PR DESCRIPTION
- package matching for list() call can be fine tuned - icase, with_nevra, with_provides, with_filenames, with_src
- compatibility - replace --strict with --skip-broken
- remove hard coded default for strict option (get the default from config file)
- set allow_erasing always to true for remove command