### PR TITLE
[dnf5] rpm::Transaction: use `BaseWeakPtr` instead raw pointer `Base*`

### DIFF
--- a/bindings/libdnf/base.i
+++ b/bindings/libdnf/base.i
@@ -25,6 +25,7 @@
 
 #define CV __perl_CV
 
+%template(BaseWeakPtr) libdnf::WeakPtr<libdnf::Base, false>;
 %template(LogRouterWeakPtr) libdnf::WeakPtr<libdnf::LogRouter, false>;
 %template(VarsWeakPtr) libdnf::WeakPtr<libdnf::Vars, false>;
 

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -35,6 +35,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
+class Base;
+using BaseWeakPtr = WeakPtr<Base, false>;
+
 using LogRouterWeakPtr = WeakPtr<LogRouter, false>;
 using VarsWeakPtr = WeakPtr<Vars, false>;
 
@@ -73,7 +76,11 @@ public:
     void load_plugins();
     plugin::Plugins & get_plugins() { return plugins; }
 
+    BaseWeakPtr get_weak_ptr() { return BaseWeakPtr(this, &base_guard); }
+
 private:
+    WeakPtrGuard<Base, false> base_guard;
+
     //TODO(jrohel): Make public?
     /// Loads main configuration from file defined by path.
     void load_config_from_file(const std::string & path);

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -30,6 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf {
 
 class Base;
+using BaseWeakPtr = WeakPtr<Base, false>;
 
 }  // namespace libdnf
 
@@ -187,6 +188,7 @@ public:
     using rpm_tid_t = uint32_t;
 
     explicit Transaction(Base & base);
+    explicit Transaction(const BaseWeakPtr & base);
     Transaction(const Transaction &) = delete;
     Transaction(Transaction &&) = delete;
     ~Transaction();

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -302,6 +302,10 @@ public:
     /// @param file_path  new file path
     void set_script_out_file(const std::string & file_path);
 
+    /// @return A `Base` object to which the transaction belongs.
+    /// @since 5.0
+    BaseWeakPtr get_base() const;
+
 private:
     class Impl;
     std::unique_ptr<Impl> p_impl;

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -749,4 +749,8 @@ void Transaction::set_script_out_file(const std::string & file_path) {
     p_impl->set_script_fd(script_fd);
 }
 
+BaseWeakPtr Transaction::get_base() const {
+    return p_impl->base;
+}
+
 }  // namespace libdnf::rpm


### PR DESCRIPTION
- implements `BaseWeakPtr` and `Base::get_weak_ptr()` method.
- rpm::Transaction stores `BaseWeakPtr` instead of `Base*`
- adds `rpm::Transaction::get_base()` method