### PR TITLE
[dnf5] Define internal classes/structs in trans units into anonymous namespace

### DIFF
--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -32,6 +32,8 @@ along with dnfdaemon-server.  If not, see <https://www.gnu.org/licenses/>.
 #include <iostream>
 #include <string>
 
+namespace {
+
 // repository attributes available to be retrieved
 // based on `dnf repolist` command
 enum class RepoAttribute {
@@ -196,6 +198,8 @@ dnfdaemon::KeyValueMap repo_to_map(
 bool keyval_repo_compare(const dnfdaemon::KeyValueMap & first, const dnfdaemon::KeyValueMap & second) {
     return key_value_map_get<std::string>(first, "id") < key_value_map_get<std::string>(second, "id");
 }
+
+}  // namespace
 
 void Repo::dbus_register() {
     auto dbus_object = session.get_dbus_object();

--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -35,6 +35,8 @@ along with dnfdaemon-server.  If not, see <https://www.gnu.org/licenses/>.
 #include <iostream>
 #include <string>
 
+namespace {
+
 class StderrLogger : public libdnf::Logger {
 public:
     explicit StderrLogger() {}
@@ -47,6 +49,8 @@ void StderrLogger::write(time_t, pid_t, Level, const std::string & message) noex
     } catch (...) {
     }
 }
+
+}  // namespace
 
 Session::Session(
     sdbus::IConnection & connection,

--- a/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -29,6 +29,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 using namespace libdnf::plugin;
 namespace fs = std::filesystem;
 
+namespace {
+
 constexpr const char * PLUGIN_NAME = "python_plugin_loader";
 constexpr Version PLUGIN_VERSION{0, 1, 0};
 constexpr const char * PLUGIN_DESCRIPTION = "Plugin for loading Python plugins.";
@@ -176,6 +178,8 @@ static void fetch_python_error_to_exception(const char * msg) {
     auto pycomp_str = PycompString(objectsRepresentation.get());
     throw std::runtime_error(msg + pycomp_str.get_string());
 }
+
+}  // namespace
 
 /// Load Python plugin from path
 void PythonPluginLoader::load_plugin_file(const fs::path & file_path) {

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -519,6 +519,8 @@ PackageQuery & PackageQuery::filter_arch(const std::vector<std::string> & patter
     return *this;
 }
 
+namespace {
+
 struct NevraID {
     NevraID() : name(0), arch(0), evr(0){};
     NevraID(const NevraID & src) = default;
@@ -634,6 +636,8 @@ inline static void filter_nevra_internal(
         ++low;
     }
 }
+
+}  // namespace
 
 PackageQuery & PackageQuery::filter_nevra(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -69,6 +69,8 @@ bool userconfirm(libdnf::ConfigMain & config) {
     }
 }
 
+namespace {
+
 class MicrodnfRepoCB : public libdnf::repo::RepoCB {
 public:
     explicit MicrodnfRepoCB(libdnf::ConfigMain & config) : config(&config) {}
@@ -169,6 +171,8 @@ private:
 };
 
 std::chrono::time_point<std::chrono::steady_clock> MicrodnfRepoCB::prev_print_time = std::chrono::steady_clock::now();
+
+}  // namespace
 
 void Context::load_rpm_repo(libdnf::repo::Repo & repo) {
     //repo->set_substitutions(variables);
@@ -305,6 +309,8 @@ void Context::load_rpm_repos(libdnf::repo::RepoQuery & repos, libdnf::rpm::Packa
 //     }
 // }
 
+namespace {
+
 class PkgDownloadCB : public libdnf::repo::PackageTargetCB {
 public:
     PkgDownloadCB(libdnf::cli::progressbar::MultiProgressBar & mp_bar, const std::string & what)
@@ -382,6 +388,8 @@ private:
 
 std::chrono::time_point<std::chrono::steady_clock> PkgDownloadCB::prev_print_time = std::chrono::steady_clock::now();
 
+}  // namespace
+
 void download_packages(const std::vector<libdnf::rpm::Package> & packages, const char * dest_dir) {
     libdnf::cli::progressbar::MultiProgressBar multi_progress_bar;
     std::vector<std::unique_ptr<PkgDownloadCB>> pkg_download_callbacks_guard;
@@ -446,6 +454,8 @@ void download_packages(libdnf::Goal & goal, const char * dest_dir) {
     download_pkgs.insert(download_pkgs.end(), downgrades_pkgs.begin(), downgrades_pkgs.end());
     download_packages(download_pkgs, dest_dir);
 }
+
+namespace {
 
 class RpmTransCB : public libdnf::rpm::TransactionCB {
 public:
@@ -656,6 +666,8 @@ private:
 };
 
 std::chrono::time_point<std::chrono::steady_clock> RpmTransCB::prev_print_time = std::chrono::steady_clock::now();
+
+}  // namespace
 
 void run_transaction(libdnf::rpm::Transaction & transaction) {
     std::cout << "Running transaction:" << std::endl;

--- a/test/libdnf/iniparser/test_iniparser.cpp
+++ b/test/libdnf/iniparser/test_iniparser.cpp
@@ -34,6 +34,9 @@ void IniparserTest::tearDown() {}
 
 
 using ItemType = libdnf::IniParser::ItemType;
+
+namespace {
+
 struct Item {
     ItemType type;
     const char * section;
@@ -41,6 +44,8 @@ struct Item {
     const char * value;
     const char * raw;
 };
+
+}  // namespace
 
 void IniparserTest::test_iniparser() {
 

--- a/test/libdnf/query/test_query.cpp
+++ b/test/libdnf/query/test_query.cpp
@@ -23,6 +23,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 CPPUNIT_TEST_SUITE_REGISTRATION(QueryTest);
 
+namespace {
+
 class QueryItem {
 public:
     bool enabled;
@@ -66,6 +68,8 @@ TestQuery & TestQuery::filter_name(const std::string & name, libdnf::sack::Query
     filter(F::name, name, cmp);
     return *this;
 }
+
+}  // namespace
 
 
 void QueryTest::setUp() {}

--- a/test/libdnf/rpm/test_nevra.cpp
+++ b/test/libdnf/rpm/test_nevra.cpp
@@ -193,6 +193,8 @@ void NevraTest::test_nevra() {
 }
 
 
+namespace {
+
 class TestPackage : public libdnf::rpm::Nevra {
 public:
     explicit TestPackage(const char * nevra_str) {
@@ -208,6 +210,8 @@ public:
         return get_epoch() + ":" + get_version() + "-" + get_release();
     }
 };
+
+}  // namespace
 
 
 void NevraTest::test_cmp_nevra() {

--- a/test/libdnf/rpm/test_package_query.cpp
+++ b/test/libdnf/rpm/test_package_query.cpp
@@ -33,11 +33,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 CPPUNIT_TEST_SUITE_REGISTRATION(RpmPackageQueryTest);
 
 
+namespace {
+
 // make constructor public so we can create Package instances in the tests
 class TestPackage : public libdnf::rpm::Package {
 public:
     TestPackage(const libdnf::rpm::PackageSackWeakPtr & sack, libdnf::rpm::PackageId id) : libdnf::rpm::Package(sack, id) {}
 };
+
+}  // namespace
 
 
 void RpmPackageQueryTest::setUp() {

--- a/test/libdnf/rpm/test_package_set.cpp
+++ b/test/libdnf/rpm/test_package_set.cpp
@@ -28,11 +28,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 CPPUNIT_TEST_SUITE_REGISTRATION(RpmPackageSetTest);
 
+namespace {
+
 // make constructor public so we can create Package instances in the tests
 class TestPackage : public libdnf::rpm::Package {
 public:
     TestPackage(const libdnf::rpm::PackageSackWeakPtr & sack, libdnf::rpm::PackageId id) : libdnf::rpm::Package(sack, id) {}
 };
+
+}  // namespace
 
 
 void RpmPackageSetTest::setUp() {


### PR DESCRIPTION
If there are multiple different entity definitions with the same name in different translation units, the behavior is undefined!

I suggest definning internal classes/structures in translation units into anonymous namespaces to avoid collisions in the case of multiple entities of the same name.

Accorning C++ standard:
In C++ exists "One definition rule". No translation unit shall contain more than one definition of any variable, function, class type,
enumeration type, or template.
However there can be more than one definition of class type, enumeration type, iniline function with external linkage, class template, non-static function template, static data member of a class template, member function of a class template, or template specialization for which some template parameters are not specified in a program, provided that each definition is in a different translation unit.
In that case some requirements must be satisfied.
One of the requirement is: Given such an entity named D defined in more than one translation unit, then each definition of D shall consist of the same sequence of tokens.
If the definitions of D do not satisfy that requirement, then the behavior is undefined.