### PR TITLE
dnfdaemon: Fix transaction table printing

### DIFF
--- a/dnfdaemon-client/wrappers/dbus_package_wrapper.hpp
+++ b/dnfdaemon-client/wrappers/dbus_package_wrapper.hpp
@@ -42,7 +42,7 @@ public:
     std::string get_repo_id() const { return rawdata.at("repo"); }
     std::string get_nevra() const { return rawdata.at("nevra"); }
     std::string get_full_nevra() const { return rawdata.at("full_nevra"); }
-    int get_size() const { return rawdata.at("size"); }
+    uint64_t get_size() const { return rawdata.at("size"); }
     std::string get_sourcerpm() const { return rawdata.at("sourcerpm"); }
     std::string get_summary() const { return rawdata.at("summary"); }
     std::string get_url() const { return rawdata.at("url"); }

--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -45,6 +45,7 @@ enum class PackageAttribute {
     release,
     arch,
     repo,
+    size,
 
     nevra,
     full_nevra
@@ -58,6 +59,7 @@ const static std::map<std::string, PackageAttribute> package_attributes{
     {"release", PackageAttribute::release},
     {"arch", PackageAttribute::arch},
     {"repo", PackageAttribute::repo},
+    {"size", PackageAttribute::size},
     {"nevra", PackageAttribute::nevra},
     {"full_nevra", PackageAttribute::full_nevra}};
 
@@ -89,6 +91,9 @@ dnfdaemon::KeyValueMap package_to_map(
                 break;
             case PackageAttribute::repo:
                 dbus_package.emplace(attr, libdnf_package.get_repo()->get_id());
+                break;
+            case PackageAttribute::size:
+                dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_size()));
                 break;
             case PackageAttribute::nevra:
                 dbus_package.emplace(attr, libdnf_package.get_nevra());
@@ -194,7 +199,7 @@ void packages_to_transaction(
     std::vector<dnfdaemon::DbusTransactionItem> & result,
     const libdnf::transaction::TransactionItemAction action,
     const std::vector<libdnf::rpm::Package> & packages) {
-    std::vector<std::string> attr{"name", "epoch", "version", "release", "arch", "repo", "size"};
+    std::vector<std::string> attr{"name", "epoch", "version", "release", "arch", "repo", "size", "full_nevra"};
     for (auto & p : packages) {
         result.push_back(dnfdaemon::DbusTransactionItem(static_cast<unsigned int>(action), package_to_map(p, attr)));
     }


### PR DESCRIPTION
- add "size" to available package attributes
- add "full_nevra" field to the results of resolve() method