### PR TITLE
[dnf5] Rename query methods "ifilter*" to "filter*"

### DIFF
--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -118,7 +118,7 @@ dnfdaemon::KeyValueMap repo_to_map(
                 uint64_t size = 0;
                 libdnf::rpm::PackageQuery query(package_sack);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
-                query.ifilter_repoid(reponames);
+                query.filter_repoid(reponames);
                 for (auto pkg : query) {
                     size += pkg.get_package_size();
                 }
@@ -146,14 +146,14 @@ dnfdaemon::KeyValueMap repo_to_map(
                 auto package_sack = base.get_rpm_package_sack();
                 libdnf::rpm::PackageQuery query(package_sack, libdnf::rpm::PackageQuery::InitFlags::IGNORE_EXCLUDES);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
-                query.ifilter_repoid(reponames);
+                query.filter_repoid(reponames);
                 dbus_repo.emplace(attr, query.size());
             } break;
             case RepoAttribute::available_pkgs: {
                 auto package_sack = base.get_rpm_package_sack();
                 libdnf::rpm::PackageQuery query(package_sack);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
-                query.ifilter_repoid(reponames);
+                query.filter_repoid(reponames);
                 dbus_repo.emplace(attr, query.size());
             } break;
             case RepoAttribute::metalink: {
@@ -243,15 +243,15 @@ sdbus::MethodReply Repo::list(sdbus::MethodCall && call) {
     auto repos_query = rpm_repo_sack->new_query();
 
     if (enable_disable == "enabled") {
-        repos_query.ifilter_enabled(true);
+        repos_query.filter_enabled(true);
     } else if (enable_disable == "disabled") {
-        repos_query.ifilter_enabled(false);
+        repos_query.filter_enabled(false);
     }
 
     if (patterns.size() > 0) {
         auto query_names = repos_query;
-        repos_query.ifilter_id(libdnf::sack::QueryCmp::IGLOB, patterns);
-        repos_query |= query_names.ifilter_name(libdnf::sack::QueryCmp::IGLOB, patterns);
+        repos_query.filter_id(libdnf::sack::QueryCmp::IGLOB, patterns);
+        repos_query |= query_names.filter_name(libdnf::sack::QueryCmp::IGLOB, patterns);
     }
 
     // create reply from the query

--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -137,7 +137,7 @@ bool Session::read_all_repos() {
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     //auto & logger = base->get_logger();
     auto rpm_repo_sack = base->get_rpm_repo_sack();
-    auto enabled_repos = rpm_repo_sack->new_query().ifilter_enabled(true);
+    auto enabled_repos = rpm_repo_sack->new_query().filter_enabled(true);
     auto & package_sack = *base->get_rpm_package_sack();
     bool retval = true;
     for (auto & repo : enabled_repos.get_data()) {

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -53,28 +53,28 @@ public:
     ///
     /// @param pattern      Pattern used when matching agains advisory names.
     /// @param cmp_type     What comparator to use with pattern, allows: EQ, GLOB, IGLOB.
-    AdvisoryQuery & ifilter_name(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & ifilter_name(
+    AdvisoryQuery & filter_name(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & filter_name(
         const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    AdvisoryQuery & ifilter_type(const Advisory::Type type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & ifilter_type(
+    AdvisoryQuery & filter_type(const Advisory::Type type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & filter_type(
         const std::vector<Advisory::Type> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    AdvisoryQuery & ifilter_reference(
+    AdvisoryQuery & filter_reference(
         const std::vector<std::string> & reference_id,
         std::vector<AdvisoryReferenceType> types,
         sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     //TODO(amatej): What about other reference fitlers (title, url?) - do we want them?
-    AdvisoryQuery & ifilter_CVE(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & ifilter_CVE(
+    AdvisoryQuery & filter_CVE(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & filter_CVE(
         const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & ifilter_bug(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & ifilter_bug(
+    AdvisoryQuery & filter_bug(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & filter_bug(
         const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    AdvisoryQuery & ifilter_severity(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & ifilter_severity(
+    AdvisoryQuery & filter_severity(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & filter_severity(
         const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     //TODO(amatej): this might not be needed and could be possibly removed
@@ -83,7 +83,7 @@ public:
     /// @param package_set  libdnf::rpm::PackageSet used when filtering.
     /// @param cmp_type     Condition to fulfill with packages.
     /// @return This AdvisoryQuery with applied filter.
-    AdvisoryQuery & ifilter_packages(
+    AdvisoryQuery & filter_packages(
         const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     std::vector<AdvisoryPackage> get_advisory_packages(

--- a/include/libdnf/common/sack/query.hpp
+++ b/include/libdnf/common/sack/query.hpp
@@ -61,20 +61,20 @@ public:
     explicit Query(const Set<T> & src_set) : Set<T>::Set(src_set) {}
     explicit Query(Set<T> && src_set) : Set<T>::Set(std::move(src_set)) {}
 
-    void ifilter(std::string (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
-    void ifilter(std::vector<std::string> (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
-    void ifilter(std::string (*getter)(const T &), QueryCmp cmp, const std::vector<std::string> & patterns);
-    void ifilter(
+    void filter(std::string (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
+    void filter(std::vector<std::string> (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
+    void filter(std::string (*getter)(const T &), QueryCmp cmp, const std::vector<std::string> & patterns);
+    void filter(
         std::vector<std::string> (*getter)(const T &), QueryCmp cmp, const std::vector<std::string> & patterns);
 
-    void ifilter(int64_t (*getter)(const T &), QueryCmp cmp, int64_t pattern);
-    void ifilter(std::vector<int64_t> (*getter)(const T &), QueryCmp cmp, int64_t pattern);
-    void ifilter(int64_t (*getter)(const T &), QueryCmp cmp, const std::vector<int64_t> & patterns);
-    void ifilter(std::vector<int64_t> (*getter)(const T &), QueryCmp cmp, const std::vector<int64_t> & patterns);
+    void filter(int64_t (*getter)(const T &), QueryCmp cmp, int64_t pattern);
+    void filter(std::vector<int64_t> (*getter)(const T &), QueryCmp cmp, int64_t pattern);
+    void filter(int64_t (*getter)(const T &), QueryCmp cmp, const std::vector<int64_t> & patterns);
+    void filter(std::vector<int64_t> (*getter)(const T &), QueryCmp cmp, const std::vector<int64_t> & patterns);
 
-    void ifilter(bool (*getter)(const T &), QueryCmp cmp, bool pattern);
+    void filter(bool (*getter)(const T &), QueryCmp cmp, bool pattern);
 
-    void ifilter(char * (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
+    void filter(char * (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
 
     /// Get a single object. Raise an exception if none or multiple objects match the query.
     const T & get() const {
@@ -94,7 +94,7 @@ public:
 
 
 template <typename T>
-inline void Query<T>::ifilter(Query<T>::FilterFunctionString * getter, QueryCmp cmp, const std::string & pattern) {
+inline void Query<T>::filter(Query<T>::FilterFunctionString * getter, QueryCmp cmp, const std::string & pattern) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_string(value, cmp, pattern)) {
@@ -108,7 +108,7 @@ inline void Query<T>::ifilter(Query<T>::FilterFunctionString * getter, QueryCmp 
 
 
 template <typename T>
-inline void Query<T>::ifilter(
+inline void Query<T>::filter(
     Query<T>::FilterFunctionVectorString * getter, QueryCmp cmp, const std::string & pattern) {
 
     for (auto it = get_data().begin(); it != get_data().end();) {
@@ -122,7 +122,7 @@ inline void Query<T>::ifilter(
 }
 
 template <typename T>
-inline void Query<T>::ifilter(
+inline void Query<T>::filter(
     Query<T>::FilterFunctionString * getter, QueryCmp cmp, const std::vector<std::string> & patterns) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
@@ -135,7 +135,7 @@ inline void Query<T>::ifilter(
 }
 
 template <typename T>
-inline void Query<T>::ifilter(
+inline void Query<T>::filter(
     Query<T>::FilterFunctionVectorString * getter, QueryCmp cmp, const std::vector<std::string> & patterns) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto values = getter(*it);
@@ -148,7 +148,7 @@ inline void Query<T>::ifilter(
 }
 
 template <typename T>
-inline void Query<T>::ifilter(FilterFunctionInt64 * getter, QueryCmp cmp, int64_t pattern) {
+inline void Query<T>::filter(FilterFunctionInt64 * getter, QueryCmp cmp, int64_t pattern) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_int64(value, cmp, pattern)) {
@@ -160,7 +160,7 @@ inline void Query<T>::ifilter(FilterFunctionInt64 * getter, QueryCmp cmp, int64_
 }
 
 template <typename T>
-inline void Query<T>::ifilter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, int64_t pattern) {
+inline void Query<T>::filter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, int64_t pattern) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto values = getter(*it);
         if (match_int64(values, cmp, pattern)) {
@@ -172,7 +172,7 @@ inline void Query<T>::ifilter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, 
 }
 
 template <typename T>
-inline void Query<T>::ifilter(FilterFunctionInt64 * getter, QueryCmp cmp, const std::vector<int64_t> & patterns) {
+inline void Query<T>::filter(FilterFunctionInt64 * getter, QueryCmp cmp, const std::vector<int64_t> & patterns) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_int64(value, cmp, patterns)) {
@@ -184,7 +184,7 @@ inline void Query<T>::ifilter(FilterFunctionInt64 * getter, QueryCmp cmp, const 
 }
 
 template <typename T>
-inline void Query<T>::ifilter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, const std::vector<int64_t> & patterns) {
+inline void Query<T>::filter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, const std::vector<int64_t> & patterns) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto values = getter(*it);
         if (match_int64(values, cmp, patterns)) {
@@ -197,7 +197,7 @@ inline void Query<T>::ifilter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, 
 
 // TODO: other cmp
 template <typename T>
-inline void Query<T>::ifilter(Query<T>::FilterFunctionBool * getter, QueryCmp cmp, bool pattern) {
+inline void Query<T>::filter(Query<T>::FilterFunctionBool * getter, QueryCmp cmp, bool pattern) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (cmp == QueryCmp::EQ && value == pattern) {
@@ -209,7 +209,7 @@ inline void Query<T>::ifilter(Query<T>::FilterFunctionBool * getter, QueryCmp cm
 }
 
 template <typename T>
-inline void Query<T>::ifilter(Query<T>::FilterFunctionCString * getter, QueryCmp cmp, const std::string & pattern) {
+inline void Query<T>::filter(Query<T>::FilterFunctionCString * getter, QueryCmp cmp, const std::string & pattern) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_string(value, cmp, pattern)) {

--- a/include/libdnf/comps/group/query.hpp
+++ b/include/libdnf/comps/group/query.hpp
@@ -42,13 +42,13 @@ public:
     explicit GroupQuery(const GroupQuery & query);
     ~GroupQuery();
 
-    GroupQuery & ifilter_groupid(sack::QueryCmp cmp, const std::string & pattern);
-    GroupQuery & ifilter_groupid(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
-    GroupQuery & ifilter_name(sack::QueryCmp cmp, const std::string & pattern);
-    GroupQuery & ifilter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
-    GroupQuery & ifilter_uservisible(bool value);
-    GroupQuery & ifilter_default(bool value);
-    GroupQuery & ifilter_installed(bool value);
+    GroupQuery & filter_groupid(sack::QueryCmp cmp, const std::string & pattern);
+    GroupQuery & filter_groupid(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
+    GroupQuery & filter_name(sack::QueryCmp cmp, const std::string & pattern);
+    GroupQuery & filter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
+    GroupQuery & filter_uservisible(bool value);
+    GroupQuery & filter_default(bool value);
+    GroupQuery & filter_installed(bool value);
 
     /// Create WeakPtr to GroupQuery
     GroupQueryWeakPtr get_weak_ptr();
@@ -76,44 +76,44 @@ private:
 };
 
 
-inline GroupQuery & GroupQuery::ifilter_groupid(sack::QueryCmp cmp, const std::string & pattern) {
-    ifilter(F::groupid, cmp, pattern);
+inline GroupQuery & GroupQuery::filter_groupid(sack::QueryCmp cmp, const std::string & pattern) {
+    filter(F::groupid, cmp, pattern);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::ifilter_groupid(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
-    ifilter(F::groupid, cmp, patterns);
+inline GroupQuery & GroupQuery::filter_groupid(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
+    filter(F::groupid, cmp, patterns);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::ifilter_name(sack::QueryCmp cmp, const std::string & pattern) {
-    ifilter(F::name, cmp, pattern);
+inline GroupQuery & GroupQuery::filter_name(sack::QueryCmp cmp, const std::string & pattern) {
+    filter(F::name, cmp, pattern);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::ifilter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
-    ifilter(F::name, cmp, patterns);
+inline GroupQuery & GroupQuery::filter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
+    filter(F::name, cmp, patterns);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::ifilter_default(bool value) {
-    ifilter(F::is_default, sack::QueryCmp::EQ, value);
+inline GroupQuery & GroupQuery::filter_default(bool value) {
+    filter(F::is_default, sack::QueryCmp::EQ, value);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::ifilter_uservisible(bool value) {
-    ifilter(F::is_uservisible, sack::QueryCmp::EQ, value);
+inline GroupQuery & GroupQuery::filter_uservisible(bool value) {
+    filter(F::is_uservisible, sack::QueryCmp::EQ, value);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::ifilter_installed(bool value) {
-    ifilter(F::is_installed, sack::QueryCmp::EQ, value);
+inline GroupQuery & GroupQuery::filter_installed(bool value) {
+    filter(F::is_installed, sack::QueryCmp::EQ, value);
     return *this;
 }
 

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -100,30 +100,30 @@ public:
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NAME
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NAME
-    PackageQuery & ifilter_name(
+    PackageQuery & filter_name(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Keeps only packages with same name as packages in package_set
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ.
     ///
-    PackageQuery & ifilter_name(
+    PackageQuery & filter_name(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Keeps only packages with same name and arch as packages in package_set
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ.
     ///
-    PackageQuery & ifilter_name_arch(
+    PackageQuery & filter_name_arch(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::GT, LT, GTE, LTE, EQ.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_EVR
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_EVR
-    PackageQuery & ifilter_evr(
+    PackageQuery & filter_evr(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB.
-    PackageQuery & ifilter_arch(
+    PackageQuery & filter_arch(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Requires full nevra including epoch. QueryCmp::EQ, NEG, GT, GTE, LT, and LTE are tolerant when epoch 0 is not present.
@@ -133,267 +133,267 @@ public:
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NEVRA
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NEVRA_STRICT
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NEVRA_STRICT
-    PackageQuery & ifilter_nevra(
+    PackageQuery & filter_nevra(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB, IEXACT, NOT_IEXACT, IGLOB, NOT_IGLOB.
-    PackageQuery & ifilter_nevra(
+    PackageQuery & filter_nevra(
         const libdnf::rpm::Nevra & pattern, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type can be only libdnf::sack::QueryCmp::EQ, NEQ.
-    PackageQuery & ifilter_nevra(
+    PackageQuery & filter_nevra(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GT, GTE, LT, LTE, GLOB, NOT_GLOB.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_VERSION
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_VERSION
-    PackageQuery & ifilter_version(
+    PackageQuery & filter_version(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GT, GTE, LT, LTE, GLOB, NOT_GLOB.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_RELEASE
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_RELEASE
-    PackageQuery & ifilter_release(
+    PackageQuery & filter_release(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_REPONAME
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_REPONAME
-    PackageQuery & ifilter_repoid(
+    PackageQuery & filter_repoid(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SOURCERPM
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SOURCERPM
-    PackageQuery & ifilter_sourcerpm(
+    PackageQuery & filter_sourcerpm(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GT, GTE, LT, LTE.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_EPOCH
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_EPOCH
-    PackageQuery & ifilter_epoch(
+    PackageQuery & filter_epoch(
         const std::vector<unsigned long> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB.
-    PackageQuery & ifilter_epoch(
+    PackageQuery & filter_epoch(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB, IEXACT, NOT_IEXACT, ICONTAINS, NOT_ICONTAINS, IGLOB, NOT_IGLOB, CONTAINS, NOT_CONTAINS.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_FILE
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_FILE
-    PackageQuery & ifilter_file(
+    PackageQuery & filter_file(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB, IEXACT, NOT_IEXACT, ICONTAINS, NOT_ICONTAINS, IGLOB, NOT_IGLOB, CONTAINS, NOT_CONTAINS.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_DESCRIPTION
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_DESCRIPTION
-    PackageQuery & ifilter_description(
+    PackageQuery & filter_description(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB, IEXACT, NOT_IEXACT, ICONTAINS, NOT_ICONTAINS, IGLOB, NOT_IGLOB, CONTAINS, NOT_CONTAINS.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUMMARY
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SUMMARY
-    PackageQuery & ifilter_summary(
+    PackageQuery & filter_summary(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB, IEXACT, NOT_IEXACT, ICONTAINS, NOT_ICONTAINS, IGLOB, NOT_IGLOB, CONTAINS, NOT_CONTAINS.
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_URL
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_URL
-    PackageQuery & ifilter_url(
+    PackageQuery & filter_url(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_LOCATION
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_LOCATION
-    PackageQuery & ifilter_location(
+    PackageQuery & filter_location(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_PROVIDES
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_PROVIDES
-    PackageQuery & ifilter_provides(
+    PackageQuery & filter_provides(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_PROVIDES
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_PROVIDES
-    PackageQuery & ifilter_provides(
+    PackageQuery & filter_provides(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_CONFLICTS
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_CONFLICTS
-    PackageQuery & ifilter_conflicts(
+    PackageQuery & filter_conflicts(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_CONFLICTS
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_CONFLICTS
-    PackageQuery & ifilter_conflicts(
+    PackageQuery & filter_conflicts(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_CONFLICTS
-    PackageQuery & ifilter_conflicts(
+    PackageQuery & filter_conflicts(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_ENHANCES
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_ENHANCES
-    PackageQuery & ifilter_enhances(
+    PackageQuery & filter_enhances(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_ENHANCES
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_ENHANCES
-    PackageQuery & ifilter_enhances(
+    PackageQuery & filter_enhances(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_ENHANCES
-    PackageQuery & ifilter_enhances(
+    PackageQuery & filter_enhances(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_OBSOLETES
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_OBSOLETES
-    PackageQuery & ifilter_obsoletes(
+    PackageQuery & filter_obsoletes(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_OBSOLETES
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_OBSOLETES
-    PackageQuery & ifilter_obsoletes(
+    PackageQuery & filter_obsoletes(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_OBSOLETES
-    PackageQuery & ifilter_obsoletes(
+    PackageQuery & filter_obsoletes(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_RECOMMENDS
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_RECOMMENDS
-    PackageQuery & ifilter_recommends(
+    PackageQuery & filter_recommends(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_RECOMMENDS
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_RECOMMENDS
-    PackageQuery & ifilter_recommends(
+    PackageQuery & filter_recommends(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_RECOMMENDS
-    PackageQuery & ifilter_recommends(
+    PackageQuery & filter_recommends(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_REQUIRES
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_REQUIRES
-    PackageQuery & ifilter_requires(
+    PackageQuery & filter_requires(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_REQUIRES
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_REQUIRES
-    PackageQuery & ifilter_requires(
+    PackageQuery & filter_requires(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_REQUIRES
-    PackageQuery & ifilter_requires(
+    PackageQuery & filter_requires(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_SUGGESTS
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_SUGGESTS
-    PackageQuery & ifilter_suggests(
+    PackageQuery & filter_suggests(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUGGESTS
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SUGGESTS
-    PackageQuery & ifilter_suggests(
+    PackageQuery & filter_suggests(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_SUGGESTS
-    PackageQuery & ifilter_suggests(
+    PackageQuery & filter_suggests(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_SUPPLEMENTS
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_SUPPLEMENTS
-    PackageQuery & ifilter_supplements(
+    PackageQuery & filter_supplements(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GLOB, NOT_GLOB
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUPPLEMENTS
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SUPPLEMENTS
-    PackageQuery & ifilter_supplements(
+    PackageQuery & filter_supplements(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_SUPPLEMENTS
-    PackageQuery & ifilter_supplements(
+    PackageQuery & filter_supplements(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// cmp_type could be only libdnf::sack::QueryCmp::EQ, NEQ, GT, GTE, LT, LTE
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_ADVISORY/_BUG/_CVE/_SEVERITY/_TYPE
-    PackageQuery & ifilter_advisories(
+    PackageQuery & filter_advisories(
         const libdnf::advisory::AdvisoryQuery & advisory_query,
         libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    PackageQuery & ifilter_installed();
+    PackageQuery & filter_installed();
 
-    PackageQuery & ifilter_available();
+    PackageQuery & filter_available();
 
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_UPGRADES
-    PackageQuery & ifilter_upgrades();
+    PackageQuery & filter_upgrades();
 
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_DOWNGRADES
-    PackageQuery & ifilter_downgrades();
+    PackageQuery & filter_downgrades();
 
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_UPGRADABLE
-    PackageQuery & ifilter_upgradable();
+    PackageQuery & filter_upgradable();
 
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_DOWNGRADABLE
-    PackageQuery & ifilter_downgradable();
+    PackageQuery & filter_downgradable();
 
     /// @brief Keep number of latest versions of packages. When negative limit is used it removes a number of latest versions.
     ///
@@ -403,7 +403,7 @@ public:
     ///
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_LATEST
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_LATEST_PER_ARCH
-    PackageQuery & ifilter_latest(int limit = 1);
+    PackageQuery & filter_latest(int limit = 1);
 
     /// @brief Keep all installed packages and available packages from repo with lower priority
     ///
@@ -413,7 +413,7 @@ public:
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_UPGRADES_BY_PRIORITY
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_OBSOLETES_BY_PRIORITY
     /// @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_LATEST_PER_ARCH_BY_PRIORITY
-    PackageQuery & ifilter_priority();
+    PackageQuery & filter_priority();
 
     // TODO(jmracek) return std::pair<bool, std::unique_ptr<libdnf::rpm::Nevra>>
     /// @replaces libdnf/sack/query.hpp:method:std::pair<bool, std::unique_ptr<Nevra>> filterSubject(const char * subject, HyForm * forms, bool icase, bool with_nevra, bool with_provides, bool with_filenames);

--- a/include/libdnf/rpm/repo_query.hpp
+++ b/include/libdnf/rpm/repo_query.hpp
@@ -35,13 +35,13 @@ public:
 #ifndef SWIG
     using Query<RepoWeakPtr>::Query;
 #endif
-    RepoQuery & ifilter_enabled(bool enabled);
-    RepoQuery & ifilter_expired(bool expired);
-    RepoQuery & ifilter_id(sack::QueryCmp cmp, const std::string & pattern);
-    RepoQuery & ifilter_id(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
-    RepoQuery & ifilter_local(bool local);
-    RepoQuery & ifilter_name(sack::QueryCmp cmp, const std::string & pattern);
-    RepoQuery & ifilter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
+    RepoQuery & filter_enabled(bool enabled);
+    RepoQuery & filter_expired(bool expired);
+    RepoQuery & filter_id(sack::QueryCmp cmp, const std::string & pattern);
+    RepoQuery & filter_id(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
+    RepoQuery & filter_local(bool local);
+    RepoQuery & filter_name(sack::QueryCmp cmp, const std::string & pattern);
+    RepoQuery & filter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
 
 private:
     struct F {
@@ -53,38 +53,38 @@ private:
     };
 };
 
-inline RepoQuery & RepoQuery::ifilter_enabled(bool enabled) {
-    ifilter(F::enabled, sack::QueryCmp::EQ, enabled);
+inline RepoQuery & RepoQuery::filter_enabled(bool enabled) {
+    filter(F::enabled, sack::QueryCmp::EQ, enabled);
     return *this;
 }
 
-inline RepoQuery & RepoQuery::ifilter_expired(bool expired) {
-    ifilter(F::expired, sack::QueryCmp::EQ, expired);
+inline RepoQuery & RepoQuery::filter_expired(bool expired) {
+    filter(F::expired, sack::QueryCmp::EQ, expired);
     return *this;
 }
 
-inline RepoQuery & RepoQuery::ifilter_id(sack::QueryCmp cmp, const std::string & pattern) {
-    ifilter(F::id, cmp, pattern);
+inline RepoQuery & RepoQuery::filter_id(sack::QueryCmp cmp, const std::string & pattern) {
+    filter(F::id, cmp, pattern);
     return *this;
 }
 
-inline RepoQuery & RepoQuery::ifilter_id(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
-    ifilter(F::id, cmp, patterns);
+inline RepoQuery & RepoQuery::filter_id(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
+    filter(F::id, cmp, patterns);
     return *this;
 }
 
-inline RepoQuery & RepoQuery::ifilter_local(bool local) {
-    ifilter(F::local, sack::QueryCmp::EQ, local);
+inline RepoQuery & RepoQuery::filter_local(bool local) {
+    filter(F::local, sack::QueryCmp::EQ, local);
     return *this;
 }
 
-inline RepoQuery & RepoQuery::ifilter_name(sack::QueryCmp cmp, const std::string & pattern) {
-    ifilter(F::name, cmp, pattern);
+inline RepoQuery & RepoQuery::filter_name(sack::QueryCmp cmp, const std::string & pattern) {
+    filter(F::name, cmp, pattern);
     return *this;
 }
 
-inline RepoQuery & RepoQuery::ifilter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
-    ifilter(F::name, cmp, patterns);
+inline RepoQuery & RepoQuery::filter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
+    filter(F::name, cmp, patterns);
     return *this;
 }
 

--- a/include/libdnf/transaction/query.hpp
+++ b/include/libdnf/transaction/query.hpp
@@ -49,15 +49,15 @@ public:
     TransactionQuery(TransactionSack & sack);
 
     /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.dbSelect(int64_t transaction_id)
-    TransactionQuery & ifilter_id(sack::QueryCmp cmp, int64_t pattern);
-    TransactionQuery & ifilter_id(sack::QueryCmp cmp, const std::vector<int64_t> & pattern);
+    TransactionQuery & filter_id(sack::QueryCmp cmp, int64_t pattern);
+    TransactionQuery & filter_id(sack::QueryCmp cmp, const std::vector<int64_t> & pattern);
 
 private:
     friend TransactionSack;
     TransactionSack * sack = nullptr;
 
-    // Load Transaction objects during first ifilter call.
-    // The following ifilter calls only modify the previously created set of Transactions.
+    // Load Transaction objects during first filter call.
+    // The following filter calls only modify the previously created set of Transactions.
     bool initialized = false;
 
     struct F {

--- a/include/libdnf/transaction/rpm_package.hpp
+++ b/include/libdnf/transaction/rpm_package.hpp
@@ -97,7 +97,7 @@ public:
     void set_arch(const std::string & value) { arch = value; }
 
     /*
-    // TODO(dmach): Implement TransactionSack.new_filter().ifilter_package_pattern()
+    // TODO(dmach): Implement TransactionSack.new_filter().filter_package_pattern()
     static std::vector<int64_t> searchTransactions(
         libdnf::utils::SQLite3 & conn, const std::vector<std::string> & patterns);
 

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -55,13 +55,13 @@ AdvisoryQuery & AdvisoryQuery::operator=(AdvisoryQuery && src) noexcept {
     return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::ifilter_name(const std::string & pattern, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp_type) {
     const std::vector<std::string> patterns = {pattern};
-    ifilter_name(patterns, cmp_type);
+    filter_name(patterns, cmp_type);
     return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::ifilter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
     auto & package_sack = *advisory_sack->base->get_rpm_package_sack();
     Pool * pool = package_sack.p_impl->get_pool();
     libdnf::rpm::solv::SolvMap filter_result(package_sack.p_impl->get_nsolvables());
@@ -130,14 +130,14 @@ AdvisoryQuery & AdvisoryQuery::ifilter_name(const std::vector<std::string> & pat
 }
 
 //TODO(amatej): Add a wrapper that accepts string type, eg: "security" not enum
-AdvisoryQuery & AdvisoryQuery::ifilter_type(const Advisory::Type type, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_type(const Advisory::Type type, sack::QueryCmp cmp_type) {
     const std::vector<Advisory::Type> types = {type};
-    ifilter_type(types, cmp_type);
+    filter_type(types, cmp_type);
     return *this;
 }
 
 //TODO(amatej): Add a wrapper that accepts vector of string types, eg: "security", "bugfix" not enums
-AdvisoryQuery & AdvisoryQuery::ifilter_type(const std::vector<AdvisoryType> & types, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_type(const std::vector<AdvisoryType> & types, sack::QueryCmp cmp_type) {
     auto & package_sack = *advisory_sack->base->get_rpm_package_sack();
     Pool * pool = package_sack.p_impl->get_pool();
     libdnf::rpm::solv::SolvMap filter_result(package_sack.p_impl->get_nsolvables());
@@ -183,7 +183,7 @@ AdvisoryQuery & AdvisoryQuery::ifilter_type(const std::vector<AdvisoryType> & ty
     return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::ifilter_reference(
+AdvisoryQuery & AdvisoryQuery::filter_reference(
     const std::vector<std::string> & reference_id, std::vector<AdvisoryReferenceType> types, sack::QueryCmp cmp_type) {
     auto package_sack = advisory_sack->base->get_rpm_package_sack();
     libdnf::rpm::solv::SolvMap filter_result(package_sack->p_impl->get_nsolvables());
@@ -246,32 +246,32 @@ AdvisoryQuery & AdvisoryQuery::ifilter_reference(
     }
     return *this;
 }
-AdvisoryQuery & AdvisoryQuery::ifilter_CVE(const std::string & pattern, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_CVE(const std::string & pattern, sack::QueryCmp cmp_type) {
     const std::vector<std::string> patterns = {pattern};
-    ifilter_reference(patterns, {AdvisoryReferenceType::CVE}, cmp_type);
+    filter_reference(patterns, {AdvisoryReferenceType::CVE}, cmp_type);
     return *this;
 }
-AdvisoryQuery & AdvisoryQuery::ifilter_CVE(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    ifilter_reference(patterns, {AdvisoryReferenceType::CVE}, cmp_type);
+AdvisoryQuery & AdvisoryQuery::filter_CVE(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+    filter_reference(patterns, {AdvisoryReferenceType::CVE}, cmp_type);
     return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::ifilter_bug(const std::string & pattern, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_bug(const std::string & pattern, sack::QueryCmp cmp_type) {
     const std::vector<std::string> patterns = {pattern};
-    ifilter_reference(patterns, {AdvisoryReferenceType::BUGZILLA}, cmp_type);
+    filter_reference(patterns, {AdvisoryReferenceType::BUGZILLA}, cmp_type);
     return *this;
 }
-AdvisoryQuery & AdvisoryQuery::ifilter_bug(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    ifilter_reference(patterns, {AdvisoryReferenceType::BUGZILLA}, cmp_type);
+AdvisoryQuery & AdvisoryQuery::filter_bug(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+    filter_reference(patterns, {AdvisoryReferenceType::BUGZILLA}, cmp_type);
     return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::ifilter_severity(const std::string & pattern, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_severity(const std::string & pattern, sack::QueryCmp cmp_type) {
     const std::vector<std::string> patterns = {pattern};
-    ifilter_severity(patterns, cmp_type);
+    filter_severity(patterns, cmp_type);
     return *this;
 }
-AdvisoryQuery & AdvisoryQuery::ifilter_severity(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_severity(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
     auto & package_sack = *advisory_sack->base->get_rpm_package_sack();
     Pool * pool = package_sack.p_impl->get_pool();
     libdnf::rpm::solv::SolvMap filter_result(package_sack.p_impl->get_nsolvables());
@@ -309,7 +309,7 @@ AdvisoryQuery & AdvisoryQuery::ifilter_severity(const std::vector<std::string> &
 }
 
 //TODO(amatej): this might not be needed and could be possibly removed
-AdvisoryQuery & AdvisoryQuery::ifilter_packages(const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
+AdvisoryQuery & AdvisoryQuery::filter_packages(const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
     auto & package_sack = *advisory_sack->base->get_rpm_package_sack();
     Pool * pool = package_sack.p_impl->get_pool();
     libdnf::rpm::solv::SolvMap filter_result(package_sack.p_impl->get_nsolvables());

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -246,7 +246,7 @@ inline static void filter_glob_internal(
     }
 }
 
-PackageQuery & PackageQuery::ifilter_name(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_name(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
@@ -333,7 +333,7 @@ PackageQuery & PackageQuery::ifilter_name(const std::vector<std::string> & patte
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_name(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_name(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
@@ -366,7 +366,7 @@ PackageQuery & PackageQuery::ifilter_name(const PackageSet & package_set, libdnf
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_name_arch(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_name_arch(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
@@ -439,7 +439,7 @@ inline static void filter_evr_internal(
     query_result &= filter_result;
 }
 
-PackageQuery & PackageQuery::ifilter_evr(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_evr(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Pool * pool = p_impl->sack->p_impl->get_pool();
     switch (cmp_type) {
         case libdnf::sack::QueryCmp::GT:
@@ -463,7 +463,7 @@ PackageQuery & PackageQuery::ifilter_evr(const std::vector<std::string> & patter
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_arch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_arch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     solv::SolvMap filter_result(sack->p_impl->get_nsolvables());
@@ -630,7 +630,7 @@ inline static void filter_nevra_internal(
     }
 }
 
-PackageQuery & PackageQuery::ifilter_nevra(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_nevra(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -658,7 +658,7 @@ PackageQuery & PackageQuery::ifilter_nevra(const std::vector<std::string> & patt
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_nevra(const libdnf::rpm::Nevra & pattern, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_nevra(const libdnf::rpm::Nevra & pattern, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -681,7 +681,7 @@ PackageQuery & PackageQuery::ifilter_nevra(const libdnf::rpm::Nevra & pattern, l
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_nevra(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_nevra(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
     }
@@ -731,7 +731,7 @@ inline static void filter_version_internal(
     solv_free(formated_c_pattern);
 }
 
-PackageQuery & PackageQuery::ifilter_version(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_version(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -799,7 +799,7 @@ inline static void filter_release_internal(
     solv_free(formated_c_pattern);
 }
 
-PackageQuery & PackageQuery::ifilter_release(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_release(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -852,7 +852,7 @@ PackageQuery & PackageQuery::ifilter_release(const std::vector<std::string> & pa
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_repoid(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_repoid(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -915,7 +915,7 @@ PackageQuery & PackageQuery::ifilter_repoid(const std::vector<std::string> & pat
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_sourcerpm(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_sourcerpm(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -976,7 +976,7 @@ PackageQuery & PackageQuery::ifilter_sourcerpm(const std::vector<std::string> & 
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_epoch(const std::vector<unsigned long> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_epoch(const std::vector<unsigned long> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1052,7 +1052,7 @@ PackageQuery & PackageQuery::ifilter_epoch(const std::vector<unsigned long> & pa
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_epoch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_epoch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1182,7 +1182,7 @@ static void filter_dataiterator_internal(
     }
 }
 
-PackageQuery & PackageQuery::ifilter_file(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_file(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Pool * pool = get_sack()->p_impl->get_pool();
 
     filter_dataiterator_internal(pool, SOLVABLE_FILELIST, *p_impl, cmp_type, patterns);
@@ -1190,7 +1190,7 @@ PackageQuery & PackageQuery::ifilter_file(const std::vector<std::string> & patte
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_description(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_description(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Pool * pool = get_sack()->p_impl->get_pool();
 
     filter_dataiterator_internal(pool, SOLVABLE_DESCRIPTION, *p_impl, cmp_type, patterns);
@@ -1198,7 +1198,7 @@ PackageQuery & PackageQuery::ifilter_description(const std::vector<std::string> 
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_summary(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_summary(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Pool * pool = get_sack()->p_impl->get_pool();
 
     filter_dataiterator_internal(pool, SOLVABLE_SUMMARY, *p_impl, cmp_type, patterns);
@@ -1206,7 +1206,7 @@ PackageQuery & PackageQuery::ifilter_summary(const std::vector<std::string> & pa
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_url(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_url(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Pool * pool = get_sack()->p_impl->get_pool();
 
     filter_dataiterator_internal(pool, SOLVABLE_URL, *p_impl, cmp_type, patterns);
@@ -1214,7 +1214,7 @@ PackageQuery & PackageQuery::ifilter_url(const std::vector<std::string> & patter
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_location(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_location(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1252,7 +1252,7 @@ PackageQuery & PackageQuery::ifilter_location(const std::vector<std::string> & p
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_provides(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_provides(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1309,7 +1309,7 @@ void PackageQuery::Impl::str2reldep_internal(
     }
 }
 
-PackageQuery & PackageQuery::ifilter_provides(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_provides(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1321,9 +1321,9 @@ PackageQuery & PackageQuery::ifilter_provides(const std::vector<std::string> & p
     Impl::str2reldep_internal(reldep_list, cmp_type, patterns);
 
     if (cmp_not) {
-        return ifilter_provides(reldep_list, libdnf::sack::QueryCmp::NEQ);
+        return filter_provides(reldep_list, libdnf::sack::QueryCmp::NEQ);
     } else {
-        return ifilter_provides(reldep_list, libdnf::sack::QueryCmp::EQ);
+        return filter_provides(reldep_list, libdnf::sack::QueryCmp::EQ);
     }
 }
 
@@ -1728,48 +1728,48 @@ void PackageQuery::Impl::filter_nevra(
     }
 }
 
-PackageQuery & PackageQuery::ifilter_conflicts(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_conflicts(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_CONFLICTS, cmp_type, reldep_list);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_conflicts(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_conflicts(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_CONFLICTS, cmp_type, patterns);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_conflicts(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_conflicts(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_CONFLICTS, cmp_type, package_set);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_enhances(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_enhances(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_ENHANCES, cmp_type, reldep_list);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_enhances(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_enhances(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_ENHANCES, cmp_type, patterns);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_enhances(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_enhances(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_ENHANCES, cmp_type, package_set);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_obsoletes(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_obsoletes(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_OBSOLETES, cmp_type, reldep_list);
 
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_obsoletes(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_obsoletes(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_OBSOLETES, cmp_type, patterns);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_obsoletes(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_obsoletes(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not;
     switch (cmp_type) {
         case libdnf::sack::QueryCmp::EQ:
@@ -1825,67 +1825,67 @@ PackageQuery & PackageQuery::ifilter_obsoletes(const PackageSet & package_set, l
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_recommends(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_recommends(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_RECOMMENDS, cmp_type, reldep_list);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_recommends(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_recommends(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_RECOMMENDS, cmp_type, patterns);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_recommends(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_recommends(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_RECOMMENDS, cmp_type, package_set);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_requires(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_requires(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_REQUIRES, cmp_type, reldep_list);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_requires(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_requires(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_REQUIRES, cmp_type, patterns);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_requires(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_requires(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_REQUIRES, cmp_type, package_set);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_suggests(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_suggests(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_SUGGESTS, cmp_type, reldep_list);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_suggests(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_suggests(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_SUGGESTS, cmp_type, patterns);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_suggests(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_suggests(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_SUGGESTS, cmp_type, package_set);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_supplements(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_supplements(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_SUPPLEMENTS, cmp_type, reldep_list);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_supplements(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_supplements(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_SUPPLEMENTS, cmp_type, patterns);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_supplements(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+PackageQuery & PackageQuery::filter_supplements(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     Impl::filter_reldep(*this, SOLVABLE_SUPPLEMENTS, cmp_type, package_set);
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_advisories(
+PackageQuery & PackageQuery::filter_advisories(
     const libdnf::advisory::AdvisoryQuery & advisory_query, libdnf::sack::QueryCmp cmp_type) {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
@@ -1954,7 +1954,7 @@ PackageQuery & PackageQuery::ifilter_advisories(
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_installed() {
+PackageQuery & PackageQuery::filter_installed() {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
@@ -1981,7 +1981,7 @@ PackageQuery & PackageQuery::ifilter_installed() {
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_available() {
+PackageQuery & PackageQuery::filter_available() {
     Pool * pool = p_impl->sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
@@ -2002,7 +2002,7 @@ PackageQuery & PackageQuery::ifilter_available() {
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_upgrades() {
+PackageQuery & PackageQuery::filter_upgrades() {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
@@ -2027,7 +2027,7 @@ PackageQuery & PackageQuery::ifilter_upgrades() {
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_downgrades() {
+PackageQuery & PackageQuery::filter_downgrades() {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
@@ -2053,7 +2053,7 @@ PackageQuery & PackageQuery::ifilter_downgrades() {
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_upgradable() {
+PackageQuery & PackageQuery::filter_upgradable() {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
@@ -2092,7 +2092,7 @@ PackageQuery & PackageQuery::ifilter_upgradable() {
     return *this;
 }
 
-PackageQuery & PackageQuery::ifilter_downgradable() {
+PackageQuery & PackageQuery::filter_downgradable() {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
     auto * installed_repo = pool->installed;
@@ -2184,7 +2184,7 @@ static int filter_latest_sortcmp_byarch(const void * ap, const void * bp, void *
     return *(Id *)ap - *(Id *)bp;
 }
 
-PackageQuery & PackageQuery::ifilter_latest(int limit) {
+PackageQuery & PackageQuery::filter_latest(int limit) {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
 
@@ -2230,7 +2230,7 @@ static inline bool priority_solvable_cmp_key(const Solvable * first, const Solva
     return first->repo->priority > second->repo->priority;
 }
 
-PackageQuery & PackageQuery::ifilter_priority() {
+PackageQuery & PackageQuery::filter_priority() {
     auto sack = get_sack();
     Pool * pool = sack->p_impl->get_pool();
 

--- a/libdnf/transaction/query.cpp
+++ b/libdnf/transaction/query.cpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 // TransactionSack and TransactionQuery are different than any other similar objects.
 // TransactionSack is loaded lazily any time a TransactionQuery retrieves a Transaction from the database.
 // The filters should make a query to the database and return a list of matching transction IDs
-// and the IDs should be passed  to ifilter_id() to load the Transaction objects.
+// and the IDs should be passed  to filter_id() to load the Transaction objects.
 
 
 #include "libdnf/transaction/query.hpp"
@@ -40,7 +40,7 @@ namespace libdnf::transaction {
 TransactionQuery::TransactionQuery(TransactionSack & sack) : sack{&sack} {}
 
 
-TransactionQuery & TransactionQuery::ifilter_id(sack::QueryCmp cmp, const std::vector<int64_t> & patterns) {
+TransactionQuery & TransactionQuery::filter_id(sack::QueryCmp cmp, const std::vector<int64_t> & patterns) {
     switch (cmp) {
         case libdnf::sack::QueryCmp::EQ:
             // currently only EQ operator is supported
@@ -117,14 +117,14 @@ TransactionQuery & TransactionQuery::ifilter_id(sack::QueryCmp cmp, const std::v
         initialized = true;
     }
 
-    ifilter(F::id, cmp, patterns);
+    filter(F::id, cmp, patterns);
     return *this;
 }
 
 
-TransactionQuery & TransactionQuery::ifilter_id(sack::QueryCmp cmp, int64_t pattern) {
+TransactionQuery & TransactionQuery::filter_id(sack::QueryCmp cmp, int64_t pattern) {
     std::vector<int64_t> patterns{pattern};
-    return ifilter_id(cmp, patterns);
+    return filter_id(cmp, patterns);
 }
 
 

--- a/microdnf/commands/advisory/advisory.cpp
+++ b/microdnf/commands/advisory/advisory.cpp
@@ -172,14 +172,14 @@ void CmdAdvisory::run(Context & ctx) {
 
     auto package_sack = ctx.base.get_rpm_package_sack();
     package_sack->create_system_repo(false);
-    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().filter_enabled(true);
     using LoadFlags = libdnf::rpm::PackageSack::LoadRepoFlags;
     ctx.load_rpm_repos(enabled_repos, LoadFlags::USE_UPDATEINFO);
 
     libdnf::rpm::PackageQuery package_query(package_sack);
     using QueryCmp = libdnf::sack::QueryCmp;
     if (patterns_to_show.size() > 0) {
-        package_query.ifilter_name(patterns_to_show, QueryCmp::IGLOB);
+        package_query.filter_name(patterns_to_show, QueryCmp::IGLOB);
     }
 
     //DATA IS PREPARED
@@ -187,29 +187,29 @@ void CmdAdvisory::run(Context & ctx) {
     //TODO(amatej): create advisory_query with filters on advisories prensent (if we want to limit by severity, reference..)
     auto advisory_query = ctx.base.get_rpm_advisory_sack()->new_query();
     if (with_cve_option->get_value()) {
-        advisory_query.ifilter_CVE("*", QueryCmp::IGLOB);
+        advisory_query.filter_CVE("*", QueryCmp::IGLOB);
     }
     if (with_bz_option->get_value()) {
-        advisory_query.ifilter_bug("*", QueryCmp::IGLOB);
+        advisory_query.filter_bug("*", QueryCmp::IGLOB);
     }
-    //advisory_query.ifilter_name(QueryCmp::IGLOB, input_name);
-    //advisory_query.ifilter_severity(QueryCmp::EQ, input_severity);
+    //advisory_query.filter_name(QueryCmp::IGLOB, input_name);
+    //advisory_query.filter_severity(QueryCmp::EQ, input_severity);
 
     std::vector<libdnf::advisory::AdvisoryPackage> result_pkgs;
 
     if (availability_option->get_value() == "installed") {
-        auto installed_package_query = package_query.ifilter_installed();
+        auto installed_package_query = package_query.filter_installed();
         result_pkgs = advisory_query.get_advisory_packages(installed_package_query, QueryCmp::LTE);
     } else if (availability_option->get_value() == "available") {
         //TODO(amatej): filter for latest and add kernel..
-        auto installed_package_query = package_query.ifilter_installed();
+        auto installed_package_query = package_query.filter_installed();
         result_pkgs = advisory_query.get_advisory_packages(installed_package_query, QueryCmp::GT);
     } else if (availability_option->get_value() == "all") {
-        auto installed_package_query = package_query.ifilter_installed();
+        auto installed_package_query = package_query.filter_installed();
         result_pkgs =
             advisory_query.get_advisory_packages(installed_package_query, QueryCmp::LT | QueryCmp::EQ | QueryCmp::GT);
     } else if (availability_option->get_value() == "updates") {
-        //auto upgradable_package_query = package_query.ifilter_upgradable().ifilter_nevra(keys, QueryCmp::GT);
+        //auto upgradable_package_query = package_query.filter_upgradable().filter_nevra(keys, QueryCmp::GT);
         //result_pkgs = advisory_query.get_advisory_packages(upgradable_package_query, QueryCmp::LT | QueryCmp::EQ | QueryCmp::GT);
     }
 

--- a/microdnf/commands/downgrade/downgrade.cpp
+++ b/microdnf/commands/downgrade/downgrade.cpp
@@ -78,7 +78,7 @@ void CmdDowngrade::run(Context & ctx) {
     package_sack.create_system_repo(false);
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().filter_enabled(true);
     using LoadFlags = libdnf::rpm::PackageSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -70,7 +70,7 @@ void CmdDownload::run(Context & ctx) {
     auto package_sack = ctx.base.get_rpm_package_sack();
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().filter_enabled(true);
     using LoadFlags = libdnf::rpm::PackageSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);

--- a/microdnf/commands/groupinfo/groupinfo.cpp
+++ b/microdnf/commands/groupinfo/groupinfo.cpp
@@ -128,17 +128,17 @@ void CmdGroupinfo::run([[maybe_unused]] Context & ctx) {
     // Filter by patterns if given
     if (patterns_to_show.size() > 0) {
         auto query_names = libdnf::comps::GroupQuery(query);
-        query.ifilter_groupid(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
-        query |= query_names.ifilter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query.filter_groupid(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query |= query_names.filter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
     } else if (not hidden_option->get_value()) {
         // Filter uservisible only if patterns are not given
-        query.ifilter_uservisible(true);
+        query.filter_uservisible(true);
     }
 
     std::set<libdnf::comps::Group> group_list;
 
     auto query_installed = libdnf::comps::GroupQuery(query);
-    query_installed.ifilter_installed(true);
+    query_installed.filter_installed(true);
 
     // --installed -> filter installed groups
     if (installed_option->get_value()) {
@@ -153,7 +153,7 @@ void CmdGroupinfo::run([[maybe_unused]] Context & ctx) {
         }
         // --available / all -> add available not-installed groups into the list
         auto query_available = libdnf::comps::GroupQuery(query);
-        query_available.ifilter_installed(false);
+        query_available.filter_installed(false);
         std::set<std::string> installed_groupids;
         for (auto group: query_installed.list()) {
             installed_groupids.insert(group.get_groupid());

--- a/microdnf/commands/grouplist/grouplist.cpp
+++ b/microdnf/commands/grouplist/grouplist.cpp
@@ -126,17 +126,17 @@ void CmdGrouplist::run([[maybe_unused]] Context & ctx) {
     // Filter by patterns if given
     if (patterns_to_show.size() > 0) {
         auto query_names = libdnf::comps::GroupQuery(query);
-        query.ifilter_groupid(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
-        query |= query_names.ifilter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query.filter_groupid(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query |= query_names.filter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
     } else if (not hidden_option->get_value()) {
         // Filter uservisible only if patterns are not given
-        query.ifilter_uservisible(true);
+        query.filter_uservisible(true);
     }
 
     std::set<libdnf::comps::Group> group_list;
 
     auto query_installed = libdnf::comps::GroupQuery(query);
-    query_installed.ifilter_installed(true);
+    query_installed.filter_installed(true);
 
     // --installed -> filter installed groups
     if (installed_option->get_value()) {
@@ -151,7 +151,7 @@ void CmdGrouplist::run([[maybe_unused]] Context & ctx) {
         }
         // --available / all -> add available not-installed groups into the list
         auto query_available = libdnf::comps::GroupQuery(query);
-        query_available.ifilter_installed(false);
+        query_available.filter_installed(false);
         std::set<std::string> installed_groupids;
         for (auto group: query_installed.list()) {
             installed_groupids.insert(group.get_groupid());

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -78,7 +78,7 @@ void CmdInstall::run(Context & ctx) {
     package_sack.create_system_repo(false);
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().filter_enabled(true);
     using LoadFlags = libdnf::rpm::PackageSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -77,7 +77,7 @@ void CmdReinstall::run(Context & ctx) {
     package_sack->create_system_repo(false);
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().filter_enabled(true);
     using LoadFlags = libdnf::rpm::PackageSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);

--- a/microdnf/commands/repolist/repolist.cpp
+++ b/microdnf/commands/repolist/repolist.cpp
@@ -124,15 +124,15 @@ void CmdRepolist::run(Context & ctx) {
 
     auto query = ctx.base.get_rpm_repo_sack()->new_query();
     if (enable_disable_option->get_value() == "enabled") {
-        query.ifilter_enabled(true);
+        query.filter_enabled(true);
     } else if (enable_disable_option->get_value() == "disabled") {
-        query.ifilter_enabled(false);
+        query.filter_enabled(false);
     }
 
     if (patterns_to_show.size() > 0) {
         auto query_names = query;
-        query.ifilter_id(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
-        query |= query_names.ifilter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query.filter_id(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query |= query_names.filter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
     }
 
     bool with_status = enable_disable_option->get_value() == "all";

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -122,7 +122,7 @@ void CmdRepoquery::run(Context & ctx) {
 
     // To search in available repositories (available packages)
     if (available_option->get_priority() >= libdnf::Option::Priority::COMMANDLINE || !installed_option->get_value()) {
-        auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
+        auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().filter_enabled(true);
         using LoadFlags = libdnf::rpm::PackageSack::LoadRepoFlags;
         auto flags =
             LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -77,7 +77,7 @@ void CmdUpgrade::run(Context & ctx) {
     package_sack.create_system_repo(false);
 
     // To search in available repositories (available packages)
-    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().ifilter_enabled(true);
+    auto enabled_repos = ctx.base.get_rpm_repo_sack()->new_query().filter_enabled(true);
     using LoadFlags = libdnf::rpm::PackageSack::LoadRepoFlags;
     auto flags = LoadFlags::USE_FILELISTS | LoadFlags::USE_PRESTO | LoadFlags::USE_UPDATEINFO | LoadFlags::USE_OTHER;
     ctx.load_rpm_repos(enabled_repos, flags);

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -299,7 +299,7 @@ int main(int argc, char * argv[]) {
     for (const auto & setopt : context.setopts) {
         auto last_dot_pos = setopt.first.rfind('.');
         auto repo_pattern = setopt.first.substr(0, last_dot_pos);
-        auto query = rpm_repo_sack->new_query().ifilter_id(libdnf::sack::QueryCmp::GLOB, repo_pattern);
+        auto query = rpm_repo_sack->new_query().filter_id(libdnf::sack::QueryCmp::GLOB, repo_pattern);
         auto key = setopt.first.substr(last_dot_pos + 1);
         for (auto & repo : query.get_data()) {
             try {

--- a/test/libdnf/advisory/test_advisory.cpp
+++ b/test/libdnf/advisory/test_advisory.cpp
@@ -38,7 +38,7 @@ void AdvisoryAdvisoryTest::setUp() {
     RepoFixture::add_repo_repomd("repomd-repo1");
     advisory_sack = base->get_rpm_advisory_sack();
     libdnf::advisory::AdvisoryQuery q =
-        advisory_sack->new_query().ifilter_type(libdnf::advisory::Advisory::Type::SECURITY);
+        advisory_sack->new_query().filter_type(libdnf::advisory::Advisory::Type::SECURITY);
     advisories = q.get_advisories();
     advisory = &(advisories[0]);
 }
@@ -91,7 +91,7 @@ void AdvisoryAdvisoryTest::test_get_collections() {
     CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), mods[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), mods[1].get_name());
 
-    auto adv_vec = advisory_sack->new_query().ifilter_name("DNF-2020-1").get_advisories();
+    auto adv_vec = advisory_sack->new_query().filter_name("DNF-2020-1").get_advisories();
     CPPUNIT_ASSERT_EQUAL(1lu, adv_vec.size());
     libdnf::advisory::Advisory * advisory2 = &(adv_vec[0]);
     colls = advisory2->get_collections();

--- a/test/libdnf/advisory/test_advisory.hpp
+++ b/test/libdnf/advisory/test_advisory.hpp
@@ -48,7 +48,7 @@ public:
     void test_get_type();
     void test_get_type_cstring();
     void test_get_severity();
-    //void test_ifilter_package();
+    //void test_filter_package();
 
     void test_get_references();
     void test_get_collections();

--- a/test/libdnf/advisory/test_advisory_module.cpp
+++ b/test/libdnf/advisory/test_advisory_module.cpp
@@ -33,7 +33,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryModuleTest, "AdvisoryAdvis
 void AdvisoryAdvisoryModuleTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    auto advisory = base->get_rpm_advisory_sack()->new_query().ifilter_name("DNF-2019-1").get_advisories()[0];
+    auto advisory = base->get_rpm_advisory_sack()->new_query().filter_name("DNF-2019-1").get_advisories()[0];
     std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
     modules = collections[0].get_modules();
 }

--- a/test/libdnf/advisory/test_advisory_package.cpp
+++ b/test/libdnf/advisory/test_advisory_package.cpp
@@ -33,7 +33,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryPackageTest, "AdvisoryAdvi
 void AdvisoryAdvisoryPackageTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    auto advisory = base->get_rpm_advisory_sack()->new_query().ifilter_name("DNF-2019-1").get_advisories()[0];
+    auto advisory = base->get_rpm_advisory_sack()->new_query().filter_name("DNF-2019-1").get_advisories()[0];
     std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
     packages = collections[0].get_packages();
 }

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -44,35 +44,35 @@ void AdvisoryAdvisoryQueryTest::test_size() {
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 
-void AdvisoryAdvisoryQueryTest::test_ifilter_name() {
-    // Tests ifilter_name method
+void AdvisoryAdvisoryQueryTest::test_filter_name() {
+    // Tests filter_name method
     libdnf::advisory::AdvisoryQuery adv_query =
-        advisory_sack->new_query().ifilter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
+        advisory_sack->new_query().filter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
     std::vector<std::string> expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = advisory_sack->new_query().filter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_name(
+    adv_query = advisory_sack->new_query().filter_name(
         std::vector<std::string>{"DNF-2019-1", "DNF-2020-1"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 
-void AdvisoryAdvisoryQueryTest::test_ifilter_type() {
-    // Tests ifilter_type method
+void AdvisoryAdvisoryQueryTest::test_filter_type() {
+    // Tests filter_type method
     libdnf::advisory::AdvisoryQuery adv_query =
-        advisory_sack->new_query().ifilter_type(libdnf::advisory::Advisory::Type::BUGFIX);
+        advisory_sack->new_query().filter_type(libdnf::advisory::Advisory::Type::BUGFIX);
     std::vector<std::string> expected = {"DNF-2020-1", "PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_type(libdnf::advisory::Advisory::Type::ENHANCEMENT);
+    adv_query = advisory_sack->new_query().filter_type(libdnf::advisory::Advisory::Type::ENHANCEMENT);
     expected = {"PKG-NEWER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_type(
+    adv_query = advisory_sack->new_query().filter_type(
         std::vector<libdnf::advisory::Advisory::Type>{
             libdnf::advisory::Advisory::Type::BUGFIX, libdnf::advisory::Advisory::Type::SECURITY},
         libdnf::sack::QueryCmp::EQ);
@@ -80,79 +80,79 @@ void AdvisoryAdvisoryQueryTest::test_ifilter_type() {
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 
-void AdvisoryAdvisoryQueryTest::test_ifilter_packages() {
-    // Tests ifilter_packages method
+void AdvisoryAdvisoryQueryTest::test_filter_packages() {
+    // Tests filter_packages method
     libdnf::rpm::PackageQuery pkg_query(sack);
 
     libdnf::advisory::AdvisoryQuery adv_query =
-        advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
+        advisory_sack->new_query().filter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
     std::vector<std::string> expected = {"PKG-NEWER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
+    adv_query = advisory_sack->new_query().filter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
     expected = {"DNF-2019-1", "PKG-NEWER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
+    adv_query = advisory_sack->new_query().filter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
+    adv_query = advisory_sack->new_query().filter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
     expected = {"DNF-2019-1", "PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
+    adv_query = advisory_sack->new_query().filter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
     expected = {"PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 
-void AdvisoryAdvisoryQueryTest::test_ifilter_cve() {
-    // Tests ifilter_cve method
+void AdvisoryAdvisoryQueryTest::test_filter_cve() {
+    // Tests filter_cve method
     libdnf::advisory::AdvisoryQuery adv_query =
-        advisory_sack->new_query().ifilter_CVE("3333", libdnf::sack::QueryCmp::EQ);
+        advisory_sack->new_query().filter_CVE("3333", libdnf::sack::QueryCmp::EQ);
     std::vector<std::string> expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
     adv_query =
-        advisory_sack->new_query().ifilter_CVE(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
+        advisory_sack->new_query().filter_CVE(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
     adv_query =
-        advisory_sack->new_query().ifilter_CVE(std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ);
+        advisory_sack->new_query().filter_CVE(std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_CVE("*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = advisory_sack->new_query().filter_CVE("*", libdnf::sack::QueryCmp::GLOB);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 
-void AdvisoryAdvisoryQueryTest::test_ifilter_bug() {
-    // Tests ifilter_bug method
+void AdvisoryAdvisoryQueryTest::test_filter_bug() {
+    // Tests filter_bug method
     libdnf::advisory::AdvisoryQuery adv_query =
-        advisory_sack->new_query().ifilter_bug("2222", libdnf::sack::QueryCmp::EQ);
+        advisory_sack->new_query().filter_bug("2222", libdnf::sack::QueryCmp::EQ);
     std::vector<std::string> expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
     adv_query =
-        advisory_sack->new_query().ifilter_bug(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
+        advisory_sack->new_query().filter_bug(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
     expected = {};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_bug("*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = advisory_sack->new_query().filter_bug("*", libdnf::sack::QueryCmp::GLOB);
     expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 
-void AdvisoryAdvisoryQueryTest::test_ifilter_severity() {
-    // Tests ifilter_severity method
+void AdvisoryAdvisoryQueryTest::test_filter_severity() {
+    // Tests filter_severity method
     libdnf::advisory::AdvisoryQuery adv_query =
-        advisory_sack->new_query().ifilter_severity("moderate", libdnf::sack::QueryCmp::EQ);
+        advisory_sack->new_query().filter_severity("moderate", libdnf::sack::QueryCmp::EQ);
     std::vector<std::string> expected = {"DNF-2019-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = advisory_sack->new_query().ifilter_severity(
+    adv_query = advisory_sack->new_query().filter_severity(
         std::vector<std::string>{"moderate", "critical"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
@@ -177,7 +177,7 @@ void AdvisoryAdvisoryQueryTest::test_get_sorted_advisory_packages() {
     CPPUNIT_ASSERT_EQUAL(std::string("yum"), adv_pkgs[6].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("3.4.3-0"), adv_pkgs[6].get_evr());
 
-    adv_pkgs = advisory_sack->new_query().ifilter_name("DNF-2020-1").get_sorted_advisory_packages();
+    adv_pkgs = advisory_sack->new_query().filter_name("DNF-2020-1").get_sorted_advisory_packages();
     CPPUNIT_ASSERT_EQUAL(3lu, adv_pkgs.size());
     CPPUNIT_ASSERT_EQUAL(std::string("bitcoin"), adv_pkgs[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("2.5-1"), adv_pkgs[0].get_evr());

--- a/test/libdnf/advisory/test_advisory_query.hpp
+++ b/test/libdnf/advisory/test_advisory_query.hpp
@@ -32,12 +32,12 @@ class AdvisoryAdvisoryQueryTest : public RepoFixture {
     CPPUNIT_TEST_SUITE(AdvisoryAdvisoryQueryTest);
 
     CPPUNIT_TEST(test_size);
-    CPPUNIT_TEST(test_ifilter_name);
-    CPPUNIT_TEST(test_ifilter_type);
-    CPPUNIT_TEST(test_ifilter_packages);
-    CPPUNIT_TEST(test_ifilter_cve);
-    CPPUNIT_TEST(test_ifilter_bug);
-    CPPUNIT_TEST(test_ifilter_severity);
+    CPPUNIT_TEST(test_filter_name);
+    CPPUNIT_TEST(test_filter_type);
+    CPPUNIT_TEST(test_filter_packages);
+    CPPUNIT_TEST(test_filter_cve);
+    CPPUNIT_TEST(test_filter_bug);
+    CPPUNIT_TEST(test_filter_severity);
     CPPUNIT_TEST(test_get_sorted_advisory_packages);
 
     CPPUNIT_TEST_SUITE_END();
@@ -46,12 +46,12 @@ public:
     void setUp() override;
 
     void test_size();
-    void test_ifilter_name();
-    void test_ifilter_type();
-    void test_ifilter_packages();
-    void test_ifilter_cve();
-    void test_ifilter_bug();
-    void test_ifilter_severity();
+    void test_filter_name();
+    void test_filter_type();
+    void test_filter_packages();
+    void test_filter_cve();
+    void test_filter_bug();
+    void test_filter_severity();
     void test_get_sorted_advisory_packages();
 
 private:

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -245,7 +245,7 @@ void BaseGoalTest::test_install_installed_pkg() {
     sack->add_cmdline_package(rpm_path, false);
 
     libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
-    query.ifilter_available().ifilter_nevra({"cmdline-0:1.2-3.noarch"});
+    query.filter_available().filter_nevra({"cmdline-0:1.2-3.noarch"});
 
     std::vector<std::string> expected = {"cmdline-0:1.2-3.noarch"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -478,7 +478,7 @@ void BaseGoalTest::test_install_or_reinstall() {
 
     libdnf::Goal goal(base.get());
     libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
-    query.ifilter_available().ifilter_nevra({"cmdline-0:1.2-3.noarch"});
+    query.filter_available().filter_nevra({"cmdline-0:1.2-3.noarch"});
     CPPUNIT_ASSERT_EQUAL(1lu, query.size());
     goal.add_rpm_install_or_reinstall(query);
     goal.resolve(false);

--- a/test/libdnf/comps/test_group.cpp
+++ b/test/libdnf/comps/test_group.cpp
@@ -49,8 +49,8 @@ void CompsGroupTest::test_load() {
 
     comps.load_from_file(data_path / "core.xml", reponame);
     auto q_core = comps.get_group_sack().new_query();
-    q_core.ifilter_installed(false);
-    q_core.ifilter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core.filter_installed(false);
+    q_core.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
     auto core = q_core.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Core"), core.get_name());
@@ -77,8 +77,8 @@ void CompsGroupTest::test_load() {
 
     comps.load_from_file(data_path / "standard.xml", reponame);
     auto q_standard = comps.get_group_sack().new_query();
-    q_standard.ifilter_installed(false);
-    q_standard.ifilter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
+    q_standard.filter_installed(false);
+    q_standard.filter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
     auto standard = q_standard.get();
     CPPUNIT_ASSERT_EQUAL(std::string("standard"), standard.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Standard"), standard.get_name());
@@ -110,7 +110,7 @@ void CompsGroupTest::test_load_defaults() {
 
     comps.load_from_file(data_path / "core-empty.xml", reponame);
     auto q_core_empty = comps.get_group_sack().new_query();
-    q_core_empty.ifilter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core_empty.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
     auto core_empty = q_core_empty.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core_empty.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string(""), core_empty.get_name());
@@ -137,7 +137,7 @@ void CompsGroupTest::test_merge() {
     comps.load_from_file(data_path / "core-v2.xml", reponame);
 
     auto q_core2 = comps.get_group_sack().new_query();
-    q_core2.ifilter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core2.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
     auto core2 = q_core2.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core2.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Core v2"), core2.get_name());
@@ -176,7 +176,7 @@ void CompsGroupTest::test_merge_with_empty() {
     comps.load_from_file(data_path / "core-empty.xml", reponame);
 
     auto q_core_empty = comps.get_group_sack().new_query();
-    q_core_empty.ifilter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core_empty.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
     auto core_empty = q_core_empty.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core_empty.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Core"), core_empty.get_name());
@@ -206,7 +206,7 @@ void CompsGroupTest::test_merge_empty_with_nonempty() {
     comps.load_from_file(data_path / "core.xml", reponame);
 
     auto q_core = comps.get_group_sack().new_query();
-    q_core.ifilter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
     auto core = q_core.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Core"), core.get_name());
@@ -240,7 +240,7 @@ void CompsGroupTest::test_dump_and_load() {
 
     comps.load_from_file(data_path / "standard.xml", reponame);
     auto q_standard = comps.get_group_sack().new_query();
-    q_standard.ifilter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
+    q_standard.filter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
     auto standard = q_standard.get();
     
     auto dumped_standard_path = std::filesystem::temp_directory_path() / "dumped-standard.xml";
@@ -249,7 +249,7 @@ void CompsGroupTest::test_dump_and_load() {
     comps2.load_from_file(dumped_standard_path, reponame);
 
     auto q_dumped_standard = comps2.get_group_sack().new_query();
-    q_dumped_standard.ifilter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
+    q_dumped_standard.filter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
     auto dumped_standard = q_dumped_standard.get();
 
     CPPUNIT_ASSERT_EQUAL(std::string("standard"), dumped_standard.get_groupid());

--- a/test/libdnf/query/test_query.cpp
+++ b/test/libdnf/query/test_query.cpp
@@ -40,9 +40,9 @@ class TestQuery : public libdnf::sack::Query<QueryItem> {
 public:
     using Query<QueryItem>::Query;
 
-    TestQuery & ifilter_enabled(bool enabled);
-    TestQuery & ifilter_id(libdnf::sack::QueryCmp cmp, int64_t id);
-    TestQuery & ifilter_name(libdnf::sack::QueryCmp cmp, const std::string & name);
+    TestQuery & filter_enabled(bool enabled);
+    TestQuery & filter_id(libdnf::sack::QueryCmp cmp, int64_t id);
+    TestQuery & filter_name(libdnf::sack::QueryCmp cmp, const std::string & name);
 
 private:
     struct F {
@@ -52,18 +52,18 @@ private:
     };
 };
 
-TestQuery & TestQuery::ifilter_enabled(bool enabled) {
-    ifilter(F::enabled, libdnf::sack::QueryCmp::EQ, enabled);
+TestQuery & TestQuery::filter_enabled(bool enabled) {
+    filter(F::enabled, libdnf::sack::QueryCmp::EQ, enabled);
     return *this;
 }
 
-TestQuery & TestQuery::ifilter_id(libdnf::sack::QueryCmp cmp, int64_t id) {
-    ifilter(F::id, cmp, id);
+TestQuery & TestQuery::filter_id(libdnf::sack::QueryCmp cmp, int64_t id) {
+    filter(F::id, cmp, id);
     return *this;
 }
 
-TestQuery & TestQuery::ifilter_name(libdnf::sack::QueryCmp cmp, const std::string & name) {
-    ifilter(F::name, cmp, name);
+TestQuery & TestQuery::filter_name(libdnf::sack::QueryCmp cmp, const std::string & name) {
+    filter(F::name, cmp, name);
     return *this;
 }
 
@@ -81,25 +81,25 @@ void QueryTest::test_query_basics() {
     auto q1 = q;
     CPPUNIT_ASSERT_EQUAL(q1.size(), static_cast<size_t>(3));
 
-    // test ifilter_enabled()
-    q1.ifilter_enabled(true);
+    // test filter_enabled()
+    q1.filter_enabled(true);
     CPPUNIT_ASSERT_EQUAL(q1.size(), static_cast<size_t>(2));
     CPPUNIT_ASSERT((q1 == libdnf::Set<QueryItem>{{true, 4, "item4"}, {true, 10, "item10"}}));
 
-    // test ifilter_name()
-    q1.ifilter_name(libdnf::sack::QueryCmp::EQ, "item10");
+    // test filter_name()
+    q1.filter_name(libdnf::sack::QueryCmp::EQ, "item10");
     CPPUNIT_ASSERT_EQUAL(q1.size(), static_cast<size_t>(1));
     CPPUNIT_ASSERT((q1 == libdnf::Set<QueryItem>{{true, 10, "item10"}}));
 
-    // test ifilter_id()
+    // test filter_id()
     q1 = q;
-    q1.ifilter_id(libdnf::sack::QueryCmp::GTE, 6);
+    q1.filter_id(libdnf::sack::QueryCmp::GTE, 6);
     CPPUNIT_ASSERT_EQUAL(q1.size(), static_cast<size_t>(2));
     CPPUNIT_ASSERT((q1 == libdnf::Set<QueryItem>{{false, 6, "item6"}, {true, 10, "item10"}}));
 
     // test chaining of filter calling
     q1 = q;
-    q1.ifilter_name(libdnf::sack::QueryCmp::GLOB, "item?").ifilter_enabled(false);
+    q1.filter_name(libdnf::sack::QueryCmp::GLOB, "item?").filter_enabled(false);
     CPPUNIT_ASSERT_EQUAL(q1.size(), static_cast<size_t>(1));
     CPPUNIT_ASSERT((q1 == libdnf::Set<QueryItem>{{false, 6, "item6"}}));
 }

--- a/test/libdnf/rpm/test_package.cpp
+++ b/test/libdnf/rpm/test_package.cpp
@@ -39,7 +39,7 @@ void RpmPackageTest::setUp() {
 
 libdnf::rpm::Package RpmPackageTest::get_pkg(const std::string & nevra) {
     libdnf::rpm::PackageQuery query(sack);
-    query.ifilter_nevra({nevra});
+    query.filter_nevra({nevra});
     CPPUNIT_ASSERT_EQUAL_MESSAGE(
         "get_pkg(\"" + nevra + "\"): no package or more than one package found.", 1lu, query.size());
     return *query.begin();

--- a/test/libdnf/rpm/test_package_query.cpp
+++ b/test/libdnf/rpm/test_package_query.cpp
@@ -51,7 +51,7 @@ void RpmPackageQueryTest::test_size() {
     CPPUNIT_ASSERT_EQUAL(5LU, query.size());
 }
 
-void RpmPackageQueryTest::test_ifilter_latest() {
+void RpmPackageQueryTest::test_filter_latest() {
     add_repo_solv("solv-24pkgs");
     std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
     // also add 2 time the same package
@@ -60,7 +60,7 @@ void RpmPackageQueryTest::test_ifilter_latest() {
 
     {
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_latest(1);
+        query.filter_latest(1);
         std::vector<std::string> expected = {
             "pkg-0:1.2-3.src",
             "pkg-0:1.2-3.x86_64",
@@ -72,7 +72,7 @@ void RpmPackageQueryTest::test_ifilter_latest() {
     }
     {
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_latest(2);
+        query.filter_latest(2);
         std::vector<std::string> expected = {
             "pkg-0:1.2-3.src",
             "pkg-0:1.2-3.x86_64",
@@ -86,7 +86,7 @@ void RpmPackageQueryTest::test_ifilter_latest() {
     }
     {
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_latest(-1);
+        query.filter_latest(-1);
         std::vector<std::string> expected = {
             "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-0:1-1.noarch",  "pkg-0:1-2.noarch",
             "pkg-0:1-3.noarch",        "pkg-0:1-4.noarch",        "pkg-0:1-5.noarch",  "pkg-0:1-6.noarch",
@@ -99,16 +99,16 @@ void RpmPackageQueryTest::test_ifilter_latest() {
     }
     {
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_latest(-23);
+        query.filter_latest(-23);
         std::vector<std::string> expected = {"pkg-0:1-1.noarch"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
 }
 
-void RpmPackageQueryTest::test_ifilter_name() {
+void RpmPackageQueryTest::test_filter_name() {
     // packages with Name == "pkg"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_name({"pkg"});
+    query1.filter_name({"pkg"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
@@ -117,7 +117,7 @@ void RpmPackageQueryTest::test_ifilter_name() {
 
     // packages with Name matching "pkg*" glob
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_name({"pkg*"}, libdnf::sack::QueryCmp::GLOB);
+    query2.filter_name({"pkg*"}, libdnf::sack::QueryCmp::GLOB);
 
     expected = {
         "pkg-0:1.2-3.src",
@@ -131,7 +131,7 @@ void RpmPackageQueryTest::test_ifilter_name() {
 
     // packages with Name matching "p?g" glob
     libdnf::rpm::PackageQuery query3(sack);
-    query3.ifilter_name({"p?g"}, libdnf::sack::QueryCmp::GLOB);
+    query3.filter_name({"p?g"}, libdnf::sack::QueryCmp::GLOB);
 
     expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query3));
@@ -140,7 +140,7 @@ void RpmPackageQueryTest::test_ifilter_name() {
 
     // packages with Name != "pkg"
     libdnf::rpm::PackageQuery query4(sack);
-    query4.ifilter_name({"pkg"}, libdnf::sack::QueryCmp::NEQ);
+    query4.filter_name({"pkg"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query4));
@@ -149,7 +149,7 @@ void RpmPackageQueryTest::test_ifilter_name() {
 
     // packages with Name == "Pkg" - case insensitive match
     libdnf::rpm::PackageQuery query5(sack);
-    query5.ifilter_name({"Pkg"}, libdnf::sack::QueryCmp::IEXACT);
+    query5.filter_name({"Pkg"}, libdnf::sack::QueryCmp::IEXACT);
 
     expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query5));
@@ -159,7 +159,7 @@ void RpmPackageQueryTest::test_ifilter_name() {
     // packages with Name matching "P?g" glob - case insensitive match
     libdnf::rpm::PackageQuery query6(sack);
     std::vector<std::string> names_glob_icase{"cq?lib"};
-    query6.ifilter_name({"P?g"}, libdnf::sack::QueryCmp::IGLOB);
+    query6.filter_name({"P?g"}, libdnf::sack::QueryCmp::IGLOB);
 
     expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query6));
@@ -168,7 +168,7 @@ void RpmPackageQueryTest::test_ifilter_name() {
 
     // packages with Name that contain "kg-l"
     libdnf::rpm::PackageQuery query7(sack);
-    query7.ifilter_name({"kg-l"}, libdnf::sack::QueryCmp::CONTAINS);
+    query7.filter_name({"kg-l"}, libdnf::sack::QueryCmp::CONTAINS);
 
     expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query7));
@@ -177,7 +177,7 @@ void RpmPackageQueryTest::test_ifilter_name() {
 
     // packages with Name that contain "kG-l" - case insensitive match
     libdnf::rpm::PackageQuery query8(sack);
-    query8.ifilter_name({"kG-l"}, libdnf::sack::QueryCmp::ICONTAINS);
+    query8.filter_name({"kG-l"}, libdnf::sack::QueryCmp::ICONTAINS);
 
     expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query8));
@@ -186,13 +186,13 @@ void RpmPackageQueryTest::test_ifilter_name() {
 
     // unsupported comparison type (operator)
     CPPUNIT_ASSERT_THROW(
-        query8.ifilter_name({"pkg"}, libdnf::sack::QueryCmp::GT), libdnf::rpm::PackageQuery::NotSupportedCmpType);
+        query8.filter_name({"pkg"}, libdnf::sack::QueryCmp::GT), libdnf::rpm::PackageQuery::NotSupportedCmpType);
 
     // ---
 
     // packages with Name "pkg" or "pkg-libs" - two patterns matched in one expression
     libdnf::rpm::PackageQuery query9(sack);
-    query9.ifilter_name({"pkg", "pkg-libs"});
+    query9.filter_name({"pkg", "pkg-libs"});
 
     expected = {
         "pkg-0:1.2-3.src",
@@ -203,86 +203,86 @@ void RpmPackageQueryTest::test_ifilter_name() {
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query9));
 }
 
-void RpmPackageQueryTest::test_ifilter_name_packgset() {
+void RpmPackageQueryTest::test_filter_name_packgset() {
     // packages with Name == "pkg"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_name({"pkg"});
-    query1.ifilter_arch({"src"});
+    query1.filter_name({"pkg"});
+    query1.filter_arch({"src"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
 
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_name(query1);
+    query2.filter_name(query1);
 
     std::vector<std::string> expected2 = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected2, to_vector_string(query2));
 }
 
-void RpmPackageQueryTest::test_ifilter_nevra_packgset() {
+void RpmPackageQueryTest::test_filter_nevra_packgset() {
     std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
     sack->add_system_package(rpm_path, false, false);
     sack->add_cmdline_package(rpm_path, false);
 
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_name({"cmdline"});
+    query1.filter_name({"cmdline"});
     std::vector<std::string> expected1 = {"cmdline-0:1.2-3.noarch", "cmdline-0:1.2-3.noarch"};
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query1));
-    query1.ifilter_installed();
+    query1.filter_installed();
 
     std::vector<std::string> expected = {"cmdline-0:1.2-3.noarch"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
     CPPUNIT_ASSERT_EQUAL(1lu, query1.size());
 
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_nevra(query1);
+    query2.filter_nevra(query1);
 
     CPPUNIT_ASSERT_EQUAL(2lu, query2.size());
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query2));
 }
 
-void RpmPackageQueryTest::test_ifilter_name_arch() {
+void RpmPackageQueryTest::test_filter_name_arch() {
     // packages with Name == "pkg"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_name({"pkg"});
-    query1.ifilter_arch({"src"});
+    query1.filter_name({"pkg"});
+    query1.filter_arch({"src"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
 
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_name_arch(query1);
+    query2.filter_name_arch(query1);
 
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
 }
 
-void RpmPackageQueryTest::test_ifilter_name_arch2() {
+void RpmPackageQueryTest::test_filter_name_arch2() {
     std::filesystem::path rpm_path = PROJECT_BINARY_DIR "/test/data/cmdline-rpms/cmdline-1.2-3.noarch.rpm";
     sack->add_system_package(rpm_path, false, false);
     sack->add_cmdline_package(rpm_path, false);
 
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_name({"cmdline"});
+    query1.filter_name({"cmdline"});
     std::vector<std::string> expected1 = {"cmdline-0:1.2-3.noarch", "cmdline-0:1.2-3.noarch"};
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query1));
-    query1.ifilter_installed();
+    query1.filter_installed();
 
     std::vector<std::string> expected = {"cmdline-0:1.2-3.noarch"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
     CPPUNIT_ASSERT_EQUAL(1lu, query1.size());
 
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_name_arch(query1);
+    query2.filter_name_arch(query1);
 
     CPPUNIT_ASSERT_EQUAL(2lu, query2.size());
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query2));
 }
 
-void RpmPackageQueryTest::test_ifilter_nevra() {
+void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument without 0 epoch - two elements
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_nevra({"pkg-1.2-3.src", "pkg-1.2-3.x86_64"});
+        query.filter_nevra({"pkg-1.2-3.src", "pkg-1.2-3.x86_64"});
         std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
@@ -290,7 +290,7 @@ void RpmPackageQueryTest::test_ifilter_nevra() {
     {
         // Test QueryCmp::EQ - argument without 0 epoch - two elements
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_nevra({"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"});
+        query.filter_nevra({"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"});
         std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
@@ -298,7 +298,7 @@ void RpmPackageQueryTest::test_ifilter_nevra() {
     {
         // Test QueryCmp::EQ - argument without 0 epoch - single argument
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_nevra({"pkg-1.2-3.src"});
+        query.filter_nevra({"pkg-1.2-3.src"});
         std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
@@ -306,7 +306,7 @@ void RpmPackageQueryTest::test_ifilter_nevra() {
     {
         // Test QueryCmp::EQ - argument with 0 epoch - single argument
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_nevra({"pkg-0:1.2-3.src"});
+        query.filter_nevra({"pkg-0:1.2-3.src"});
         std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
@@ -314,7 +314,7 @@ void RpmPackageQueryTest::test_ifilter_nevra() {
     {
         // Test QueryCmp::EQ - argument with unknown release - two elements
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_nevra({"pkg-0:1.2-unknown.src", "pkg-0:1.2-unknown1.x86_64"});
+        query.filter_nevra({"pkg-0:1.2-unknown.src", "pkg-0:1.2-unknown1.x86_64"});
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
@@ -322,7 +322,7 @@ void RpmPackageQueryTest::test_ifilter_nevra() {
     {
         // Test QueryCmp::EQ - argument with unknown version - single argument
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_nevra({"pkg-0:1.2-unknown2.x86_64"});
+        query.filter_nevra({"pkg-0:1.2-unknown2.x86_64"});
         CPPUNIT_ASSERT_EQUAL(0LU, query.size());
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -331,17 +331,17 @@ void RpmPackageQueryTest::test_ifilter_nevra() {
     {
         // Test QueryCmp::EQ - argument without epoch, but package with epoch - single argument
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_nevra({"pkg-libs-1.2-4.x86_64"});
+        query.filter_nevra({"pkg-libs-1.2-4.x86_64"});
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
 }
 
 
-void RpmPackageQueryTest::test_ifilter_version() {
+void RpmPackageQueryTest::test_filter_version() {
     // packages with version == "1.2"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_version({"1.2"});
+    query1.filter_version({"1.2"});
 
     std::vector<std::string> expected = {
         "pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64", "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64"};
@@ -351,17 +351,17 @@ void RpmPackageQueryTest::test_ifilter_version() {
 
     // packages with version != "1.2"
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_version({"1.2"}, libdnf::sack::QueryCmp::NEQ);
+    query2.filter_version({"1.2"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-libs-1:1.3-4.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
 }
 
 
-void RpmPackageQueryTest::test_ifilter_release() {
+void RpmPackageQueryTest::test_filter_release() {
     // packages with release == "3"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_release({"3"});
+    query1.filter_release({"3"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64", "pkg-libs-0:1.2-3.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
@@ -370,24 +370,24 @@ void RpmPackageQueryTest::test_ifilter_release() {
 
     // packages with Release != "3"
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_release({"3"}, libdnf::sack::QueryCmp::NEQ);
+    query2.filter_release({"3"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
 }
 
-void RpmPackageQueryTest::test_ifilter_priority() {
+void RpmPackageQueryTest::test_filter_priority() {
     add_repo_solv("solv-24pkgs");
     add_repo_solv("solv-repo1");
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_priority();
+    query1.filter_priority();
     /// TODO(jmracek) Run test with repository with a different priority and check result
 }
 
-void RpmPackageQueryTest::test_ifilter_provides() {
+void RpmPackageQueryTest::test_filter_provides() {
     // packages with Provides == "libpkg.so.0()(64bit)"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_provides({"libpkg.so.0()(64bit)"});
+    query1.filter_provides({"libpkg.so.0()(64bit)"});
 
     std::vector<std::string> expected = {"pkg-libs-1:1.2-4.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
@@ -396,17 +396,17 @@ void RpmPackageQueryTest::test_ifilter_provides() {
 
     // packages without Provides == "libpkg.so.0()(64bit)"
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_provides({"libpkg.so.0()(64bit)"}, libdnf::sack::QueryCmp::NEQ);
+    query2.filter_provides({"libpkg.so.0()(64bit)"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64", "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.3-4.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
 }
 
 
-void RpmPackageQueryTest::test_ifilter_requires() {
+void RpmPackageQueryTest::test_filter_requires() {
     // packages with Requires == "pkg-libs"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_requires({"pkg-libs"});
+    query1.filter_requires({"pkg-libs"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
@@ -415,13 +415,13 @@ void RpmPackageQueryTest::test_ifilter_requires() {
 
     // packages without Requires == "pkg-libs"
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_requires({"pkg-libs"}, libdnf::sack::QueryCmp::NEQ);
+    query2.filter_requires({"pkg-libs"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-0:1.2-3.src", "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
 }
 
-void RpmPackageQueryTest::test_ifilter_advisories() {
+void RpmPackageQueryTest::test_filter_advisories() {
     // Run setUp again to have a clean sack (without solv-repo1)
     RepoFixture::setUp();
     add_repo_repomd("repomd-repo1");
@@ -429,45 +429,45 @@ void RpmPackageQueryTest::test_ifilter_advisories() {
 
     {
         // Test QueryCmp::EQ with equal advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("DNF-2019-1");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().filter_name("DNF-2019-1");
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
+        query.filter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
 
     {
         // Test QueryCmp::GT with older advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("PKG-OLDER");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().filter_name("PKG-OLDER");
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::GT);
+        query.filter_advisories(adv_query, libdnf::sack::QueryCmp::GT);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
 
     {
         // Test QueryCmp::LTE with older advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("PKG-OLDER");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().filter_name("PKG-OLDER");
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::LTE);
+        query.filter_advisories(adv_query, libdnf::sack::QueryCmp::LTE);
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
 
     {
         // Test QueryCmp::LT with newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("PKG-NEWER");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().filter_name("PKG-NEWER");
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::LT);
+        query.filter_advisories(adv_query, libdnf::sack::QueryCmp::LT);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
 
     {
         // Test QueryCmp::GTE with newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().ifilter_name("PKG-NEWER");
+        libdnf::advisory::AdvisoryQuery adv_query = advisory_sack->new_query().filter_name("PKG-NEWER");
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::GTE);
+        query.filter_advisories(adv_query, libdnf::sack::QueryCmp::GTE);
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
@@ -475,24 +475,24 @@ void RpmPackageQueryTest::test_ifilter_advisories() {
     {
         // Test QueryCmp::EQ with older and newer advisory pkg
         libdnf::advisory::AdvisoryQuery adv_query =
-            advisory_sack->new_query().ifilter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
+            advisory_sack->new_query().filter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
         ;
         libdnf::rpm::PackageQuery query(sack);
-        query.ifilter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
+        query.filter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
 }
 
-void RpmPackageQueryTest::test_ifilter_chain() {
+void RpmPackageQueryTest::test_filter_chain() {
     libdnf::rpm::PackageQuery query(sack);
-    query.ifilter_name({"pkg"})
-        .ifilter_epoch({"0"})
-        .ifilter_version({"1.2"})
-        .ifilter_release({"3"})
-        .ifilter_arch({"x86_64"})
-        .ifilter_provides({"foo"}, libdnf::sack::QueryCmp::NEQ)
-        .ifilter_requires({"foo"}, libdnf::sack::QueryCmp::NEQ);
+    query.filter_name({"pkg"})
+        .filter_epoch({"0"})
+        .filter_version({"1.2"})
+        .filter_release({"3"})
+        .filter_arch({"x86_64"})
+        .filter_provides({"foo"}, libdnf::sack::QueryCmp::NEQ)
+        .filter_requires({"foo"}, libdnf::sack::QueryCmp::NEQ);
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -574,10 +574,10 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 void RpmPackageQueryTest::test_update() {
     // packages with Release == "3"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_release({"3"});
+    query1.filter_release({"3"});
 
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_name({"pkg-libs"});
+    query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(3LU, query2.size());
 
     query1.update(query2);
@@ -597,12 +597,12 @@ void RpmPackageQueryTest::test_update() {
 void RpmPackageQueryTest::test_intersection() {
     // packages with Release == "3"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_release({"3"});
+    query1.filter_release({"3"});
     CPPUNIT_ASSERT_EQUAL(3LU, query1.size());
 
     // packages with Name == "pkg-libs"
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_name({"pkg-libs"});
+    query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(3LU, query2.size());
 
     query1.intersection(query2);
@@ -617,13 +617,13 @@ void RpmPackageQueryTest::test_intersection() {
 void RpmPackageQueryTest::test_difference() {
     // packages with Release == "3"
     libdnf::rpm::PackageQuery query1(sack);
-    query1.ifilter_release({"3"});
+    query1.filter_release({"3"});
     CPPUNIT_ASSERT_EQUAL(3LU, query1.size());
 
     // packages with Release == "3" and name == "pkg-libs"
     libdnf::rpm::PackageQuery query2(sack);
-    query2.ifilter_release({"3"});
-    query2.ifilter_name({"pkg-libs"});
+    query2.filter_release({"3"});
+    query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(1LU, query2.size());
 
     query1.difference(query2);

--- a/test/libdnf/rpm/test_package_query.hpp
+++ b/test/libdnf/rpm/test_package_query.hpp
@@ -32,20 +32,20 @@ class RpmPackageQueryTest : public RepoFixture {
 
 #ifndef WITH_PERFORMANCE_TESTS
     CPPUNIT_TEST(test_size);
-    CPPUNIT_TEST(test_ifilter_latest);
-    CPPUNIT_TEST(test_ifilter_name);
-    CPPUNIT_TEST(test_ifilter_name_packgset);
-    CPPUNIT_TEST(test_ifilter_nevra_packgset);
-    CPPUNIT_TEST(test_ifilter_name_arch);
-    CPPUNIT_TEST(test_ifilter_name_arch2);
-    CPPUNIT_TEST(test_ifilter_nevra);
-    CPPUNIT_TEST(test_ifilter_version);
-    CPPUNIT_TEST(test_ifilter_release);
-    CPPUNIT_TEST(test_ifilter_priority);
-    CPPUNIT_TEST(test_ifilter_provides);
-    CPPUNIT_TEST(test_ifilter_requires);
-    CPPUNIT_TEST(test_ifilter_advisories);
-    CPPUNIT_TEST(test_ifilter_chain);
+    CPPUNIT_TEST(test_filter_latest);
+    CPPUNIT_TEST(test_filter_name);
+    CPPUNIT_TEST(test_filter_name_packgset);
+    CPPUNIT_TEST(test_filter_nevra_packgset);
+    CPPUNIT_TEST(test_filter_name_arch);
+    CPPUNIT_TEST(test_filter_name_arch2);
+    CPPUNIT_TEST(test_filter_nevra);
+    CPPUNIT_TEST(test_filter_version);
+    CPPUNIT_TEST(test_filter_release);
+    CPPUNIT_TEST(test_filter_priority);
+    CPPUNIT_TEST(test_filter_provides);
+    CPPUNIT_TEST(test_filter_requires);
+    CPPUNIT_TEST(test_filter_advisories);
+    CPPUNIT_TEST(test_filter_chain);
     CPPUNIT_TEST(test_resolve_pkg_spec);
     CPPUNIT_TEST(test_update);
     CPPUNIT_TEST(test_intersection);
@@ -61,29 +61,29 @@ public:
     void setUp() override;
 
     void test_size();
-    void test_ifilter_latest();
-    void test_ifilter_name();
-    void test_ifilter_name_packgset();
-    void test_ifilter_nevra_packgset();
-    void test_ifilter_name_arch();
-    void test_ifilter_name_arch2();
-    void test_ifilter_nevra();
-    void test_ifilter_version();
-    void test_ifilter_release();
-    void test_ifilter_provides();
-    void test_ifilter_priority();
-    void test_ifilter_requires();
-    void test_ifilter_advisories();
-    void test_ifilter_chain();
+    void test_filter_latest();
+    void test_filter_name();
+    void test_filter_name_packgset();
+    void test_filter_nevra_packgset();
+    void test_filter_name_arch();
+    void test_filter_name_arch2();
+    void test_filter_nevra();
+    void test_filter_version();
+    void test_filter_release();
+    void test_filter_provides();
+    void test_filter_priority();
+    void test_filter_requires();
+    void test_filter_advisories();
+    void test_filter_chain();
     void test_resolve_pkg_spec();
     void test_update();
     void test_intersection();
     void test_difference();
     // TODO(jmracek) Add tests when system repo will be available
-    // PackageQuery & ifilter_upgrades();
-    // PackageQuery & ifilter_downgrades();
-    // PackageQuery & ifilter_upgradable();
-    // PackageQuery & ifilter_downgradable();
+    // PackageQuery & filter_upgrades();
+    // PackageQuery & filter_downgrades();
+    // PackageQuery & filter_upgradable();
+    // PackageQuery & filter_downgradable();
 };
 
 

--- a/test/libdnf/rpm/test_repo_query.cpp
+++ b/test/libdnf/rpm/test_repo_query.cpp
@@ -56,15 +56,15 @@ void RepoQueryTest::test_query_basics() {
     CPPUNIT_ASSERT_EQUAL(repo_query.size(), static_cast<size_t>(4));
     CPPUNIT_ASSERT((repo_query == libdnf::Set{repo1, repo2, repo1_updates, repo2_updates}));
 
-    // Tests ifilter_enabled method
-    repo_query.ifilter_enabled(true);
+    // Tests filter_enabled method
+    repo_query.filter_enabled(true);
     CPPUNIT_ASSERT((repo_query == libdnf::Set{repo1, repo2_updates}));
 
-    // Tests ifilter_id method
-    auto repo_query1 = repo_sack.new_query().ifilter_id(libdnf::sack::QueryCmp::GLOB, "*updates");
+    // Tests filter_id method
+    auto repo_query1 = repo_sack.new_query().filter_id(libdnf::sack::QueryCmp::GLOB, "*updates");
     CPPUNIT_ASSERT((repo_query1 == libdnf::Set{repo1_updates, repo2_updates}));
 
-    // Tests ifilter_local method
-    repo_query1 = repo_sack.new_query().ifilter_local(false);
+    // Tests filter_local method
+    repo_query1 = repo_sack.new_query().filter_local(false);
     CPPUNIT_ASSERT((repo_query1 == libdnf::Set{repo2, repo1_updates, repo2_updates}));
 }

--- a/test/libdnf/transaction/test_comps_environment.cpp
+++ b/test/libdnf/transaction/test_comps_environment.cpp
@@ -81,7 +81,7 @@ void TransactionCompsEnvironmentTest::test_save_load() {
 
     // get the written transaction
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
     // check that there's exactly 1 environment

--- a/test/libdnf/transaction/test_comps_group.cpp
+++ b/test/libdnf/transaction/test_comps_group.cpp
@@ -81,7 +81,7 @@ void TransactionCompsGroupTest::test_save_load() {
 
     // get the written transaction
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
     // check that there's exactly 1 group

--- a/test/libdnf/transaction/test_query.cpp
+++ b/test/libdnf/transaction/test_query.cpp
@@ -32,7 +32,7 @@ using namespace libdnf::transaction;
 CPPUNIT_TEST_SUITE_REGISTRATION(TransactionQueryTest);
 
 
-void TransactionQueryTest::test_ifilter_id_eq() {
+void TransactionQueryTest::test_filter_id_eq() {
     auto base = new_base();
 
     // create a new empty transaction
@@ -47,12 +47,12 @@ void TransactionQueryTest::test_ifilter_id_eq() {
 
     // get the written transaction
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 }
 
 
-void TransactionQueryTest::test_ifilter_id_eq_parallel_queries() {
+void TransactionQueryTest::test_filter_id_eq_parallel_queries() {
     auto base = new_base();
     auto transaction_sack = base->get_transaction_sack();
 
@@ -74,13 +74,13 @@ void TransactionQueryTest::test_ifilter_id_eq_parallel_queries() {
     auto q2 = transaction_sack2->new_query();
     auto q3 = transaction_sack2->new_query();
 
-    q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
     // one item loaded into the sack
     CPPUNIT_ASSERT_EQUAL(1LU, transaction_sack2->get_data().size());
 
-    q3.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q3.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans3 = q3.get();
 
     // query reused the existing item in the sack

--- a/test/libdnf/transaction/test_query.hpp
+++ b/test/libdnf/transaction/test_query.hpp
@@ -30,13 +30,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 class TransactionQueryTest : public TransactionTestBase {
     CPPUNIT_TEST_SUITE(TransactionQueryTest);
-    CPPUNIT_TEST(test_ifilter_id_eq);
-    CPPUNIT_TEST(test_ifilter_id_eq_parallel_queries);
+    CPPUNIT_TEST(test_filter_id_eq);
+    CPPUNIT_TEST(test_filter_id_eq_parallel_queries);
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    void test_ifilter_id_eq();
-    void test_ifilter_id_eq_parallel_queries();
+    void test_filter_id_eq();
+    void test_filter_id_eq_parallel_queries();
 };
 
 

--- a/test/libdnf/transaction/test_rpm_package.cpp
+++ b/test/libdnf/transaction/test_rpm_package.cpp
@@ -67,7 +67,7 @@ void TransactionRpmPackageTest::test_save_load() {
 
     // get the written transaction
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
     // check that there's exactly 10 packages

--- a/test/libdnf/transaction/test_transaction.cpp
+++ b/test/libdnf/transaction/test_transaction.cpp
@@ -62,7 +62,7 @@ void TransactionTest::test_save_load() {
     // load the saved transaction from database and compare values
     auto base2 = new_base();
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
     CPPUNIT_ASSERT_EQUAL(trans->get_id(), trans2->get_id());
@@ -116,7 +116,7 @@ void TransactionTest::test_update() {
     // load the transction from the database
     auto base2 = new_base();
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.ifilter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
     auto trans2 = q2.get();
 
     // check if the values saved during trans->finish() match

--- a/test/perl5/libdnf/rpm/test_package_query.t
+++ b/test/perl5/libdnf/rpm/test_package_query.t
@@ -66,7 +66,7 @@ my @full_nevras = ("CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64",
 # Test QueryCmp::EQ
 {
     my $query = new libdnf::rpm::PackageQuery($sack);
-    $query->ifilter_name(["pkg"]);
+    $query->filter_name(["pkg"]);
     is($query->size(), 1);
 
     my @expected = ("pkg-1.2-3.x86_64");
@@ -84,7 +84,7 @@ my @full_nevras = ("CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64",
 # Test QueryCmp::GLOB
 {
     my $query = new libdnf::rpm::PackageQuery($sack);
-    $query->ifilter_name(["pk*"], $libdnf::common::QueryCmp_GLOB);
+    $query->filter_name(["pk*"], $libdnf::common::QueryCmp_GLOB);
     is($query->size(), 2);
 
     my @expected = ("pkg-1.2-3.x86_64", "pkg-libs-1:1.3-4.x86_64");

--- a/test/python3/libdnf/rpm/test_package_query.py
+++ b/test/python3/libdnf/rpm/test_package_query.py
@@ -113,10 +113,10 @@ class TestPackageQuery(unittest.TestCase):
         self.assertLess(prev_id, self.sack.get_nsolvables())
         self.assertGreaterEqual(prev_id, libdnf.rpm.PackageQuery(self.sack).size())
 
-    def test_ifilter_name(self):
+    def test_filter_name(self):
         # Test QueryCmp::EQ
         query = libdnf.rpm.PackageQuery(self.sack)
-        query.ifilter_name(["pkg"])
+        query.filter_name(["pkg"])
         self.assertEqual(query.size(), 1)
         # TODO(dmach): implement __str__()
         self.assertEqual([i.get_nevra() for i in query], ["pkg-1.2-3.x86_64"])
@@ -125,7 +125,7 @@ class TestPackageQuery(unittest.TestCase):
 
         # Test QueryCmp::GLOB
         query = libdnf.rpm.PackageQuery(self.sack)
-        query.ifilter_name(["pk*"], libdnf.common.QueryCmp_GLOB)
+        query.filter_name(["pk*"], libdnf.common.QueryCmp_GLOB)
         self.assertEqual(query.size(), 2)
         # TODO(dmach): implement __str__()
         self.assertEqual([i.get_nevra() for i in query], ["pkg-1.2-3.x86_64", "pkg-libs-1:1.3-4.x86_64"])

--- a/test/ruby/libdnf/rpm/test_package_query.rb
+++ b/test/ruby/libdnf/rpm/test_package_query.rb
@@ -59,10 +59,10 @@ class TestSimpleNumber < Test::Unit::TestCase
         assert_equal(3, query.size(), 'Number of items in the newly created query')
     end
 
-    def test_ifilter_name()
+    def test_filter_name()
         # Test QueryCmp::EQ
         query = Rpm::PackageQuery.new(@sack)
-        query.ifilter_name(["pkg"])
+        query.filter_name(["pkg"])
         assert_equal(1, query.size())
 
         # TODO(dmach): implement each() so the query can be easily iterated or converted to an array
@@ -79,7 +79,7 @@ class TestSimpleNumber < Test::Unit::TestCase
 
         # Test QueryCmp::GLOB
         query = Rpm::PackageQuery.new(@sack)
-        query.ifilter_name(["pk*"], Common::QueryCmp_GLOB)
+        query.filter_name(["pk*"], Common::QueryCmp_GLOB)
         assert_equal(2, query.size())
 
         # TODO(dmach): implement each() so the query can be easily iterated or converted to an array


### PR DESCRIPTION
The prefix "i" meant a "in place" filter. For compatibility with old DNF.
But we agreed that the prefix is redundant and doesn't improve the code.