### PR TITLE
[dnf5] Postfix notation in *Query filter methods and default value QueryCmp = EQ

### DIFF
--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of dnfdaemon-server: https://github.com/rpm-software-management/libdnf/
 
@@ -250,8 +250,8 @@ sdbus::MethodReply Repo::list(sdbus::MethodCall && call) {
 
     if (patterns.size() > 0) {
         auto query_names = repos_query;
-        repos_query.filter_id(libdnf::sack::QueryCmp::IGLOB, patterns);
-        repos_query |= query_names.filter_name(libdnf::sack::QueryCmp::IGLOB, patterns);
+        repos_query.filter_id(patterns, libdnf::sack::QueryCmp::IGLOB);
+        repos_query |= query_names.filter_name(patterns, libdnf::sack::QueryCmp::IGLOB);
     }
 
     // create reply from the query

--- a/include/libdnf/common/sack/query.hpp
+++ b/include/libdnf/common/sack/query.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -61,20 +61,20 @@ public:
     explicit Query(const Set<T> & src_set) : Set<T>::Set(src_set) {}
     explicit Query(Set<T> && src_set) : Set<T>::Set(std::move(src_set)) {}
 
-    void filter(std::string (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
-    void filter(std::vector<std::string> (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
-    void filter(std::string (*getter)(const T &), QueryCmp cmp, const std::vector<std::string> & patterns);
+    void filter(std::string (*getter)(const T &), const std::string & pattern, QueryCmp cmp);
+    void filter(std::vector<std::string> (*getter)(const T &), const std::string & pattern, QueryCmp cmp);
+    void filter(std::string (*getter)(const T &), const std::vector<std::string> & patterns, QueryCmp cmp);
     void filter(
-        std::vector<std::string> (*getter)(const T &), QueryCmp cmp, const std::vector<std::string> & patterns);
+        std::vector<std::string> (*getter)(const T &), const std::vector<std::string> & patterns, QueryCmp cmp);
 
-    void filter(int64_t (*getter)(const T &), QueryCmp cmp, int64_t pattern);
-    void filter(std::vector<int64_t> (*getter)(const T &), QueryCmp cmp, int64_t pattern);
-    void filter(int64_t (*getter)(const T &), QueryCmp cmp, const std::vector<int64_t> & patterns);
-    void filter(std::vector<int64_t> (*getter)(const T &), QueryCmp cmp, const std::vector<int64_t> & patterns);
+    void filter(int64_t (*getter)(const T &), int64_t pattern, QueryCmp cmp);
+    void filter(std::vector<int64_t> (*getter)(const T &), int64_t pattern, QueryCmp cmp);
+    void filter(int64_t (*getter)(const T &), const std::vector<int64_t> & patterns, QueryCmp cmp);
+    void filter(std::vector<int64_t> (*getter)(const T &), const std::vector<int64_t> & patterns, QueryCmp cmp);
 
-    void filter(bool (*getter)(const T &), QueryCmp cmp, bool pattern);
+    void filter(bool (*getter)(const T &), bool pattern, QueryCmp cmp);
 
-    void filter(char * (*getter)(const T &), QueryCmp cmp, const std::string & pattern);
+    void filter(char * (*getter)(const T &), const std::string & pattern, QueryCmp cmp);
 
     /// Get a single object. Raise an exception if none or multiple objects match the query.
     const T & get() const {
@@ -94,7 +94,7 @@ public:
 
 
 template <typename T>
-inline void Query<T>::filter(Query<T>::FilterFunctionString * getter, QueryCmp cmp, const std::string & pattern) {
+inline void Query<T>::filter(Query<T>::FilterFunctionString * getter, const std::string & pattern, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_string(value, cmp, pattern)) {
@@ -109,7 +109,7 @@ inline void Query<T>::filter(Query<T>::FilterFunctionString * getter, QueryCmp c
 
 template <typename T>
 inline void Query<T>::filter(
-    Query<T>::FilterFunctionVectorString * getter, QueryCmp cmp, const std::string & pattern) {
+    Query<T>::FilterFunctionVectorString * getter, const std::string & pattern, QueryCmp cmp) {
 
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto values = getter(*it);
@@ -123,7 +123,7 @@ inline void Query<T>::filter(
 
 template <typename T>
 inline void Query<T>::filter(
-    Query<T>::FilterFunctionString * getter, QueryCmp cmp, const std::vector<std::string> & patterns) {
+    Query<T>::FilterFunctionString * getter, const std::vector<std::string> & patterns, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_string(value, cmp, patterns)) {
@@ -136,7 +136,7 @@ inline void Query<T>::filter(
 
 template <typename T>
 inline void Query<T>::filter(
-    Query<T>::FilterFunctionVectorString * getter, QueryCmp cmp, const std::vector<std::string> & patterns) {
+    Query<T>::FilterFunctionVectorString * getter, const std::vector<std::string> & patterns, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto values = getter(*it);
         if (match_string(values, cmp, patterns)) {
@@ -148,7 +148,7 @@ inline void Query<T>::filter(
 }
 
 template <typename T>
-inline void Query<T>::filter(FilterFunctionInt64 * getter, QueryCmp cmp, int64_t pattern) {
+inline void Query<T>::filter(FilterFunctionInt64 * getter, int64_t pattern, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_int64(value, cmp, pattern)) {
@@ -160,7 +160,7 @@ inline void Query<T>::filter(FilterFunctionInt64 * getter, QueryCmp cmp, int64_t
 }
 
 template <typename T>
-inline void Query<T>::filter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, int64_t pattern) {
+inline void Query<T>::filter(FilterFunctionVectorInt64 * getter, int64_t pattern, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto values = getter(*it);
         if (match_int64(values, cmp, pattern)) {
@@ -172,7 +172,7 @@ inline void Query<T>::filter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, i
 }
 
 template <typename T>
-inline void Query<T>::filter(FilterFunctionInt64 * getter, QueryCmp cmp, const std::vector<int64_t> & patterns) {
+inline void Query<T>::filter(FilterFunctionInt64 * getter, const std::vector<int64_t> & patterns, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_int64(value, cmp, patterns)) {
@@ -184,7 +184,7 @@ inline void Query<T>::filter(FilterFunctionInt64 * getter, QueryCmp cmp, const s
 }
 
 template <typename T>
-inline void Query<T>::filter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, const std::vector<int64_t> & patterns) {
+inline void Query<T>::filter(FilterFunctionVectorInt64 * getter, const std::vector<int64_t> & patterns, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto values = getter(*it);
         if (match_int64(values, cmp, patterns)) {
@@ -197,7 +197,7 @@ inline void Query<T>::filter(FilterFunctionVectorInt64 * getter, QueryCmp cmp, c
 
 // TODO: other cmp
 template <typename T>
-inline void Query<T>::filter(Query<T>::FilterFunctionBool * getter, QueryCmp cmp, bool pattern) {
+inline void Query<T>::filter(Query<T>::FilterFunctionBool * getter, bool pattern, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (cmp == QueryCmp::EQ && value == pattern) {
@@ -209,7 +209,7 @@ inline void Query<T>::filter(Query<T>::FilterFunctionBool * getter, QueryCmp cmp
 }
 
 template <typename T>
-inline void Query<T>::filter(Query<T>::FilterFunctionCString * getter, QueryCmp cmp, const std::string & pattern) {
+inline void Query<T>::filter(Query<T>::FilterFunctionCString * getter, const std::string & pattern, QueryCmp cmp) {
     for (auto it = get_data().begin(); it != get_data().end();) {
         auto value = getter(*it);
         if (match_string(value, cmp, pattern)) {

--- a/include/libdnf/comps/group/query.hpp
+++ b/include/libdnf/comps/group/query.hpp
@@ -79,43 +79,43 @@ private:
 
 
 inline GroupQuery & GroupQuery::filter_groupid(const std::string & pattern, sack::QueryCmp cmp) {
-    filter(F::groupid, cmp, pattern);
+    filter(F::groupid, pattern, cmp);
     return *this;
 }
 
 
 inline GroupQuery & GroupQuery::filter_groupid(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
-    filter(F::groupid, cmp, patterns);
+    filter(F::groupid, patterns, cmp);
     return *this;
 }
 
 
 inline GroupQuery & GroupQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp) {
-    filter(F::name, cmp, pattern);
+    filter(F::name, pattern, cmp);
     return *this;
 }
 
 
 inline GroupQuery & GroupQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
-    filter(F::name, cmp, patterns);
+    filter(F::name, patterns, cmp);
     return *this;
 }
 
 
 inline GroupQuery & GroupQuery::filter_default(bool value) {
-    filter(F::is_default, sack::QueryCmp::EQ, value);
+    filter(F::is_default, value, sack::QueryCmp::EQ);
     return *this;
 }
 
 
 inline GroupQuery & GroupQuery::filter_uservisible(bool value) {
-    filter(F::is_uservisible, sack::QueryCmp::EQ, value);
+    filter(F::is_uservisible, value, sack::QueryCmp::EQ);
     return *this;
 }
 
 
 inline GroupQuery & GroupQuery::filter_installed(bool value) {
-    filter(F::is_installed, sack::QueryCmp::EQ, value);
+    filter(F::is_installed, value, sack::QueryCmp::EQ);
     return *this;
 }
 

--- a/include/libdnf/comps/group/query.hpp
+++ b/include/libdnf/comps/group/query.hpp
@@ -22,8 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_COMPS_GROUP_QUERY_HPP
 
 #include "libdnf/common/sack/query.hpp"
-#include "libdnf/comps/group/group.hpp"
 #include "libdnf/common/weak_ptr.hpp"
+#include "libdnf/comps/group/group.hpp"
 
 #include <memory>
 
@@ -42,10 +42,12 @@ public:
     explicit GroupQuery(const GroupQuery & query);
     ~GroupQuery();
 
-    GroupQuery & filter_groupid(sack::QueryCmp cmp, const std::string & pattern);
-    GroupQuery & filter_groupid(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
-    GroupQuery & filter_name(sack::QueryCmp cmp, const std::string & pattern);
-    GroupQuery & filter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
+    GroupQuery & filter_groupid(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    GroupQuery & filter_groupid(
+        const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    GroupQuery & filter_name(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    GroupQuery & filter_name(
+        const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
     GroupQuery & filter_uservisible(bool value);
     GroupQuery & filter_default(bool value);
     GroupQuery & filter_installed(bool value);
@@ -76,25 +78,25 @@ private:
 };
 
 
-inline GroupQuery & GroupQuery::filter_groupid(sack::QueryCmp cmp, const std::string & pattern) {
+inline GroupQuery & GroupQuery::filter_groupid(const std::string & pattern, sack::QueryCmp cmp) {
     filter(F::groupid, cmp, pattern);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::filter_groupid(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
+inline GroupQuery & GroupQuery::filter_groupid(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
     filter(F::groupid, cmp, patterns);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::filter_name(sack::QueryCmp cmp, const std::string & pattern) {
+inline GroupQuery & GroupQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp) {
     filter(F::name, cmp, pattern);
     return *this;
 }
 
 
-inline GroupQuery & GroupQuery::filter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
+inline GroupQuery & GroupQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
     filter(F::name, cmp, patterns);
     return *this;
 }

--- a/include/libdnf/rpm/repo_query.hpp
+++ b/include/libdnf/rpm/repo_query.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -21,8 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_RPM_REPO_QUERY_HPP
 
 #include "libdnf/common/sack/query.hpp"
-#include "libdnf/rpm/repo.hpp"
 #include "libdnf/common/weak_ptr.hpp"
+#include "libdnf/rpm/repo.hpp"
 
 namespace libdnf::rpm {
 
@@ -37,11 +37,11 @@ public:
 #endif
     RepoQuery & filter_enabled(bool enabled);
     RepoQuery & filter_expired(bool expired);
-    RepoQuery & filter_id(sack::QueryCmp cmp, const std::string & pattern);
-    RepoQuery & filter_id(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
+    RepoQuery & filter_id(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    RepoQuery & filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
     RepoQuery & filter_local(bool local);
-    RepoQuery & filter_name(sack::QueryCmp cmp, const std::string & pattern);
-    RepoQuery & filter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns);
+    RepoQuery & filter_name(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    RepoQuery & filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
 private:
     struct F {
@@ -63,12 +63,12 @@ inline RepoQuery & RepoQuery::filter_expired(bool expired) {
     return *this;
 }
 
-inline RepoQuery & RepoQuery::filter_id(sack::QueryCmp cmp, const std::string & pattern) {
+inline RepoQuery & RepoQuery::filter_id(const std::string & pattern, sack::QueryCmp cmp) {
     filter(F::id, cmp, pattern);
     return *this;
 }
 
-inline RepoQuery & RepoQuery::filter_id(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
+inline RepoQuery & RepoQuery::filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
     filter(F::id, cmp, patterns);
     return *this;
 }
@@ -78,12 +78,12 @@ inline RepoQuery & RepoQuery::filter_local(bool local) {
     return *this;
 }
 
-inline RepoQuery & RepoQuery::filter_name(sack::QueryCmp cmp, const std::string & pattern) {
+inline RepoQuery & RepoQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp) {
     filter(F::name, cmp, pattern);
     return *this;
 }
 
-inline RepoQuery & RepoQuery::filter_name(sack::QueryCmp cmp, const std::vector<std::string> & patterns) {
+inline RepoQuery & RepoQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
     filter(F::name, cmp, patterns);
     return *this;
 }

--- a/include/libdnf/rpm/repo_query.hpp
+++ b/include/libdnf/rpm/repo_query.hpp
@@ -54,37 +54,37 @@ private:
 };
 
 inline RepoQuery & RepoQuery::filter_enabled(bool enabled) {
-    filter(F::enabled, sack::QueryCmp::EQ, enabled);
+    filter(F::enabled, enabled, sack::QueryCmp::EQ);
     return *this;
 }
 
 inline RepoQuery & RepoQuery::filter_expired(bool expired) {
-    filter(F::expired, sack::QueryCmp::EQ, expired);
+    filter(F::expired, expired, sack::QueryCmp::EQ);
     return *this;
 }
 
 inline RepoQuery & RepoQuery::filter_id(const std::string & pattern, sack::QueryCmp cmp) {
-    filter(F::id, cmp, pattern);
+    filter(F::id, pattern, cmp);
     return *this;
 }
 
 inline RepoQuery & RepoQuery::filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
-    filter(F::id, cmp, patterns);
+    filter(F::id, patterns, cmp);
     return *this;
 }
 
 inline RepoQuery & RepoQuery::filter_local(bool local) {
-    filter(F::local, sack::QueryCmp::EQ, local);
+    filter(F::local, local, sack::QueryCmp::EQ);
     return *this;
 }
 
 inline RepoQuery & RepoQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp) {
-    filter(F::name, cmp, pattern);
+    filter(F::name, pattern, cmp);
     return *this;
 }
 
 inline RepoQuery & RepoQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
-    filter(F::name, cmp, patterns);
+    filter(F::name, patterns, cmp);
     return *this;
 }
 

--- a/include/libdnf/transaction/query.hpp
+++ b/include/libdnf/transaction/query.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -49,8 +49,8 @@ public:
     TransactionQuery(TransactionSack & sack);
 
     /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.dbSelect(int64_t transaction_id)
-    TransactionQuery & filter_id(sack::QueryCmp cmp, int64_t pattern);
-    TransactionQuery & filter_id(sack::QueryCmp cmp, const std::vector<int64_t> & pattern);
+    TransactionQuery & filter_id(int64_t pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    TransactionQuery & filter_id(const std::vector<int64_t> & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
 private:
     friend TransactionSack;

--- a/libdnf/transaction/query.cpp
+++ b/libdnf/transaction/query.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -40,7 +40,7 @@ namespace libdnf::transaction {
 TransactionQuery::TransactionQuery(TransactionSack & sack) : sack{&sack} {}
 
 
-TransactionQuery & TransactionQuery::filter_id(sack::QueryCmp cmp, const std::vector<int64_t> & patterns) {
+TransactionQuery & TransactionQuery::filter_id(const std::vector<int64_t> & patterns, sack::QueryCmp cmp) {
     switch (cmp) {
         case libdnf::sack::QueryCmp::EQ:
             // currently only EQ operator is supported
@@ -122,9 +122,9 @@ TransactionQuery & TransactionQuery::filter_id(sack::QueryCmp cmp, const std::ve
 }
 
 
-TransactionQuery & TransactionQuery::filter_id(sack::QueryCmp cmp, int64_t pattern) {
+TransactionQuery & TransactionQuery::filter_id(int64_t pattern, sack::QueryCmp cmp) {
     std::vector<int64_t> patterns{pattern};
-    return filter_id(cmp, patterns);
+    return filter_id(patterns, cmp);
 }
 
 

--- a/libdnf/transaction/query.cpp
+++ b/libdnf/transaction/query.cpp
@@ -117,7 +117,7 @@ TransactionQuery & TransactionQuery::filter_id(const std::vector<int64_t> & patt
         initialized = true;
     }
 
-    filter(F::id, cmp, patterns);
+    filter(F::id, patterns, cmp);
     return *this;
 }
 

--- a/microdnf/commands/groupinfo/groupinfo.cpp
+++ b/microdnf/commands/groupinfo/groupinfo.cpp
@@ -128,8 +128,8 @@ void CmdGroupinfo::run([[maybe_unused]] Context & ctx) {
     // Filter by patterns if given
     if (patterns_to_show.size() > 0) {
         auto query_names = libdnf::comps::GroupQuery(query);
-        query.filter_groupid(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
-        query |= query_names.filter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query.filter_groupid(patterns_to_show, libdnf::sack::QueryCmp::IGLOB);
+        query |= query_names.filter_name(patterns_to_show, libdnf::sack::QueryCmp::IGLOB);
     } else if (not hidden_option->get_value()) {
         // Filter uservisible only if patterns are not given
         query.filter_uservisible(true);

--- a/microdnf/commands/grouplist/grouplist.cpp
+++ b/microdnf/commands/grouplist/grouplist.cpp
@@ -126,8 +126,8 @@ void CmdGrouplist::run([[maybe_unused]] Context & ctx) {
     // Filter by patterns if given
     if (patterns_to_show.size() > 0) {
         auto query_names = libdnf::comps::GroupQuery(query);
-        query.filter_groupid(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
-        query |= query_names.filter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query.filter_groupid(patterns_to_show, libdnf::sack::QueryCmp::IGLOB);
+        query |= query_names.filter_name(patterns_to_show, libdnf::sack::QueryCmp::IGLOB);
     } else if (not hidden_option->get_value()) {
         // Filter uservisible only if patterns are not given
         query.filter_uservisible(true);

--- a/microdnf/commands/repolist/repolist.cpp
+++ b/microdnf/commands/repolist/repolist.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2019-2020 Red Hat, Inc.
+Copyright (C) 2019-2021 Red Hat, Inc.
 
 This file is part of microdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -131,8 +131,8 @@ void CmdRepolist::run(Context & ctx) {
 
     if (patterns_to_show.size() > 0) {
         auto query_names = query;
-        query.filter_id(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
-        query |= query_names.filter_name(libdnf::sack::QueryCmp::IGLOB, patterns_to_show);
+        query.filter_id(patterns_to_show, libdnf::sack::QueryCmp::IGLOB);
+        query |= query_names.filter_name(patterns_to_show, libdnf::sack::QueryCmp::IGLOB);
     }
 
     bool with_status = enable_disable_option->get_value() == "all";

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -299,7 +299,7 @@ int main(int argc, char * argv[]) {
     for (const auto & setopt : context.setopts) {
         auto last_dot_pos = setopt.first.rfind('.');
         auto repo_pattern = setopt.first.substr(0, last_dot_pos);
-        auto query = rpm_repo_sack->new_query().filter_id(libdnf::sack::QueryCmp::GLOB, repo_pattern);
+        auto query = rpm_repo_sack->new_query().filter_id(repo_pattern, libdnf::sack::QueryCmp::GLOB);
         auto key = setopt.first.substr(last_dot_pos + 1);
         for (auto & repo : query.get_data()) {
             try {

--- a/test/libdnf/comps/test_group.cpp
+++ b/test/libdnf/comps/test_group.cpp
@@ -50,7 +50,7 @@ void CompsGroupTest::test_load() {
     comps.load_from_file(data_path / "core.xml", reponame);
     auto q_core = comps.get_group_sack().new_query();
     q_core.filter_installed(false);
-    q_core.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core.filter_groupid("core");
     auto core = q_core.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Core"), core.get_name());
@@ -78,7 +78,7 @@ void CompsGroupTest::test_load() {
     comps.load_from_file(data_path / "standard.xml", reponame);
     auto q_standard = comps.get_group_sack().new_query();
     q_standard.filter_installed(false);
-    q_standard.filter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
+    q_standard.filter_groupid("standard");
     auto standard = q_standard.get();
     CPPUNIT_ASSERT_EQUAL(std::string("standard"), standard.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Standard"), standard.get_name());
@@ -110,7 +110,7 @@ void CompsGroupTest::test_load_defaults() {
 
     comps.load_from_file(data_path / "core-empty.xml", reponame);
     auto q_core_empty = comps.get_group_sack().new_query();
-    q_core_empty.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core_empty.filter_groupid("core");
     auto core_empty = q_core_empty.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core_empty.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string(""), core_empty.get_name());
@@ -137,7 +137,7 @@ void CompsGroupTest::test_merge() {
     comps.load_from_file(data_path / "core-v2.xml", reponame);
 
     auto q_core2 = comps.get_group_sack().new_query();
-    q_core2.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core2.filter_groupid("core");
     auto core2 = q_core2.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core2.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Core v2"), core2.get_name());
@@ -176,7 +176,7 @@ void CompsGroupTest::test_merge_with_empty() {
     comps.load_from_file(data_path / "core-empty.xml", reponame);
 
     auto q_core_empty = comps.get_group_sack().new_query();
-    q_core_empty.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core_empty.filter_groupid("core");
     auto core_empty = q_core_empty.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core_empty.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Core"), core_empty.get_name());
@@ -206,7 +206,7 @@ void CompsGroupTest::test_merge_empty_with_nonempty() {
     comps.load_from_file(data_path / "core.xml", reponame);
 
     auto q_core = comps.get_group_sack().new_query();
-    q_core.filter_groupid(libdnf::sack::QueryCmp::EQ, "core");
+    q_core.filter_groupid("core");
     auto core = q_core.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core.get_groupid());
     CPPUNIT_ASSERT_EQUAL(std::string("Core"), core.get_name());
@@ -240,16 +240,16 @@ void CompsGroupTest::test_dump_and_load() {
 
     comps.load_from_file(data_path / "standard.xml", reponame);
     auto q_standard = comps.get_group_sack().new_query();
-    q_standard.filter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
+    q_standard.filter_groupid("standard");
     auto standard = q_standard.get();
-    
+
     auto dumped_standard_path = std::filesystem::temp_directory_path() / "dumped-standard.xml";
     standard.dump(dumped_standard_path);
     libdnf::comps::Comps comps2(*base.get());
     comps2.load_from_file(dumped_standard_path, reponame);
 
     auto q_dumped_standard = comps2.get_group_sack().new_query();
-    q_dumped_standard.filter_groupid(libdnf::sack::QueryCmp::EQ, "standard");
+    q_dumped_standard.filter_groupid("standard");
     auto dumped_standard = q_dumped_standard.get();
 
     CPPUNIT_ASSERT_EQUAL(std::string("standard"), dumped_standard.get_groupid());

--- a/test/libdnf/query/test_query.cpp
+++ b/test/libdnf/query/test_query.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -41,8 +41,8 @@ public:
     using Query<QueryItem>::Query;
 
     TestQuery & filter_enabled(bool enabled);
-    TestQuery & filter_id(libdnf::sack::QueryCmp cmp, int64_t id);
-    TestQuery & filter_name(libdnf::sack::QueryCmp cmp, const std::string & name);
+    TestQuery & filter_id(int64_t id, libdnf::sack::QueryCmp cmp);
+    TestQuery & filter_name(const std::string & name, libdnf::sack::QueryCmp cmp);
 
 private:
     struct F {
@@ -53,17 +53,17 @@ private:
 };
 
 TestQuery & TestQuery::filter_enabled(bool enabled) {
-    filter(F::enabled, libdnf::sack::QueryCmp::EQ, enabled);
+    filter(F::enabled, enabled, libdnf::sack::QueryCmp::EQ);
     return *this;
 }
 
-TestQuery & TestQuery::filter_id(libdnf::sack::QueryCmp cmp, int64_t id) {
-    filter(F::id, cmp, id);
+TestQuery & TestQuery::filter_id(int64_t id, libdnf::sack::QueryCmp cmp) {
+    filter(F::id, id, cmp);
     return *this;
 }
 
-TestQuery & TestQuery::filter_name(libdnf::sack::QueryCmp cmp, const std::string & name) {
-    filter(F::name, cmp, name);
+TestQuery & TestQuery::filter_name(const std::string & name, libdnf::sack::QueryCmp cmp) {
+    filter(F::name, name, cmp);
     return *this;
 }
 
@@ -87,19 +87,19 @@ void QueryTest::test_query_basics() {
     CPPUNIT_ASSERT((q1 == libdnf::Set<QueryItem>{{true, 4, "item4"}, {true, 10, "item10"}}));
 
     // test filter_name()
-    q1.filter_name(libdnf::sack::QueryCmp::EQ, "item10");
+    q1.filter_name("item10", libdnf::sack::QueryCmp::EQ);
     CPPUNIT_ASSERT_EQUAL(q1.size(), static_cast<size_t>(1));
     CPPUNIT_ASSERT((q1 == libdnf::Set<QueryItem>{{true, 10, "item10"}}));
 
     // test filter_id()
     q1 = q;
-    q1.filter_id(libdnf::sack::QueryCmp::GTE, 6);
+    q1.filter_id(6, libdnf::sack::QueryCmp::GTE);
     CPPUNIT_ASSERT_EQUAL(q1.size(), static_cast<size_t>(2));
     CPPUNIT_ASSERT((q1 == libdnf::Set<QueryItem>{{false, 6, "item6"}, {true, 10, "item10"}}));
 
     // test chaining of filter calling
     q1 = q;
-    q1.filter_name(libdnf::sack::QueryCmp::GLOB, "item?").filter_enabled(false);
+    q1.filter_name("item?", libdnf::sack::QueryCmp::GLOB).filter_enabled(false);
     CPPUNIT_ASSERT_EQUAL(q1.size(), static_cast<size_t>(1));
     CPPUNIT_ASSERT((q1 == libdnf::Set<QueryItem>{{false, 6, "item6"}}));
 }

--- a/test/libdnf/rpm/test_repo_query.cpp
+++ b/test/libdnf/rpm/test_repo_query.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -61,7 +61,7 @@ void RepoQueryTest::test_query_basics() {
     CPPUNIT_ASSERT((repo_query == libdnf::Set{repo1, repo2_updates}));
 
     // Tests filter_id method
-    auto repo_query1 = repo_sack.new_query().filter_id(libdnf::sack::QueryCmp::GLOB, "*updates");
+    auto repo_query1 = repo_sack.new_query().filter_id("*updates", libdnf::sack::QueryCmp::GLOB);
     CPPUNIT_ASSERT((repo_query1 == libdnf::Set{repo1_updates, repo2_updates}));
 
     // Tests filter_local method

--- a/test/libdnf/transaction/test_comps_environment.cpp
+++ b/test/libdnf/transaction/test_comps_environment.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2017-2020 Red Hat, Inc.
+Copyright (C) 2017-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -81,7 +81,7 @@ void TransactionCompsEnvironmentTest::test_save_load() {
 
     // get the written transaction
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 
     // check that there's exactly 1 environment

--- a/test/libdnf/transaction/test_comps_group.cpp
+++ b/test/libdnf/transaction/test_comps_group.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2017-2020 Red Hat, Inc.
+Copyright (C) 2017-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -81,7 +81,7 @@ void TransactionCompsGroupTest::test_save_load() {
 
     // get the written transaction
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 
     // check that there's exactly 1 group

--- a/test/libdnf/transaction/test_query.cpp
+++ b/test/libdnf/transaction/test_query.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2017-2020 Red Hat, Inc.
+Copyright (C) 2017-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -47,7 +47,7 @@ void TransactionQueryTest::test_filter_id_eq() {
 
     // get the written transaction
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 }
 
@@ -74,13 +74,13 @@ void TransactionQueryTest::test_filter_id_eq_parallel_queries() {
     auto q2 = transaction_sack2->new_query();
     auto q3 = transaction_sack2->new_query();
 
-    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 
     // one item loaded into the sack
     CPPUNIT_ASSERT_EQUAL(1LU, transaction_sack2->get_data().size());
 
-    q3.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q3.filter_id(trans->get_id());
     auto trans3 = q3.get();
 
     // query reused the existing item in the sack

--- a/test/libdnf/transaction/test_rpm_package.cpp
+++ b/test/libdnf/transaction/test_rpm_package.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2017-2020 Red Hat, Inc.
+Copyright (C) 2017-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -67,7 +67,7 @@ void TransactionRpmPackageTest::test_save_load() {
 
     // get the written transaction
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 
     // check that there's exactly 10 packages

--- a/test/libdnf/transaction/test_transaction.cpp
+++ b/test/libdnf/transaction/test_transaction.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2017-2020 Red Hat, Inc.
+Copyright (C) 2017-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -62,7 +62,7 @@ void TransactionTest::test_save_load() {
     // load the saved transaction from database and compare values
     auto base2 = new_base();
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 
     CPPUNIT_ASSERT_EQUAL(trans->get_id(), trans2->get_id());
@@ -116,7 +116,7 @@ void TransactionTest::test_update() {
     // load the transction from the database
     auto base2 = new_base();
     auto q2 = base2->get_transaction_sack()->new_query();
-    q2.filter_id(libdnf::sack::QueryCmp::EXACT, trans->get_id());
+    q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 
     // check if the values saved during trans->finish() match


### PR DESCRIPTION
Some `*Query` classes used postfix notation in the `filter*` methods and the default value `EQ` for the `QueryCmp` operator.
The PR unifies the API. All `*Query` classes now use postfix notation in `filter*` methods. 