### PR TITLE
[dnf5] clang-format: BreakConstructorInitializers: BeforeColon

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -179,7 +179,7 @@ AllowAllParametersOfDeclarationOnNextLine: true
 #     member0(0), member1(2)
 #
 AllowAllConstructorInitializersOnNextLine: false
-BreakConstructorInitializers: BeforeComma
+BreakConstructorInitializers: BeforeColon
 
 
 # Align consecutive C/C++ preprocessor macros.


### PR DESCRIPTION
Looks marginally better IMO, e.g.:

```diff
 template <typename T>
 OptionEnum<T>::OptionEnum(
     ValueType default_value, const std::vector<ValueType> & enum_vals, FromStringFunc && from_string_func)
-    : Option(Priority::DEFAULT)
-    , from_string_user(std::move(from_string_func))
-    , enum_vals(enum_vals)
-    , default_value(default_value)
-    , value(default_value) {
+    : Option(Priority::DEFAULT),
+      from_string_user(std::move(from_string_func)),
+      enum_vals(enum_vals),
+      default_value(default_value),
+      value(default_value) {
     test(default_value);
 }
```

It visually indents the initializers more.