### PR TITLE
surrogateescape error handler to decode UTF-8 strings (RhBug:1893176)

### DIFF
--- a/python/hawkey/iutil-py.cpp
+++ b/python/hawkey/iutil-py.cpp
@@ -285,7 +285,7 @@ strlist_to_pylist(const char **slist)
         return NULL;
 
     for (const char **iter = slist; *iter; ++iter) {
-        UniquePtrPyObject str(PyUnicode_FromString(*iter));
+        UniquePtrPyObject str(PyUnicode_DecodeUTF8(*iter, strlen(*iter), "surrogateescape"));
         if (!str)
             return NULL;
         int rc = PyList_Append(list.get(), str.get());


### PR DESCRIPTION
This ensures that libdnf does not raise UnicodeDecodeError when
accessing package with non UTF-8 file names.

= changelog =
msg:           DNF does not fail on non UTF-8 file names in a package
type:          bugfix
resolves:      https://bugzilla.redhat.com/show_bug.cgi?id=1893176