### PR TITLE
[dnf5] Attempt to share command line parser configuration

### DIFF
--- a/dnfdaemon-client/commands/command.cpp
+++ b/dnfdaemon-client/commands/command.cpp
@@ -21,15 +21,15 @@ along with dnfdaemon-client.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../context.hpp"
 #include "../utils.hpp"
-#include "../wrappers/dbus_package_wrapper.hpp"
 #include "../wrappers/dbus_goal_wrapper.hpp"
+#include "../wrappers/dbus_package_wrapper.hpp"
+
+#include "libdnf-cli/output/transaction_table.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
 
 #include <iostream>
 #include <vector>
-
-#include "libdnf-cli/output/transaction_table.hpp"
 
 namespace dnfdaemon::client {
 
@@ -37,7 +37,8 @@ void TransactionCommand::run_transaction(Context & ctx) {
     dnfdaemon::KeyValueMap options = {};
 
     // resolve the transaction
-    options["allow_erasing"] = ctx.allow_erasing.get_value();
+    options["allow_erasing"] =
+        static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("allowerasing"))->get_value();
     std::vector<dnfdaemon::DbusTransactionItem> transaction;
     ctx.session_proxy->callMethod("resolve")
         .onInterface(dnfdaemon::INTERFACE_GOAL)

--- a/dnfdaemon-client/commands/downgrade/downgrade.cpp
+++ b/dnfdaemon-client/commands/downgrade/downgrade.cpp
@@ -24,6 +24,7 @@ along with dnfdaemon-client.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnfdaemon-server/dbus.hpp>
 #include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/downgrade.hpp>
 #include <libdnf/conf/option_bool.hpp>
 #include <libdnf/conf/option_string.hpp>
 
@@ -33,29 +34,8 @@ along with dnfdaemon-client.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnfdaemon::client {
 
 void CmdDowngrade::set_argument_parser(Context & ctx) {
-    auto downgrade = ctx.arg_parser.add_new_command("downgrade");
-    downgrade->set_short_description("downgrade packages on the system");
-    downgrade->set_description("");
-    downgrade->set_named_args_help_header("Optional arguments:");
-    downgrade->set_positional_args_help_header("Positional arguments:");
-    downgrade->set_parse_hook_func([this, &ctx](
-                                       [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
-                                       [[maybe_unused]] const char * option,
-                                       [[maybe_unused]] int argc,
-                                       [[maybe_unused]] const char * const argv[]) {
-        ctx.select_command(this);
-        return true;
-    });
-    ctx.arg_parser.get_root_command()->register_command(downgrade);
-
-    patterns_options = ctx.arg_parser.add_new_values();
-    auto keys = ctx.arg_parser.add_new_positional_arg(
-        "keys_to_match",
-        libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
-        patterns_options);
-    keys->set_short_description("List of packages to downgrade");
-    downgrade->register_positional_arg(keys);
+    auto downgrade = ctx.argparser_config->register_subcommand(libdnf::cli::arguments::downgrade);
+    ctx.argparser_config->register_positional_arg(libdnf::cli::arguments::downgrade_patterns, downgrade);
 }
 
 void CmdDowngrade::run(Context & ctx) {
@@ -66,7 +46,9 @@ void CmdDowngrade::run(Context & ctx) {
     }
 
     // get package specs from command line and add them to the goal
+    auto selected_command = ctx.argparser_config->get_selected_command();
     std::vector<std::string> patterns;
+    auto patterns_options = selected_command->get_positional_arg("downgrade_patterns").get_linked_values();
     if (patterns_options->size() > 0) {
         patterns.reserve(patterns_options->size());
         for (auto & pattern : *patterns_options) {

--- a/dnfdaemon-client/commands/downgrade/downgrade.hpp
+++ b/dnfdaemon-client/commands/downgrade/downgrade.hpp
@@ -31,9 +31,6 @@ class CmdDowngrade : public TransactionCommand {
 public:
     void set_argument_parser(Context & ctx) override;
     void run(Context & ctx) override;
-
-private:
-    std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnfdaemon-client/commands/install/install.hpp
+++ b/dnfdaemon-client/commands/install/install.hpp
@@ -31,10 +31,6 @@ class CmdInstall : public TransactionCommand {
 public:
     void set_argument_parser(Context & ctx) override;
     void run(Context & ctx) override;
-
-private:
-    libdnf::OptionBool strict_option{false};
-    std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnfdaemon-client/commands/remove/remove.hpp
+++ b/dnfdaemon-client/commands/remove/remove.hpp
@@ -31,9 +31,6 @@ class CmdRemove : public TransactionCommand {
 public:
     void set_argument_parser(Context & ctx) override;
     void run(Context & ctx) override;
-
-private:
-    std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnfdaemon-client/commands/repolist/repolist.cpp
+++ b/dnfdaemon-client/commands/repolist/repolist.cpp
@@ -25,8 +25,9 @@ along with dnfdaemon-client.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf-cli/output/repolist.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
-#include <libdnf/conf/option_string.hpp>
+#include <libdnf-cli/argument_parser_config/repolist.hpp>
 #include <libdnf-cli/output/repo_info.hpp>
+#include <libdnf/conf/option_string.hpp>
 
 #include <iostream>
 #include <numeric>
@@ -34,71 +35,36 @@ along with dnfdaemon-client.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnfdaemon::client {
 
 void CmdRepolist::set_argument_parser(Context & ctx) {
-    enable_disable_option = dynamic_cast<libdnf::OptionEnum<std::string> *>(
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionEnum<std::string>>(
-            new libdnf::OptionEnum<std::string>("enabled", {"all", "enabled", "disabled"}))));
+    libdnf::cli::ArgumentParser::Command * ap_command;
+    if (command == "repolist") {
+        ap_command = ctx.argparser_config->register_subcommand(libdnf::cli::arguments::repolist);
+    } else {
+        ap_command = ctx.argparser_config->register_subcommand(libdnf::cli::arguments::repoinfo);
+    }
 
-    auto all = ctx.arg_parser.add_new_named_arg("all");
-    all->set_long_name("all");
-    all->set_short_description("show all repos");
-    all->set_const_value("all");
-    all->link_value(enable_disable_option);
+    auto all = ctx.argparser_config->register_named_arg(libdnf::cli::arguments::all, ap_command);
+    auto enabled = ctx.argparser_config->register_named_arg(libdnf::cli::arguments::enabled, ap_command);
+    auto disabled = ctx.argparser_config->register_named_arg(libdnf::cli::arguments::disabled, ap_command);
 
-    auto enabled = ctx.arg_parser.add_new_named_arg("enabled");
-    enabled->set_long_name("enabled");
-    enabled->set_short_description("show enabled repos (default)");
-    enabled->set_const_value("enabled");
-    enabled->link_value(enable_disable_option);
+    ctx.argparser_config->register_positional_arg(libdnf::cli::arguments::repolist_patterns, ap_command);
 
-    auto disabled = ctx.arg_parser.add_new_named_arg("disabled");
-    disabled->set_long_name("disabled");
-    disabled->set_short_description("show disabled repos");
-    disabled->set_const_value("disabled");
-    disabled->link_value(enable_disable_option);
-
-    patterns_options = ctx.arg_parser.add_new_values();
-    auto repos = ctx.arg_parser.add_new_positional_arg(
-        "repos_to_show",
-        libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
-        patterns_options);
-    repos->set_short_description("List of repos to show");
-
+    auto & arg_parser = ctx.argparser_config->get_arg_parser();
     auto conflict_args =
-        ctx.arg_parser.add_conflict_args_group(std::unique_ptr<std::vector<libdnf::cli::ArgumentParser::Argument *>>(
+        arg_parser.add_conflict_args_group(std::unique_ptr<std::vector<libdnf::cli::ArgumentParser::Argument *>>(
             new std::vector<libdnf::cli::ArgumentParser::Argument *>{all, enabled, disabled}));
 
     all->set_conflict_arguments(conflict_args);
     enabled->set_conflict_arguments(conflict_args);
     disabled->set_conflict_arguments(conflict_args);
-
-    auto repolist = ctx.arg_parser.add_new_command(command);
-    repolist->set_short_description("display the configured software repositories");
-    repolist->set_description("");
-    repolist->set_named_args_help_header("Optional arguments:");
-    repolist->set_positional_args_help_header("Positional arguments:");
-    repolist->set_parse_hook_func([this, &ctx](
-                                      [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
-                                      [[maybe_unused]] const char * option,
-                                      [[maybe_unused]] int argc,
-                                      [[maybe_unused]] const char * const argv[]) {
-        ctx.select_command(this);
-        return true;
-    });
-
-    repolist->register_named_arg(all);
-    repolist->register_named_arg(enabled);
-    repolist->register_named_arg(disabled);
-    repolist->register_positional_arg(repos);
-
-    ctx.arg_parser.get_root_command()->register_command(repolist);
 }
 
 /// Joins vector of strings to a single string using given separator
 /// ["a", "b", "c"] -> "a b c"
 std::string join(const std::vector<std::string> & str_list, const std::string & separator) {
     return std::accumulate(
-        str_list.begin(), str_list.end(), std::string(),
+        str_list.begin(),
+        str_list.end(),
+        std::string(),
         [&](const std::string & a, const std::string & b) -> std::string {
             return a + (a.length() > 0 ? separator : "") + b;
         });
@@ -107,35 +73,66 @@ std::string join(const std::vector<std::string> & str_list, const std::string & 
 /// Joins vector of string pairs to a single string. Pairs are joined using
 /// field_separator, records using record_separator
 /// [("a", "1"), ("b", "2")] -> "a: 1, b: 2"
-std::string join_pairs(const std::vector<std::pair<std::string, std::string>> & pair_list, const std::string & field_separator, const std::string & record_separator) {
-    std::vector<std::string> records {};
-    for (auto & pair: pair_list) {
+std::string join_pairs(
+    const std::vector<std::pair<std::string, std::string>> & pair_list,
+    const std::string & field_separator,
+    const std::string & record_separator) {
+    std::vector<std::string> records{};
+    for (auto & pair : pair_list) {
         records.emplace_back(pair.first + field_separator + pair.second);
     }
     return join(records, record_separator);
 }
 
+std::string enable_disable(Context & ctx) {
+    std::string retval{"enabled"};
+    auto sc = ctx.argparser_config->get_selected_command();
+    auto all = static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("all", sc));
+    auto disabled = static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("disabled", sc));
+    if (all->get_value()) {
+        retval = "all";
+    } else if (disabled->get_value()) {
+        retval = "disabled";
+    }
+    return retval;
+}
+
 void CmdRepolist::run(Context & ctx) {
     // prepare options from command line arguments
     dnfdaemon::KeyValueMap options = {};
-    options["enable_disable"] = enable_disable_option->get_value();
+    auto enable_disable_option = enable_disable(ctx);
+    options["enable_disable"] = enable_disable_option;
+
+    auto selected_command = ctx.argparser_config->get_selected_command();
     std::vector<std::string> patterns;
+    auto patterns_options = selected_command->get_positional_arg("repolist_patterns").get_linked_values();
     if (!patterns_options->empty()) {
         options["enable_disable"] = "all";
         patterns.reserve(patterns_options->size());
         for (auto & pattern : *patterns_options) {
-            auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());
+            auto option = static_cast<libdnf::OptionString *>(pattern.get());
             patterns.emplace_back(option->get_value());
         }
     }
     options["patterns"] = patterns;
 
-    std::vector<std::string> attrs {"id", "name", "enabled"};
+    std::vector<std::string> attrs{"id", "name", "enabled"};
     if (command == "repoinfo") {
-        std::vector<std::string> repoinfo_attrs {
-            "size", "revision", "content_tags", "distro_tags", "updated",
-            "pkgs", "available_pkgs", "metalink", "mirrorlist", "baseurl",
-            "metadata_expire", "excludepkgs", "includepkgs", "repofile"};
+        std::vector<std::string> repoinfo_attrs{
+            "size",
+            "revision",
+            "content_tags",
+            "distro_tags",
+            "updated",
+            "pkgs",
+            "available_pkgs",
+            "metalink",
+            "mirrorlist",
+            "baseurl",
+            "metadata_expire",
+            "excludepkgs",
+            "includepkgs",
+            "repofile"};
         attrs.insert(attrs.end(), repoinfo_attrs.begin(), repoinfo_attrs.end());
     }
     options["repo_attrs"] = attrs;
@@ -149,17 +146,18 @@ void CmdRepolist::run(Context & ctx) {
 
     if (command == "repolist") {
         // print the output table
-        bool with_status = enable_disable_option->get_value() == "all";
+        bool with_status = enable_disable_option == "all";
         libdnf::cli::output::print_repolist_table(
             DbusQueryRepoWrapper(repositories), with_status,
             libdnf::cli::output::COL_REPO_ID);
     } else {
         // repoinfo command
+        auto verbose = static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("verbose"));
 
         for (auto & raw_repo : repositories) {
             DbusRepoWrapper repo(raw_repo);
             auto repo_info = libdnf::cli::output::RepoInfo();
-            repo_info.add_repo(repo, ctx.verbose.get_value(), ctx.verbose.get_value());
+            repo_info.add_repo(repo, verbose->get_value(), verbose->get_value());
             repo_info.print();
             std::cout << std::endl;
         }

--- a/dnfdaemon-client/commands/repolist/repolist.hpp
+++ b/dnfdaemon-client/commands/repolist/repolist.hpp
@@ -31,13 +31,11 @@ namespace dnfdaemon::client {
 
 class CmdRepolist : public Command {
 public:
-    CmdRepolist(const char * command) : command(command) {};
+    CmdRepolist(const char * command) : command(command){};
     void set_argument_parser(Context & ctx) override;
     void run(Context & ctx) override;
 
 private:
-    libdnf::OptionEnum<std::string> * enable_disable_option{nullptr};
-    std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
     const std::string command;
 };
 

--- a/dnfdaemon-client/commands/repoquery/repoquery.cpp
+++ b/dnfdaemon-client/commands/repoquery/repoquery.cpp
@@ -24,8 +24,11 @@ along with dnfdaemon-client.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf-cli/output/repoquery.hpp"
 
+#include "libdnf-cli/output/repoquery.hpp"
+
 #include <dnfdaemon-server/dbus.hpp>
 #include <fmt/format.h>
+#include <libdnf-cli/argument_parser_config/repoquery.hpp>
 #include <libdnf/conf/option_string.hpp>
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
@@ -36,66 +39,22 @@ along with dnfdaemon-client.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnfdaemon::client {
 
 using namespace libdnf::cli;
+
 void CmdRepoquery::set_argument_parser(Context & ctx) {
-    available_option = dynamic_cast<libdnf::OptionBool *>(
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(true))));
-
-    installed_option = dynamic_cast<libdnf::OptionBool *>(
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(false))));
-
-    info_option = dynamic_cast<libdnf::OptionBool *>(
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionBool>(new libdnf::OptionBool(false))));
-
-    auto available = ctx.arg_parser.add_new_named_arg("available");
-    available->set_long_name("available");
-    available->set_short_description("display available packages (default)");
-    available->set_const_value("true");
-    available->link_value(available_option);
-
-    auto installed = ctx.arg_parser.add_new_named_arg("installed");
-    installed->set_long_name("installed");
-    installed->set_short_description("display installed packages");
-    installed->set_const_value("true");
-    installed->link_value(installed_option);
-
-    auto info = ctx.arg_parser.add_new_named_arg("info");
-    info->set_long_name("info");
-    info->set_short_description("show detailed information about the packages");
-    info->set_const_value("true");
-    info->link_value(info_option);
-
-    patterns_options = ctx.arg_parser.add_new_values();
-    auto keys = ctx.arg_parser.add_new_positional_arg(
-        "keys_to_match",
-        ArgumentParser::PositionalArg::UNLIMITED,
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
-        patterns_options);
-    keys->set_short_description("List of keys to match");
-
-    auto repoquery = ctx.arg_parser.add_new_command("repoquery");
-    repoquery->set_short_description("search for packages matching keyword");
-    repoquery->set_description("");
-    repoquery->set_named_args_help_header("Optional arguments:");
-    repoquery->set_positional_args_help_header("Positional arguments:");
-    repoquery->set_parse_hook_func([this, &ctx](
-                                       [[maybe_unused]] ArgumentParser::Argument * arg,
-                                       [[maybe_unused]] const char * option,
-                                       [[maybe_unused]] int argc,
-                                       [[maybe_unused]] const char * const argv[]) {
-        ctx.select_command(this);
-        return true;
-    });
-
-    repoquery->register_named_arg(available);
-    repoquery->register_named_arg(installed);
-    repoquery->register_named_arg(info);
-    repoquery->register_positional_arg(keys);
-
-    ctx.arg_parser.get_root_command()->register_command(repoquery);
+    auto repoquery = ctx.argparser_config->register_subcommand(libdnf::cli::arguments::repoquery);
+    ctx.argparser_config->register_named_arg(libdnf::cli::arguments::available, repoquery);
+    ctx.argparser_config->register_named_arg(libdnf::cli::arguments::installed, repoquery);
+    ctx.argparser_config->register_named_arg(libdnf::cli::arguments::info, repoquery);
+    ctx.argparser_config->register_positional_arg(libdnf::cli::arguments::repoquery_patterns, repoquery);
 }
 
 dnfdaemon::KeyValueMap CmdRepoquery::session_config([[maybe_unused]] Context & ctx) {
+    auto selected_command = ctx.argparser_config->get_selected_command();
     dnfdaemon::KeyValueMap cfg = {};
+    auto installed_option =
+        static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("installed", selected_command));
+    auto available_option =
+        static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("available", selected_command));
     cfg["load_system_repo"] = installed_option->get_value();
     cfg["load_available_repos"] =
         (available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !installed_option->get_value());
@@ -104,10 +63,12 @@ dnfdaemon::KeyValueMap CmdRepoquery::session_config([[maybe_unused]] Context & c
 
 void CmdRepoquery::run(Context & ctx) {
     // query packages
+    auto selected_command = ctx.argparser_config->get_selected_command();
     dnfdaemon::KeyValueMap options = {};
 
     std::vector<std::string> patterns;
-    if (patterns_options->size() > 0) {
+    auto patterns_options = selected_command->get_positional_arg("repoquery_patterns").get_linked_values();
+    if (!patterns_options->empty()) {
         patterns.reserve(patterns_options->size());
         for (auto & pattern : *patterns_options) {
             auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());
@@ -115,6 +76,8 @@ void CmdRepoquery::run(Context & ctx) {
         }
     }
     options["patterns"] = patterns;
+    auto info_option =
+        static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("info", selected_command));
     if (info_option->get_value()) {
         options.insert(std::pair<std::string, std::vector<std::string>>(
             "package_attrs", {"name", "epoch", "version", "release", "arch", "repo"}));

--- a/dnfdaemon-client/commands/repoquery/repoquery.hpp
+++ b/dnfdaemon-client/commands/repoquery/repoquery.hpp
@@ -34,12 +34,6 @@ public:
     void set_argument_parser(Context & ctx) override;
     void run(Context & ctx) override;
     dnfdaemon::KeyValueMap session_config(Context &) override;
-
-private:
-    libdnf::OptionBool * available_option{nullptr};
-    libdnf::OptionBool * installed_option{nullptr};
-    libdnf::OptionBool * info_option{nullptr};
-    std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnfdaemon-client/commands/upgrade/upgrade.hpp
+++ b/dnfdaemon-client/commands/upgrade/upgrade.hpp
@@ -31,9 +31,6 @@ class CmdUpgrade : public TransactionCommand {
 public:
     void set_argument_parser(Context & ctx) override;
     void run(Context & ctx) override;
-
-private:
-    std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
 };
 
 }  // namespace dnfdaemon::client

--- a/dnfdaemon-client/context.cpp
+++ b/dnfdaemon-client/context.cpp
@@ -81,10 +81,10 @@ dnfdaemon::RepoStatus Context::wait_for_repos() {
 
 bool userconfirm(Context & ctx) {
     // "assumeno" takes precedence over "assumeyes"
-    if (ctx.assume_no.get_value()) {
+    if (static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("assumeno"))->get_value()) {
         return false;
     }
-    if (ctx.assume_yes.get_value()) {
+    if (static_cast<libdnf::OptionBool *>(ctx.argparser_config->get_arg_value("assumeyes"))->get_value()) {
         return true;
     }
     std::string msg = "Is this ok [y/N]: ";

--- a/include/libdnf-cli/argument_parser_config/argument_parser_config.hpp
+++ b/include/libdnf-cli/argument_parser_config/argument_parser_config.hpp
@@ -1,0 +1,86 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_ARGUMENT_PARSER_CONFIG_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_ARGUMENT_PARSER_CONFIG_HPP
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf/conf/config_main.hpp>
+
+#include <map>
+#include <string>
+
+namespace libdnf::cli {
+
+class ArgumentParserConfig {
+public:
+    explicit ArgumentParserConfig(libdnf::ConfigMain & config);
+
+    ArgumentParser & get_arg_parser() noexcept { return arg_parser; }
+    libdnf::ConfigMain & get_config() const noexcept { return config; };
+    ArgumentParser::Command * get_root_command() { return arg_parser.get_root_command(); };
+
+    ArgumentParser::Command * get_selected_command() { return selected_command; };
+    void set_selected_command(ArgumentParser::Command * command) { selected_command = command; };
+
+    ArgumentParser::Command * register_subcommand(
+        ArgumentParser::Command * (*command_factory)(ArgumentParserConfig & arg), ArgumentParser::Command * parent);
+    ArgumentParser::Command * register_subcommand(
+        ArgumentParser::Command * (*command_factory)(ArgumentParserConfig & arg)) {
+        return register_subcommand(command_factory, arg_parser.get_root_command());
+    }
+
+    ArgumentParser::PositionalArg * register_positional_arg(
+        ArgumentParser::PositionalArg * (*arg_factory)(ArgumentParserConfig & arg), ArgumentParser::Command * command);
+    ArgumentParser::PositionalArg * register_positional_arg(
+        ArgumentParser::PositionalArg * (*arg_factory)(ArgumentParserConfig & arg)) {
+        return register_positional_arg(arg_factory, arg_parser.get_root_command());
+    }
+
+    ArgumentParser::NamedArg * register_named_arg(
+        ArgumentParser::NamedArg * (*arg_factory)(ArgumentParserConfig & arg), ArgumentParser::Command * command);
+    ArgumentParser::NamedArg * register_named_arg(
+        ArgumentParser::NamedArg * (*arg_factory)(ArgumentParserConfig & arg)) {
+        return register_named_arg(arg_factory, arg_parser.get_root_command());
+    };
+
+    ArgumentParser::NamedArg & get_arg(const std::string & id, ArgumentParser::Command * command);
+    ArgumentParser::NamedArg & get_arg(const std::string & id) {
+        return get_arg(id, arg_parser.get_root_command());
+    };
+
+    libdnf::Option * get_arg_value(const std::string & id, ArgumentParser::Command * command);
+    libdnf::Option * get_arg_value(const std::string & id) {
+        return get_arg_value(id, arg_parser.get_root_command());
+    };
+
+    void parse(int argc, const char * const argv[]) { arg_parser.parse(argc, argv); };
+
+    // TODO(mblaha) handle setopts properly
+    std::vector<std::pair<std::string, std::string>> setopts;
+
+private:
+    libdnf::ConfigMain & config;
+    ArgumentParser arg_parser;
+    ArgumentParser::Command * selected_command{nullptr};
+};
+
+}  // namespace libdnf::cli
+
+#endif

--- a/include/libdnf-cli/argument_parser_config/downgrade.hpp
+++ b/include/libdnf-cli/argument_parser_config/downgrade.hpp
@@ -1,0 +1,32 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_DOWNGRADE_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_DOWNGRADE_HPP
+
+#include "argument_parser_config.hpp"
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * downgrade(ArgumentParserConfig & parser_config);
+
+ArgumentParser::PositionalArg * downgrade_patterns(ArgumentParserConfig & parser_config);
+
+}  // namespace libdnf::cli::arguments
+#endif

--- a/include/libdnf-cli/argument_parser_config/global_arguments.hpp
+++ b/include/libdnf-cli/argument_parser_config/global_arguments.hpp
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_GLOBAL_ARGUMENTS_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_GLOBAL_ARGUMENTS_HPP
+
+#include "argument_parser_config.hpp"
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::NamedArg * allowerasing(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * assumeno(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * assumeyes(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * comment(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * help(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * setopt(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * verbose(ArgumentParserConfig & parser_config);
+
+}  // namespace libdnf::cli::arguments
+
+#endif

--- a/include/libdnf-cli/argument_parser_config/install.hpp
+++ b/include/libdnf-cli/argument_parser_config/install.hpp
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_INSTALL_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_INSTALL_HPP
+
+#include "argument_parser_config.hpp"
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * install(ArgumentParserConfig & parser_config);
+
+ArgumentParser::NamedArg * strict(ArgumentParserConfig & parser_config);
+
+ArgumentParser::PositionalArg * install_patterns(ArgumentParserConfig & parser_config);
+
+}  // namespace libdnf::cli::arguments
+#endif

--- a/include/libdnf-cli/argument_parser_config/remove.hpp
+++ b/include/libdnf-cli/argument_parser_config/remove.hpp
@@ -1,0 +1,32 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_REMOVE_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_REMOVE_HPP
+
+#include "argument_parser_config.hpp"
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * remove(ArgumentParserConfig & parser_config);
+
+ArgumentParser::PositionalArg * remove_patterns(ArgumentParserConfig & parser_config);
+
+}  // namespace libdnf::cli::arguments
+#endif

--- a/include/libdnf-cli/argument_parser_config/repolist.hpp
+++ b/include/libdnf-cli/argument_parser_config/repolist.hpp
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_REPOLIST_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_REPOLIST_HPP
+
+#include "argument_parser_config.hpp"
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * repolist(ArgumentParserConfig & parser_config);
+ArgumentParser::Command * repoinfo(ArgumentParserConfig & parser_config);
+
+ArgumentParser::NamedArg * all(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * enabled(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * disabled(ArgumentParserConfig & parser_config);
+
+ArgumentParser::PositionalArg * repolist_patterns(ArgumentParserConfig & parser_config);
+
+}  // namespace libdnf::cli::arguments
+#endif

--- a/include/libdnf-cli/argument_parser_config/repoquery.hpp
+++ b/include/libdnf-cli/argument_parser_config/repoquery.hpp
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_REPOQUERY_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_REPOQUERY_HPP
+
+#include "argument_parser_config.hpp"
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * repoquery(ArgumentParserConfig & parser_config);
+
+ArgumentParser::NamedArg * available(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * installed(ArgumentParserConfig & parser_config);
+ArgumentParser::NamedArg * info(ArgumentParserConfig & parser_config);
+
+ArgumentParser::PositionalArg * repoquery_patterns(ArgumentParserConfig & parser_config);
+
+}  // namespace libdnf::cli::arguments
+#endif

--- a/include/libdnf-cli/argument_parser_config/upgrade.hpp
+++ b/include/libdnf-cli/argument_parser_config/upgrade.hpp
@@ -1,0 +1,32 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_UPGRADE_HPP
+#define LIBDNF_CLI_ARGUMENT_PARSER_CONFIG_UPGRADE_HPP
+
+#include "argument_parser_config.hpp"
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * upgrade(ArgumentParserConfig & parser_config);
+
+ArgumentParser::PositionalArg * upgrade_patterns(ArgumentParserConfig & parser_config);
+
+}  // namespace libdnf::cli::arguments
+#endif

--- a/libdnf-cli/argument_parser_config/argument_parser_config.cpp
+++ b/libdnf-cli/argument_parser_config/argument_parser_config.cpp
@@ -1,0 +1,70 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/argument_parser_config.hpp>
+#include <libdnf/conf/config_main.hpp>
+
+#include <map>
+#include <string>
+
+namespace libdnf::cli {
+
+ArgumentParserConfig::ArgumentParserConfig(libdnf::ConfigMain & config) : config(config) {
+    auto root_command = arg_parser.add_new_command("_root");
+    arg_parser.set_root_command(root_command);
+}
+
+
+ArgumentParser::Command * ArgumentParserConfig::register_subcommand(
+    ArgumentParser::Command * (*command_factory)(ArgumentParserConfig & arg), ArgumentParser::Command * parent) {
+    auto cmd = command_factory(*this);
+    parent->register_command(cmd);
+    return cmd;
+}
+
+
+ArgumentParser::NamedArg * ArgumentParserConfig::register_named_arg(
+    ArgumentParser::NamedArg * (*arg_factory)(ArgumentParserConfig & arg), ArgumentParser::Command * command) {
+    auto arg = arg_factory(*this);
+    command->register_named_arg(arg);
+    return arg;
+}
+
+
+ArgumentParser::PositionalArg * ArgumentParserConfig::register_positional_arg(
+    ArgumentParser::PositionalArg * (*arg_factory)(ArgumentParserConfig & arg), ArgumentParser::Command * command) {
+    auto arg = arg_factory(*this);
+    command->register_positional_arg(arg);
+    return arg;
+}
+
+
+ArgumentParser::NamedArg & ArgumentParserConfig::get_arg(
+    const std::string & id, ArgumentParser::Command * command) {
+    return command->get_named_arg(id);
+}
+
+
+libdnf::Option * ArgumentParserConfig::get_arg_value(
+    const std::string & id, ArgumentParser::Command * command) {
+    return get_arg(id, command).get_linked_value();
+}
+
+}  // namespace libdnf::cli

--- a/libdnf-cli/argument_parser_config/downgrade.cpp
+++ b/libdnf-cli/argument_parser_config/downgrade.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/argument_parser_config.hpp>
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * downgrade(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto downgrade = arg_parser.add_new_command("downgrade");
+    downgrade->set_short_description("downgrade packages on the system");
+    downgrade->set_description("");
+    downgrade->set_named_args_help_header("Optional arguments:");
+    downgrade->set_positional_args_help_header("Positional arguments:");
+    downgrade->set_parse_hook_func([downgrade, &parser_config](
+                                     [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
+                                     [[maybe_unused]] const char * option,
+                                     [[maybe_unused]] int argc,
+                                     [[maybe_unused]] const char * const argv[]) {
+        parser_config.set_selected_command(downgrade);
+        return true;
+    });
+    return downgrade;
+}
+
+
+ArgumentParser::PositionalArg * downgrade_patterns(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto patterns_options = arg_parser.add_new_values();
+    auto keys = arg_parser.add_new_positional_arg(
+        "downgrade_patterns",
+        libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
+        arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_options);
+    keys->set_short_description("List of packages to downgrade");
+    return keys;
+}
+
+}  // namespace libdnf::cli::arguments

--- a/libdnf-cli/argument_parser_config/global_arguments.cpp
+++ b/libdnf-cli/argument_parser_config/global_arguments.cpp
@@ -1,0 +1,141 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/argument_parser_config.hpp>
+#include <libdnf-cli/argument_parser_config/global_arguments.hpp>
+#include <string.h>
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::NamedArg * assumeyes(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto assumeyes = arg_parser.add_new_named_arg("assumeyes");
+    assumeyes->set_long_name("assumeyes");
+    assumeyes->set_short_name('y');
+    assumeyes->set_short_description("automatically answer yes for all questions");
+    assumeyes->set_const_value("true");
+    assumeyes->link_value(&parser_config.get_config().assumeyes());
+    return assumeyes;
+}
+
+ArgumentParser::NamedArg * comment(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionString *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionString>(nullptr)));
+    auto comment = arg_parser.add_new_named_arg("comment");
+    comment->set_long_name("comment");
+    comment->set_has_value(true);
+    comment->set_arg_value_help("COMMENT");
+    comment->set_short_description("add a comment to transaction");
+    comment->set_description(
+        "Adds a comment to the action. If a transaction takes place, the comment is stored in it.");
+    comment->link_value(value);
+    return comment;
+}
+
+
+ArgumentParser::NamedArg * help(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto help = arg_parser.add_new_named_arg("help");
+    help->set_long_name("help");
+    help->set_short_name('h');
+    help->set_short_description("Print help");
+    help->link_value(value);
+    return help;
+}
+
+
+ArgumentParser::NamedArg * verbose(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto verbose = arg_parser.add_new_named_arg("verbose");
+    verbose->set_short_name('v');
+    verbose->set_long_name("verbose");
+    verbose->set_short_description("increase output verbosity");
+    verbose->set_const_value("true");
+    verbose->link_value(value);
+    return verbose;
+}
+
+
+ArgumentParser::NamedArg * assumeno(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto assumeno = arg_parser.add_new_named_arg("assumeno");
+    assumeno->set_long_name("assumeno");
+    assumeno->set_short_description("automatically answer no for all questions");
+    assumeno->set_const_value("true");
+    assumeno->link_value(&parser_config.get_config().assumeno());
+    return assumeno;
+}
+
+
+ArgumentParser::NamedArg * allowerasing(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto allowerasing = arg_parser.add_new_named_arg("allowerasing");
+    allowerasing->set_long_name("allowerasing");
+    allowerasing->set_short_description("installed package can be removed to resolve the transaction");
+    allowerasing->set_const_value("true");
+    allowerasing->link_value(value);
+    return allowerasing;
+}
+
+
+ArgumentParser::NamedArg * setopt(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto setopt = arg_parser.add_new_named_arg("setopt");
+    setopt->set_long_name("setopt");
+    setopt->set_has_value(true);
+    setopt->set_arg_value_help("KEY=VALUE");
+    setopt->set_short_description("set arbitrary config and repo options");
+    setopt->set_description(
+        R"**(Override a configuration option from the configuration file. To override configuration options for repositories, use repoid.option for  the
+              <option>.  Values  for configuration options like excludepkgs, includepkgs, installonlypkgs and tsflags are appended to the original value,
+              they do not override it. However, specifying an empty value (e.g. --setopt=tsflags=) will clear the option.)**");
+
+    // --setopt option support
+    setopt->set_parse_hook_func([&parser_config](
+                                    [[maybe_unused]] libdnf::cli::ArgumentParser::NamedArg * arg,
+                                    [[maybe_unused]] const char * option,
+                                    const char * value) {
+        auto val = strchr(value + 1, '=');
+        if (!val) {
+            throw std::runtime_error(std::string("setopt: Invalid argument value format: Missing '=': ") + value);
+        }
+        auto key = std::string(value, val);
+        auto dot_pos = key.rfind('.');
+        if (dot_pos != std::string::npos) {
+            if (dot_pos == key.size() - 1) {
+                throw std::runtime_error(
+                    std::string("setopt: Invalid argument value format: Last key character cannot be '.': ") + value);
+            }
+        }
+        // Store option to vector for later use
+        parser_config.setopts.emplace_back(key, val + 1);
+        return true;
+    });
+    return setopt;
+}
+
+}  // namespace libdnf::cli::arguments

--- a/libdnf-cli/argument_parser_config/install.cpp
+++ b/libdnf-cli/argument_parser_config/install.cpp
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/argument_parser_config.hpp>
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * install(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto install = arg_parser.add_new_command("install");
+    install->set_short_description("install packages on the system");
+    install->set_description("");
+    install->set_named_args_help_header("Optional arguments:");
+    install->set_positional_args_help_header("Positional arguments:");
+    install->set_parse_hook_func([install, &parser_config](
+                                     [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
+                                     [[maybe_unused]] const char * option,
+                                     [[maybe_unused]] int argc,
+                                     [[maybe_unused]] const char * const argv[]) {
+        parser_config.set_selected_command(install);
+        return true;
+    });
+    return install;
+}
+
+
+ArgumentParser::NamedArg * strict(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto strict = arg_parser.add_new_named_arg("strict");
+    strict->set_long_name("strict");
+    strict->set_short_description(
+        "Broken or unavailable packages cause the transaction to fail (yes) or will be skipped (no).");
+    strict->set_has_value(true);
+    strict->set_arg_value_help("<yes/no>");
+    strict->link_value(value);
+    return strict;
+}
+
+
+ArgumentParser::PositionalArg * install_patterns(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto patterns_options = arg_parser.add_new_values();
+    auto keys = arg_parser.add_new_positional_arg(
+        "install_patterns",
+        libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED_BUT_ONE,
+        arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_options);
+    keys->set_short_description("List of packages to install");
+    return keys;
+}
+
+}  // namespace libdnf::cli::arguments

--- a/libdnf-cli/argument_parser_config/remove.cpp
+++ b/libdnf-cli/argument_parser_config/remove.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/argument_parser_config.hpp>
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * remove(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto remove = arg_parser.add_new_command("remove");
+    remove->set_short_description("remove packages from the system");
+    remove->set_description("");
+    remove->set_named_args_help_header("Optional arguments:");
+    remove->set_positional_args_help_header("Positional arguments:");
+    remove->set_parse_hook_func([remove, &parser_config](
+                                    [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
+                                    [[maybe_unused]] const char * option,
+                                    [[maybe_unused]] int argc,
+                                    [[maybe_unused]] const char * const argv[]) {
+        parser_config.set_selected_command(remove);
+        return true;
+    });
+    return remove;
+}
+
+
+ArgumentParser::PositionalArg * remove_patterns(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto patterns_options = arg_parser.add_new_values();
+    auto keys = arg_parser.add_new_positional_arg(
+        "remove_patterns",
+        libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED_BUT_ONE,
+        arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_options);
+    keys->set_short_description("List of packages to remove");
+    return keys;
+}
+
+}  // namespace libdnf::cli::arguments

--- a/libdnf-cli/argument_parser_config/repolist.cpp
+++ b/libdnf-cli/argument_parser_config/repolist.cpp
@@ -1,0 +1,114 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/argument_parser_config.hpp>
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * repolist(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto repolist = arg_parser.add_new_command("repolist");
+    repolist->set_short_description("display the configured software repositories");
+    repolist->set_description("");
+    repolist->set_named_args_help_header("Optional arguments:");
+    repolist->set_positional_args_help_header("Positional arguments:");
+    repolist->set_parse_hook_func([repolist, &parser_config](
+                                      [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
+                                      [[maybe_unused]] const char * option,
+                                      [[maybe_unused]] int argc,
+                                      [[maybe_unused]] const char * const argv[]) {
+        parser_config.set_selected_command(repolist);
+        return true;
+    });
+    return repolist;
+}
+
+
+ArgumentParser::Command * repoinfo(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto repoinfo = arg_parser.add_new_command("repoinfo");
+    repoinfo->set_short_description("display the configured software repositories");
+    repoinfo->set_description("");
+    repoinfo->set_named_args_help_header("Optional arguments:");
+    repoinfo->set_positional_args_help_header("Positional arguments:");
+    repoinfo->set_parse_hook_func([repoinfo, &parser_config](
+                                      [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
+                                      [[maybe_unused]] const char * option,
+                                      [[maybe_unused]] int argc,
+                                      [[maybe_unused]] const char * const argv[]) {
+        parser_config.set_selected_command(repoinfo);
+        return true;
+    });
+    return repoinfo;
+}
+
+
+ArgumentParser::NamedArg * all(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto all = arg_parser.add_new_named_arg("all");
+    all->set_long_name("all");
+    all->set_short_description("show all repos");
+    all->set_const_value("true");
+    all->link_value(value);
+    return all;
+}
+
+
+ArgumentParser::NamedArg * enabled(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto enabled = arg_parser.add_new_named_arg("enabled");
+    enabled->set_long_name("enabled");
+    enabled->set_short_description("show enabled repos (default)");
+    enabled->set_const_value("true");
+    enabled->link_value(value);
+    return enabled;
+}
+
+
+ArgumentParser::NamedArg * disabled(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto disabled = arg_parser.add_new_named_arg("disabled");
+    disabled->set_long_name("disabled");
+    disabled->set_short_description("show disabled repos");
+    disabled->set_const_value("true");
+    disabled->link_value(value);
+    return disabled;
+}
+
+
+ArgumentParser::PositionalArg * repolist_patterns(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto patterns_options = arg_parser.add_new_values();
+    auto keys = arg_parser.add_new_positional_arg(
+        "repolist_patterns",
+        libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
+        arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_options);
+    keys->set_short_description("List of repositories to query");
+    return keys;
+}
+
+}  // namespace libdnf::cli::arguments

--- a/libdnf-cli/argument_parser_config/repoquery.cpp
+++ b/libdnf-cli/argument_parser_config/repoquery.cpp
@@ -1,0 +1,95 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/argument_parser_config.hpp>
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * repoquery(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto repoquery = arg_parser.add_new_command("repoquery");
+    repoquery->set_short_description("list packages matching keywords");
+    repoquery->set_description("");
+    repoquery->set_named_args_help_header("Optional arguments:");
+    repoquery->set_positional_args_help_header("Positional arguments:");
+    repoquery->set_parse_hook_func([repoquery, &parser_config](
+                                       [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
+                                       [[maybe_unused]] const char * option,
+                                       [[maybe_unused]] int argc,
+                                       [[maybe_unused]] const char * const argv[]) {
+        parser_config.set_selected_command(repoquery);
+        return true;
+    });
+    return repoquery;
+}
+
+
+ArgumentParser::NamedArg * available(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto available = arg_parser.add_new_named_arg("available");
+    available->set_long_name("available");
+    available->set_short_description("search in available packages (default)");
+    available->set_const_value("true");
+    available->link_value(value);
+    return available;
+}
+
+
+ArgumentParser::NamedArg * installed(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto installed = arg_parser.add_new_named_arg("installed");
+    installed->set_long_name("installed");
+    installed->set_short_description("search in installed packages");
+    installed->set_const_value("true");
+    installed->link_value(value);
+    return installed;
+}
+
+
+ArgumentParser::NamedArg * info(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto value =
+        static_cast<libdnf::OptionBool *>(arg_parser.add_init_value(std::make_unique<libdnf::OptionBool>(false)));
+    auto info = arg_parser.add_new_named_arg("info");
+    info->set_long_name("info");
+    info->set_short_description("show detailed information about the packages");
+    info->set_const_value("true");
+    info->link_value(value);
+    return info;
+}
+
+
+ArgumentParser::PositionalArg * repoquery_patterns(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto patterns_options = arg_parser.add_new_values();
+    auto keys = arg_parser.add_new_positional_arg(
+        "repoquery_patterns",
+        libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
+        arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_options);
+    keys->set_short_description("List of packages to search for");
+    return keys;
+}
+
+}  // namespace libdnf::cli::arguments

--- a/libdnf-cli/argument_parser_config/upgrade.cpp
+++ b/libdnf-cli/argument_parser_config/upgrade.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/argument_parser_config/argument_parser_config.hpp>
+
+namespace libdnf::cli::arguments {
+
+ArgumentParser::Command * upgrade(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto upgrade = arg_parser.add_new_command("upgrade");
+    upgrade->set_short_description("upgrade packages on the system");
+    upgrade->set_description("");
+    upgrade->set_named_args_help_header("Optional arguments:");
+    upgrade->set_positional_args_help_header("Positional arguments:");
+    upgrade->set_parse_hook_func([upgrade, &parser_config](
+                                     [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
+                                     [[maybe_unused]] const char * option,
+                                     [[maybe_unused]] int argc,
+                                     [[maybe_unused]] const char * const argv[]) {
+        parser_config.set_selected_command(upgrade);
+        return true;
+    });
+    return upgrade;
+}
+
+
+ArgumentParser::PositionalArg * upgrade_patterns(ArgumentParserConfig & parser_config) {
+    auto & arg_parser = parser_config.get_arg_parser();
+    auto patterns_options = arg_parser.add_new_values();
+    auto keys = arg_parser.add_new_positional_arg(
+        "upgrade_patterns",
+        libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
+        arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_options);
+    keys->set_short_description("List of packages to upgrade");
+    return keys;
+}
+
+}  // namespace libdnf::cli::arguments


### PR DESCRIPTION
Both microdnf and dnfdamon-client share a lot of similar code just to configure their command line parsers.
Let's have a shared library of those configurations usable for both tools.