### PR TITLE
[dnf5] Fix downgrade in rpm::Transaction

### DIFF
--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -175,7 +175,7 @@ void fill_transactions(
         transaction_items.push_back(std::move(item));
         auto & trans_pkg = transaction->new_package();
         set_trans_pkg(package, trans_pkg, libdnf::transaction::TransactionItemAction::DOWNGRADE);
-        rpm_ts.upgrade(*item_ptr);
+        rpm_ts.downgrade(*item_ptr);
     }
 }
 

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2020 Red Hat, Inc.
+Copyright (C) 2020-2021 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
@@ -259,6 +259,12 @@ public:
     /// If found, the package with the "newest" EVR will be replaced.
     /// @param item  item to be upgraded
     void upgrade(TransactionItem & item);
+
+    /// Add package to be downgraded to transaction set.
+    /// The transaction set is checked for duplicate package names.
+    /// If found, the package with the "newest" EVR will be replaced.
+    /// @param item  item to be downgraded
+    void downgrade(TransactionItem & item);
 
     /// Add package to be reinstalled to transaction set.
     /// @param item  item to be reinstalled

--- a/microdnf/commands/downgrade/downgrade.cpp
+++ b/microdnf/commands/downgrade/downgrade.cpp
@@ -48,12 +48,12 @@ void CmdDowngrade::set_argument_parser(Context & ctx) {
         patterns_to_downgrade_options);
     keys->set_short_description("List of keys to match");
 
-    auto downgarde = ctx.arg_parser.add_new_command("downgrade");
-    downgarde->set_short_description("Downgarde a package or packages on your system");
-    downgarde->set_description("");
-    downgarde->set_named_args_help_header("Optional arguments:");
-    downgarde->set_positional_args_help_header("Positional arguments:");
-    downgarde->set_parse_hook_func([this, &ctx](
+    auto downgrade = ctx.arg_parser.add_new_command("downgrade");
+    downgrade->set_short_description("Downgrade a package or packages on your system");
+    downgrade->set_description("");
+    downgrade->set_named_args_help_header("Optional arguments:");
+    downgrade->set_positional_args_help_header("Positional arguments:");
+    downgrade->set_parse_hook_func([this, &ctx](
                                        [[maybe_unused]] ArgumentParser::Argument * arg,
                                        [[maybe_unused]] const char * option,
                                        [[maybe_unused]] int argc,
@@ -62,9 +62,9 @@ void CmdDowngrade::set_argument_parser(Context & ctx) {
         return true;
     });
 
-    downgarde->register_positional_arg(keys);
+    downgrade->register_positional_arg(keys);
 
-    ctx.arg_parser.get_root_command()->register_command(downgarde);
+    ctx.arg_parser.get_root_command()->register_command(downgrade);
 }
 
 void CmdDowngrade::configure([[maybe_unused]] Context & ctx) {}

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -759,7 +759,7 @@ void fill_transactions(
         transaction_items.push_back(std::move(item));
         auto & trans_pkg = transaction->new_package();
         set_trans_pkg(package, trans_pkg, libdnf::transaction::TransactionItemAction::DOWNGRADE);
-        rpm_ts.upgrade(*item_ptr);
+        rpm_ts.downgrade(*item_ptr);
     }
 }
 


### PR DESCRIPTION
With current implementation attempt to downgrade a package ends with rpm
error "package xxx (which is newer than xxx) is already installed"