### PR TITLE
Make read_login_uid_from_proc() public API

### DIFF
--- a/include/libdnf/common/proc.hpp
+++ b/include/libdnf/common/proc.hpp
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_COMMON_PROC_HPP
+#define LIBDNF_COMMON_PROC_HPP
+
+#include <sys/types.h>
+
+namespace libdnf {
+
+constexpr uid_t INVALID_UID = static_cast<uid_t>(-1);
+
+/// Read the login uid from the "/proc/self/loginuid".
+uid_t read_login_uid_from_proc() noexcept;
+
+}  // namespace libdnf
+
+#endif

--- a/include/libdnf/common/proc.hpp
+++ b/include/libdnf/common/proc.hpp
@@ -26,8 +26,11 @@ namespace libdnf {
 
 constexpr uid_t INVALID_UID = static_cast<uid_t>(-1);
 
-/// Read the login uid from the "/proc/self/loginuid".
-uid_t read_login_uid_from_proc() noexcept;
+/// Read the process owner login uid from the "/proc/<pid>/loginuid".
+/// @param pid process id
+/// @return libdnf::INVALID_UID if fails, login uid otherwise
+/// @since 5.0
+uid_t read_login_uid_from_proc(pid_t pid) noexcept;
 
 }  // namespace libdnf
 

--- a/libdnf/common/proc.cpp
+++ b/libdnf/common/proc.cpp
@@ -21,14 +21,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <errno.h>
 #include <fcntl.h>
+#include <fmt/format.h>
 #include <unistd.h>
 
 #include <cstdlib>
 
 namespace libdnf {
 
-uid_t read_login_uid_from_proc() noexcept {
-    auto in = open("/proc/self/loginuid", O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+uid_t read_login_uid_from_proc(pid_t pid) noexcept {
+    auto in = open(fmt::format("/proc/{}/loginuid", pid).c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
     if (in == -1) {
         return INVALID_UID;
     }

--- a/libdnf/common/proc.cpp
+++ b/libdnf/common/proc.cpp
@@ -1,0 +1,60 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "libdnf/common/proc.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdlib>
+
+namespace libdnf {
+
+uid_t read_login_uid_from_proc() noexcept {
+    auto in = open("/proc/self/loginuid", O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (in == -1) {
+        return INVALID_UID;
+    }
+
+    ssize_t len;
+    char buf[16];
+    do {
+        errno = 0;
+        len = read(in, buf, sizeof(buf) - 1);
+    } while (len < 0 && errno == EINTR);
+
+    close(in);
+
+    if (len <= 0) {
+        return INVALID_UID;
+    }
+
+    buf[len] = '\0';
+    char * endptr;
+    errno = 0;
+    auto uid = static_cast<uid_t>(strtol(buf, &endptr, 10));
+    if (buf == endptr || errno != 0) {
+        return INVALID_UID;
+    }
+
+    return uid;
+}
+
+}  // namespace libdnf

--- a/microdnf/utils.cpp
+++ b/microdnf/utils.cpp
@@ -19,16 +19,8 @@ along with microdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "utils.hpp"
 
-#include <fcntl.h>
-#include <libsmartcols/libsmartcols.h>
-#include <pwd.h>
-#include <sys/stat.h>
+#include <libdnf/common/proc.hpp>
 #include <unistd.h>
-
-#include <cstdlib>
-#include <cstring>
-#include <iostream>
-#include <stdexcept>
 
 namespace microdnf {
 
@@ -36,44 +28,11 @@ bool am_i_root() noexcept {
     return geteuid() == 0;
 }
 
-static constexpr uid_t INVALID_UID = static_cast<uid_t>(-1);
-
-/// Read the login uid from the "/proc/self/loginuid".
-static uid_t read_login_uid_from_proc() noexcept {
-    auto in = open("/proc/self/loginuid", O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
-    if (in == -1) {
-        return INVALID_UID;
-    }
-
-    ssize_t len;
-    char buf[16];
-    do {
-        errno = 0;
-        len = read(in, buf, sizeof(buf) - 1);
-    } while (len < 0 && errno == EINTR);
-
-    close(in);
-
-    if (len <= 0) {
-        return INVALID_UID;
-    }
-
-    buf[len] = '\0';
-    char * endptr;
-    errno = 0;
-    auto uid = static_cast<uid_t>(strtol(buf, &endptr, 10));
-    if (buf == endptr || errno != 0) {
-        return INVALID_UID;
-    }
-
-    return uid;
-}
-
 uid_t get_login_uid() noexcept {
-    static uid_t cached_uid = INVALID_UID;
-    if (cached_uid == INVALID_UID) {
-        cached_uid = read_login_uid_from_proc();
-        if (cached_uid == INVALID_UID) {
+    static uid_t cached_uid = libdnf::INVALID_UID;
+    if (cached_uid == libdnf::INVALID_UID) {
+        cached_uid = libdnf::read_login_uid_from_proc();
+        if (cached_uid == libdnf::INVALID_UID) {
             cached_uid = getuid();
         }
     }

--- a/microdnf/utils.cpp
+++ b/microdnf/utils.cpp
@@ -31,7 +31,7 @@ bool am_i_root() noexcept {
 uid_t get_login_uid() noexcept {
     static uid_t cached_uid = libdnf::INVALID_UID;
     if (cached_uid == libdnf::INVALID_UID) {
-        cached_uid = libdnf::read_login_uid_from_proc();
+        cached_uid = libdnf::read_login_uid_from_proc(getpid());
         if (cached_uid == libdnf::INVALID_UID) {
             cached_uid = getuid();
         }


### PR DESCRIPTION
Move code from microdnf to libdnf because the dnfdaemon-server also needs this functionality.