### PR TITLE
[dnf5] ArgumentParser: New methods, improvements, unit tests

### DIFF
--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -71,6 +71,15 @@ public:
 
     class Argument {
     public:
+        /// Exception is generated when the Argument `id` contains not allowed '.' character.
+        class InvalidId : public Exception {
+        public:
+            using Exception::Exception;
+            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Argument"; }
+            const char * get_name() const noexcept override { return "InvalidId"; }
+            const char * get_description() const noexcept override { return "Invalid id"; }
+        };
+
         Argument(const Argument &) = delete;
         Argument(Argument &&) = delete;
         Argument & operator=(const Argument &) = delete;
@@ -112,7 +121,7 @@ public:
     private:
         friend class ArgumentParser;
 
-        Argument(ArgumentParser & owner, std::string id) : owner(owner), id(std::move(id)) {}
+        Argument(ArgumentParser & owner, std::string id);
         static std::string get_conflict_arg_msg(const Argument * conflict_arg);
         ArgumentParser & get_owner() const noexcept { return owner; }
 

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -494,6 +494,15 @@ public:
     /// Returns true if the inheritance of named arguments is enabled for the parser.
     bool get_inherit_named_args() const noexcept { return inherit_named_args; }
 
+    /// Gets a list of all commands stored in the argument parser.
+    const std::vector<std::unique_ptr<Command>> & get_commands() const noexcept { return cmds; }
+
+    /// Gets a list of all named arguments stored in the argument parser.
+    const std::vector<std::unique_ptr<NamedArg>> & get_named_args() const noexcept { return named_args; }
+
+    /// Gets a list of all positional argument stored in the argument parser.
+    const std::vector<std::unique_ptr<PositionalArg>> & get_positional_args() const noexcept { return pos_args; }
+
 private:
     std::vector<std::unique_ptr<Command>> cmds;
     std::vector<std::unique_ptr<NamedArg>> named_args;

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -494,6 +494,37 @@ public:
     /// Returns true if the inheritance of named arguments is enabled for the parser.
     bool get_inherit_named_args() const noexcept { return inherit_named_args; }
 
+    /// Returns (sub)command with given ID path.
+    /// The root command ID must be omitted. It is added automatically.
+    /// @param id_path  command ID path, e.g. "module.list"; "" - returns root_command
+    /// @exception ArgumentParser::LogicError  if root command is not set
+    /// @exception ArgumentParser::Command::CommandNotFound  if command is not found.
+    Command & get_command(const std::string & id_path);
+
+    /// Returns named argument with given full ID path.
+    /// The root command ID must be omitted. It is added automatically.
+    /// If the named argument is not found in the path and search in the parent command is enabled,
+    /// it will be searched in the parent command. E.g. "installroot" is global option -> instead
+    /// of "repoquery.installroot" returns "installroot".
+    /// @param id_path  named argument ID path, e.g. "installroot", "repoquery.installed"
+    /// @param search_in_parent  true - enable search in parrent command, false - disable
+    /// @exception ArgumentParser::LogicError  if root command is not set
+    /// @exception ArgumentParser::Command::CommandNotFound  if command is not found.
+    /// @exception ArgumentParser::Command::PositionalArgNotFound  if argument is not found.
+    NamedArg & get_named_arg(const std::string & id_path, bool search_in_parent);
+
+    /// Returns positional argument with given full ID path.
+    /// The root command ID must be omitted. It is added automatically.
+    /// If the positional argument is not found in the path and search in the parent command is enabled,
+    /// it will be searched in the parent command. E.g. "installroot" is global option -> instead
+    /// of "repoquery.installroot" returns "installroot".
+    /// @param id_path  positional argument ID path, e.g. "repoquery.keys"
+    /// @param search_in_parent  true - enable search in parrent command, false - disable
+    /// @exception ArgumentParser::LogicError  if root command is not set
+    /// @exception ArgumentParser::Command::CommandNotFound  if command is not found.
+    /// @exception ArgumentParser::Command::NamedArgNotFound  if argument is not found.
+    PositionalArg & get_positional_arg(const std::string & id_path, bool search_in_parent);
+
     /// Gets a list of all commands stored in the argument parser.
     const std::vector<std::unique_ptr<Command>> & get_commands() const noexcept { return cmds; }
 

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2019-2020 Red Hat, Inc.
+Copyright (C) 2019-2021 Red Hat, Inc.
 
 This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -350,7 +350,6 @@ public:
         using ParseHookFunc = std::function<bool(Command * arg, const char * cmd, int argc, const char * const argv[])>;
 
         /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
-        /// Returns number of consumed arguments from the input.
         void parse(const char * option, int argc, const char * const argv[]);
 
         /// Registers (sub)command to the command.
@@ -413,6 +412,13 @@ public:
         const std::string & get_positional_args_help_header() const noexcept { return positional_args_help_header; }
 
     private:
+        /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
+        void parse(
+            const char * option,
+            int argc,
+            const char * const argv[],
+            const std::vector<NamedArg *> * additional_named_args);
+
         friend class ArgumentParser;
 
         Command(ArgumentParser & owner, const std::string & id) : Argument(owner, id) {}
@@ -479,6 +485,15 @@ public:
     /// Reset parse count in all arguments.
     void reset_parse_count();
 
+    /// Enables/disables the inheritance of named arguments for the parser.
+    /// If the parser does not find a named argument definition during subcommand processing and
+    /// named arguments inheritance is enabled, parser searches the named arguments of the parent commands.
+    /// @param enable  true - enable parent argument inheritance, false - disable
+    void set_inherit_named_args(bool enable) noexcept { inherit_named_args = enable; }
+
+    /// Returns true if the inheritance of named arguments is enabled for the parser.
+    bool get_inherit_named_args() const noexcept { return inherit_named_args; }
+
 private:
     std::vector<std::unique_ptr<Command>> cmds;
     std::vector<std::unique_ptr<NamedArg>> named_args;
@@ -487,6 +502,7 @@ private:
     std::vector<std::unique_ptr<libdnf::Option>> values_init;
     std::vector<std::unique_ptr<std::vector<std::unique_ptr<libdnf::Option>>>> values;
     Command * root_command{nullptr};
+    bool inherit_named_args{false};
 };
 
 }  // namespace libdnf::cli

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -29,6 +29,13 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::cli {
 
+ArgumentParser::Argument::Argument(ArgumentParser & owner, std::string id) : owner(owner) {
+    if (id.find('.') != id.npos) {
+        throw InvalidId(id);
+    }
+    this->id = std::move(id);
+}
+
 ArgumentParser::Argument * ArgumentParser::Argument::get_conflict_argument() const noexcept {
     if (conflict_args) {
         for (auto * arg : *conflict_args) {

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -180,6 +180,7 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
     microdnf->register_named_arg(releasever);
 
     ctx.arg_parser.set_root_command(microdnf);
+    ctx.arg_parser.set_inherit_named_args(true);
 
     for (auto & command : ctx.commands) {
         command->set_argument_parser(ctx);

--- a/test/libdnf-cli/test_argument_parser.cpp
+++ b/test/libdnf-cli/test_argument_parser.cpp
@@ -1,0 +1,223 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_argument_parser.hpp"
+
+#include "../libdnf/utils.hpp"
+
+#include "libdnf-cli/argument_parser.hpp"
+
+#include "libdnf/conf/option_bool.hpp"
+#include "libdnf/conf/option_string.hpp"
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ArgumentParserTest);
+
+using ArgParser = libdnf::cli::ArgumentParser;
+
+void ArgumentParserTest::test_argument_parser() {
+    ArgParser arg_parser;
+    ArgParser::Command * selected_cmd{nullptr};
+
+    auto * test = arg_parser.add_new_command("test");
+    test->set_short_description("Unit test for testing ArgumentParser");
+    test->set_description("Tets is a unit test for testing ArgumentParser.");
+    test->set_commands_help_header("List of commands:");
+    test->set_named_args_help_header("Global arguments:");
+
+    arg_parser.set_root_command(test);
+
+    auto * help = arg_parser.add_new_named_arg("help");
+    help->set_long_name("help");
+    help->set_short_name('h');
+    help->set_short_description("Print help");
+    help->set_parse_hook_func([test](
+                                  [[maybe_unused]] ArgParser::NamedArg * arg,
+                                  [[maybe_unused]] const char * option,
+                                  [[maybe_unused]] const char * value) {
+        test->help();
+        return true;
+    });
+    test->register_named_arg(help);
+
+    auto * global_arg = arg_parser.add_new_named_arg("global_arg");
+    global_arg->set_long_name("global_arg");
+    global_arg->set_short_description("Global argument for test");
+    test->register_named_arg(global_arg);
+
+    auto * available_option =
+        dynamic_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(true)));
+    CPPUNIT_ASSERT(available_option);
+
+    auto * installed_option =
+        dynamic_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    CPPUNIT_ASSERT(installed_option);
+
+    auto * info_option =
+        dynamic_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    CPPUNIT_ASSERT(info_option);
+
+    auto * nevra_option =
+        dynamic_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(true)));
+    CPPUNIT_ASSERT(nevra_option);
+
+    auto * available = arg_parser.add_new_named_arg("available");
+    available->set_long_name("available");
+    available->set_short_description("display available packages (default)");
+    available->set_const_value("true");
+    available->link_value(available_option);
+
+    auto * installed = arg_parser.add_new_named_arg("installed");
+    installed->set_long_name("installed");
+    installed->set_short_description("display installed packages");
+    installed->set_const_value("true");
+    installed->link_value(installed_option);
+
+    auto * info = arg_parser.add_new_named_arg("info");
+    info->set_long_name("info");
+    info->set_short_description("show detailed information about the packages");
+    info->set_const_value("true");
+    info->link_value(info_option);
+
+    auto * nevra = arg_parser.add_new_named_arg("nevra");
+    nevra->set_long_name("nevra");
+    nevra->set_short_description(
+        "use name-epoch:version-release.architecture format for displaying packages (default)");
+    nevra->set_const_value("true");
+    nevra->link_value(nevra_option);
+
+    auto * keys_options = arg_parser.add_new_values();
+    auto * keys = arg_parser.add_new_positional_arg(
+        "keys",
+        ArgParser::PositionalArg::UNLIMITED,
+        arg_parser.add_init_value(std::make_unique<libdnf::OptionString>(nullptr)),
+        keys_options);
+    keys->set_short_description("List of keys to match");
+
+    auto * conflict_args = arg_parser.add_conflict_args_group(
+        std::unique_ptr<std::vector<ArgParser::Argument *>>(new std::vector<ArgParser::Argument *>{info, nevra}));
+
+    info->set_conflict_arguments(conflict_args);
+    nevra->set_conflict_arguments(conflict_args);
+
+    auto * repoquery = arg_parser.add_new_command("repoquery");
+    repoquery->set_short_description("search for packages matching keyword");
+    repoquery->set_description("");
+    repoquery->set_named_args_help_header("Optional arguments:");
+    repoquery->set_positional_args_help_header("Positional arguments:");
+    repoquery->set_parse_hook_func([&selected_cmd](
+                                       ArgParser::Argument * arg,
+                                       [[maybe_unused]] const char * option,
+                                       [[maybe_unused]] int argc,
+                                       [[maybe_unused]] const char * const argv[]) {
+        selected_cmd = dynamic_cast<ArgParser::Command *>(arg);
+        return true;
+    });
+
+    repoquery->register_named_arg(available);
+    repoquery->register_named_arg(installed);
+    repoquery->register_named_arg(info);
+    repoquery->register_named_arg(nevra);
+    repoquery->register_positional_arg(keys);
+
+    test->register_command(repoquery);
+
+    CPPUNIT_ASSERT_THROW(arg_parser.add_new_command("bad.id"), ArgParser::Argument::InvalidId);
+    CPPUNIT_ASSERT_THROW(arg_parser.add_new_named_arg("bad.id"), ArgParser::Argument::InvalidId);
+    CPPUNIT_ASSERT_THROW(
+        arg_parser.add_new_positional_arg("bad.id", ArgParser::PositionalArg::UNLIMITED, nullptr, nullptr),
+        ArgParser::Argument::InvalidId);
+
+    CPPUNIT_ASSERT_EQUAL(test, arg_parser.get_root_command());
+
+    CPPUNIT_ASSERT_EQUAL(repoquery, &arg_parser.get_command("repoquery"));
+    CPPUNIT_ASSERT_THROW(arg_parser.get_command("unknowncmd"), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_command("global_arg"), ArgParser::Command::CommandNotFound);
+
+    CPPUNIT_ASSERT_EQUAL(global_arg, &arg_parser.get_named_arg("global_arg", false));
+    CPPUNIT_ASSERT_EQUAL(global_arg, &arg_parser.get_named_arg("global_arg", true));
+    CPPUNIT_ASSERT_EQUAL(installed, &arg_parser.get_named_arg("repoquery.installed", false));
+    CPPUNIT_ASSERT_EQUAL(installed, &arg_parser.get_named_arg("repoquery.installed", true));
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.global_arg", false), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_EQUAL(global_arg, &arg_parser.get_named_arg("repoquery.global_arg", true));
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("unknowncmd.installed", false), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("unknowncmd.installed", true), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.unknown", false), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.unknown", true), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.keys", false), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.keys", true), ArgParser::Command::NamedArgNotFound);
+
+    CPPUNIT_ASSERT_EQUAL(keys, &arg_parser.get_positional_arg("repoquery.keys", false));
+    CPPUNIT_ASSERT_EQUAL(keys, &arg_parser.get_positional_arg("repoquery.keys", true));
+    CPPUNIT_ASSERT_THROW(arg_parser.get_positional_arg("unknowncmd.keys", false), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_positional_arg("unknowncmd.keys", true), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(
+        arg_parser.get_positional_arg("repoquery.unknown", false), ArgParser::Command::PositionalArgNotFound);
+    CPPUNIT_ASSERT_THROW(
+        arg_parser.get_positional_arg("repoquery.unknown", true), ArgParser::Command::PositionalArgNotFound);
+    CPPUNIT_ASSERT_THROW(
+        arg_parser.get_positional_arg("repoquery.installed", false), ArgParser::Command::PositionalArgNotFound);
+    CPPUNIT_ASSERT_THROW(
+        arg_parser.get_positional_arg("repoquery.installed", true), ArgParser::Command::PositionalArgNotFound);
+
+    CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::Command *>{repoquery}), test->get_commands());
+    CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::NamedArg *>{help, global_arg}), test->get_named_args());
+    CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::PositionalArg *>{}), test->get_positional_args());
+    CPPUNIT_ASSERT_EQUAL(repoquery, &test->get_command("repoquery"));
+    CPPUNIT_ASSERT_THROW(test->get_command("unknowncmd"), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_EQUAL(global_arg, &test->get_named_arg("global_arg"));
+    CPPUNIT_ASSERT_THROW(test->get_named_arg("unknown"), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_THROW(test->get_positional_arg("keys"), ArgParser::Command::PositionalArgNotFound);
+
+    CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::Command *>{}), repoquery->get_commands());
+    CPPUNIT_ASSERT_EQUAL(
+        (std::vector<ArgParser::NamedArg *>{available, installed, info, nevra}), repoquery->get_named_args());
+    CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::PositionalArg *>{keys}), repoquery->get_positional_args());
+    CPPUNIT_ASSERT_THROW(repoquery->get_command("repoquery"), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_EQUAL(info, &repoquery->get_named_arg("info"));
+    CPPUNIT_ASSERT_THROW(repoquery->get_named_arg("unknown"), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_EQUAL(keys, &repoquery->get_positional_arg("keys"));
+    CPPUNIT_ASSERT_THROW(repoquery->get_positional_arg("unknown"), ArgParser::Command::PositionalArgNotFound);
+
+    CPPUNIT_ASSERT_EQUAL(std::string("info"), info->get_id());
+    CPPUNIT_ASSERT_EQUAL(info_option, dynamic_cast<libdnf::OptionBool *>(info->get_linked_value()));
+    CPPUNIT_ASSERT_EQUAL(0, info->get_parse_count());
+
+    CPPUNIT_ASSERT_EQUAL(std::string("keys"), keys->get_id());
+    CPPUNIT_ASSERT_EQUAL(keys_options, keys->get_linked_values());
+    CPPUNIT_ASSERT_EQUAL(0, info->get_parse_count());
+
+    {
+        constexpr const char * argv[]{"test", "repoquery", "--installed", "--info"};
+        arg_parser.parse(std::size(argv), argv);
+
+        CPPUNIT_ASSERT_EQUAL(repoquery, selected_cmd);
+
+        auto * installed_linked_option = dynamic_cast<libdnf::OptionBool *>(installed->get_linked_value());
+        CPPUNIT_ASSERT(installed_linked_option);
+        CPPUNIT_ASSERT_EQUAL(true, installed_linked_option->get_value());
+    }
+
+    {
+        // "--info" and "--nevra" cannot be used together
+        constexpr const char * argv[]{"test", "repoquery", "--nevra", "--info"};
+        CPPUNIT_ASSERT_THROW(arg_parser.parse(std::size(argv), argv), ArgParser::Conflict);
+    }
+}

--- a/test/libdnf-cli/test_argument_parser.hpp
+++ b/test/libdnf-cli/test_argument_parser.hpp
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF_CLI_ARGUMENT_PARSER_HPP
+#define TEST_LIBDNF_CLI_ARGUMENT_PARSER_HPP
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+class ArgumentParserTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(ArgumentParserTest);
+
+    CPPUNIT_TEST(test_argument_parser);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void test_argument_parser();
+};
+
+
+#endif  // TEST_LIBDNF_CLI_ARGUMENT_PARSER_HPP


### PR DESCRIPTION
- Support inheritance of named arguments for parsing

  Example:
  The named argument `--named_arg` is defined for the `command`.
  The named argument `--subcommand_named_arg` is defined for the `subcommand`.

  A valid command line is:
  `command --named_arg subcommand --subcommand_named_arg`

  With named arguments inheritance enabled, the following commandline is also valid:
  `command subcommand --named_arg --subcommand_named_arg`

  The inherited argument is used only if the parser does not find an argument
  definition in the processed subcommand.

- Methods to get list of all stored arguments
   ```
   const std::vector<std::unique_ptr<Command>> & ArgumentParser::get_commands() const noexcept;
   const std::vector<std::unique_ptr<NamedArg>> & ArgumentParser::get_named_args() const noexcept;
   const std::vector<std::unique_ptr<PositionalArg>> & ArgumentParser::get_positional_args() const noexcept;
   ```

- Add methods to get command/named/positional argument by ID path
  ```
  Command & ArgumentParser::get_command(const std::string & id_path);
  NamedArg & ArgumentParser::get_named_arg(const std::string & id_path, bool search_in_parent);
  PositionalArg & ArgumentParser::get_positional_arg(const std::string & id_path, bool search_in_parent);
  ```

- Unit tests