### PR TITLE
[dnf5] Make contructors without "base" argument private, fix AdvisoryQuery constructor

### DIFF
--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -114,9 +114,8 @@ dnfdaemon::KeyValueMap repo_to_map(
                 dbus_repo.emplace(attr, libdnf_repo->is_enabled());
                 break;
             case RepoAttribute::size: {
-                auto package_sack = base.get_rpm_package_sack();
                 uint64_t size = 0;
-                libdnf::rpm::PackageQuery query(package_sack);
+                libdnf::rpm::PackageQuery query(base);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
                 query.filter_repoid(reponames);
                 for (auto pkg : query) {
@@ -143,15 +142,13 @@ dnfdaemon::KeyValueMap repo_to_map(
                 dbus_repo.emplace(attr, libdnf_repo->get_max_timestamp());
                 break;
             case RepoAttribute::pkgs: {
-                auto package_sack = base.get_rpm_package_sack();
-                libdnf::rpm::PackageQuery query(package_sack, libdnf::rpm::PackageQuery::InitFlags::IGNORE_EXCLUDES);
+                libdnf::rpm::PackageQuery query(base, libdnf::rpm::PackageQuery::InitFlags::IGNORE_EXCLUDES);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
                 query.filter_repoid(reponames);
                 dbus_repo.emplace(attr, query.size());
             } break;
             case RepoAttribute::available_pkgs: {
-                auto package_sack = base.get_rpm_package_sack();
-                libdnf::rpm::PackageQuery query(package_sack);
+                libdnf::rpm::PackageQuery query(base);
                 std::vector<std::string> reponames = {libdnf_repo->get_id()};
                 query.filter_repoid(reponames);
                 dbus_repo.emplace(attr, query.size());

--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -60,7 +60,8 @@ sdbus::MethodReply Rpm::list(sdbus::MethodCall && call) {
     call >> options;
 
     session.fill_sack();
-    auto package_sack = session.get_base()->get_rpm_package_sack();
+    auto base = session.get_base();
+    auto package_sack = base->get_rpm_package_sack();
 
     // patterns to search
     std::vector<std::string> default_patterns{};
@@ -74,7 +75,7 @@ sdbus::MethodReply Rpm::list(sdbus::MethodCall && call) {
     bool with_src = key_value_map_get<bool>(options, "with_src", true);
 
     libdnf::rpm::PackageSet result_pset(package_sack);
-    libdnf::rpm::PackageQuery full_package_query(package_sack);
+    libdnf::rpm::PackageQuery full_package_query(*base);
     if (patterns.size() > 0) {
         for (auto & pattern : patterns) {
             libdnf::rpm::PackageQuery package_query(full_package_query);

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -41,7 +41,6 @@ using AdvisorySackWeakPtr = WeakPtr<AdvisorySack, false>;
 
 class AdvisoryQuery {
 public:
-    explicit AdvisoryQuery(const AdvisorySackWeakPtr & sack);
     explicit AdvisoryQuery(const BaseWeakPtr & base);
     explicit AdvisoryQuery(Base & base);
     AdvisoryQuery(const AdvisoryQuery & src);
@@ -104,6 +103,8 @@ public:
     std::vector<AdvisoryPackage> get_sorted_advisory_packages(bool only_applicable = false) const;
 
 private:
+    explicit AdvisoryQuery(const AdvisorySackWeakPtr & sack);
+
     AdvisorySackWeakPtr advisory_sack;
 
     class Impl;

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -68,7 +68,6 @@ public:
     /// @replaces libdnf/hy-query.h:function:hy_query_create_flags(DnfSack *sack, int flags);
     /// @replaces libdnf/sack/query.hpp:method:Query(DnfSack* sack, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES)
     /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_free(DnfReldep *reldep)
-    explicit PackageQuery(const PackageSackWeakPtr & sack, InitFlags flags = InitFlags::APPLY_EXCLUDES);
     explicit PackageQuery(const BaseWeakPtr & base, InitFlags flags = InitFlags::APPLY_EXCLUDES);
     explicit PackageQuery(Base & base, InitFlags flags = InitFlags::APPLY_EXCLUDES);
     PackageQuery(const PackageQuery & src) = default;
@@ -427,6 +426,8 @@ public:
     void swap(PackageQuery & other) noexcept;
 
 private:
+    explicit PackageQuery(const PackageSackWeakPtr & sack, InitFlags flags = InitFlags::APPLY_EXCLUDES);
+
     friend libdnf::Goal;
     class Impl;
     InitFlags init_flags;

--- a/include/libdnf/transaction/query.hpp
+++ b/include/libdnf/transaction/query.hpp
@@ -55,7 +55,6 @@ public:
 
     // create an *empty* query
     // the content is lazily loaded/cached while running the queries
-    explicit TransactionQuery(const TransactionSackWeakPtr & sack);
     explicit TransactionQuery(const BaseWeakPtr & base);
     explicit TransactionQuery(Base & base);
 
@@ -64,6 +63,8 @@ public:
     TransactionQuery & filter_id(const std::vector<int64_t> & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
 private:
+    explicit TransactionQuery(const TransactionSackWeakPtr & sack);
+
     friend TransactionSack;
     TransactionSackWeakPtr sack;
 

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -40,9 +40,9 @@ AdvisoryQuery::AdvisoryQuery(const AdvisorySackWeakPtr & sack) : advisory_sack(s
     p_impl.reset(new Impl(sack->data_map));
 };
 
-AdvisoryQuery::AdvisoryQuery(const BaseWeakPtr & base) : advisory_sack(base->get_rpm_advisory_sack()) {}
+AdvisoryQuery::AdvisoryQuery(const BaseWeakPtr & base) : AdvisoryQuery(base->get_rpm_advisory_sack()) {}
 
-AdvisoryQuery::AdvisoryQuery(Base & base) : advisory_sack(base.get_rpm_advisory_sack()) {}
+AdvisoryQuery::AdvisoryQuery(Base & base) : AdvisoryQuery(base.get_rpm_advisory_sack()) {}
 
 AdvisoryQuery::~AdvisoryQuery() = default;
 AdvisoryQuery::AdvisoryQuery(const AdvisoryQuery & src)

--- a/microdnf/commands/advisory/advisory.cpp
+++ b/microdnf/commands/advisory/advisory.cpp
@@ -178,7 +178,7 @@ void CmdAdvisory::run(Context & ctx) {
     using LoadFlags = libdnf::rpm::PackageSack::LoadRepoFlags;
     ctx.load_rpm_repos(enabled_repos, LoadFlags::USE_UPDATEINFO);
 
-    libdnf::rpm::PackageQuery package_query(package_sack);
+    libdnf::rpm::PackageQuery package_query(ctx.base);
     using QueryCmp = libdnf::sack::QueryCmp;
     if (patterns_to_show.size() > 0) {
         package_query.filter_name(patterns_to_show, QueryCmp::IGLOB);
@@ -187,7 +187,7 @@ void CmdAdvisory::run(Context & ctx) {
     //DATA IS PREPARED
 
     //TODO(amatej): create advisory_query with filters on advisories prensent (if we want to limit by severity, reference..)
-    auto advisory_query = libdnf::advisory::AdvisoryQuery(ctx.base.get_rpm_advisory_sack());
+    auto advisory_query = libdnf::advisory::AdvisoryQuery(ctx.base);
     if (with_cve_option->get_value()) {
         advisory_query.filter_CVE("*", QueryCmp::IGLOB);
     }

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -79,7 +79,7 @@ void CmdDownload::run(Context & ctx) {
     std::cout << std::endl;
 
     libdnf::rpm::PackageSet result_pset(package_sack);
-    libdnf::rpm::PackageQuery full_package_query(package_sack);
+    libdnf::rpm::PackageQuery full_package_query(ctx.base);
     for (auto & pattern : *patterns_to_download_options) {
         libdnf::rpm::PackageQuery package_query(full_package_query);
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());

--- a/microdnf/commands/repoquery/repoquery.cpp
+++ b/microdnf/commands/repoquery/repoquery.cpp
@@ -132,7 +132,7 @@ void CmdRepoquery::run(Context & ctx) {
     }
 
     libdnf::rpm::PackageSet result_pset(package_sack);
-    libdnf::rpm::PackageQuery full_package_query(package_sack);
+    libdnf::rpm::PackageQuery full_package_query(ctx.base);
     for (auto & pattern : *patterns_to_show_options) {
         libdnf::rpm::PackageQuery package_query(full_package_query);
         auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());

--- a/test/libdnf/advisory/test_advisory.cpp
+++ b/test/libdnf/advisory/test_advisory.cpp
@@ -36,9 +36,8 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryTest, "AdvisoryAdvisoryTes
 void AdvisoryAdvisoryTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    advisory_sack = base->get_rpm_advisory_sack();
     libdnf::advisory::AdvisoryQuery q =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_type(libdnf::advisory::Advisory::Type::SECURITY);
+        libdnf::advisory::AdvisoryQuery(*base).filter_type(libdnf::advisory::Advisory::Type::SECURITY);
     advisories = q.get_advisories();
     advisory = &(advisories[0]);
 }
@@ -91,7 +90,7 @@ void AdvisoryAdvisoryTest::test_get_collections() {
     CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), mods[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), mods[1].get_name());
 
-    auto adv_vec = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("DNF-2020-1").get_advisories();
+    auto adv_vec = libdnf::advisory::AdvisoryQuery(*base).filter_name("DNF-2020-1").get_advisories();
     CPPUNIT_ASSERT_EQUAL(1lu, adv_vec.size());
     libdnf::advisory::Advisory * advisory2 = &(adv_vec[0]);
     colls = advisory2->get_collections();

--- a/test/libdnf/advisory/test_advisory.hpp
+++ b/test/libdnf/advisory/test_advisory.hpp
@@ -54,7 +54,6 @@ public:
     void test_get_collections();
 
 private:
-    libdnf::advisory::AdvisorySackWeakPtr advisory_sack;
     std::vector<libdnf::advisory::Advisory> advisories;
     libdnf::advisory::Advisory * advisory;
 };

--- a/test/libdnf/advisory/test_advisory_module.cpp
+++ b/test/libdnf/advisory/test_advisory_module.cpp
@@ -33,7 +33,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryModuleTest, "AdvisoryAdvis
 void AdvisoryAdvisoryModuleTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    auto advisory = libdnf::advisory::AdvisoryQuery(base->get_rpm_advisory_sack()).filter_name("DNF-2019-1").get_advisories()[0];
+    auto advisory = libdnf::advisory::AdvisoryQuery(*base).filter_name("DNF-2019-1").get_advisories()[0];
     std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
     modules = collections[0].get_modules();
 }

--- a/test/libdnf/advisory/test_advisory_package.cpp
+++ b/test/libdnf/advisory/test_advisory_package.cpp
@@ -33,7 +33,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryPackageTest, "AdvisoryAdvi
 void AdvisoryAdvisoryPackageTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    auto advisory = libdnf::advisory::AdvisoryQuery(base->get_rpm_advisory_sack()).filter_name("DNF-2019-1").get_advisories()[0];
+    auto advisory = libdnf::advisory::AdvisoryQuery(*base).filter_name("DNF-2019-1").get_advisories()[0];
     std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
     packages = collections[0].get_packages();
 }

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -35,11 +35,10 @@ CPPUNIT_TEST_SUITE_REGISTRATION(AdvisoryAdvisoryQueryTest);
 void AdvisoryAdvisoryQueryTest::setUp() {
     RepoFixture::setUp();
     RepoFixture::add_repo_repomd("repomd-repo1");
-    advisory_sack = base->get_rpm_advisory_sack();
 }
 
 void AdvisoryAdvisoryQueryTest::test_size() {
-    auto adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack);
+    auto adv_query = libdnf::advisory::AdvisoryQuery(*base);
     std::vector<std::string> expected = {"DNF-2019-1", "DNF-2020-1", "PKG-NEWER", "PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
@@ -47,15 +46,15 @@ void AdvisoryAdvisoryQueryTest::test_size() {
 void AdvisoryAdvisoryQueryTest::test_filter_name() {
     // Tests filter_name method
     libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
+        libdnf::advisory::AdvisoryQuery(*base).filter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
     std::vector<std::string> expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name(
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_name(
         std::vector<std::string>{"DNF-2019-1", "DNF-2020-1"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
@@ -64,15 +63,15 @@ void AdvisoryAdvisoryQueryTest::test_filter_name() {
 void AdvisoryAdvisoryQueryTest::test_filter_type() {
     // Tests filter_type method
     libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_type(libdnf::advisory::Advisory::Type::BUGFIX);
+        libdnf::advisory::AdvisoryQuery(*base).filter_type(libdnf::advisory::Advisory::Type::BUGFIX);
     std::vector<std::string> expected = {"DNF-2020-1", "PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_type(libdnf::advisory::Advisory::Type::ENHANCEMENT);
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_type(libdnf::advisory::Advisory::Type::ENHANCEMENT);
     expected = {"PKG-NEWER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_type(
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_type(
         std::vector<libdnf::advisory::Advisory::Type>{
             libdnf::advisory::Advisory::Type::BUGFIX, libdnf::advisory::Advisory::Type::SECURITY},
         libdnf::sack::QueryCmp::EQ);
@@ -82,26 +81,26 @@ void AdvisoryAdvisoryQueryTest::test_filter_type() {
 
 void AdvisoryAdvisoryQueryTest::test_filter_packages() {
     // Tests filter_packages method
-    libdnf::rpm::PackageQuery pkg_query(sack);
+    libdnf::rpm::PackageQuery pkg_query(*base);
 
     libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
+        libdnf::advisory::AdvisoryQuery(*base).filter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
     std::vector<std::string> expected = {"PKG-NEWER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
     expected = {"DNF-2019-1", "PKG-NEWER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
     expected = {"DNF-2019-1", "PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
     expected = {"PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
@@ -109,21 +108,21 @@ void AdvisoryAdvisoryQueryTest::test_filter_packages() {
 void AdvisoryAdvisoryQueryTest::test_filter_cve() {
     // Tests filter_cve method
     libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_CVE("3333", libdnf::sack::QueryCmp::EQ);
+        libdnf::advisory::AdvisoryQuery(*base).filter_CVE("3333", libdnf::sack::QueryCmp::EQ);
     std::vector<std::string> expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
     adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_CVE(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
+        libdnf::advisory::AdvisoryQuery(*base).filter_CVE(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
     adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_CVE(std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ);
+        libdnf::advisory::AdvisoryQuery(*base).filter_CVE(std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_CVE("*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_CVE("*", libdnf::sack::QueryCmp::GLOB);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
@@ -131,16 +130,16 @@ void AdvisoryAdvisoryQueryTest::test_filter_cve() {
 void AdvisoryAdvisoryQueryTest::test_filter_bug() {
     // Tests filter_bug method
     libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_bug("2222", libdnf::sack::QueryCmp::EQ);
+        libdnf::advisory::AdvisoryQuery(*base).filter_bug("2222", libdnf::sack::QueryCmp::EQ);
     std::vector<std::string> expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
     adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_bug(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
+        libdnf::advisory::AdvisoryQuery(*base).filter_bug(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
     expected = {};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_bug("*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_bug("*", libdnf::sack::QueryCmp::GLOB);
     expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
@@ -148,11 +147,11 @@ void AdvisoryAdvisoryQueryTest::test_filter_bug() {
 void AdvisoryAdvisoryQueryTest::test_filter_severity() {
     // Tests filter_severity method
     libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(advisory_sack).filter_severity("moderate", libdnf::sack::QueryCmp::EQ);
+        libdnf::advisory::AdvisoryQuery(*base).filter_severity("moderate", libdnf::sack::QueryCmp::EQ);
     std::vector<std::string> expected = {"DNF-2019-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_severity(
+    adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_severity(
         std::vector<std::string>{"moderate", "critical"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
@@ -160,7 +159,7 @@ void AdvisoryAdvisoryQueryTest::test_filter_severity() {
 
 void AdvisoryAdvisoryQueryTest::test_get_sorted_advisory_packages() {
     // Tests get_sorted_advisory_packages method
-    std::vector<libdnf::advisory::AdvisoryPackage> adv_pkgs = libdnf::advisory::AdvisoryQuery(advisory_sack).get_sorted_advisory_packages();
+    std::vector<libdnf::advisory::AdvisoryPackage> adv_pkgs = libdnf::advisory::AdvisoryQuery(*base).get_sorted_advisory_packages();
     CPPUNIT_ASSERT_EQUAL(7lu, adv_pkgs.size());
     CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("1.2-3"), adv_pkgs[0].get_evr());
@@ -177,7 +176,7 @@ void AdvisoryAdvisoryQueryTest::test_get_sorted_advisory_packages() {
     CPPUNIT_ASSERT_EQUAL(std::string("yum"), adv_pkgs[6].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("3.4.3-0"), adv_pkgs[6].get_evr());
 
-    adv_pkgs = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("DNF-2020-1").get_sorted_advisory_packages();
+    adv_pkgs = libdnf::advisory::AdvisoryQuery(*base).filter_name("DNF-2020-1").get_sorted_advisory_packages();
     CPPUNIT_ASSERT_EQUAL(3lu, adv_pkgs.size());
     CPPUNIT_ASSERT_EQUAL(std::string("bitcoin"), adv_pkgs[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("2.5-1"), adv_pkgs[0].get_evr());

--- a/test/libdnf/advisory/test_advisory_query.hpp
+++ b/test/libdnf/advisory/test_advisory_query.hpp
@@ -53,9 +53,6 @@ public:
     void test_filter_bug();
     void test_filter_severity();
     void test_get_sorted_advisory_packages();
-
-private:
-    libdnf::advisory::AdvisorySackWeakPtr advisory_sack;
 };
 
 

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -244,7 +244,7 @@ void BaseGoalTest::test_install_installed_pkg() {
     // also add it to the @Commandline repo to make it available for install
     sack->add_cmdline_package(rpm_path, false);
 
-    libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
+    libdnf::rpm::PackageQuery query(*base);
     query.filter_available().filter_nevra({"cmdline-0:1.2-3.noarch"});
 
     std::vector<std::string> expected = {"cmdline-0:1.2-3.noarch"};
@@ -278,7 +278,7 @@ void BaseGoalTest::test_upgrade() {
 
     add_repo_solv("solv-upgrade");
 
-    libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
+    libdnf::rpm::PackageQuery query(*base);
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_upgrade("cmdline");
@@ -311,7 +311,7 @@ void BaseGoalTest::test_upgrade_not_available() {
 
     add_repo_solv("solv-upgrade");
 
-    libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
+    libdnf::rpm::PackageQuery query(*base);
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_upgrade("not_available");
@@ -351,7 +351,7 @@ void BaseGoalTest::test_upgrade_all() {
 
     add_repo_solv("solv-upgrade");
 
-    libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
+    libdnf::rpm::PackageQuery query(*base);
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_upgrade();
@@ -382,7 +382,7 @@ void BaseGoalTest::test_downgrade() {
 
     add_repo_solv("solv-downgrade");
 
-    libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
+    libdnf::rpm::PackageQuery query(*base);
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_downgrade("cmdline");
@@ -413,7 +413,7 @@ void BaseGoalTest::test_distrosync() {
 
     add_repo_solv("solv-distrosync");
 
-    libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
+    libdnf::rpm::PackageQuery query(*base);
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_distro_sync("cmdline");
@@ -444,7 +444,7 @@ void BaseGoalTest::test_distrosync_all() {
 
     add_repo_solv("solv-distrosync");
 
-    libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
+    libdnf::rpm::PackageQuery query(*base);
 
     libdnf::Goal goal(base.get());
     goal.add_rpm_distro_sync();
@@ -477,7 +477,7 @@ void BaseGoalTest::test_install_or_reinstall() {
     sack->add_cmdline_package(rpm_path, false);
 
     libdnf::Goal goal(base.get());
-    libdnf::rpm::PackageQuery query(base->get_rpm_package_sack());
+    libdnf::rpm::PackageQuery query(*base);
     query.filter_available().filter_nevra({"cmdline-0:1.2-3.noarch"});
     CPPUNIT_ASSERT_EQUAL(1lu, query.size());
     goal.add_rpm_install_or_reinstall(query);

--- a/test/libdnf/rpm/test_package.cpp
+++ b/test/libdnf/rpm/test_package.cpp
@@ -38,7 +38,7 @@ void RpmPackageTest::setUp() {
 
 
 libdnf::rpm::Package RpmPackageTest::get_pkg(const std::string & nevra) {
-    libdnf::rpm::PackageQuery query(sack);
+    libdnf::rpm::PackageQuery query(*base);
     query.filter_nevra({nevra});
     CPPUNIT_ASSERT_EQUAL_MESSAGE(
         "get_pkg(\"" + nevra + "\"): no package or more than one package found.", 1lu, query.size());

--- a/test/libdnf/rpm/test_package_query.cpp
+++ b/test/libdnf/rpm/test_package_query.cpp
@@ -47,7 +47,7 @@ void RpmPackageQueryTest::setUp() {
 
 
 void RpmPackageQueryTest::test_size() {
-    libdnf::rpm::PackageQuery query(sack);
+    libdnf::rpm::PackageQuery query(*base);
     CPPUNIT_ASSERT_EQUAL(5LU, query.size());
 }
 
@@ -59,7 +59,7 @@ void RpmPackageQueryTest::test_filter_latest() {
     sack->add_cmdline_package(rpm_path, false);
 
     {
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_latest(1);
         std::vector<std::string> expected = {
             "pkg-0:1.2-3.src",
@@ -71,7 +71,7 @@ void RpmPackageQueryTest::test_filter_latest() {
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
     {
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_latest(2);
         std::vector<std::string> expected = {
             "pkg-0:1.2-3.src",
@@ -85,7 +85,7 @@ void RpmPackageQueryTest::test_filter_latest() {
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
     {
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_latest(-1);
         std::vector<std::string> expected = {
             "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-0:1-1.noarch",  "pkg-0:1-2.noarch",
@@ -98,7 +98,7 @@ void RpmPackageQueryTest::test_filter_latest() {
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
     }
     {
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_latest(-23);
         std::vector<std::string> expected = {"pkg-0:1-1.noarch"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -107,7 +107,7 @@ void RpmPackageQueryTest::test_filter_latest() {
 
 void RpmPackageQueryTest::test_filter_name() {
     // packages with Name == "pkg"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_name({"pkg"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
@@ -116,7 +116,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name matching "pkg*" glob
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_name({"pkg*"}, libdnf::sack::QueryCmp::GLOB);
 
     expected = {
@@ -130,7 +130,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name matching "p?g" glob
-    libdnf::rpm::PackageQuery query3(sack);
+    libdnf::rpm::PackageQuery query3(*base);
     query3.filter_name({"p?g"}, libdnf::sack::QueryCmp::GLOB);
 
     expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
@@ -139,7 +139,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name != "pkg"
-    libdnf::rpm::PackageQuery query4(sack);
+    libdnf::rpm::PackageQuery query4(*base);
     query4.filter_name({"pkg"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
@@ -148,7 +148,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name == "Pkg" - case insensitive match
-    libdnf::rpm::PackageQuery query5(sack);
+    libdnf::rpm::PackageQuery query5(*base);
     query5.filter_name({"Pkg"}, libdnf::sack::QueryCmp::IEXACT);
 
     expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
@@ -157,7 +157,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name matching "P?g" glob - case insensitive match
-    libdnf::rpm::PackageQuery query6(sack);
+    libdnf::rpm::PackageQuery query6(*base);
     std::vector<std::string> names_glob_icase{"cq?lib"};
     query6.filter_name({"P?g"}, libdnf::sack::QueryCmp::IGLOB);
 
@@ -167,7 +167,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name that contain "kg-l"
-    libdnf::rpm::PackageQuery query7(sack);
+    libdnf::rpm::PackageQuery query7(*base);
     query7.filter_name({"kg-l"}, libdnf::sack::QueryCmp::CONTAINS);
 
     expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
@@ -176,7 +176,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name that contain "kG-l" - case insensitive match
-    libdnf::rpm::PackageQuery query8(sack);
+    libdnf::rpm::PackageQuery query8(*base);
     query8.filter_name({"kG-l"}, libdnf::sack::QueryCmp::ICONTAINS);
 
     expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
@@ -191,7 +191,7 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name "pkg" or "pkg-libs" - two patterns matched in one expression
-    libdnf::rpm::PackageQuery query9(sack);
+    libdnf::rpm::PackageQuery query9(*base);
     query9.filter_name({"pkg", "pkg-libs"});
 
     expected = {
@@ -205,14 +205,14 @@ void RpmPackageQueryTest::test_filter_name() {
 
 void RpmPackageQueryTest::test_filter_name_packgset() {
     // packages with Name == "pkg"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_name({"pkg"});
     query1.filter_arch({"src"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
 
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_name(query1);
 
     std::vector<std::string> expected2 = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
@@ -224,7 +224,7 @@ void RpmPackageQueryTest::test_filter_nevra_packgset() {
     sack->add_system_package(rpm_path, false, false);
     sack->add_cmdline_package(rpm_path, false);
 
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_name({"cmdline"});
     std::vector<std::string> expected1 = {"cmdline-0:1.2-3.noarch", "cmdline-0:1.2-3.noarch"};
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query1));
@@ -234,7 +234,7 @@ void RpmPackageQueryTest::test_filter_nevra_packgset() {
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
     CPPUNIT_ASSERT_EQUAL(1lu, query1.size());
 
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_nevra(query1);
 
     CPPUNIT_ASSERT_EQUAL(2lu, query2.size());
@@ -243,14 +243,14 @@ void RpmPackageQueryTest::test_filter_nevra_packgset() {
 
 void RpmPackageQueryTest::test_filter_name_arch() {
     // packages with Name == "pkg"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_name({"pkg"});
     query1.filter_arch({"src"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
 
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_name_arch(query1);
 
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
@@ -261,7 +261,7 @@ void RpmPackageQueryTest::test_filter_name_arch2() {
     sack->add_system_package(rpm_path, false, false);
     sack->add_cmdline_package(rpm_path, false);
 
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_name({"cmdline"});
     std::vector<std::string> expected1 = {"cmdline-0:1.2-3.noarch", "cmdline-0:1.2-3.noarch"};
     CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query1));
@@ -271,7 +271,7 @@ void RpmPackageQueryTest::test_filter_name_arch2() {
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
     CPPUNIT_ASSERT_EQUAL(1lu, query1.size());
 
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_name_arch(query1);
 
     CPPUNIT_ASSERT_EQUAL(2lu, query2.size());
@@ -281,7 +281,7 @@ void RpmPackageQueryTest::test_filter_name_arch2() {
 void RpmPackageQueryTest::test_filter_nevra() {
     {
         // Test QueryCmp::EQ - argument without 0 epoch - two elements
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_nevra({"pkg-1.2-3.src", "pkg-1.2-3.x86_64"});
         std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -289,7 +289,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
 
     {
         // Test QueryCmp::EQ - argument without 0 epoch - two elements
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_nevra({"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"});
         std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -297,7 +297,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
 
     {
         // Test QueryCmp::EQ - argument without 0 epoch - single argument
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_nevra({"pkg-1.2-3.src"});
         std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -305,7 +305,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
 
     {
         // Test QueryCmp::EQ - argument with 0 epoch - single argument
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_nevra({"pkg-0:1.2-3.src"});
         std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -313,7 +313,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
 
     {
         // Test QueryCmp::EQ - argument with unknown release - two elements
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_nevra({"pkg-0:1.2-unknown.src", "pkg-0:1.2-unknown1.x86_64"});
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -321,7 +321,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
 
     {
         // Test QueryCmp::EQ - argument with unknown version - single argument
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_nevra({"pkg-0:1.2-unknown2.x86_64"});
         CPPUNIT_ASSERT_EQUAL(0LU, query.size());
         std::vector<std::string> expected = {};
@@ -330,7 +330,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
 
     {
         // Test QueryCmp::EQ - argument without epoch, but package with epoch - single argument
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_nevra({"pkg-libs-1.2-4.x86_64"});
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -340,7 +340,7 @@ void RpmPackageQueryTest::test_filter_nevra() {
 
 void RpmPackageQueryTest::test_filter_version() {
     // packages with version == "1.2"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_version({"1.2"});
 
     std::vector<std::string> expected = {
@@ -350,7 +350,7 @@ void RpmPackageQueryTest::test_filter_version() {
     // ---
 
     // packages with version != "1.2"
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_version({"1.2"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-libs-1:1.3-4.x86_64"};
@@ -360,7 +360,7 @@ void RpmPackageQueryTest::test_filter_version() {
 
 void RpmPackageQueryTest::test_filter_release() {
     // packages with release == "3"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_release({"3"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64", "pkg-libs-0:1.2-3.x86_64"};
@@ -369,7 +369,7 @@ void RpmPackageQueryTest::test_filter_release() {
     // ---
 
     // packages with Release != "3"
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_release({"3"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
@@ -379,14 +379,14 @@ void RpmPackageQueryTest::test_filter_release() {
 void RpmPackageQueryTest::test_filter_priority() {
     add_repo_solv("solv-24pkgs");
     add_repo_solv("solv-repo1");
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_priority();
     /// TODO(jmracek) Run test with repository with a different priority and check result
 }
 
 void RpmPackageQueryTest::test_filter_provides() {
     // packages with Provides == "libpkg.so.0()(64bit)"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_provides({"libpkg.so.0()(64bit)"});
 
     std::vector<std::string> expected = {"pkg-libs-1:1.2-4.x86_64"};
@@ -395,7 +395,7 @@ void RpmPackageQueryTest::test_filter_provides() {
     // ---
 
     // packages without Provides == "libpkg.so.0()(64bit)"
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_provides({"libpkg.so.0()(64bit)"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64", "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.3-4.x86_64"};
@@ -405,7 +405,7 @@ void RpmPackageQueryTest::test_filter_provides() {
 
 void RpmPackageQueryTest::test_filter_requires() {
     // packages with Requires == "pkg-libs"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_requires({"pkg-libs"});
 
     std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
@@ -414,7 +414,7 @@ void RpmPackageQueryTest::test_filter_requires() {
     // ---
 
     // packages without Requires == "pkg-libs"
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_requires({"pkg-libs"}, libdnf::sack::QueryCmp::NEQ);
 
     expected = {"pkg-0:1.2-3.src", "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
@@ -425,12 +425,11 @@ void RpmPackageQueryTest::test_filter_advisories() {
     // Run setUp again to have a clean sack (without solv-repo1)
     RepoFixture::setUp();
     add_repo_repomd("repomd-repo1");
-    auto advisory_sack = base->get_rpm_advisory_sack();
 
     {
         // Test QueryCmp::EQ with equal advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("DNF-2019-1");
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_name("DNF-2019-1");
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -438,8 +437,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::GT with older advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("PKG-OLDER");
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_name("PKG-OLDER");
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::GT);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -447,8 +446,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::LTE with older advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("PKG-OLDER");
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_name("PKG-OLDER");
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::LTE);
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -456,8 +455,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::LT with newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("PKG-NEWER");
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_name("PKG-NEWER");
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::LT);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -465,8 +464,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::GTE with newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("PKG-NEWER");
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(*base).filter_name("PKG-NEWER");
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::GTE);
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -475,9 +474,9 @@ void RpmPackageQueryTest::test_filter_advisories() {
     {
         // Test QueryCmp::EQ with older and newer advisory pkg
         libdnf::advisory::AdvisoryQuery adv_query =
-            libdnf::advisory::AdvisoryQuery(advisory_sack).filter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
+            libdnf::advisory::AdvisoryQuery(*base).filter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
         ;
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
         std::vector<std::string> expected = {};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
@@ -485,7 +484,7 @@ void RpmPackageQueryTest::test_filter_advisories() {
 }
 
 void RpmPackageQueryTest::test_filter_chain() {
-    libdnf::rpm::PackageQuery query(sack);
+    libdnf::rpm::PackageQuery query(*base);
     query.filter_name({"pkg"})
         .filter_epoch({"0"})
         .filter_version({"1.2"})
@@ -502,7 +501,7 @@ void RpmPackageQueryTest::test_filter_chain() {
 void RpmPackageQueryTest::test_resolve_pkg_spec() {
     {
         // test Name.Arch
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         libdnf::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("pkg.x86_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
@@ -512,7 +511,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 
     {
         // Test NA icase
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         libdnf::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("Pkg.x86_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
@@ -522,7 +521,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 
     {
         // Test a provide
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         libdnf::ResolveSpecSettings settings{.with_filenames = false};
         auto return_value = query.resolve_pkg_spec("pkg >= 1", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
@@ -532,7 +531,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 
     {
         // Test NEVRA glob
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         libdnf::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
@@ -542,7 +541,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 
     {
         // Test NEVRA glob - icase == false, nothing found
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         libdnf::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("Pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, false);
@@ -552,7 +551,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 
     {
         // Test NEVRA glob - icase == true
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         libdnf::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("Pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
@@ -562,7 +561,7 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 
     {
         // Test NEVRA icase
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         libdnf::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("Pkg-0:1.2-3.X86_64", settings, true);
         std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
@@ -573,10 +572,10 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 
 void RpmPackageQueryTest::test_update() {
     // packages with Release == "3"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_release({"3"});
 
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(3LU, query2.size());
 
@@ -596,12 +595,12 @@ void RpmPackageQueryTest::test_update() {
 
 void RpmPackageQueryTest::test_intersection() {
     // packages with Release == "3"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_release({"3"});
     CPPUNIT_ASSERT_EQUAL(3LU, query1.size());
 
     // packages with Name == "pkg-libs"
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(3LU, query2.size());
 
@@ -616,12 +615,12 @@ void RpmPackageQueryTest::test_intersection() {
 
 void RpmPackageQueryTest::test_difference() {
     // packages with Release == "3"
-    libdnf::rpm::PackageQuery query1(sack);
+    libdnf::rpm::PackageQuery query1(*base);
     query1.filter_release({"3"});
     CPPUNIT_ASSERT_EQUAL(3LU, query1.size());
 
     // packages with Release == "3" and name == "pkg-libs"
-    libdnf::rpm::PackageQuery query2(sack);
+    libdnf::rpm::PackageQuery query2(*base);
     query2.filter_release({"3"});
     query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(1LU, query2.size());
@@ -639,7 +638,7 @@ void RpmPackageQueryTest::test_filter_latest_performance() {
     add_repo_solv("solv-humongous");
 
     for (int i = 0; i < 10000; ++i) {
-        libdnf::rpm::PackageQuery query(sack);
+        libdnf::rpm::PackageQuery query(*base);
         query.filter_latest();
     }
 }

--- a/test/libdnf/transaction/test_comps_environment.cpp
+++ b/test/libdnf/transaction/test_comps_environment.cpp
@@ -80,7 +80,7 @@ void TransactionCompsEnvironmentTest::test_save_load() {
     auto base2 = new_base();
 
     // get the written transaction
-    libdnf::transaction::TransactionQuery q2(base2->get_transaction_sack());
+    libdnf::transaction::TransactionQuery q2(*base2);
     q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 

--- a/test/libdnf/transaction/test_comps_group.cpp
+++ b/test/libdnf/transaction/test_comps_group.cpp
@@ -80,7 +80,7 @@ void TransactionCompsGroupTest::test_save_load() {
     auto base2 = new_base();
 
     // get the written transaction
-    libdnf::transaction::TransactionQuery q2(base2->get_transaction_sack());
+    libdnf::transaction::TransactionQuery q2(*base2);
     q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 

--- a/test/libdnf/transaction/test_query.cpp
+++ b/test/libdnf/transaction/test_query.cpp
@@ -46,7 +46,7 @@ void TransactionQueryTest::test_filter_id_eq() {
     auto base2 = new_base();
 
     // get the written transaction
-    libdnf::transaction::TransactionQuery q2(base2->get_transaction_sack());
+    libdnf::transaction::TransactionQuery q2(*base2);
     q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 }
@@ -71,8 +71,8 @@ void TransactionQueryTest::test_filter_id_eq_parallel_queries() {
     CPPUNIT_ASSERT_EQUAL(0LU, transaction_sack2->get_data().size());
 
     // create 2 queries that are empty, none of them loaded any transaction yet
-    libdnf::transaction::TransactionQuery q2(transaction_sack2);
-    libdnf::transaction::TransactionQuery q3(transaction_sack2);
+    libdnf::transaction::TransactionQuery q2(*base2);
+    libdnf::transaction::TransactionQuery q3(*base2);
 
     q2.filter_id(trans->get_id());
     auto trans2 = q2.get();

--- a/test/libdnf/transaction/test_rpm_package.cpp
+++ b/test/libdnf/transaction/test_rpm_package.cpp
@@ -66,7 +66,7 @@ void TransactionRpmPackageTest::test_save_load() {
     auto base2 = new_base();
 
     // get the written transaction
-    libdnf::transaction::TransactionQuery q2(base2->get_transaction_sack());
+    libdnf::transaction::TransactionQuery q2(*base2);
     q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 

--- a/test/libdnf/transaction/test_transaction.cpp
+++ b/test/libdnf/transaction/test_transaction.cpp
@@ -61,7 +61,7 @@ void TransactionTest::test_save_load() {
 
     // load the saved transaction from database and compare values
     auto base2 = new_base();
-    libdnf::transaction::TransactionQuery q2(base2->get_transaction_sack());
+    libdnf::transaction::TransactionQuery q2(*base2);
     q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 
@@ -115,7 +115,7 @@ void TransactionTest::test_update() {
 
     // load the transction from the database
     auto base2 = new_base();
-    libdnf::transaction::TransactionQuery q2(base2->get_transaction_sack());
+    libdnf::transaction::TransactionQuery q2(*base2);
     q2.filter_id(trans->get_id());
     auto trans2 = q2.get();
 

--- a/test/perl5/libdnf/rpm/test_package_query.t
+++ b/test/perl5/libdnf/rpm/test_package_query.t
@@ -53,7 +53,7 @@ $sack->load_repo($repo->get(), $libdnf::rpm::PackageSack::LoadRepoFlags_NONE);
 
 #test_size()
 {
-    my $query = new libdnf::rpm::PackageQuery($sack);
+    my $query = new libdnf::rpm::PackageQuery($base);
     is($query->size(), 3);
 }
 
@@ -65,7 +65,7 @@ my @full_nevras = ("CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64",
 
 # Test QueryCmp::EQ
 {
-    my $query = new libdnf::rpm::PackageQuery($sack);
+    my $query = new libdnf::rpm::PackageQuery($base);
     $query->filter_name(["pkg"]);
     is($query->size(), 1);
 
@@ -83,7 +83,7 @@ my @full_nevras = ("CQRlib-0:1.1.1-4.fc29.src", "CQRlib-0:1.1.1-4.fc29.x86_64",
 
 # Test QueryCmp::GLOB
 {
-    my $query = new libdnf::rpm::PackageQuery($sack);
+    my $query = new libdnf::rpm::PackageQuery($base);
     $query->filter_name(["pk*"], $libdnf::common::QueryCmp_GLOB);
     is($query->size(), 2);
 

--- a/test/python3/libdnf/rpm/test_package_query.py
+++ b/test/python3/libdnf/rpm/test_package_query.py
@@ -54,11 +54,11 @@ class TestPackageQuery(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_size(self):
-        query = libdnf.rpm.PackageQuery(self.sack)
+        query = libdnf.rpm.PackageQuery(self.base)
         self.assertEqual(query.size(), 3)
 
     def test_iterate_package_query(self):
-        query = libdnf.rpm.PackageQuery(self.sack)
+        query = libdnf.rpm.PackageQuery(self.base)
 
         # Iterates over reference "query".
         prev_id = 0
@@ -87,18 +87,18 @@ class TestPackageQuery(unittest.TestCase):
         # Tests the iteration of an unreferenced PackageQuery object. The iterator must hold a reference
         # to the iterated object, otherwise the gargabe collector can remove the object.
 
-        # Iterates directly over "libdnf.rpm.PackageQuery(self.sack)" result. No helping reference.
+        # Iterates directly over "libdnf.rpm.PackageQuery(self.base)" result. No helping reference.
         prev_id = 0
-        for pkg in libdnf.rpm.PackageQuery(self.sack):
+        for pkg in libdnf.rpm.PackageQuery(self.base):
             id = pkg.get_id().id
             self.assertGreater(id, prev_id)
             prev_id = id
         self.assertLess(prev_id, self.sack.get_nsolvables())
-        self.assertGreaterEqual(prev_id, libdnf.rpm.PackageQuery(self.sack).size())
+        self.assertGreaterEqual(prev_id, libdnf.rpm.PackageQuery(self.base).size())
 
         # Another test. The iterator is created from the "query" reference, but the reference
         # is removed (set to "None") before starting the iteration.
-        query = libdnf.rpm.PackageQuery(self.sack)
+        query = libdnf.rpm.PackageQuery(self.base)
         query_iterator = iter(query)
         query = None
         prev_id = 0
@@ -111,11 +111,11 @@ class TestPackageQuery(unittest.TestCase):
             except StopIteration:
                 break
         self.assertLess(prev_id, self.sack.get_nsolvables())
-        self.assertGreaterEqual(prev_id, libdnf.rpm.PackageQuery(self.sack).size())
+        self.assertGreaterEqual(prev_id, libdnf.rpm.PackageQuery(self.base).size())
 
     def test_filter_name(self):
         # Test QueryCmp::EQ
-        query = libdnf.rpm.PackageQuery(self.sack)
+        query = libdnf.rpm.PackageQuery(self.base)
         query.filter_name(["pkg"])
         self.assertEqual(query.size(), 1)
         # TODO(dmach): implement __str__()
@@ -124,7 +124,7 @@ class TestPackageQuery(unittest.TestCase):
         # ---
 
         # Test QueryCmp::GLOB
-        query = libdnf.rpm.PackageQuery(self.sack)
+        query = libdnf.rpm.PackageQuery(self.base)
         query.filter_name(["pk*"], libdnf.common.QueryCmp_GLOB)
         self.assertEqual(query.size(), 2)
         # TODO(dmach): implement __str__()

--- a/test/ruby/libdnf/rpm/test_package_query.rb
+++ b/test/ruby/libdnf/rpm/test_package_query.rb
@@ -55,13 +55,13 @@ class TestSimpleNumber < Test::Unit::TestCase
     end
 
     def test_size()
-        query = Rpm::PackageQuery.new(@sack)
+        query = Rpm::PackageQuery.new(@base)
         assert_equal(3, query.size(), 'Number of items in the newly created query')
     end
 
     def test_filter_name()
         # Test QueryCmp::EQ
-        query = Rpm::PackageQuery.new(@sack)
+        query = Rpm::PackageQuery.new(@base)
         query.filter_name(["pkg"])
         assert_equal(1, query.size())
 
@@ -78,7 +78,7 @@ class TestSimpleNumber < Test::Unit::TestCase
         # ---
 
         # Test QueryCmp::GLOB
-        query = Rpm::PackageQuery.new(@sack)
+        query = Rpm::PackageQuery.new(@base)
         query.filter_name(["pk*"], Common::QueryCmp_GLOB)
         assert_equal(2, query.size())
 


### PR DESCRIPTION
- Fix: `advisory::AdvisoryQuery` constructors with "base" argument - `p_impl` was not constructed
- Make contructors without "base" argument private - All calls were replaced by constructors with "base" argument