### PR TITLE
DnfContext: fix handling of default module profiles

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -3531,10 +3531,8 @@ dnf_context_module_install(DnfContext * context, const char ** module_specs, GEr
                             auto matching = latest->getProfiles(profileName);
                             profiles.insert(profiles.begin(), matching.begin(), matching.end());
                         }
-                        // Fallback to the new `default` knob in the modulemd proper.
-                        // This isn't actually used yet, at least in Fedora.
                         if (profiles.empty()) {
-                            profiles.push_back(latest->getDefaultProfile());
+                            throw std::runtime_error("No default profile found for " + latest->getFullIdentifier());
                         }
                     }
 

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -3525,7 +3525,17 @@ dnf_context_module_install(DnfContext * context, const char ** module_specs, GEr
                             throw std::runtime_error(tfm::format(_("No profile found matching '%s'"), nsvcap_obj->getProfile().c_str()));
                         }
                     } else {
-                        profiles.push_back(latest->getDefaultProfile());
+                        // This queries the distro-level modulemd-defaults.
+                        auto default_profiles = container->getDefaultProfiles(latest->getName(), latest->getStream());
+                        for (auto & profileName : default_profiles) {
+                            auto matching = latest->getProfiles(profileName);
+                            profiles.insert(profiles.begin(), matching.begin(), matching.end());
+                        }
+                        // Fallback to the new `default` knob in the modulemd proper.
+                        // This isn't actually used yet, at least in Fedora.
+                        if (profiles.empty()) {
+                            profiles.push_back(latest->getDefaultProfile());
+                        }
                     }
 
                     g_autoptr(GPtrArray) pkgnames = g_ptr_array_new_with_free_func (g_free);

--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -442,6 +442,19 @@ ModulePackage::getProfiles(const std::string &name) const
     return result_profiles;
 }
 
+/* @brief Return default profiles as defined in the modulemd itself.
+ *
+ * Note this is probably not the function you want. You likely want to use
+ * ModulePackageContainer::getDefaultProfiles() instead, which sources the
+ * distro-level modulemd-defaults.
+ *
+ * Also, this function returns the first default profile, but instead we want it
+ * to return all default profiles. So supporting this properly in the future
+ * would require a new ModulePackage::getDefaultProfiles() which returns an
+ * std::vec<ModuleProfile> instead.
+ *
+ * @return ModuleProfile
+ */
 ModuleProfile
 ModulePackage::getDefaultProfile() const
 {


### PR DESCRIPTION
Currently, default profiles are encoded in modulemd-defaults, which are
separate from the modulemd spec. E.g. in Fedora, it's in:
https://pagure.io/releng/fedora-module-defaults

The `ModulePackage::getDefaultProfile()` function only queried for the
modulemd data, not modulemd-defaults data. Eventually, once MBS learns
about defaults in modulemds Fedora may start using it, but until then
and regardless we need to support defaults in modulemd-defaults, i.e.
using `container->getDefaultProfiles()`, just like `dnf` does.