### PR TITLE
[dnf5] Implement split and rsplit, unit tests for split, rsplit, join

### DIFF
--- a/dnf-4/libdnf/utils/utils.cpp
+++ b/dnf-4/libdnf/utils/utils.cpp
@@ -46,58 +46,6 @@ bool isAdvisoryApplicable(libdnf::Advisory & advisory, DnfSack * sack)
 
 namespace string {
 
-std::vector<std::string> split(const std::string &source, const char *delimiter, int maxSplit)
-{
-    if (source.empty())
-        throw std::runtime_error{"Source cannot be empty"};
-
-    std::string::size_type tokenBeginIndex = 0;
-    std::vector<std::string> container;
-
-    while ((tokenBeginIndex = source.find_first_not_of(delimiter, tokenBeginIndex)) != source.npos) {
-        if (maxSplit != -1 && ((int) (container.size() + 1 )) == maxSplit) {
-            container.emplace_back(source.substr(tokenBeginIndex));
-            break;
-        }
-
-        auto tokenEndIndex = source.find_first_of(delimiter, tokenBeginIndex);
-        container.emplace_back(source.substr(tokenBeginIndex, tokenEndIndex - tokenBeginIndex));
-        tokenBeginIndex = tokenEndIndex;
-    }
-
-    if (container.empty()) {
-        throw std::runtime_error{"No delimiter found in source: " + source};
-    }
-
-    return container;
-}
-
-std::vector<std::string> rsplit(const std::string &source, const char *delimiter, int maxSplit)
-{
-    if (source.empty())
-        throw std::runtime_error{"Source cannot be empty"};
-
-    std::string sequence = source;
-    std::string::size_type tokenBeginIndex = 0;
-    std::vector<std::string> container;
-
-    while ((tokenBeginIndex = sequence.find_last_of(delimiter)) != sequence.npos) {
-        if (maxSplit != -1 && ((int) (container.size() + 1 )) == maxSplit) {
-            container.emplace_back(source.substr(0, tokenBeginIndex));
-            break;
-        }
-
-        container.emplace(container.begin(), source.substr(tokenBeginIndex + 1));
-        sequence = sequence.substr(0, tokenBeginIndex);
-    }
-
-    if (container.empty()) {
-        throw std::runtime_error{"No delimiter found in source: " + source};
-    }
-
-    return container;
-}
-
 std::string trimSuffix(const std::string &source, const std::string &suffix)
 {
     if (source.length() < suffix.length())

--- a/dnf-4/libdnf/utils/utils.hpp
+++ b/dnf-4/libdnf/utils/utils.hpp
@@ -40,8 +40,6 @@ bool isAdvisoryApplicable(Advisory & advisory, DnfSack * sack);
 
 namespace string {
 inline std::string fromCstring(const char * cstring) { return cstring ? cstring : ""; }
-std::vector<std::string> split(const std::string &source, const char *delimiter, int maxSplit = -1);
-std::vector<std::string> rsplit(const std::string &source, const char *delimiter, int maxSplit = -1);
 std::string trimSuffix(const std::string &source, const std::string &suffix);
 std::string trimPrefix(const std::string &source, const std::string &prefix);
 std::string trim(const std::string &source);

--- a/libdnf/utils/string.cpp
+++ b/libdnf/utils/string.cpp
@@ -1,0 +1,90 @@
+/*
+Copyright (C) 2020-2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "string.hpp"
+
+
+namespace libdnf::utils::string {
+
+
+static std::vector<std::string> split_impl(
+    const std::string & str, const std::string & delimiter, std::size_t limit, bool from_right) {
+    std::vector<std::string> result;
+
+    // For an empty input string, return a vector with one empty token.
+    if (str.empty()) {
+        result.emplace_back("");
+        return result;
+    }
+
+    if (limit < 2) {
+        result.emplace_back(str);
+        return result;
+    }
+
+    const auto delim_length = delimiter.size();
+
+    // Count the number of tokens on the input.
+    std::size_t tokens_count = 1;
+    for (auto pos = str.find(delimiter); pos != std::string::npos; pos = str.find(delimiter, pos + delim_length)) {
+        ++tokens_count;
+    }
+
+    auto delim_pos = str.find(delimiter);
+
+    // The resulting number of tokens must be less than or equal to the limit.
+    if (tokens_count > limit) {
+        if (from_right) {
+            // For right-split, skip the left excess delimiters.
+            for (; tokens_count > limit; --tokens_count) {
+                delim_pos = str.find(delimiter, delim_pos + delim_length);
+            }
+        } else {
+            // For left-split, adjust the tokens_count.
+            tokens_count = limit;
+        }
+    }
+
+    // Reserve memory to avoid realocations.
+    result.reserve(tokens_count);
+
+    // Split the input string.
+    std::size_t token_pos = 0;
+    while (--tokens_count != 0) {
+        result.emplace_back(str, token_pos, delim_pos - token_pos);
+        token_pos = delim_pos + delim_length;
+        delim_pos = str.find(delimiter, token_pos);
+    }
+    // Put the rest as the last token.
+    result.emplace_back(str, token_pos);
+
+    return result;
+}
+
+std::vector<std::string> rsplit(const std::string & str, const std::string & delimiter, std::size_t limit) {
+    return split_impl(str, delimiter, limit, true);
+}
+
+std::vector<std::string> split(const std::string & str, const std::string & delimiter, std::size_t limit) {
+    return split_impl(str, delimiter, limit, false);
+}
+
+
+}  // namespace libdnf::utils::string

--- a/libdnf/utils/string.hpp
+++ b/libdnf/utils/string.hpp
@@ -1,14 +1,18 @@
 /*
 Copyright (C) 2020-2021 Red Hat, Inc.
+
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
 Libdnf is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 2.1 of the License, or
 (at your option) any later version.
+
 Libdnf is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU Lesser General Public License for more details.
+
 You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
@@ -42,9 +46,10 @@ inline bool ends_with(const std::string & value, const std::string & pattern) {
     return std::equal(pattern.rbegin(), pattern.rend(), value.rbegin());
 }
 
-/// Join all items in a container into a string using a joiner
+
+/// Join elements from the `input` container with a `delimiter` string
 template <typename ContainerT>
-inline std::string join(const ContainerT & input, const std::string & joiner) {
+inline std::string join(const ContainerT & input, const std::string & delimiter) {
     auto it = std::begin(input);
     auto it_end = std::end(input);
 
@@ -59,12 +64,23 @@ inline std::string join(const ContainerT & input, const std::string & joiner) {
     ++it;
 
     for (; it != it_end; ++it) {
-        result.append(joiner);
+        result.append(delimiter);
         result.append(*it);
     }
 
     return result;
 }
+
+
+/// Right-split `str` with a `delimiter` into a vector of strings.
+/// The `limit` argument determines maximum number of elements in the resulting vector.
+std::vector<std::string> rsplit(const std::string & str, const std::string & delimiter, std::size_t limit);
+
+
+/// Split `str` with a `delimiter` into a vector of strings.
+/// The `limit` argument determines maximum number of elements in the resulting vector.
+std::vector<std::string> split(
+    const std::string & str, const std::string & delimiter, std::size_t limit = std::string::npos);
 
 
 }  // namespace libdnf::utils::string

--- a/test/libdnf/utils/test_string.cpp
+++ b/test/libdnf/utils/test_string.cpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_string.hpp"
 
+#include "test/libdnf/utils.hpp"
+
 #include "libdnf/utils/string.hpp"
 
 
@@ -54,4 +56,37 @@ void UtilsStringTest::test_ends_with() {
     CPPUNIT_ASSERT_EQUAL(true, ends_with("abc", "abc"));
     CPPUNIT_ASSERT_EQUAL(false, ends_with("abc", "0abc"));
     CPPUNIT_ASSERT_EQUAL(false, ends_with("abc", "b"));
+}
+
+
+void UtilsStringTest::test_join() {
+    CPPUNIT_ASSERT_EQUAL(std::string(""), join(std::vector<std::string>(), ""));
+    CPPUNIT_ASSERT_EQUAL(std::string(""), join(std::vector<std::string>(), "; "));
+    CPPUNIT_ASSERT_EQUAL(std::string(""), join(std::vector<std::string>({""}), ""));
+    CPPUNIT_ASSERT_EQUAL(std::string(""), join(std::vector<std::string>({""}), "; "));
+    CPPUNIT_ASSERT_EQUAL(std::string("aa"), join(std::vector<std::string>({"aa"}), "; "));
+    CPPUNIT_ASSERT_EQUAL(std::string("aa; bb"), join(std::vector<std::string>({"aa", "bb"}), "; "));
+}
+
+
+void UtilsStringTest::test_split() {
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({""}), split("", "; "));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa"}), split("aa", "; "));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa", "bb"}), split("aa; bb", "; "));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa; bb; cc"}), split("aa; bb; cc", "; ", 0));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa; bb; cc"}), split("aa; bb; cc", "; ", 1));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa", "bb; cc"}), split("aa; bb; cc", "; ", 2));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa", "bb", "cc"}), split("aa; bb; cc", "; ", 3));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa", "bb", "cc"}), split("aa; bb; cc", "; ", 4));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa", "bb", "cc", ""}), split("aa; bb; cc; ", "; ", 4));
+}
+
+
+void UtilsStringTest::test_rsplit() {
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa; bb; cc"}), rsplit("aa; bb; cc", "; ", 0));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa; bb; cc"}), rsplit("aa; bb; cc", "; ", 1));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa; bb", "cc"}), rsplit("aa; bb; cc", "; ", 2));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa", "bb", "cc"}), rsplit("aa; bb; cc", "; ", 3));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa", "bb", "cc"}), rsplit("aa; bb; cc", "; ", 4));
+    CPPUNIT_ASSERT_EQUAL(std::vector<std::string>({"aa", "bb", "cc", ""}), rsplit("aa; bb; cc; ", "; ", 4));
 }

--- a/test/libdnf/utils/test_string.hpp
+++ b/test/libdnf/utils/test_string.hpp
@@ -30,6 +30,9 @@ class UtilsStringTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE(UtilsStringTest);
     CPPUNIT_TEST(test_starts_with);
     CPPUNIT_TEST(test_ends_with);
+    CPPUNIT_TEST(test_join);
+    CPPUNIT_TEST(test_split);
+    CPPUNIT_TEST(test_rsplit);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -38,6 +41,9 @@ public:
 
     void test_starts_with();
     void test_ends_with();
+    void test_join();
+    void test_split();
+    void test_rsplit();
 
 private:
 };


### PR DESCRIPTION
I did review of https://github.com/rpm-software-management/libdnf/pull/1154. Thanks to Daniel for his PR.

I thought about it and prepared a competitive solution.

This implementation of `split` and` rsplit`:
- The algorithm has a linear complexity.
- Memory for the vector is allocated only once (no reallocations occur).
- Both functions share the same code. 