### PR TITLE
Completely remove failovermethod config option (RhBug:1961083)

### DIFF
--- a/libdnf/conf/ConfigRepo.cpp
+++ b/libdnf/conf/ConfigRepo.cpp
@@ -79,7 +79,6 @@ class ConfigRepo::Impl {
     OptionString enabled_metadata{""};
     OptionChild<OptionString> user_agent{mainConfig.user_agent()};
     OptionChild<OptionBool> countme{mainConfig.countme()};
-    OptionEnum<std::string> failovermethod{"priority", {"priority", "roundrobin"}};
     OptionChild<OptionBool> sslverifystatus{mainConfig.sslverifystatus()};
 };
 
@@ -230,7 +229,6 @@ OptionChild<OptionBool> & ConfigRepo::skip_if_unavailable() { return pImpl->skip
 OptionString & ConfigRepo::enabled_metadata() { return pImpl->enabled_metadata; }
 OptionChild<OptionString> & ConfigRepo::user_agent() { return pImpl->user_agent; }
 OptionChild<OptionBool> & ConfigRepo::countme() { return pImpl->countme; }
-OptionEnum<std::string> & ConfigRepo::failovermethod() { return pImpl->failovermethod; }
 OptionChild<OptionBool> & ConfigRepo::sslverifystatus() { return pImpl->sslverifystatus; }
 
 }

--- a/libdnf/conf/ConfigRepo.hpp
+++ b/libdnf/conf/ConfigRepo.hpp
@@ -95,7 +95,6 @@ public:
     OptionChild<OptionString> & user_agent();
     OptionChild<OptionBool> & countme();
     // yum compatibility options
-    OptionEnum<std::string> & failovermethod();
     OptionChild<OptionBool> & sslverifystatus();
 
 private:


### PR DESCRIPTION
Currently the failovermethod option is "half supported" in dnf - it is
defined as a repo config option, but has no binding. This results in
misleading error messages on the terminal when the user has this option
set in their repofiles:

Invalid configuration value: failovermethod=priority in /etc/yum.repos.d/fedora.repo; Configuration: OptionBinding with id "failovermethod" does not exist

After the fix, the option is handled the same way as any other
non-existent option - no error message printed on the console and a
clear message in the dnf.log:

Unknown configuration option: failovermethod = priority in /etc/yum.repos.d/fedora.repo

= changelog =
type:          enhancement
resolves:      https://bugzilla.redhat.com/show_bug.cgi?id=1961083