### PR TITLE
[dnf5] Disable unused-argument checking for TransactionCB for better readability

### DIFF
--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -305,6 +305,12 @@ private:
     std::unique_ptr<Impl> p_impl;
 };
 
+
+// suppress "unused-parameter" warnings because TransactionCB is a virtual class
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+
 /// Base class for Transaction callbacks
 /// User implements Transaction callbacks by inheriting this class and overriding its methods.
 class TransactionCB {
@@ -312,31 +318,34 @@ public:
     virtual ~TransactionCB() = default;
 
     virtual void install_progress(
-        const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*amount*/, uint64_t /*total*/) {}
-    virtual void install_start(const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*total*/) {}
-    virtual void install_stop(
-        const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*amount*/, uint64_t /*total*/) {}
-    virtual void transaction_progress(uint64_t /*amount*/, uint64_t /*total*/) {}
-    virtual void transaction_start(uint64_t /*total*/) {}
-    virtual void transaction_stop(uint64_t /*total*/) {}
+        const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {}
+    virtual void install_start(const TransactionItem * item, const RpmHeader & header, uint64_t total) {}
+    virtual void install_stop(const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {
+    }
+    virtual void transaction_progress(uint64_t amount, uint64_t total) {}
+    virtual void transaction_start(uint64_t total) {}
+    virtual void transaction_stop(uint64_t total) {}
     virtual void uninstall_progress(
-        const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*amount*/, uint64_t /*total*/) {}
-    virtual void uninstall_start(const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*total*/) {}
+        const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {}
+    virtual void uninstall_start(const TransactionItem * item, const RpmHeader & header, uint64_t total) {}
     virtual void uninstall_stop(
-        const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*amount*/, uint64_t /*total*/) {}
-    virtual void unpack_error(const TransactionItem * /*item*/, const RpmHeader & /*header*/) {}
-    virtual void cpio_error(const TransactionItem * /*item*/, const RpmHeader & /*header*/) {}
+        const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {}
+    virtual void unpack_error(const TransactionItem * item, const RpmHeader & header) {}
+    virtual void cpio_error(const TransactionItem * item, const RpmHeader & header) {}
     virtual void script_error(
-        const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*tag*/, uint64_t /*return_code*/) {}
-    virtual void script_start(const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*tag*/) {}
+        const TransactionItem * item, const RpmHeader & header, uint64_t tag, uint64_t return_code) {}
+    virtual void script_start(const TransactionItem * item, const RpmHeader & header, uint64_t tag) {}
     virtual void script_stop(
-        const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*tag*/, uint64_t /*return_code*/) {}
+        const TransactionItem * item, const RpmHeader & header, uint64_t tag, uint64_t return_code) {}
     virtual void elem_progress(
-        const TransactionItem * /*item*/, const RpmHeader & /*header*/, uint64_t /*amount*/, uint64_t /*total*/) {}
-    virtual void verify_progress(uint64_t /*amount*/, uint64_t /*total*/) {}
-    virtual void verify_start(uint64_t /*total*/) {}
-    virtual void verify_stop(uint64_t /*total*/) {}
+        const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {}
+    virtual void verify_progress(uint64_t amount, uint64_t total) {}
+    virtual void verify_start(uint64_t total) {}
+    virtual void verify_stop(uint64_t total) {}
 };
+
+
+#pragma GCC diagnostic pop
 
 
 }  // namespace libdnf::rpm


### PR DESCRIPTION
This looks to me better than commented variable names or adding [[maybe_unused]].