### PR TITLE
[dnf5] Use WeakPtr instead of raw pointers and references in API

### DIFF
--- a/bindings/libdnf/base.i
+++ b/bindings/libdnf/base.i
@@ -17,10 +17,15 @@
 %import "transaction.i"
 
 %{
+    #include "libdnf/logger/memory_buffer_logger.hpp"
     #include "libdnf/base/base.hpp"
     #include "libdnf/base/goal.hpp"
 %}
 
 #define CV __perl_CV
+
+%template(LogRouterWeakPtr) libdnf::WeakPtr<libdnf::LogRouter, false>;
+%template(VarsWeakPtr) libdnf::WeakPtr<libdnf::Vars, false>;
+
 %include "libdnf/base/base.hpp"
 %include "libdnf/base/goal.hpp"

--- a/bindings/libdnf/common.i
+++ b/bindings/libdnf/common.i
@@ -18,12 +18,19 @@
 %include <std_string.i>
 %include <std_vector.i>
 
+%{
+    #include "libdnf/common/weak_ptr.hpp"
+%}
+%include "libdnf/common/weak_ptr.hpp"
+
 // Cant use %include <catch_error.i> here, SWIG includes each file only once,
 // but the exception handler actually doesnt get registered when this file is
 // %imported (as opposed to %included).
 %exception {
     try {
         $action
+    } catch (const libdnf::InvalidPointer & e) {
+        SWIG_exception(SWIG_NullReferenceError, e.what());
     } catch (const std::out_of_range & e) {
         SWIG_exception(SWIG_IndexError, e.what());
     } catch (const std::exception & e) {
@@ -117,7 +124,6 @@ del ClassName##__iter__
     #include "libdnf/common/sack/match_int64.hpp"
     #include "libdnf/common/sack/match_string.hpp"
     #include "libdnf/common/set.hpp"
-    #include "libdnf/common/weak_ptr.hpp"
 %}
 
 %ignore libdnf::Set::Set;
@@ -129,7 +135,6 @@ del ClassName##__iter__
 %include "libdnf/common/sack/match_int64.hpp"
 %include "libdnf/common/sack/match_string.hpp"
 %include "libdnf/common/set.hpp"
-%include "libdnf/common/weak_ptr.hpp"
 
 %{
     #include "libdnf/common/preserve_order_map.hpp"

--- a/bindings/libdnf/conf.i
+++ b/bindings/libdnf/conf.i
@@ -6,9 +6,20 @@
 %module "libdnf/conf"
 #endif
 
+%include <exception.i>
 %include <std_vector.i>
 
 %import "common.i"
+
+%exception {
+    try {
+        $action
+    } catch (const libdnf::InvalidPointer & e) {
+        SWIG_exception(SWIG_NullReferenceError, e.what());
+    } catch (const libdnf::RuntimeError & e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+}
 
 %{
     #include "libdnf/conf/option_child.hpp"

--- a/bindings/libdnf/rpm.i
+++ b/bindings/libdnf/rpm.i
@@ -13,7 +13,20 @@
 %import "common.i"
 %import "conf.i"
 
+%exception {
+    try {
+        $action
+    } catch (const libdnf::InvalidPointer & e) {
+        SWIG_exception(SWIG_NullReferenceError, e.what());
+    } catch (const libdnf::RuntimeError & e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+}
+
 %{
+
+    #include "libdnf/advisory/advisory_module.hpp"
+    #include "libdnf/advisory/advisory_query.hpp"
     #include "libdnf/rpm/checksum.hpp"
     #include "libdnf/conf/config_main.hpp"
     #include "libdnf/rpm/config_repo.hpp"
@@ -39,6 +52,14 @@
 %template(VectorNevra) std::vector<libdnf::rpm::Nevra>;
 
 %include "libdnf/rpm/solv_sack.hpp"
+%template(SolvSackWeakPtr) libdnf::WeakPtr<libdnf::rpm::SolvSack, false>;
+
+
+%ignore libdnf::advisory::AdvisorySack::new_query();
+%include "libdnf/advisory/advisory_sack.hpp"
+%template(AdvisorySackWeakPtr) libdnf::WeakPtr<libdnf::advisory::AdvisorySack, false>;
+
+
 %include "libdnf/rpm/reldep.hpp"
 
 %rename(next) libdnf::rpm::ReldepListIterator::operator++();
@@ -65,6 +86,7 @@
 %include "libdnf/rpm/repo_query.hpp"
 %template(SackRepoRepoQuery) libdnf::sack::Sack<libdnf::rpm::Repo, libdnf::rpm::RepoQuery>;
 %include "libdnf/rpm/repo_sack.hpp"
+%template(RepoSackWeakPtr) libdnf::WeakPtr<libdnf::rpm::RepoSack, false>;
 
 add_iterator(PackageSet)
 add_iterator(ReldepList)

--- a/bindings/libdnf/transaction.i
+++ b/bindings/libdnf/transaction.i
@@ -48,6 +48,7 @@
 // sack and query
 %include "libdnf/transaction/query.hpp"
 %include "libdnf/transaction/sack.hpp"
+%template(TransactionSackWeakPtr) libdnf::WeakPtr<libdnf::transaction::TransactionSack, false>;
 
 // transaction
 %include "libdnf/transaction/transaction.hpp"

--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -114,9 +114,9 @@ dnfdaemon::KeyValueMap repo_to_map(
                 dbus_repo.emplace(attr, libdnf_repo->is_enabled());
                 break;
             case RepoAttribute::size: {
-                auto & solv_sack = base.get_rpm_solv_sack();
+                auto solv_sack = base.get_rpm_solv_sack();
                 uint64_t size = 0;
-                libdnf::rpm::SolvQuery query(&solv_sack);
+                libdnf::rpm::SolvQuery query(solv_sack);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
                 query.ifilter_repoid(reponames);
                 for (auto pkg : query) {
@@ -143,15 +143,15 @@ dnfdaemon::KeyValueMap repo_to_map(
                 dbus_repo.emplace(attr, libdnf_repo->get_max_timestamp());
                 break;
             case RepoAttribute::pkgs: {
-                auto & solv_sack = base.get_rpm_solv_sack();
-                libdnf::rpm::SolvQuery query(&solv_sack, libdnf::rpm::SolvQuery::InitFlags::IGNORE_EXCLUDES);
+                auto solv_sack = base.get_rpm_solv_sack();
+                libdnf::rpm::SolvQuery query(solv_sack, libdnf::rpm::SolvQuery::InitFlags::IGNORE_EXCLUDES);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
                 query.ifilter_repoid(reponames);
                 dbus_repo.emplace(attr, query.size());
             } break;
             case RepoAttribute::available_pkgs: {
-                auto & solv_sack = base.get_rpm_solv_sack();
-                libdnf::rpm::SolvQuery query(&solv_sack);
+                auto solv_sack = base.get_rpm_solv_sack();
+                libdnf::rpm::SolvQuery query(solv_sack);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
                 query.ifilter_repoid(reponames);
                 dbus_repo.emplace(attr, query.size());
@@ -239,8 +239,8 @@ sdbus::MethodReply Repo::list(sdbus::MethodCall && call) {
 
     // prepare repository query filtered by options
     auto base = session.get_base();
-    auto & rpm_repo_sack = base->get_rpm_repo_sack();
-    auto repos_query = rpm_repo_sack.new_query();
+    auto rpm_repo_sack = base->get_rpm_repo_sack();
+    auto repos_query = rpm_repo_sack->new_query();
 
     if (enable_disable == "enabled") {
         repos_query.ifilter_enabled(true);

--- a/dnfdaemon-server/services/repoconf/configuration.cpp
+++ b/dnfdaemon-server/services/repoconf/configuration.cpp
@@ -34,7 +34,7 @@ void Configuration::read_configuration() {
 }
 
 void Configuration::read_main_config() {
-    auto & logger = session.get_base()->get_logger();
+    auto & logger = *session.get_base()->get_logger();
     auto base = session.get_base();
     auto & cfg_main = base->get_config();
     auto main_config_path = cfg_main.config_file_path().get_value();
@@ -44,9 +44,9 @@ void Configuration::read_main_config() {
         std::unique_ptr<libdnf::ConfigParser> main_parser(new libdnf::ConfigParser);
 
         main_parser->read(main_config_path);
-        cfg_main.load_from_parser(*main_parser, "main", base->get_vars(), base->get_logger());
+        cfg_main.load_from_parser(*main_parser, "main", *base->get_vars(), *base->get_logger());
 
-        base->get_vars().load(cfg_main.installroot().get_value(), cfg_main.varsdir().get_value());
+        base->get_vars()->load(cfg_main.installroot().get_value(), cfg_main.varsdir().get_value());
 
         // read repos possibly configured in the main config file
         read_repos(main_parser.get(), main_config_path);
@@ -67,7 +67,8 @@ void Configuration::read_repos(const libdnf::ConfigParser * repo_parser, const s
             auto section = cfg_parser_data_iter.first;
             std::unique_ptr<libdnf::rpm::ConfigRepo> cfg_repo(new libdnf::rpm::ConfigRepo(cfg_main));
 
-            cfg_repo->load_from_parser(*repo_parser, section, base->get_vars(), base->get_logger());
+            cfg_repo->load_from_parser(*repo_parser, section, *base->get_vars(), *base->get_logger());
+
             // save configured repo
             std::unique_ptr<RepoInfo> repoinfo(new RepoInfo());
             repoinfo->file_path = std::string(file_path);
@@ -79,7 +80,7 @@ void Configuration::read_repos(const libdnf::ConfigParser * repo_parser, const s
 
 void Configuration::read_repo_configs() {
     auto base = session.get_base();
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     auto & cfg_main = base->get_config();
     for (const auto & repos_dir : cfg_main.reposdir().get_value()) {
         // use canonical to resolve symlinks in repos_dir

--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -144,7 +144,7 @@ sdbus::MethodReply Rpm::list(sdbus::MethodCall && call) {
     call >> options;
 
     session.fill_sack();
-    auto & solv_sack = session.get_base()->get_rpm_solv_sack();
+    auto solv_sack = session.get_base()->get_rpm_solv_sack();
 
     // patterns to search
     std::vector<std::string> default_patterns{};
@@ -157,8 +157,8 @@ sdbus::MethodReply Rpm::list(sdbus::MethodCall && call) {
     bool with_filenames = key_value_map_get<bool>(options, "with_filenames", true);
     bool with_src = key_value_map_get<bool>(options, "with_src", true);
 
-    libdnf::rpm::PackageSet result_pset(&solv_sack);
-    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    libdnf::rpm::PackageSet result_pset(solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(solv_sack);
     if (patterns.size() > 0) {
         for (auto & pattern : patterns) {
             libdnf::rpm::SolvQuery solv_query(full_solv_query);
@@ -227,15 +227,15 @@ sdbus::MethodReply Rpm::resolve(sdbus::MethodCall && call) {
 }
 
 libdnf::transaction::TransactionWeakPtr new_db_transaction(libdnf::Base * base, const std::string & comment) {
-    auto & transaction_sack = base->get_transaction_sack();
-    auto transaction = transaction_sack.new_transaction();
+    auto transaction_sack = base->get_transaction_sack();
+    auto transaction = transaction_sack->new_transaction();
     // TODO(mblaha): user id
     //transaction->set_user_id(get_login_uid());
     if (!comment.empty()) {
         transaction->set_comment(comment);
     }
     // TODO(jrohel): What if the "releasever" variable is not set?
-    transaction->set_releasever(base->get_vars().get_value("releasever"));
+    transaction->set_releasever(base->get_vars()->get_value("releasever"));
 
     // TODO (mblaha): command line for the transaction?
     //transaction->set_cmdline(cmd_line);

--- a/dnfdaemon-server/session.hpp
+++ b/dnfdaemon-server/session.hpp
@@ -90,7 +90,7 @@ public:
                     try {
                         reply.send();
                     } catch (const std::exception & e) {
-                        auto & logger = base->get_logger();
+                        auto & logger = *base->get_logger();
                         logger.error(fmt::format("Error sending d-bus error reply: {}", e.what()));
                     }
                 }

--- a/include/libdnf/advisory/advisory.hpp
+++ b/include/libdnf/advisory/advisory.hpp
@@ -97,10 +97,10 @@ class Advisory {
 public:
     /// Construct the Advisory object
     ///
-    /// @param sack   Reference to libdnf::rpm::SolvSack instance which holds are the data.
+    /// @param sack   WeakPtr to libdnf::rpm::SolvSack instance which holds the data.
     /// @param id     AdvisoryId into libsolv pool.
     /// @return New Advisory instance.
-    Advisory(libdnf::rpm::SolvSack & sack, AdvisoryId id);
+    Advisory(const libdnf::rpm::SolvSackWeakPtr & sack, AdvisoryId id);
 
     /// Destroy the Advisory object
     ~Advisory();

--- a/include/libdnf/advisory/advisory_collection.hpp
+++ b/include/libdnf/advisory/advisory_collection.hpp
@@ -66,7 +66,7 @@ private:
     friend AdvisoryPackage;
     friend AdvisoryModule;
 
-    AdvisoryCollection(libdnf::rpm::SolvSack & sack, AdvisoryId advisory, int index);
+    AdvisoryCollection(const libdnf::rpm::SolvSackWeakPtr & sack, AdvisoryId advisory, int index);
 
     //TODO(amatej): Hide into an Impl?
     /// Get all AdvisoryPackages stored in this AdvisoryCollection

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -30,9 +30,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::advisory {
 
+using AdvisorySackWeakPtr = WeakPtr<AdvisorySack, false>;
+
 class AdvisoryQuery {
 public:
-    explicit AdvisoryQuery(AdvisorySack * sack);
+    explicit AdvisoryQuery(const AdvisorySackWeakPtr & sack);
     AdvisoryQuery(const AdvisoryQuery & src);
     AdvisoryQuery(AdvisoryQuery && src);
     ~AdvisoryQuery();
@@ -93,7 +95,7 @@ public:
     std::vector<AdvisoryPackage> get_sorted_advisory_packages(bool only_applicable = false) const;
 
 private:
-    AdvisorySack * advisory_sack;
+    AdvisorySackWeakPtr advisory_sack;
 
     class Impl;
     std::unique_ptr<Impl> p_impl;

--- a/include/libdnf/advisory/advisory_reference.hpp
+++ b/include/libdnf/advisory/advisory_reference.hpp
@@ -63,7 +63,7 @@ private:
     /// @param advisory AdvisoryId into libsolv pool.
     /// @param index    Index of this reference in its advisory.
     /// @return New AdvisoryReference instance.
-    AdvisoryReference(libdnf::rpm::SolvSack & sack, AdvisoryId advisory, int index);
+    AdvisoryReference(const libdnf::rpm::SolvSackWeakPtr & sack, AdvisoryId advisory, int index);
 
     libdnf::rpm::SolvSackWeakPtr sack;
     AdvisoryId advisory;

--- a/include/libdnf/advisory/advisory_sack.hpp
+++ b/include/libdnf/advisory/advisory_sack.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "advisory_query.hpp"
 
+#include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/rpm/solv/solv_map.hpp"
 
 namespace libdnf {
@@ -29,6 +30,10 @@ class Base;
 }
 
 namespace libdnf::advisory {
+
+//class AsdvisorySack;
+
+using AdvisorySackWeakPtr = WeakPtr<AdvisorySack, false>;
 
 class AdvisorySack {
 public:
@@ -40,8 +45,12 @@ public:
     /// @return new AdvisoryQuery.
     AdvisoryQuery new_query();
 
+    AdvisorySackWeakPtr get_weak_ptr();
+
 private:
     friend AdvisoryQuery;
+
+    WeakPtrGuard<AdvisorySack, false> data_guard;
 
     /// Load all advisories present in SolvSack from base. This method is
     /// called automatically when creating a new query and the cached number
@@ -54,6 +63,8 @@ private:
 
     libdnf::Base * base;
 };
+
+inline AdvisorySackWeakPtr AdvisorySack::get_weak_ptr() { return AdvisorySackWeakPtr(this, &data_guard); }
 
 }  // namespace libdnf::advisory
 

--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -86,6 +86,13 @@ private:
     mutable std::string description;
 };
 
+class InvalidPointer : public Exception {
+public:
+    using Exception::Exception;
+    const char * get_name() const noexcept override { return "InvalidPointer"; }
+    const char * get_description() const noexcept override { return "Invalid pointer"; }
+};
+
 /// Formats the explanatory string of an exception.
 /// If the exception is nested, recurses to format the explanatory of the exception it holds.
 std::string format(const std::exception & e, std::size_t level = 0);

--- a/include/libdnf/common/weak_ptr.hpp
+++ b/include/libdnf/common/weak_ptr.hpp
@@ -96,12 +96,11 @@ public:
         const char * get_description() const noexcept override { return "Invalid pointer"; }
     };
 
+    WeakPtr() : ptr(nullptr), guard(nullptr) { }
+
     WeakPtr(TPtr * ptr, TWeakPtrGuard * guard) : ptr(ptr), guard(guard) {
-        if (!ptr) {
-            throw InvalidPtr("Creating null WeakPtr is not allowed");
-        }
-        if (!guard) {
-            throw InvalidPtr("Creating WeakPtr without guard is not allowed");
+        if (ptr && !guard) {
+            throw InvalidPtr("Creating a non-null WeakPtr without a guard is not allowed");
         }
         guard->register_ptr(this);
     }

--- a/include/libdnf/common/weak_ptr.hpp
+++ b/include/libdnf/common/weak_ptr.hpp
@@ -88,9 +88,9 @@ public:
     using TWeakPtrGuard = WeakPtrGuard<TPtr, ptr_owner>;
 
     /// Exception generated when the managed object is not valid.
-    class InvalidPtr : public RuntimeError {
+    class InvalidPtr : public InvalidPointer {
     public:
-        using RuntimeError::RuntimeError;
+        using InvalidPointer::InvalidPointer;
         const char * get_domain_name() const noexcept override { return "libdnf::WeakPtr"; }
         const char * get_name() const noexcept override { return "InvalidPtr"; }
         const char * get_description() const noexcept override { return "Invalid pointer"; }

--- a/include/libdnf/comps/comps.hpp
+++ b/include/libdnf/comps/comps.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_COMPS_COMPS_HPP
 #define LIBDNF_COMPS_COMPS_HPP
 
+#include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/comps/group/sack.hpp"
 
 #include <memory>
@@ -33,6 +34,7 @@ class Base;
 
 namespace libdnf::comps {
 
+using CompsWeakPtr = libdnf::WeakPtr<Comps, false>;
 
 class Comps {
 public:
@@ -43,6 +45,8 @@ public:
     // Load comps from given file into the pool
     void load_from_file(const std::string & path, const char * reponame);
     GroupSack & get_group_sack() { return group_sack; }
+
+    CompsWeakPtr get_weak_ptr();
 
 private:
     libdnf::Base & base;

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -278,7 +278,7 @@ public:
 
 protected:
     /// @replaces libdnf:libdnf/dnf-package.h:function:dnf_package_new(DnfSack *sack, Id id)
-    Package(SolvSack * sack, PackageId id);
+    Package(const SolvSackWeakPtr & sack, PackageId id);
     const char * get_name_cstring() const;
 
     /// @return const char* !! Return temporal values !!
@@ -302,7 +302,7 @@ private:
     PackageId id;
 };
 
-inline Package::Package(SolvSack * sack, PackageId id) : sack(sack->get_weak_ptr()), id(id) {}
+inline Package::Package(const SolvSackWeakPtr & sack, PackageId id) : sack(sack), id(id) {}
 
 inline bool Package::operator==(const Package & other) const noexcept {
     return id == other.id && sack == other.sack;

--- a/include/libdnf/rpm/package_set.hpp
+++ b/include/libdnf/rpm/package_set.hpp
@@ -53,7 +53,7 @@ public:
     };
 
     /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_new(DnfSack * sack)
-    explicit PackageSet(SolvSack * sack);
+    explicit PackageSet(const SolvSackWeakPtr & sack);
 
     /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_clone(DnfPackageSet * pset)
     PackageSet(const PackageSet & pset);
@@ -95,7 +95,7 @@ public:
     void remove(const Package & pkg);
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.getSack()
-    SolvSack * get_sack() const;
+    SolvSackWeakPtr get_sack() const;
 
     /// @replaces libdnf:sack/packageset.hpp:method:PackageSet.size()
     /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_count(DnfPackageSet * pset)
@@ -109,7 +109,7 @@ private:
     friend Transaction;
     friend libdnf::Goal;
     friend libdnf::Swdb;
-    PackageSet(SolvSack * sack, libdnf::rpm::solv::SolvMap & solv_map);
+    PackageSet(const SolvSackWeakPtr & sack, libdnf::rpm::solv::SolvMap & solv_map);
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/include/libdnf/rpm/reldep.hpp
+++ b/include/libdnf/rpm/reldep.hpp
@@ -45,7 +45,7 @@ public:
     /// @param sack p_sack:...
     /// @param dependency p_dependency:...
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(Sack * sack, const std::string & dependency)
-    Reldep(SolvSack * sack, const std::string & reldep_string);
+    Reldep(const SolvSackWeakPtr & sack, const std::string & reldep_string);
 
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:Dependency(const Dependency & dependency);
     Reldep(const Reldep & reldep) = default;

--- a/include/libdnf/rpm/reldep_list.hpp
+++ b/include/libdnf/rpm/reldep_list.hpp
@@ -44,7 +44,7 @@ public:
 
     /// @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_new(DnfSack *sack)
     /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:DependencyContainer(DnfSack *sack)
-    explicit ReldepList(SolvSack * sack);
+    explicit ReldepList(const SolvSackWeakPtr & sack);
 
     /// @replaces libdnf/dnf-reldep-list.h:function:dnf_reldep_list_free(DnfReldepList *reldep_list)
     /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:method:~DependencyContainer()

--- a/include/libdnf/rpm/repo_sack.hpp
+++ b/include/libdnf/rpm/repo_sack.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repo_query.hpp"
 
 #include "libdnf/common/sack/sack.hpp"
+#include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/logger/logger.hpp"
 
 namespace libdnf {
@@ -33,6 +34,10 @@ class Base;
 }  // namespace libdnf
 
 namespace libdnf::rpm {
+
+class RepoSack;
+
+using RepoSackWeakPtr = WeakPtr<RepoSack, false>;
 
 class RepoSack : public sack::Sack<Repo, RepoQuery> {
 public:
@@ -62,7 +67,11 @@ public:
     /// Create a new repository from a libsolv testcase file
     RepoWeakPtr new_repo_from_libsolv_testcase(const std::string & repoid, const std::string & path);
 
+    RepoSackWeakPtr get_weak_ptr();
+
 private:
+    WeakPtrGuard<RepoSack, false> data_guard;
+
     //TODO(jrohel): Make public?
     /// Creates new repositories according to the configuration in the files with ".repo" extension in the directory
     /// defined by dir_path.
@@ -72,6 +81,8 @@ private:
 
     Base * base;
 };
+
+inline RepoSackWeakPtr RepoSack::get_weak_ptr() { return RepoSackWeakPtr(this, &data_guard); }
 
 }  // namespace libdnf::rpm
 

--- a/include/libdnf/rpm/solv_query.hpp
+++ b/include/libdnf/rpm/solv_query.hpp
@@ -66,7 +66,7 @@ public:
     /// @replaces libdnf/hy-query.h:function:hy_query_create_flags(DnfSack *sack, int flags);
     /// @replaces libdnf/sack/query.hpp:method:Query(DnfSack* sack, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES)
     /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_free(DnfReldep *reldep)
-    explicit SolvQuery(SolvSack * sack, InitFlags flags = InitFlags::APPLY_EXCLUDES);
+    explicit SolvQuery(const SolvSackWeakPtr & sack, InitFlags flags = InitFlags::APPLY_EXCLUDES);
     SolvQuery(const SolvQuery & src) = default;
     SolvQuery(SolvQuery && src) noexcept = default;
     ~SolvQuery() = default;

--- a/include/libdnf/transaction/sack.hpp
+++ b/include/libdnf/transaction/sack.hpp
@@ -62,15 +62,20 @@ public:
 
     using libdnf::sack::Sack<Transaction, TransactionQuery>::get_data;
 
+    TransactionSackWeakPtr get_weak_ptr();
+
 private:
     friend class Transaction;
     friend class TransactionQuery;
     libdnf::Base & base;
 
+    WeakPtrGuard<TransactionSack, false> data_guard;
+
     // Lazy adding new items to the sack needs to be thread-safe to avoid adding duplicates.
     std::mutex mtx;
 };
 
+inline TransactionSackWeakPtr TransactionSack::get_weak_ptr() { return TransactionSackWeakPtr(this, &data_guard); }
 
 }  // namespace libdnf::transaction
 

--- a/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -239,7 +239,7 @@ void PythonPluginLoader::load_plugin_file(const fs::path & file_path) {
 
 
 void PythonPluginLoader::load_plugins_from_dir(const fs::path & dir_path) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
 
     if (dir_path.empty())
         throw std::runtime_error("PythonPluginLoader::load_from_dir() dir_path cannot be empty");

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -185,6 +185,7 @@ BuildRequires:  swig >= %{swig_version}
 %if %{with tests}
 BuildRequires:  perl(strict)
 BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Test::Exception)
 BuildRequires:  perl(warnings)
 %endif
 
@@ -212,6 +213,7 @@ BuildRequires:  swig >= %{swig_version}
 %if %{with tests}
 BuildRequires:  perl(strict)
 BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Test::Exception)
 BuildRequires:  perl(warnings)
 %endif
 

--- a/libdnf/advisory/advisory.cpp
+++ b/libdnf/advisory/advisory.cpp
@@ -30,7 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::advisory {
 
-Advisory::Advisory(libdnf::rpm::SolvSack & sack, AdvisoryId id) : id(id), sack(sack.get_weak_ptr()) {}
+Advisory::Advisory(const libdnf::rpm::SolvSackWeakPtr & sack, AdvisoryId id) : id(id), sack(sack) {}
 
 std::string Advisory::get_name() const {
     const char * name;
@@ -128,7 +128,7 @@ std::vector<AdvisoryReference> Advisory::get_references(AdvisoryReferenceType re
              (strcmp(current_type, "bugzilla") == 0)) ||
             ((ref_type & AdvisoryReferenceType::VENDOR) == AdvisoryReferenceType::VENDOR &&
              (strcmp(current_type, "vendor") == 0))) {
-            output.emplace_back(AdvisoryReference(*sack, id, index));
+            output.emplace_back(AdvisoryReference(sack, id, index));
         }
     }
 
@@ -146,7 +146,7 @@ std::vector<AdvisoryCollection> Advisory::get_collections() const {
 
     for (int index = 0; dataiterator_step(&di); index++) {
         dataiterator_setpos(&di);
-        output.emplace_back(AdvisoryCollection(*sack, id, index));
+        output.emplace_back(AdvisoryCollection(sack, id, index));
     }
 
     dataiterator_free(&di);

--- a/libdnf/advisory/advisory_collection.cpp
+++ b/libdnf/advisory/advisory_collection.cpp
@@ -26,8 +26,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::advisory {
 
-AdvisoryCollection::AdvisoryCollection(libdnf::rpm::SolvSack & sack, AdvisoryId advisory, int index)
-    : sack(sack.get_weak_ptr())
+AdvisoryCollection::AdvisoryCollection(const libdnf::rpm::SolvSackWeakPtr & sack, AdvisoryId advisory, int index)
+    : sack(sack)
     , advisory(advisory)
     , index(index) {}
 
@@ -113,7 +113,7 @@ AdvisoryId AdvisoryCollection::get_advisory_id() const {
 }
 
 Advisory AdvisoryCollection::get_advisory() const {
-    return Advisory(*sack, advisory);
+    return Advisory(sack, advisory);
 }
 
 }  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_module.cpp
+++ b/libdnf/advisory/advisory_module.cpp
@@ -69,10 +69,10 @@ AdvisoryId AdvisoryModule::get_advisory_id() const {
     return p_impl->advisory;
 }
 Advisory AdvisoryModule::get_advisory() const {
-    return Advisory(*(p_impl->sack), p_impl->advisory);
+    return Advisory(p_impl->sack, p_impl->advisory);
 }
 AdvisoryCollection AdvisoryModule::get_advisory_collection() const {
-    return AdvisoryCollection(*(p_impl->sack), p_impl->advisory, p_impl->owner_collection_index);
+    return AdvisoryCollection(p_impl->sack, p_impl->advisory, p_impl->owner_collection_index);
 }
 
 // AdvisoryModule::Impl

--- a/libdnf/advisory/advisory_package.cpp
+++ b/libdnf/advisory/advisory_package.cpp
@@ -69,10 +69,10 @@ AdvisoryId AdvisoryPackage::get_advisory_id() const {
     return p_impl->get_advisory_id();
 }
 Advisory AdvisoryPackage::get_advisory() const {
-    return Advisory(*(p_impl->sack), p_impl->get_advisory_id());
+    return Advisory(p_impl->sack, p_impl->get_advisory_id());
 }
 AdvisoryCollection AdvisoryPackage::get_advisory_collection() const {
-    return AdvisoryCollection(*(p_impl->sack), p_impl->get_advisory_id(), p_impl->owner_collection_index);
+    return AdvisoryCollection(p_impl->sack, p_impl->get_advisory_id(), p_impl->owner_collection_index);
 }
 
 // AdvisoryPackage::Impl

--- a/libdnf/advisory/advisory_package_private.hpp
+++ b/libdnf/advisory/advisory_package_private.hpp
@@ -57,7 +57,7 @@ public:
     /// @param first        First AdvisoryPackage to compare.
     /// @param second       Secondf AdvisoryPackage to compare.
     /// @return True if first AdvisoryPackage has smaller NEVRA, False otherwise.
-    inline static bool nevra_compare_lower_id(const AdvisoryPackage & first, const AdvisoryPackage & second) {
+    static bool nevra_compare_lower_id(const AdvisoryPackage & first, const AdvisoryPackage & second) {
         if (first.p_impl->name != second.p_impl->name)
             return first.p_impl->name < second.p_impl->name;
         if (first.p_impl->arch != second.p_impl->arch)
@@ -71,7 +71,7 @@ public:
     /// @param adv_pkg      AdvisoryPackage to compare.
     /// @param pkg          libdnf::rpm::Package to compare.
     /// @return True if AdvisoryPackage has smaller name or architecture than libdnf::rpm::package, False otherwise.
-    inline static bool name_arch_compare_lower_id(const AdvisoryPackage & adv_pkg, const rpm::Package & pkg) {
+    static bool name_arch_compare_lower_id(const AdvisoryPackage & adv_pkg, const rpm::Package & pkg) {
         Pool * pool = adv_pkg.p_impl->sack->p_impl->get_pool();
         Solvable * s = libdnf::rpm::solv::get_solvable(pool, pkg.get_id().id);
 
@@ -86,7 +86,7 @@ public:
     /// @param solvable     Solvable to compare
     /// @param adv_pkg      AdvisoryPackage::Impl to compare.
     /// @return True if Solvable has smaller name or architecture than AdvisoryPackage::Impl, False otherwise.
-    inline static bool name_arch_compare_lower_solvable(const Solvable * solvable, const AdvisoryPackage::Impl & adv_pkg) {
+    static bool name_arch_compare_lower_solvable(const Solvable * solvable, const AdvisoryPackage::Impl & adv_pkg) {
         if (solvable->name != adv_pkg.name) {
             return solvable->name < adv_pkg.name;
         }
@@ -99,7 +99,7 @@ public:
     /// @param solvable     Solvable to compare
     /// @param adv_pkg      AdvisoryPackage::Impl to compare.
     /// @return True if Solvable has smaller nevra than AdvisoryPackage::Impl, False otherwise.
-    inline static bool nevra_compare_lower_solvable(const Solvable * solvable, const AdvisoryPackage::Impl & adv_pkg) {
+    static bool nevra_compare_lower_solvable(const Solvable * solvable, const AdvisoryPackage::Impl & adv_pkg) {
         if (solvable->name != adv_pkg.name) {
             return solvable->name < adv_pkg.name;
         }
@@ -113,7 +113,7 @@ private:
     friend class AdvisoryCollection;
     friend AdvisoryPackage;
 
-    explicit Impl(
+    Impl(
         libdnf::rpm::SolvSack & sack,
         AdvisoryId advisory,
         int owner_collection_index,

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -33,7 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::advisory {
 
-AdvisoryQuery::AdvisoryQuery(AdvisorySack * sack) : advisory_sack(sack), p_impl{new Impl(sack->data_map)} {};
+AdvisoryQuery::AdvisoryQuery(const AdvisorySackWeakPtr & sack) : advisory_sack(sack), p_impl{new Impl(sack->data_map)} {};
 
 AdvisoryQuery::~AdvisoryQuery() = default;
 AdvisoryQuery::AdvisoryQuery(const AdvisoryQuery & src)
@@ -62,7 +62,7 @@ AdvisoryQuery & AdvisoryQuery::ifilter_name(const std::string & pattern, sack::Q
 }
 
 AdvisoryQuery & AdvisoryQuery::ifilter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    auto & solv_sack = *advisory_sack->base->get_rpm_solv_sack();
     Pool * pool = solv_sack.p_impl->get_pool();
     libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
 
@@ -138,7 +138,7 @@ AdvisoryQuery & AdvisoryQuery::ifilter_type(const Advisory::Type type, sack::Que
 
 //TODO(amatej): Add a wrapper that accepts vector of string types, eg: "security", "bugfix" not enums
 AdvisoryQuery & AdvisoryQuery::ifilter_type(const std::vector<AdvisoryType> & types, sack::QueryCmp cmp_type) {
-    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    auto & solv_sack = *advisory_sack->base->get_rpm_solv_sack();
     Pool * pool = solv_sack.p_impl->get_pool();
     libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
 
@@ -185,8 +185,8 @@ AdvisoryQuery & AdvisoryQuery::ifilter_type(const std::vector<AdvisoryType> & ty
 
 AdvisoryQuery & AdvisoryQuery::ifilter_reference(
     const std::vector<std::string> & reference_id, std::vector<AdvisoryReferenceType> types, sack::QueryCmp cmp_type) {
-    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
-    libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
+    auto solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    libdnf::rpm::solv::SolvMap filter_result(solv_sack->p_impl->get_nsolvables());
 
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
@@ -272,7 +272,7 @@ AdvisoryQuery & AdvisoryQuery::ifilter_severity(const std::string & pattern, sac
     return *this;
 }
 AdvisoryQuery & AdvisoryQuery::ifilter_severity(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    auto & solv_sack = *advisory_sack->base->get_rpm_solv_sack();
     Pool * pool = solv_sack.p_impl->get_pool();
     libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
 
@@ -310,7 +310,7 @@ AdvisoryQuery & AdvisoryQuery::ifilter_severity(const std::vector<std::string> &
 
 //TODO(amatej): this might not be needed and could be possibly removed
 AdvisoryQuery & AdvisoryQuery::ifilter_packages(const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
-    auto & solv_sack = advisory_sack->base->get_rpm_solv_sack();
+    auto & solv_sack = *advisory_sack->base->get_rpm_solv_sack();
     Pool * pool = solv_sack.p_impl->get_pool();
     libdnf::rpm::solv::SolvMap filter_result(solv_sack.p_impl->get_nsolvables());
     std::vector<AdvisoryPackage> adv_pkgs = get_sorted_advisory_packages();

--- a/libdnf/advisory/advisory_reference.cpp
+++ b/libdnf/advisory/advisory_reference.cpp
@@ -46,8 +46,8 @@ inline const char * get_str_from_pool(Id keyname, Id advisory, Pool * pool, int 
     return str;
 }
 
-AdvisoryReference::AdvisoryReference(libdnf::rpm::SolvSack & sack, AdvisoryId advisory, int index)
-    : sack(sack.get_weak_ptr())
+AdvisoryReference::AdvisoryReference(const libdnf::rpm::SolvSackWeakPtr & sack, AdvisoryId advisory, int index)
+    : sack(sack)
     , advisory(advisory)
     , index(index) {}
 

--- a/libdnf/advisory/advisory_sack.cpp
+++ b/libdnf/advisory/advisory_sack.cpp
@@ -30,18 +30,18 @@ AdvisorySack::AdvisorySack(libdnf::Base & base) : data_map(0), base(&base) {}
 AdvisorySack::~AdvisorySack() = default;
 
 AdvisoryQuery AdvisorySack::new_query() {
-    auto & solv_sack = base->get_rpm_solv_sack();
+    auto solv_sack = base->get_rpm_solv_sack();
 
-    if (cached_solvables_size != solv_sack.p_impl->get_nsolvables()) {
+    if (cached_solvables_size != solv_sack->p_impl->get_nsolvables()) {
         load_advisories_from_solvsack();
     }
 
-    return AdvisoryQuery(this);
+    return AdvisoryQuery(this->get_weak_ptr());
 };
 
 void AdvisorySack::load_advisories_from_solvsack() {
-    auto & solv_sack = base->get_rpm_solv_sack();
-    Pool * pool = solv_sack.p_impl->get_pool();
+    auto solv_sack = base->get_rpm_solv_sack();
+    Pool * pool = solv_sack->p_impl->get_pool();
 
     data_map = libdnf::rpm::solv::SolvMap(pool->nsolvables);
 

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -59,7 +59,7 @@ Base * Base::get_locked_base() noexcept {
 void Base::load_config_from_file(const std::string & path) {
     ConfigParser parser;
     parser.read(path);
-    config.load_from_parser(parser, "main", vars, get_logger());
+    config.load_from_parser(parser, "main", vars, *get_logger());
 }
 
 void Base::load_config_from_file() {

--- a/libdnf/comps/comps.cpp
+++ b/libdnf/comps/comps.cpp
@@ -70,6 +70,7 @@ void Comps::load_from_file(const std::string & path, const char * reponame) {
     fclose(xml_doc);
 }
 
+CompsWeakPtr Comps::get_weak_ptr() { return CompsWeakPtr(this, &p_impl->data_guard); }
 
 }  // namespace libdnf::comps
 

--- a/libdnf/comps/comps_impl.hpp
+++ b/libdnf/comps/comps_impl.hpp
@@ -39,6 +39,9 @@ public:
     Pool * get_pool() { return pool; }
 
 private:
+    friend class Comps;
+
+    WeakPtrGuard<Comps, false> data_guard;
     Pool * pool;
 };
 

--- a/libdnf/plugin/plugins.cpp
+++ b/libdnf/plugin/plugins.cpp
@@ -51,7 +51,7 @@ Plugins::~Plugins() {
 }
 
 void Plugins::register_plugin(std::unique_ptr<Plugin> && plugin) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     auto * iplugin = plugin->get_iplugin();
     plugins.emplace_back(std::move(plugin));
     auto name = iplugin->get_name();
@@ -65,7 +65,7 @@ void Plugins::register_plugin(std::unique_ptr<Plugin> && plugin) {
 }
 
 void Plugins::load_plugin(const std::string & file_path) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     logger.debug(fmt::format(_("Loading plugin file=\"{}\""), file_path));
     auto plugin = std::make_unique<PluginLibrary>(file_path);
     auto * iplugin = plugin->get_iplugin();
@@ -81,7 +81,7 @@ void Plugins::load_plugin(const std::string & file_path) {
 }
 
 void Plugins::load_plugins(const std::string & dir_path) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     if (dir_path.empty())
         throw std::runtime_error(_("Plugins::loadPlugins() dirPath cannot be empty"));
 

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -175,77 +175,77 @@ std::vector<std::string> Package::get_files() const {
 
 ReldepList Package::get_provides() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_provides(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_requires() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_requires(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_requires_pre() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_requires_pre(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_conflicts() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_conflicts(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_obsoletes() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_obsoletes(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_recommends() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_recommends(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_suggests() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_suggests(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_enhances() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_enhances(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_supplements() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_supplements(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_prereq_ignoreinst() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_prereq_ignoreinst(pool, id.id, list.p_impl->queue);
     return list;
 }
 
 ReldepList Package::get_regular_requires() const {
     Pool * pool = sack->p_impl->pool;
-    ReldepList list(sack.get());
+    ReldepList list(sack);
     solv::get_regular_requires(pool, id.id, list.p_impl->queue);
     return list;
 }

--- a/libdnf/rpm/package_set.cpp
+++ b/libdnf/rpm/package_set.cpp
@@ -30,8 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::rpm {
 
 
-PackageSet::PackageSet(SolvSack * sack) : p_impl(new Impl(sack)) {}
-
+PackageSet::PackageSet(const SolvSackWeakPtr & sack) : p_impl(new Impl(sack)) {}
 
 PackageSet::PackageSet(const PackageSet & other) : p_impl(new Impl(*other.p_impl)) {}
 
@@ -39,7 +38,7 @@ PackageSet::PackageSet(const PackageSet & other) : p_impl(new Impl(*other.p_impl
 PackageSet::PackageSet(PackageSet && other) noexcept : p_impl(new Impl(std::move(*other.p_impl))) {}
 
 
-PackageSet::PackageSet(SolvSack * sack, libdnf::rpm::solv::SolvMap & solv_map) : p_impl(new Impl(sack, solv_map)) {}
+PackageSet::PackageSet(const SolvSackWeakPtr & sack, libdnf::rpm::solv::SolvMap & solv_map) : p_impl(new Impl(sack, solv_map)) {}
 
 
 PackageSet::~PackageSet() = default;
@@ -133,7 +132,7 @@ void PackageSet::remove(const Package & pkg) {
 }
 
 
-SolvSack * PackageSet::get_sack() const {
+SolvSackWeakPtr PackageSet::get_sack() const {
     return p_impl->get_sack();
 }
 

--- a/libdnf/rpm/package_set_impl.hpp
+++ b/libdnf/rpm/package_set_impl.hpp
@@ -38,10 +38,13 @@ namespace libdnf::rpm {
 class PackageSet::Impl : public solv::SolvMap {
 public:
     /// Initialize with an empty map
-    explicit Impl(SolvSack * sack);
+    //explicit Impl(SolvSack * sack);
+
+    /// Initialize with an empty map
+    explicit Impl(const SolvSackWeakPtr & sack);
 
     /// Clone from an existing map
-    explicit Impl(SolvSack * sack, solv::SolvMap & solv_map);
+    explicit Impl(const SolvSackWeakPtr & sack, solv::SolvMap & solv_map);
 
     /// Copy constructor: clone from an existing PackageSet::Impl
     Impl(const Impl & other);
@@ -54,7 +57,7 @@ public:
     Impl & operator=(const solv::SolvMap & map);
     Impl & operator=(solv::SolvMap && map);
 
-    SolvSack * get_sack() const { return sack.get(); }
+    SolvSackWeakPtr get_sack() const { return sack; }
 
 private:
     friend PackageSet;
@@ -63,13 +66,13 @@ private:
 };
 
 
-inline PackageSet::Impl::Impl(SolvSack * sack)
+inline PackageSet::Impl::Impl(const SolvSackWeakPtr & sack)
     : solv::SolvMap::SolvMap(sack->p_impl->pool->nsolvables)
-    , sack(sack->get_weak_ptr()) {}
+    , sack(sack) {}
 
-inline PackageSet::Impl::Impl(SolvSack * sack, solv::SolvMap & solv_map)
+inline PackageSet::Impl::Impl(const SolvSackWeakPtr & sack, solv::SolvMap & solv_map)
     : solv::SolvMap::SolvMap(solv_map)
-    , sack(sack->get_weak_ptr()) {}
+    , sack(sack) {}
 
 inline PackageSet::Impl::Impl(const Impl & other)
     : solv::SolvMap::SolvMap(other.get_map())

--- a/libdnf/rpm/reldep.cpp
+++ b/libdnf/rpm/reldep.cpp
@@ -41,8 +41,8 @@ Reldep::Reldep(SolvSack * sack, const char * name, const char * version, CmpType
     id = get_reldep_id(sack, name, version, cmp_type);
 }
 
-Reldep::Reldep(SolvSack * sack, const std::string & reldep_string) : sack(sack->get_weak_ptr()) {
-    id = get_reldep_id(sack, reldep_string);
+Reldep::Reldep(const SolvSackWeakPtr & sack, const std::string & reldep_string) : sack(sack) {
+    id = get_reldep_id(sack.get(), reldep_string);
 }
 
 Reldep::Reldep(Reldep && reldep) : sack(std::move(reldep.sack)), id(std::move(reldep.id)) {}

--- a/libdnf/rpm/reldep_list.cpp
+++ b/libdnf/rpm/reldep_list.cpp
@@ -38,7 +38,7 @@ ReldepList::ReldepList(const ReldepList & src) : p_impl(new Impl(*src.p_impl)) {
 
 ReldepList::ReldepList(ReldepList && src) noexcept : p_impl(std::move(src.p_impl)) {}
 
-ReldepList::ReldepList(SolvSack * sack) : p_impl(new Impl(sack)) {}
+ReldepList::ReldepList(const SolvSackWeakPtr & sack) : p_impl(new Impl(sack)) {}
 
 ReldepList::~ReldepList() = default;
 

--- a/libdnf/rpm/reldep_list_impl.hpp
+++ b/libdnf/rpm/reldep_list_impl.hpp
@@ -30,8 +30,8 @@ namespace libdnf::rpm {
 class ReldepList::Impl {
 public:
     Impl(const ReldepList::Impl & src) = default;
-    Impl(SolvSack * sack) : sack(sack->get_weak_ptr()) {}
-    Impl(SolvSack * sack, libdnf::rpm::solv::IdQueue queue_src) : sack(sack->get_weak_ptr()), queue(queue_src) {}
+    Impl(const SolvSackWeakPtr & sack) : sack(sack) {}
+    Impl(const SolvSackWeakPtr & sack, libdnf::rpm::solv::IdQueue queue_src) : sack(sack), queue(queue_src) {}
     ~Impl() = default;
 
     SolvSack * get_sack() const { return sack.get(); }

--- a/libdnf/rpm/repo.cpp
+++ b/libdnf/rpm/repo.cpp
@@ -249,7 +249,7 @@ bool Repo::Impl::ends_with(const std::string & str, const std::string & ending) 
 }
 
 const std::string & Repo::Impl::get_metadata_path(const std::string & metadata_type) const {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     static const std::string empty;
     std::string lookup_metadata_type = metadata_type;
     if (config.get_main_config().zchunk().get_value()) {
@@ -891,7 +891,7 @@ static std::vector<std::string> keyids_from_pubring(const std::string & gpg_dir,
 
 // download key from URL
 std::vector<Key> Repo::Impl::retrieve(const std::string & url) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     char tmp_key_file[] = "/tmp/repokey.XXXXXX";
     auto fd = mkstemp(tmp_key_file);
     if (fd == -1) {
@@ -945,7 +945,7 @@ static void ensure_socket_dir_exists(Logger & logger) {
 }
 
 void Repo::Impl::import_repo_keys() {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
 
     auto gpg_dir = get_cachedir() + "/pubring";
     auto known_keys = keyids_from_pubring(gpg_dir, logger);
@@ -1132,7 +1132,7 @@ bool Repo::Impl::try_load_cache() {
 /// than the last counting event (which could facilitate tracking across
 /// multiple such events).
 void Repo::Impl::add_countme_flag(LrHandle * handle) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
 
     // Bail out if not counting or not running as root (since the persistdir is
     // only root-writable)
@@ -1213,7 +1213,7 @@ void Repo::Impl::add_countme_flag(LrHandle * handle) {
 
 // Use metalink to check whether our metadata are still current.
 bool Repo::Impl::is_metalink_in_sync() {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     char tmpdir[] = "/tmp/tmpdir.XXXXXX";
     char * dir = mkdtemp(tmpdir);
     if (!dir) {
@@ -1284,7 +1284,7 @@ bool Repo::Impl::is_metalink_in_sync() {
 
 // Use repomd to check whether our metadata are still current.
 bool Repo::Impl::is_repomd_in_sync() {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     LrYumRepo * yum_repo;
     char tmpdir[] = "/tmp/tmpdir.XXXXXX";
     char * dir = mkdtemp(tmpdir);
@@ -1372,7 +1372,7 @@ void Repo::Impl::download_metadata(const std::string & destdir) {
 }
 
 bool Repo::Impl::load() {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     try {
         if (!get_metadata_path(MD_FILENAME_PRIMARY).empty() || try_load_cache()) {
             reset_metadata_expired();

--- a/libdnf/rpm/repo_sack.cpp
+++ b/libdnf/rpm/repo_sack.cpp
@@ -67,7 +67,7 @@ RepoWeakPtr RepoSack::new_repo_from_libsolv_testcase(const std::string & repoid,
     }
 
     auto repo = new_repo(repoid);
-    Pool * pool = base->get_rpm_solv_sack().p_impl->get_pool();
+    Pool * pool = base->get_rpm_solv_sack()->p_impl->get_pool();
     std::unique_ptr<LibsolvRepo, decltype(&libsolv_repo_free)> libsolv_repo(repo_create(pool, repoid.c_str()), &libsolv_repo_free);
     testcase_add_testtags(libsolv_repo.get(), testcase_file.get(), 0);
     repo->p_impl->attach_libsolv_repo(libsolv_repo.release());
@@ -77,7 +77,7 @@ RepoWeakPtr RepoSack::new_repo_from_libsolv_testcase(const std::string & repoid,
 
 
 void RepoSack::new_repos_from_file(const std::string & path) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     ConfigParser parser;
     parser.read(path);
     const auto & cfg_parser_data = parser.get_data();
@@ -86,7 +86,7 @@ void RepoSack::new_repos_from_file(const std::string & path) {
         if (section == "main") {
             continue;
         }
-        auto repo_id = base->get_vars().substitute(section);
+        auto repo_id = base->get_vars()->substitute(section);
 
         logger.debug(fmt::format(
             R"**(Start of loading configuration of repository "{}" from file "{}" section "{}")**",
@@ -107,7 +107,7 @@ void RepoSack::new_repos_from_file(const std::string & path) {
 
         auto repo = new_repo(repo_id);
         auto & repo_cfg = repo->get_config();
-        repo_cfg.load_from_parser(parser, section, base->get_vars(), base->get_logger());
+        repo_cfg.load_from_parser(parser, section, *base->get_vars(), *base->get_logger());
         logger.trace(fmt::format(R"**(Loading configuration of repository "{}" from file "{}" done)**", repo_id, path));
 
         if (repo_cfg.name().get_priority() == Option::Priority::DEFAULT) {
@@ -138,7 +138,7 @@ void RepoSack::new_repos_from_dir(const std::string & dir_path) {
 }
 
 void RepoSack::new_repos_from_dirs() {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     for (auto & dir : base->get_config().reposdir().get_value()) {
         try {
             new_repos_from_dir(dir);

--- a/libdnf/rpm/solv_query.cpp
+++ b/libdnf/rpm/solv_query.cpp
@@ -217,7 +217,7 @@ static inline bool name_arch_compare_lower_solvable(const Solvable * first, cons
 }  //  namespace
 
 
-SolvQuery::SolvQuery(SolvSack * sack, InitFlags flags) : PackageSet(sack), init_flags(flags) {
+SolvQuery::SolvQuery(const SolvSackWeakPtr & sack, InitFlags flags) : PackageSet(sack), init_flags(flags) {
     switch (flags) {
         case InitFlags::EMPTY:
             break;
@@ -247,7 +247,7 @@ inline static void filter_glob_internal(
 }
 
 SolvQuery & SolvQuery::ifilter_name(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     auto & sorted_solvables = sack->p_impl->get_sorted_solvables();
@@ -337,11 +337,11 @@ SolvQuery & SolvQuery::ifilter_name(const PackageSet & package_set, libdnf::sack
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         throw SolvQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
 
-    if (sack != package_set.p_impl->sack.get()) {
+    if (sack != package_set.p_impl->sack) {
         throw UsedDifferentSack(
             "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
     }
@@ -370,11 +370,11 @@ SolvQuery & SolvQuery::ifilter_name_arch(const PackageSet & package_set, libdnf:
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         throw SolvQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
 
-    if (sack != package_set.p_impl->sack.get()) {
+    if (sack != package_set.p_impl->sack) {
         throw UsedDifferentSack(
             "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
     }
@@ -464,7 +464,7 @@ SolvQuery & SolvQuery::ifilter_evr(const std::vector<std::string> & patterns, li
 }
 
 SolvQuery & SolvQuery::ifilter_arch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
@@ -639,7 +639,7 @@ SolvQuery & SolvQuery::ifilter_nevra(const std::vector<std::string> & patterns, 
 
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
 
     auto & sorted_solvables = sack->p_impl->get_sorted_solvables();
@@ -685,11 +685,11 @@ SolvQuery & SolvQuery::ifilter_nevra(const PackageSet & package_set, libdnf::sac
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         throw SolvQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
 
-    if (sack != package_set.p_impl->sack.get()) {
+    if (sack != package_set.p_impl->sack) {
         throw UsedDifferentSack(
             "Cannot perform the action with PackageSet instances initialized with different SolvSacks");
     }
@@ -738,7 +738,7 @@ SolvQuery & SolvQuery::ifilter_version(const std::vector<std::string> & patterns
         cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
@@ -806,7 +806,7 @@ SolvQuery & SolvQuery::ifilter_release(const std::vector<std::string> & patterns
         cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
@@ -859,7 +859,7 @@ SolvQuery & SolvQuery::ifilter_repoid(const std::vector<std::string> & patterns,
         cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
@@ -922,7 +922,7 @@ SolvQuery & SolvQuery::ifilter_sourcerpm(const std::vector<std::string> & patter
         cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
     bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
@@ -983,7 +983,7 @@ SolvQuery & SolvQuery::ifilter_epoch(const std::vector<unsigned long> & patterns
         cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
 
@@ -1059,7 +1059,7 @@ SolvQuery & SolvQuery::ifilter_epoch(const std::vector<std::string> & patterns, 
         cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
 
@@ -1221,7 +1221,7 @@ SolvQuery & SolvQuery::ifilter_location(const std::vector<std::string> & pattern
         cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
 
@@ -1259,7 +1259,7 @@ SolvQuery & SolvQuery::ifilter_provides(const ReldepList & reldep_list, libdnf::
         cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
 
@@ -1377,7 +1377,7 @@ void SolvQuery::Impl::filter_reldep(
             throw SolvQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
 
-    SolvSack * sack = pkg_set.get_sack();
+    auto sack = pkg_set.get_sack();
 
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
@@ -1429,7 +1429,7 @@ void SolvQuery::Impl::filter_reldep(
             throw SolvQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
 
-    SolvSack * sack = pkg_set.get_sack();
+    auto sack = pkg_set.get_sack();
 
     sack->p_impl->make_provides_ready();
 
@@ -1474,7 +1474,7 @@ void SolvQuery::Impl::filter_nevra(
     libdnf::sack::QueryCmp cmp_type,
     solv::SolvMap & filter_result,
     bool with_src) {
-    SolvSack * sack = pkg_set.get_sack();
+    auto sack = pkg_set.get_sack();
     Pool * pool = sack->p_impl->get_pool();
 
     auto & name = pattern.get_name();
@@ -1783,7 +1783,7 @@ SolvQuery & SolvQuery::ifilter_obsoletes(const PackageSet & package_set, libdnf:
             throw SolvQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
 
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     Pool * pool = sack->p_impl->get_pool();
 
@@ -1887,7 +1887,7 @@ SolvQuery & SolvQuery::ifilter_supplements(const PackageSet & package_set, libdn
 
 SolvQuery & SolvQuery::ifilter_advisories(
     const libdnf::advisory::AdvisoryQuery & advisory_query, libdnf::sack::QueryCmp cmp_type) {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
 
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
@@ -1955,7 +1955,7 @@ SolvQuery & SolvQuery::ifilter_advisories(
 }
 
 SolvQuery & SolvQuery::ifilter_installed() {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
@@ -2003,7 +2003,7 @@ SolvQuery & SolvQuery::ifilter_available() {
 }
 
 SolvQuery & SolvQuery::ifilter_upgrades() {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
@@ -2028,7 +2028,7 @@ SolvQuery & SolvQuery::ifilter_upgrades() {
 }
 
 SolvQuery & SolvQuery::ifilter_downgrades() {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
 
@@ -2054,7 +2054,7 @@ SolvQuery & SolvQuery::ifilter_downgrades() {
 }
 
 SolvQuery & SolvQuery::ifilter_upgradable() {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
 
@@ -2093,7 +2093,7 @@ SolvQuery & SolvQuery::ifilter_upgradable() {
 }
 
 SolvQuery & SolvQuery::ifilter_downgradable() {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
 
@@ -2185,7 +2185,7 @@ static int filter_latest_sortcmp_byarch(const void * ap, const void * bp, void *
 }
 
 SolvQuery & SolvQuery::ifilter_latest(int limit) {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
 
     solv::IdQueue samename;
@@ -2231,7 +2231,7 @@ static inline bool priority_solvable_cmp_key(const Solvable * first, const Solva
 }
 
 SolvQuery & SolvQuery::ifilter_priority() {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
 
     std::vector<Solvable *> sorted_priority;
@@ -2265,7 +2265,7 @@ SolvQuery & SolvQuery::ifilter_priority() {
 
 std::pair<bool, libdnf::rpm::Nevra> SolvQuery::resolve_pkg_spec(
     const std::string & pkg_spec, const ResolveSpecSettings & settings, bool with_src) {
-    SolvSack * sack = get_sack();
+    auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
     bool glob = libdnf::utils::is_glob_pattern(pkg_spec.c_str());

--- a/libdnf/rpm/solv_sack.cpp
+++ b/libdnf/rpm/solv_sack.cpp
@@ -139,7 +139,7 @@ bool is_superset(const solv::IdQueue & q1, const solv::IdQueue * q2, solv::SolvM
 }  // end of anonymous namespace
 
 void SolvSack::Impl::write_main(LibsolvRepoExt & libsolv_repo_ext, bool switchtosolv) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     LibsolvRepo * libsolv_repo = libsolv_repo_ext.repo;
     const char * name = libsolv_repo->name;
     const char * chksum = pool_bin2hex(pool, libsolv_repo_ext.checksum, solv_chksum_len(CHKSUM_TYPE));
@@ -203,7 +203,7 @@ static int write_ext_updateinfo_filter(LibsolvRepo * repo, Repokey * key, void *
 
 void SolvSack::Impl::write_ext(
     LibsolvRepoExt & libsolv_repo_ext, Id repodata_id, RepodataType which_repodata, const char * suffix) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     auto libsolv_repo = libsolv_repo_ext.repo;
     const char * repo_id = libsolv_repo->name;
 
@@ -265,7 +265,7 @@ void SolvSack::Impl::write_ext(
 
 void SolvSack::Impl::rewrite_repos(solv::IdQueue & addedfileprovides, solv::IdQueue & addedfileprovides_inst) {
     int i;
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
 
     solv::SolvMap providedids(pool->ss.nstrings);
 
@@ -320,7 +320,7 @@ SolvSack::Impl::RepodataState SolvSack::Impl::load_repo_main(Repo & repo) {
         throw Exception("repo md file name is empty");
     }
 
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     auto id = repo.get_id().c_str();
     std::unique_ptr<LibsolvRepo, decltype(&libsolv_repo_free)> libsolv_repo(repo_create(pool, id), &libsolv_repo_free);
     const char * fn_repomd = repo_impl->repomd_fn.c_str();
@@ -368,7 +368,7 @@ SolvSack::Impl::RepodataState SolvSack::Impl::load_repo_main(Repo & repo) {
 SolvSack::Impl::RepodataInfo SolvSack::Impl::load_repo_ext(
     Repo & repo, const char * suffix, const char * which_filename, int flags, bool (*cb)(LibsolvRepo *, FILE *)) {
     RepodataInfo info;
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     auto repo_impl = repo.p_impl.get();
     auto libsolv_repo = repo_impl->libsolv_repo_ext.repo;
     const char * repo_id = libsolv_repo->name;
@@ -444,7 +444,7 @@ void SolvSack::Impl::make_provides_ready() {
 }
 
 bool SolvSack::Impl::load_system_repo() {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     auto repo_impl = system_repo->p_impl.get();
     auto id = system_repo->get_id().c_str();
 
@@ -479,7 +479,7 @@ bool SolvSack::Impl::load_system_repo() {
 }
 
 void SolvSack::Impl::load_available_repo(Repo & repo, LoadRepoFlags flags) {
-    auto & logger = base->get_logger();
+    auto & logger = *base->get_logger();
     auto repo_impl = repo.p_impl.get();
 
     bool build_cache = repo.get_config().build_cache().get_value();
@@ -595,7 +595,7 @@ Package SolvSack::add_cmdline_package(const std::string & fn, bool add_with_hdri
 
     p_impl->provides_ready = false;
     p_impl->considered_uptodate = false;
-    return Package(this, PackageId(new_id));
+    return Package(this->get_weak_ptr(), PackageId(new_id));
 }
 
 Repo & SolvSack::Impl::get_system_repo(bool build_cache) {
@@ -619,7 +619,7 @@ Package SolvSack::add_system_package(const std::string & fn, bool add_with_hdrid
 
     p_impl->provides_ready = false;
     p_impl->considered_uptodate = false;
-    return Package(this, PackageId(new_id));
+    return Package(this->get_weak_ptr(), PackageId(new_id));
 }
 
 void SolvSack::dump_debugdata(const std::string & dir) {

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -509,7 +509,7 @@ private:
         void * rc = nullptr;
         auto * cb_info = static_cast<CallbackInfo *>(data);
         auto * transaction = cb_info->transaction;
-        auto & log = transaction->base->get_logger();
+        auto & log = *transaction->base->get_logger();
         auto & cb = *cb_info->cb;
         auto * hdr = const_cast<headerToken_s *>(static_cast<const headerToken_s *>(hd));
         const auto * item = static_cast<const TransactionItem *>(pkg_key);

--- a/microdnf/commands/advisory/advisory.cpp
+++ b/microdnf/commands/advisory/advisory.cpp
@@ -170,13 +170,13 @@ void CmdAdvisory::run(Context & ctx) {
         }
     }
 
-    auto & solv_sack = ctx.base.get_rpm_solv_sack();
-    solv_sack.create_system_repo(false);
-    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    auto solv_sack = ctx.base.get_rpm_solv_sack();
+    solv_sack->create_system_repo(false);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
     using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     ctx.load_rpm_repos(enabled_repos, LoadFlags::USE_UPDATEINFO);
 
-    libdnf::rpm::SolvQuery solv_query(&solv_sack);
+    libdnf::rpm::SolvQuery solv_query(solv_sack);
     using QueryCmp = libdnf::sack::QueryCmp;
     if (patterns_to_show.size() > 0) {
         solv_query.ifilter_name(patterns_to_show, QueryCmp::IGLOB);
@@ -185,7 +185,7 @@ void CmdAdvisory::run(Context & ctx) {
     //DATA IS PREPARED
 
     //TODO(amatej): create advisory_query with filters on advisories prensent (if we want to limit by severity, reference..)
-    auto advisory_query = ctx.base.get_rpm_advisory_sack().new_query();
+    auto advisory_query = ctx.base.get_rpm_advisory_sack()->new_query();
     if (with_cve_option->get_value()) {
         advisory_query.ifilter_CVE("*", QueryCmp::IGLOB);
     }

--- a/microdnf/commands/downgrade/downgrade.cpp
+++ b/microdnf/commands/downgrade/downgrade.cpp
@@ -71,14 +71,14 @@ void CmdDowngrade::set_argument_parser(Context & ctx) {
 void CmdDowngrade::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdDowngrade::run(Context & ctx) {
-    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+    auto & solv_sack = *ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
     // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
     solv_sack.create_system_repo(false);
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
     using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -67,18 +67,18 @@ void CmdDownload::set_argument_parser(Context & ctx) {
 void CmdDownload::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdDownload::run(Context & ctx) {
-    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+    auto solv_sack = ctx.base.get_rpm_solv_sack();
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
     using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);
 
     std::cout << std::endl;
 
-    libdnf::rpm::PackageSet result_pset(&solv_sack);
-    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    libdnf::rpm::PackageSet result_pset(solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(solv_sack);
     for (auto & pattern : *patterns_to_download_options) {
         libdnf::rpm::SolvQuery solv_query(full_solv_query);
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -71,14 +71,14 @@ void CmdInstall::set_argument_parser(Context & ctx) {
 void CmdInstall::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdInstall::run(Context & ctx) {
-    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+    auto & solv_sack = *ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
     // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
     solv_sack.create_system_repo(false);
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
     using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -67,22 +67,22 @@ void CmdReinstall::set_argument_parser(Context & ctx) {
 void CmdReinstall::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdReinstall::run(Context & ctx) {
-    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+    auto solv_sack = ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
     // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
     //solv_sack.create_system_repo(false);
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
     using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);
 
     std::cout << std::endl;
 
-    libdnf::rpm::PackageSet result_pset(&solv_sack);
-    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    libdnf::rpm::PackageSet result_pset(solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(solv_sack);
     for (auto & pattern : *patterns_to_reinstall_options) {
         libdnf::rpm::SolvQuery solv_query(full_solv_query);
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());

--- a/microdnf/commands/remove/remove.cpp
+++ b/microdnf/commands/remove/remove.cpp
@@ -67,7 +67,7 @@ void CmdRemove::set_argument_parser(Context & ctx) {
 void CmdRemove::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdRemove::run(Context & ctx) {
-    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+    auto & solv_sack = *ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
     // Creates system repository in the repo_sack and loads it into rpm::SolvSack.

--- a/microdnf/commands/repolist/repolist.cpp
+++ b/microdnf/commands/repolist/repolist.cpp
@@ -122,7 +122,7 @@ void CmdRepolist::run(Context & ctx) {
         }
     }
 
-    auto query = ctx.base.get_rpm_repo_sack().new_query();
+    auto query = ctx.base.get_rpm_repo_sack()->new_query();
     if (enable_disable_option->get_value() == "enabled") {
         query.ifilter_enabled(true);
     } else if (enable_disable_option->get_value() == "disabled") {

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -112,17 +112,17 @@ void CmdRepoquery::set_argument_parser(Context & ctx) {
 void CmdRepoquery::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdRepoquery::run(Context & ctx) {
-    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+    auto solv_sack = ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
     if (installed_option->get_value()) {
         // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
-        solv_sack.create_system_repo(false);
+        solv_sack->create_system_repo(false);
     }
 
     // To search in available repositories (available packages)
     if (available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !installed_option->get_value()) {
-        auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+        auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
         using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
         auto flags =
             LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
@@ -130,8 +130,8 @@ void CmdRepoquery::run(Context & ctx) {
         std::cout << std::endl;
     }
 
-    libdnf::rpm::PackageSet result_pset(&solv_sack);
-    libdnf::rpm::SolvQuery full_solv_query(&solv_sack);
+    libdnf::rpm::PackageSet result_pset(solv_sack);
+    libdnf::rpm::SolvQuery full_solv_query(solv_sack);
     for (auto & pattern : *patterns_to_show_options) {
         libdnf::rpm::SolvQuery solv_query(full_solv_query);
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -70,14 +70,14 @@ void CmdUpgrade::set_argument_parser(Context & ctx) {
 void CmdUpgrade::configure([[maybe_unused]] Context & ctx) {}
 
 void CmdUpgrade::run(Context & ctx) {
-    auto & solv_sack = ctx.base.get_rpm_solv_sack();
+    auto & solv_sack = *ctx.base.get_rpm_solv_sack();
 
     // To search in the system repository (installed packages)
     // Creates system repository in the repo_sack and loads it into rpm::SolvSack.
     solv_sack.create_system_repo(false);
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack().new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
     using LoadFlags = libdnf::rpm::SolvSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);

--- a/test/libdnf/advisory/test_advisory.cpp
+++ b/test/libdnf/advisory/test_advisory.cpp
@@ -36,7 +36,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryTest, "AdvisoryAdvisoryTes
 void AdvisoryAdvisoryTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    advisory_sack = &(base->get_rpm_advisory_sack());
+    advisory_sack = base->get_rpm_advisory_sack();
     libdnf::advisory::AdvisoryQuery q =
         advisory_sack->new_query().ifilter_type(libdnf::advisory::Advisory::Type::SECURITY);
     advisories = q.get_advisories();

--- a/test/libdnf/advisory/test_advisory.hpp
+++ b/test/libdnf/advisory/test_advisory.hpp
@@ -54,7 +54,7 @@ public:
     void test_get_collections();
 
 private:
-    libdnf::advisory::AdvisorySack * advisory_sack;
+    libdnf::advisory::AdvisorySackWeakPtr advisory_sack;
     std::vector<libdnf::advisory::Advisory> advisories;
     libdnf::advisory::Advisory * advisory;
 };

--- a/test/libdnf/advisory/test_advisory_module.cpp
+++ b/test/libdnf/advisory/test_advisory_module.cpp
@@ -33,7 +33,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryModuleTest, "AdvisoryAdvis
 void AdvisoryAdvisoryModuleTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    auto advisory = base->get_rpm_advisory_sack().new_query().ifilter_name("DNF-2019-1").get_advisories()[0];
+    auto advisory = base->get_rpm_advisory_sack()->new_query().ifilter_name("DNF-2019-1").get_advisories()[0];
     std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
     modules = collections[0].get_modules();
 }

--- a/test/libdnf/advisory/test_advisory_package.cpp
+++ b/test/libdnf/advisory/test_advisory_package.cpp
@@ -33,7 +33,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryPackageTest, "AdvisoryAdvi
 void AdvisoryAdvisoryPackageTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    auto advisory = base->get_rpm_advisory_sack().new_query().ifilter_name("DNF-2019-1").get_advisories()[0];
+    auto advisory = base->get_rpm_advisory_sack()->new_query().ifilter_name("DNF-2019-1").get_advisories()[0];
     std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
     packages = collections[0].get_packages();
 }

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -35,7 +35,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(AdvisoryAdvisoryQueryTest);
 void AdvisoryAdvisoryQueryTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    advisory_sack = &(base->get_rpm_advisory_sack());
+    advisory_sack = base->get_rpm_advisory_sack();
 }
 
 void AdvisoryAdvisoryQueryTest::test_size() {

--- a/test/libdnf/advisory/test_advisory_query.hpp
+++ b/test/libdnf/advisory/test_advisory_query.hpp
@@ -55,7 +55,7 @@ public:
     void test_get_sorted_advisory_packages();
 
 private:
-    libdnf::advisory::AdvisorySack * advisory_sack;
+    libdnf::advisory::AdvisorySackWeakPtr advisory_sack;
 };
 
 

--- a/test/libdnf/base/test_base.cpp
+++ b/test/libdnf/base/test_base.cpp
@@ -1,0 +1,50 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "test_base.hpp"
+
+#include "libdnf/base/base.hpp"
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(BaseTest);
+
+void BaseTest::test_weak_ptr() {
+    // Creates a new Base object
+    auto base = std::make_unique<libdnf::Base>();
+
+    // Gets a WeakPtr pointing to Vars in the Base object
+    auto vars = base->get_vars();
+
+    // Creates a copy of WeakPtr
+    auto vars2 = vars;
+
+    // Base is valid -> WeakPtr is valid. Sets "test_variable" using WeakPtr vars.
+    vars->set("test_variable", "value1");
+
+    // Base is valid -> WeakPtr is valid. Gets value of "test_variable" using copy of WeakPtr vars2.
+    CPPUNIT_ASSERT_EQUAL(std::string("value1"), vars2->get_value("test_variable"));
+
+    // Invalidates Base object
+    base.reset();
+
+    // Base object is invalid. -> Both WeakPtr are invalid. The code must throw an exception.
+    CPPUNIT_ASSERT_THROW(vars->get_value("test_variable"), libdnf::VarsWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(vars2->get_value("test_variable"), libdnf::VarsWeakPtr::InvalidPtr);
+}

--- a/test/libdnf/base/test_base.hpp
+++ b/test/libdnf/base/test_base.hpp
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TEST_LIBDNF_BASE_BASE_HPP
+#define TEST_LIBDNF_BASE_BASE_HPP
+
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class BaseTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(BaseTest);
+    CPPUNIT_TEST(test_weak_ptr);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void test_weak_ptr();
+};
+
+
+#endif  // TEST_LIBDNF_BASE_GOAL_HPP

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -186,7 +186,7 @@ void BaseGoalTest::test_install_installed_pkg() {
     // also add it to the @Commandline repo to make it available for install
     sack->add_cmdline_package(rpm_path, false);
 
-    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    libdnf::rpm::SolvQuery query(base->get_rpm_solv_sack());
     query.ifilter_available().ifilter_nevra({"cmdline-0:1.2-3.noarch"});
 
     std::vector<std::string> expected = {"cmdline-0:1.2-3.noarch"};
@@ -220,7 +220,7 @@ void BaseGoalTest::test_upgrade() {
 
     add_repo_solv("solv-upgrade");
 
-    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    libdnf::rpm::SolvQuery query(base->get_rpm_solv_sack());
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_upgrade("cmdline");
@@ -253,7 +253,7 @@ void BaseGoalTest::test_upgrade_not_available() {
 
     add_repo_solv("solv-upgrade");
 
-    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    libdnf::rpm::SolvQuery query(base->get_rpm_solv_sack());
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_upgrade("not_available");
@@ -293,7 +293,7 @@ void BaseGoalTest::test_upgrade_all() {
 
     add_repo_solv("solv-upgrade");
 
-    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    libdnf::rpm::SolvQuery query(base->get_rpm_solv_sack());
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_upgrade();
@@ -324,7 +324,7 @@ void BaseGoalTest::test_downgrade() {
 
     add_repo_solv("solv-downgrade");
 
-    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    libdnf::rpm::SolvQuery query(base->get_rpm_solv_sack());
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_downgrade("cmdline");
@@ -355,7 +355,7 @@ void BaseGoalTest::test_distrosync() {
 
     add_repo_solv("solv-distrosync");
 
-    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    libdnf::rpm::SolvQuery query(base->get_rpm_solv_sack());
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_distro_sync("cmdline");
@@ -386,7 +386,7 @@ void BaseGoalTest::test_distrosync_all() {
 
     add_repo_solv("solv-distrosync");
 
-    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    libdnf::rpm::SolvQuery query(base->get_rpm_solv_sack());
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_distro_sync();
@@ -419,7 +419,7 @@ void BaseGoalTest::test_install_or_reinstall() {
     sack->add_cmdline_package(rpm_path, false);
 
     libdnf::Goal goal(base.get());
-    libdnf::rpm::SolvQuery query(&(base->get_rpm_solv_sack()));
+    libdnf::rpm::SolvQuery query(base->get_rpm_solv_sack());
     query.ifilter_available().ifilter_nevra({"cmdline-0:1.2-3.noarch"});
     CPPUNIT_ASSERT_EQUAL(1lu, query.size());
     goal.add_rpm_install_or_reinstall(query);

--- a/test/libdnf/rpm/repo/test_repo.cpp
+++ b/test/libdnf/rpm/repo/test_repo.cpp
@@ -49,7 +49,7 @@ void RepoTest::test_repo_basics() {
     libdnf::Base base;
 
     // Sets logging file.
-    auto & log_router = base.get_logger();
+    auto & log_router = *base.get_logger();
     log_router.add_logger(std::make_unique<libdnf::StreamLogger>(std::make_unique<std::ofstream>("repo.log")));
 
     // set installroot to a temp directory

--- a/test/libdnf/rpm/repo_fixture.cpp
+++ b/test/libdnf/rpm/repo_fixture.cpp
@@ -98,8 +98,8 @@ void RepoFixture::setUp() {
     }
     base->get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cache_dirs.at(class_name)->get_path());
 
-    repo_sack = &(base->get_rpm_repo_sack());
-    sack = &(base->get_rpm_solv_sack());
+    repo_sack = base->get_rpm_repo_sack();
+    sack = base->get_rpm_solv_sack();
 }
 
 void RepoFixture::dump_debugdata() {

--- a/test/libdnf/rpm/repo_fixture.hpp
+++ b/test/libdnf/rpm/repo_fixture.hpp
@@ -41,8 +41,8 @@ protected:
     void add_repo_solv(const std::string & repoid);
 
     std::unique_ptr<libdnf::Base> base;
-    libdnf::rpm::RepoSack * repo_sack;
-    libdnf::rpm::SolvSack * sack;
+    libdnf::rpm::RepoSackWeakPtr repo_sack;
+    libdnf::rpm::SolvSackWeakPtr sack;
     std::unique_ptr<libdnf::utils::TempDir> temp;
 };
 

--- a/test/libdnf/rpm/test_package_set.cpp
+++ b/test/libdnf/rpm/test_package_set.cpp
@@ -31,7 +31,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RpmPackageSetTest);
 // make constructor public so we can create Package instances in the tests
 class TestPackage : public libdnf::rpm::Package {
 public:
-    TestPackage(libdnf::rpm::SolvSack * sack, libdnf::rpm::PackageId id) : libdnf::rpm::Package(sack, id) {}
+    TestPackage(const libdnf::rpm::SolvSackWeakPtr & sack, libdnf::rpm::PackageId id) : libdnf::rpm::Package(sack, id) {}
 };
 
 

--- a/test/libdnf/rpm/test_reldep.cpp
+++ b/test/libdnf/rpm/test_reldep.cpp
@@ -26,46 +26,46 @@ CPPUNIT_TEST_SUITE_REGISTRATION(ReldepTest);
 
 void ReldepTest::setUp() {
     base = std::make_unique<libdnf::Base>();
-    sack = std::make_unique<libdnf::rpm::SolvSack>(*base);
+    sack = base->get_rpm_solv_sack();
 }
 
 
 void ReldepTest::test_short_reldep() {
-    libdnf::rpm::Reldep a(sack.get(), "labirinto.txt");
+    libdnf::rpm::Reldep a(sack, "labirinto.txt");
     CPPUNIT_ASSERT(std::string(a.get_name()) == "labirinto.txt");
     CPPUNIT_ASSERT(std::string(a.get_relation()) == "");
     CPPUNIT_ASSERT(std::string(a.get_version()) == "");
     CPPUNIT_ASSERT(a.to_string() == "labirinto.txt");
 
-    libdnf::rpm::Reldep b(sack.get(), "labirinto.txt");
+    libdnf::rpm::Reldep b(sack, "labirinto.txt");
     CPPUNIT_ASSERT(a == b);
     CPPUNIT_ASSERT(a.get_id() == b.get_id());
 
-    libdnf::rpm::Reldep c(sack.get(), "vagare");
+    libdnf::rpm::Reldep c(sack, "vagare");
     CPPUNIT_ASSERT(a != c);
 }
 
 
 void ReldepTest::test_full_reldep() {
-    libdnf::rpm::Reldep a(sack.get(), "python3-labirinto = 4.2.0");
+    libdnf::rpm::Reldep a(sack, "python3-labirinto = 4.2.0");
     CPPUNIT_ASSERT(std::string(a.get_name()) == "python3-labirinto");
     CPPUNIT_ASSERT(std::string(a.get_relation()) == " = ");
     CPPUNIT_ASSERT(std::string(a.get_version()) == "4.2.0");
     CPPUNIT_ASSERT(a.to_string() == "python3-labirinto = 4.2.0");
 
-    libdnf::rpm::Reldep b(sack.get(), "python3-labirinto > 1.2.0");
+    libdnf::rpm::Reldep b(sack, "python3-labirinto > 1.2.0");
     CPPUNIT_ASSERT(a != b);
 }
 
 
 void ReldepTest::test_rich_reldep() {
-    libdnf::rpm::Reldep a(sack.get(), "(lab-list if labirinto.txt)");
+    libdnf::rpm::Reldep a(sack, "(lab-list if labirinto.txt)");
     CPPUNIT_ASSERT(std::string(a.get_name()) == "lab-list");
     CPPUNIT_ASSERT(std::string(a.get_relation()) == " if ");
     CPPUNIT_ASSERT(std::string(a.get_version()) == "labirinto.txt");
     CPPUNIT_ASSERT(a.to_string() == "(lab-list if labirinto.txt)");
 
-    libdnf::rpm::Reldep b(sack.get(), "(labirinto unless labirinto_c)");
+    libdnf::rpm::Reldep b(sack, "(labirinto unless labirinto_c)");
     CPPUNIT_ASSERT(std::string(b.get_name()) == "labirinto");
     CPPUNIT_ASSERT(std::string(b.get_relation()) == " unless ");
     CPPUNIT_ASSERT(std::string(b.get_version()) == "labirinto_c");
@@ -77,6 +77,6 @@ void ReldepTest::test_rich_reldep() {
 
 
 void ReldepTest::test_invalid_reldep() {
-    CPPUNIT_ASSERT_THROW(libdnf::rpm::Reldep a(sack.get(), "(lab-list if labirinto.txt"), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(libdnf::rpm::Reldep a(sack.get(), "labirinto = "), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(libdnf::rpm::Reldep a(sack, "(lab-list if labirinto.txt"), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(libdnf::rpm::Reldep a(sack, "labirinto = "), std::runtime_error);
 }

--- a/test/libdnf/rpm/test_reldep.hpp
+++ b/test/libdnf/rpm/test_reldep.hpp
@@ -46,7 +46,7 @@ public:
 
 private:
     std::unique_ptr<libdnf::Base> base;
-    std::unique_ptr<libdnf::rpm::SolvSack> sack;
+    libdnf::rpm::SolvSackWeakPtr sack;
 };
 
 #endif  // TEST_LIBDNF_RPM_RELDEP_HPP

--- a/test/libdnf/rpm/test_solv_query.cpp
+++ b/test/libdnf/rpm/test_solv_query.cpp
@@ -36,7 +36,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RpmSolvQueryTest);
 // make constructor public so we can create Package instances in the tests
 class TestPackage : public libdnf::rpm::Package {
 public:
-    TestPackage(libdnf::rpm::SolvSack * sack, libdnf::rpm::PackageId id) : libdnf::rpm::Package(sack, id) {}
+    TestPackage(const libdnf::rpm::SolvSackWeakPtr & sack, libdnf::rpm::PackageId id) : libdnf::rpm::Package(sack, id) {}
 };
 
 
@@ -425,11 +425,11 @@ void RpmSolvQueryTest::test_ifilter_advisories() {
     // Run setUp again to have a clean sack (without solv-repo1)
     RepoFixture::setUp();
     add_repo_repomd("repomd-repo1");
-    auto & advisory_sack = base->get_rpm_advisory_sack();
+    auto advisory_sack = base->get_rpm_advisory_sack();
 
     {
         // Test QueryCmp::EQ with equal advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("DNF-2019-1");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("DNF-2019-1");
         libdnf::rpm::SolvQuery query(sack);
         query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
@@ -438,7 +438,7 @@ void RpmSolvQueryTest::test_ifilter_advisories() {
 
     {
         // Test QueryCmp::GT with older advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("PKG-OLDER");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("PKG-OLDER");
         libdnf::rpm::SolvQuery query(sack);
         query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::GT);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
@@ -447,7 +447,7 @@ void RpmSolvQueryTest::test_ifilter_advisories() {
 
     {
         // Test QueryCmp::LTE with older advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("PKG-OLDER");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("PKG-OLDER");
         libdnf::rpm::SolvQuery query(sack);
         query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::LTE);
         std::vector<std::string> expected = {};
@@ -456,7 +456,7 @@ void RpmSolvQueryTest::test_ifilter_advisories() {
 
     {
         // Test QueryCmp::LT with newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("PKG-NEWER");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("PKG-NEWER");
         libdnf::rpm::SolvQuery query(sack);
         query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::LT);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
@@ -465,7 +465,7 @@ void RpmSolvQueryTest::test_ifilter_advisories() {
 
     {
         // Test QueryCmp::GTE with newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack.new_query().ifilter_name("PKG-NEWER");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("PKG-NEWER");
         libdnf::rpm::SolvQuery query(sack);
         query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::GTE);
         std::vector<std::string> expected = {};
@@ -475,7 +475,7 @@ void RpmSolvQueryTest::test_ifilter_advisories() {
     {
         // Test QueryCmp::EQ with older and newer advisory pkg
         libdnf::advisory::AdvisoryQuery adv_query =
-            advisory_sack.new_query().ifilter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
+            advisory_sack->new_query().ifilter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
         ;
         libdnf::rpm::SolvQuery query(sack);
         query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);

--- a/test/libdnf/transaction/test_comps_environment.cpp
+++ b/test/libdnf/transaction/test_comps_environment.cpp
@@ -64,7 +64,7 @@ void TransactionCompsEnvironmentTest::test_save_load() {
     auto base = new_base();
 
     // create a new empty transaction
-    auto trans = base->get_transaction_sack().new_transaction();
+    auto trans = base->get_transaction_sack()->new_transaction();
 
     // create an environment in the transaction
     create_comps_environment(trans);
@@ -80,7 +80,7 @@ void TransactionCompsEnvironmentTest::test_save_load() {
     auto base2 = new_base();
 
     // get the written transaction
-    auto q2 = base2->get_transaction_sack().new_query();
+    auto q2 = base2->get_transaction_sack()->new_query();
     q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 

--- a/test/libdnf/transaction/test_comps_group.cpp
+++ b/test/libdnf/transaction/test_comps_group.cpp
@@ -64,7 +64,7 @@ void TransactionCompsGroupTest::test_save_load() {
     auto base = new_base();
 
     // create a new empty transaction
-    auto trans = base->get_transaction_sack().new_transaction();
+    auto trans = base->get_transaction_sack()->new_transaction();
 
     // create an group in the transaction
     create_comps_group(trans);
@@ -80,7 +80,7 @@ void TransactionCompsGroupTest::test_save_load() {
     auto base2 = new_base();
 
     // get the written transaction
-    auto q2 = base2->get_transaction_sack().new_query();
+    auto q2 = base2->get_transaction_sack()->new_query();
     q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 

--- a/test/libdnf/transaction/test_query.cpp
+++ b/test/libdnf/transaction/test_query.cpp
@@ -36,7 +36,7 @@ void TransactionQueryTest::test_ifilter_id_eq() {
     auto base = new_base();
 
     // create a new empty transaction
-    auto trans = base->get_transaction_sack().new_transaction();
+    auto trans = base->get_transaction_sack()->new_transaction();
 
     // save the transaction
     trans->start();
@@ -46,7 +46,7 @@ void TransactionQueryTest::test_ifilter_id_eq() {
     auto base2 = new_base();
 
     // get the written transaction
-    auto q2 = base2->get_transaction_sack().new_query();
+    auto q2 = base2->get_transaction_sack()->new_query();
     q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 }
@@ -54,9 +54,10 @@ void TransactionQueryTest::test_ifilter_id_eq() {
 
 void TransactionQueryTest::test_ifilter_id_eq_parallel_queries() {
     auto base = new_base();
+    auto transaction_sack = base->get_transaction_sack();
 
     // create a new empty transaction
-    auto trans = base->get_transaction_sack().new_transaction();
+    auto trans = transaction_sack->new_transaction();
 
     // save the transaction
     trans->start();
@@ -64,25 +65,26 @@ void TransactionQueryTest::test_ifilter_id_eq_parallel_queries() {
 
     // create a new Base to force reading the transaction from disk
     auto base2 = new_base();
+    auto transaction_sack2 = base2->get_transaction_sack();
 
     // the sack is empty
-    CPPUNIT_ASSERT_EQUAL(0LU, base2->get_transaction_sack().get_data().size());
+    CPPUNIT_ASSERT_EQUAL(0LU, transaction_sack2->get_data().size());
 
     // create 2 queries that are empty, none of them loaded any transaction yet
-    auto q2 = base2->get_transaction_sack().new_query();
-    auto q3 = base2->get_transaction_sack().new_query();
+    auto q2 = transaction_sack2->new_query();
+    auto q3 = transaction_sack2->new_query();
 
     q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
     // one item loaded into the sack
-    CPPUNIT_ASSERT_EQUAL(1LU, base2->get_transaction_sack().get_data().size());
+    CPPUNIT_ASSERT_EQUAL(1LU, transaction_sack2->get_data().size());
 
     q3.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans3 = q3.get();
 
     // query reused the existing item in the sack
-    CPPUNIT_ASSERT_EQUAL(1LU, base2->get_transaction_sack().get_data().size());
+    CPPUNIT_ASSERT_EQUAL(1LU, transaction_sack2->get_data().size());
 
     // finally compare the transactions
     CPPUNIT_ASSERT(trans2 == trans3);

--- a/test/libdnf/transaction/test_rpm_package.cpp
+++ b/test/libdnf/transaction/test_rpm_package.cpp
@@ -39,7 +39,7 @@ void TransactionRpmPackageTest::test_save_load() {
     auto base = new_base();
 
     // create a new empty transaction
-    auto trans = base->get_transaction_sack().new_transaction();
+    auto trans = base->get_transaction_sack()->new_transaction();
 
     // create packages in the transaction
     for (std::size_t i = 0; i < num; i++) {
@@ -66,7 +66,7 @@ void TransactionRpmPackageTest::test_save_load() {
     auto base2 = new_base();
 
     // get the written transaction
-    auto q2 = base2->get_transaction_sack().new_query();
+    auto q2 = base2->get_transaction_sack()->new_query();
     q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 

--- a/test/libdnf/transaction/test_transaction.cpp
+++ b/test/libdnf/transaction/test_transaction.cpp
@@ -33,7 +33,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TransactionTest);
 
 
 static TransactionWeakPtr create_transaction(libdnf::Base & base) {
-    auto trans = base.get_transaction_sack().new_transaction();
+    auto trans = base.get_transaction_sack()->new_transaction();
     trans->set_dt_start(1);
     trans->set_dt_end(2);
     trans->set_rpmdb_version_begin("begin");
@@ -61,7 +61,7 @@ void TransactionTest::test_save_load() {
 
     // load the saved transaction from database and compare values
     auto base2 = new_base();
-    auto q2 = base2->get_transaction_sack().new_query();
+    auto q2 = base2->get_transaction_sack()->new_query();
     q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
@@ -80,7 +80,7 @@ void TransactionTest::test_save_load() {
 
 void TransactionTest::test_second_start_raises() {
     auto base = new_base();
-    auto trans = base->get_transaction_sack().new_transaction();
+    auto trans = base->get_transaction_sack()->new_transaction();
     trans->start();
     // 2nd begin must throw an exception
     CPPUNIT_ASSERT_THROW(trans->start(), std::runtime_error);
@@ -89,7 +89,7 @@ void TransactionTest::test_second_start_raises() {
 
 void TransactionTest::test_save_with_specified_id_raises() {
     auto base = new_base();
-    auto trans = base->get_transaction_sack().new_transaction();
+    auto trans = base->get_transaction_sack()->new_transaction();
     trans->set_id(1);
     // it is not allowed to save a transaction with arbitrary ID
     CPPUNIT_ASSERT_THROW(trans->start(), std::runtime_error);
@@ -115,7 +115,7 @@ void TransactionTest::test_update() {
 
     // load the transction from the database
     auto base2 = new_base();
-    auto q2 = base2->get_transaction_sack().new_query();
+    auto q2 = base2->get_transaction_sack()->new_query();
     q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
@@ -137,8 +137,9 @@ void TransactionTest::test_compare() {
     auto base = new_base();
 
     // test operator ==, > and <
-    auto first = base->get_transaction_sack().new_transaction();
-    auto second = base->get_transaction_sack().new_transaction();
+    auto transaction_sack = base->get_transaction_sack();
+    auto first = transaction_sack->new_transaction();
+    auto second = transaction_sack->new_transaction();
 
     // equal id
     first->set_id(1);

--- a/test/libdnf/transaction/test_workflow.cpp
+++ b/test/libdnf/transaction/test_workflow.cpp
@@ -36,7 +36,7 @@ void TransactionWorkflowTest::test_default_workflow() {
     auto base = new_base();
 
     // create an empty Transaction object
-    auto trans = base->get_transaction_sack().new_transaction();
+    auto trans = base->get_transaction_sack()->new_transaction();
     CPPUNIT_ASSERT_EQUAL(TransactionState::UNKNOWN, trans->get_state());
 
     // set packages used to perform the transaction

--- a/test/perl5/CMakeLists.txt
+++ b/test/perl5/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 
 find_package(Perl REQUIRED)
-foreach(MODULE "strict" "Test::More" "warnings")
+foreach(MODULE "strict" "Test::More" "Test::Exception" "warnings")
     message(STATUS "Checking for ${MODULE} Perl module")
     execute_process(
         COMMAND "${PERL_EXECUTABLE}" -e "require ${MODULE}"

--- a/test/perl5/libdnf/base/test_base.t
+++ b/test/perl5/libdnf/base/test_base.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2020-2021 Red Hat, Inc.
 #
 # This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 #
@@ -17,16 +17,50 @@
 
 use strict;
 use warnings;
+
 use Test::More;
+use Test::Exception;
 
 use libdnf::base;
 
-my $base = new libdnf::base::Base();
-ok(defined $base, 'new libdnf::base::Base() returned something');
-ok($base->isa('libdnf::base::Base'), "  and it's the right class" );
-my $loger = $base->get_logger();
-my $config = $base->get_config();
-my $repo_sack = $base->get_rpm_repo_sack();
-my $solv_sack = $base->get_rpm_solv_sack();
+{
+    # Creates a new Base object
+    my $base = new libdnf::base::Base();
+    # Tests returned value
+    ok(defined $base, 'new libdnf::base::Base() returned something');
+    ok($base->isa('libdnf::base::Base'), "  and it's the right class" );
+
+    # Attempts to call some methods from Base object
+    my $loger = $base->get_logger();
+    my $config = $base->get_config();
+    my $repo_sack = $base->get_rpm_repo_sack();
+    my $solv_sack = $base->get_rpm_solv_sack();
+}
+
+{
+    # Tests WeakPtr returned from a Base object.
+
+    # Creates a new Base object
+    my $base = new libdnf::base::Base();
+
+    # Gets a WeakPtr pointing to Vars in the Base object
+    my $vars = $base->get_vars();
+
+    # Creates a copy of WeakPtr
+    my $vars2 = $vars;
+
+    # Base is valid -> WeakPtr is valid. Sets "test_variable" using WeakPtr vars.
+    $vars->set('test_variable', 'value1');
+
+    # Base is valid -> WeakPtr is valid. Gets value of "test_variable" using copy of WeakPtr vars2.
+    ok($vars2->get_value('test_variable') eq 'value1');
+
+    # Invalidates Base object
+    $base = 0;
+
+    # Base object is invalid. -> Both WeakPtr are invalid. The code must throw an exception.
+    throws_ok( sub { $vars->get_value('test_variable') }, '/InvalidPtr/', 'detected');
+    throws_ok( sub { $vars2->get_value('test_variable') }, '/InvalidPtr/', 'detected');
+}
 
 done_testing()

--- a/test/perl5/libdnf/rpm/test_solv_query.t
+++ b/test/perl5/libdnf/rpm/test_solv_query.t
@@ -34,7 +34,7 @@ my $tmpdir = tempdir("libdnf-perl5-XXXX", TMPDIR => 1, CLEANUP => 1);
 $base->get_config()->cachedir()->set($libdnf::conf::Option::Priority_RUNTIME, $tmpdir);
 
 my $repo_sack = new libdnf::rpm::RepoSack($base);
-my $sack = new libdnf::rpm::SolvSack($base);
+my $sack = $base->get_rpm_solv_sack();
 
 # Creates new repositories in the repo_sack
 my $repo = $repo_sack->new_repo("repomd-repo1");

--- a/test/python3/libdnf/base/test_base.py
+++ b/test/python3/libdnf/base/test_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2020-2021 Red Hat, Inc.
 #
 # This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 #
@@ -27,3 +27,28 @@ class TestBase(unittest.TestCase):
         config = base.get_config()
         repo_sack = base.get_rpm_repo_sack()
         solv_sack = base.get_rpm_solv_sack()
+
+    def test_weak_ptr(self):
+        # Creates a new Base object
+        base = libdnf.base.Base()
+
+        # Gets a WeakPtr pointing to Vars in the Base object
+        vars = base.get_vars()
+
+        # Creates a copy of WeakPtr
+        vars2 = vars
+
+        # Base is valid -> WeakPtr is valid. Sets "test_variable" using WeakPtr vars.
+        vars.set("test_variable", "value1")
+
+        # Base is valid -> WeakPtr is valid. Gets value of "test_variable" using copy of WeakPtr vars2.
+        self.assertEqual(vars2.get_value("test_variable"), "value1")
+
+        # Invalidates Base object
+        base = None
+
+        # Base object is invalid. -> Both WeakPtr are invalid. The code must throw an exception.
+        with self.assertRaisesRegex(RuntimeError, '.*InvalidPtr.*'):
+            vars.get_value("test_variable")
+        with self.assertRaisesRegex(RuntimeError, '.*InvalidPtr.*'):
+            vars2.get_value("test_variable")

--- a/test/python3/libdnf/rpm/test_reldep_list.py
+++ b/test/python3/libdnf/rpm/test_reldep_list.py
@@ -32,7 +32,7 @@ class TestReldepList(unittest.TestCase):
         self.base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, self.tmpdir)
 
         self.repo_sack = libdnf.rpm.RepoSack(self.base)
-        self.sack = libdnf.rpm.SolvSack(self.base)
+        self.sack = self.base.get_rpm_solv_sack()
 
         # Creates new repositories in the repo_sack
         repo = self.repo_sack.new_repo("repomd-repo1")

--- a/test/python3/libdnf/rpm/test_solv_query.py
+++ b/test/python3/libdnf/rpm/test_solv_query.py
@@ -32,7 +32,7 @@ class TestSolvQuery(unittest.TestCase):
         self.base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, self.tmpdir)
 
         self.repo_sack = libdnf.rpm.RepoSack(self.base)
-        self.sack = libdnf.rpm.SolvSack(self.base)
+        self.sack = self.base.get_rpm_solv_sack()
 
         # Creates new repositories in the repo_sack
         repo = self.repo_sack.new_repo("repomd-repo1")

--- a/test/ruby/libdnf/base/test_base.rb
+++ b/test/ruby/libdnf/base/test_base.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2020-2021 Red Hat, Inc.
 #
 # This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 #
@@ -27,5 +27,35 @@ class TestBase < Test::Unit::TestCase
         config = base.get_config()
         repo_sack = base.get_rpm_repo_sack()
         solv_sack = base.get_rpm_solv_sack()
+    end
+
+    def test_weak_ptr()
+        # Creates a new Base object
+        base = Base::Base.new()
+
+        # Gets a WeakPtr pointing to Vars in the Base object
+        vars = base.get_vars()
+
+        # Creates a copy of WeakPtr
+        vars2 = vars
+
+        # Base is valid -> WeakPtr is valid. Sets "test_variable" using WeakPtr vars.
+        vars.set("test_variable", "value1")
+
+        # Base is valid -> WeakPtr is valid. Gets value of "test_variable" using copy of WeakPtr vars2.
+        assert_equal("value1", vars2.get_value("test_variable"))
+
+        # Invalidates Base object
+        base = nil
+        # Ensure gargabe collection
+        GC.start
+
+        # Base object is invalid. -> Both WeakPtr are invalid. The code must throw an exception.
+        assert_raise do
+            vars.get_value("test_variable")
+        end
+        assert_raise do
+            vars2.get_value("test_variable")
+        end
     end
 end

--- a/test/ruby/libdnf/rpm/test_solv_query.rb
+++ b/test/ruby/libdnf/rpm/test_solv_query.rb
@@ -31,7 +31,7 @@ class TestSimpleNumber < Test::Unit::TestCase
         @base.get_config().cachedir().set(Conf::Option::Priority_RUNTIME, @tmpdir)
 
         @repo_sack = Rpm::RepoSack.new(@base)
-        @sack = Rpm::SolvSack.new(@base)
+        @sack = @base.get_rpm_solv_sack()
 
         # Creates new repositories in the repo_sack
         @repo = @repo_sack.new_repo('repomd-repo1')

--- a/test/tutorial/repo/load_repo.cpp
+++ b/test/tutorial/repo/load_repo.cpp
@@ -1,10 +1,10 @@
 // create a reference to the Base's repo_sack for better code readability
-auto & repo_sack = base.get_rpm_repo_sack();
+auto repo_sack = base.get_rpm_repo_sack();
 
 // create a new repo with a given repoid
 // the repo is a weak pointer to an object owned by the repo_sack
 std::string repoid = "example";
-auto repo = repo_sack.new_repo(repoid);
+auto repo = repo_sack->new_repo(repoid);
 
 // configure the repo
 // setting at least one of the baseurl, mirrorlist or metalink options is mandatory
@@ -19,7 +19,7 @@ repo->get_config().baseurl().set(libdnf::Option::Priority::RUNTIME, baseurl);
 repo->load();
 
 // create a reference to the Base's rpm_sack for better code readability
-auto & rpm_sack = base.get_rpm_solv_sack();
+auto & rpm_sack = *base.get_rpm_solv_sack();
 
 // load cached repodata to rpm sack (xml files are converted to solv/solvx at this point)
 rpm_sack.load_repo(*repo.get(),


### PR DESCRIPTION
API changes:
- Most methods (`get_logger`, `get_rpm_repo_sack`, `get_rpm_solv_sack`, `get_transaction_sack`, `get_comps`, `get_rpm_advisory_sack`, `get_vars`) of the `Base` class return `WeakPtr` instead of references.

- Many classes (`advisory::Advisory`, `advisory::AdvisoryCollection`, `advisory::AdvisoryQuery`, `rpm::Package`, `rpm::PackageSet`, `rpm::Reldep`, `rpm::ReldepList`, `rpm::SolvQuery`) accept `WeakPtr` instead of reference/pointer.

- Added SWIG bindings templates `LogRouterWeakPtr`, `VarsWeakPtr`, `AdvisorySackWeakPtr`, `RepoSackWeakPtr`, `SolvSackWeakPtr`, `TramsactionSackWeakPtr`.

Added unit tests of `WeakPtr` returned from `Base` object (C++, Python, Perl, Ruby) - Tested on `VarsWeakPtr` returned from `Base::get_vars()`.