### PR TITLE
dnfdaemon: handle incorrect --installroot values 

### DIFF
--- a/dnfdaemon-client/main.cpp
+++ b/dnfdaemon-client/main.cpp
@@ -97,9 +97,18 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
     auto installroot = ctx.arg_parser.add_new_named_arg("installroot");
     installroot->set_long_name("installroot");
     installroot->set_has_value(true);
-    installroot->set_arg_value_help("absolute path");
+    installroot->set_arg_value_help("<absolute path>");
     installroot->set_short_description("set install root");
     installroot->link_value(&ctx.installroot);
+    installroot->set_parse_hook_func([](
+                                    libdnf::cli::ArgumentParser::NamedArg * arg,
+                                    [[maybe_unused]] const char * option,
+                                    const char * value) {
+        if (value[0] != '/') {
+            throw std::runtime_error(fmt::format("--{}: Absolute path must be used.", arg->get_long_name()));
+        }
+        return true;
+    });
     dnfdaemon_client->register_named_arg(installroot);
 
     auto releasever = ctx.arg_parser.add_new_named_arg("releasever");

--- a/dnfdaemon-server/services/base/base.cpp
+++ b/dnfdaemon-server/services/base/base.cpp
@@ -35,7 +35,7 @@ void Base::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_BASE, "read_all_repos", "", "b", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Base::read_all_repos, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Base::read_all_repos, std::move(call));
         });
     dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_REPO_LOAD_START, "ss");
     dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_REPO_LOAD_PROGRESS, "suu");

--- a/dnfdaemon-server/services/base/base.cpp
+++ b/dnfdaemon-server/services/base/base.cpp
@@ -35,7 +35,7 @@ void Base::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_BASE, "read_all_repos", "", "b", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Base::read_all_repos, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Base::read_all_repos, std::move(call));
         });
     dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_REPO_LOAD_START, "ss");
     dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_REPO_LOAD_PROGRESS, "suu");

--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -39,11 +39,11 @@ void Goal::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_GOAL, "resolve", "a{sv}", "a(ua{sv})", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Goal::resolve, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Goal::resolve, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_GOAL, "do_transaction", "a{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Goal::do_transaction, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Goal::do_transaction, std::move(call));
         });
 }
 

--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -39,11 +39,11 @@ void Goal::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_GOAL, "resolve", "a{sv}", "a(ua{sv})", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Goal::resolve, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Goal::resolve, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_GOAL, "do_transaction", "a{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Goal::do_transaction, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Goal::do_transaction, std::move(call));
         });
 }
 

--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -205,7 +205,7 @@ void Repo::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPO, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Repo::list, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Repo::list, std::move(call));
         });
 }
 

--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -23,9 +23,9 @@ along with dnfdaemon-server.  If not, see <https://www.gnu.org/licenses/>.
 #include "dnfdaemon-server/utils.hpp"
 
 #include <fmt/format.h>
+#include <libdnf/repo/repo.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
-#include <libdnf/repo/repo.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
 #include <chrono>
@@ -205,7 +205,7 @@ void Repo::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPO, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Repo::list, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Repo::list, std::move(call));
         });
 }
 

--- a/dnfdaemon-server/services/repoconf/repo_conf.cpp
+++ b/dnfdaemon-server/services/repoconf/repo_conf.cpp
@@ -31,19 +31,19 @@ void RepoConf::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &RepoConf::list, std::move(call));
+            session.get_threads_manager().handle_method(*this, &RepoConf::list, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "get", "s", "a{sv}", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &RepoConf::get, std::move(call));
+            session.get_threads_manager().handle_method(*this, &RepoConf::get, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "enable", "as", "as", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &RepoConf::enable, std::move(call));
+            session.get_threads_manager().handle_method(*this, &RepoConf::enable, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "disable", "as", "as", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &RepoConf::disable, std::move(call));
+            session.get_threads_manager().handle_method(*this, &RepoConf::disable, std::move(call));
         });
 }
 

--- a/dnfdaemon-server/services/repoconf/repo_conf.cpp
+++ b/dnfdaemon-server/services/repoconf/repo_conf.cpp
@@ -31,19 +31,19 @@ void RepoConf::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &RepoConf::list, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &RepoConf::list, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "get", "s", "a{sv}", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &RepoConf::get, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &RepoConf::get, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "enable", "as", "as", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &RepoConf::enable, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &RepoConf::enable, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "disable", "as", "as", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &RepoConf::disable, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &RepoConf::disable, std::move(call));
         });
 }
 

--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -34,23 +34,23 @@ void Rpm::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "downgrade", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Rpm::downgrade, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Rpm::downgrade, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Rpm::list, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Rpm::list, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "install", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Rpm::install, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Rpm::install, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "upgrade", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Rpm::upgrade, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Rpm::upgrade, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "remove", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.run_in_thread(*this, &Rpm::remove, std::move(call));
+            session.get_threads_manager().run_in_thread(*this, &Rpm::remove, std::move(call));
         });
 }
 

--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -34,23 +34,23 @@ void Rpm::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "downgrade", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Rpm::downgrade, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::downgrade, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Rpm::list, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::list, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "install", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Rpm::install, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::install, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "upgrade", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Rpm::upgrade, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::upgrade, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "remove", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().run_in_thread(*this, &Rpm::remove, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::remove, std::move(call));
         });
 }
 

--- a/dnfdaemon-server/session_manager.cpp
+++ b/dnfdaemon-server/session_manager.cpp
@@ -45,11 +45,11 @@ void SessionManager::dbus_register() {
     dbus_object = sdbus::createObject(connection, object_path);
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_SESSION_MANAGER, "open_session", "a{sv}", "o", [this](sdbus::MethodCall call) -> void {
-            threads_manager.run_in_thread(*this, &SessionManager::open_session, std::move(call));
+            threads_manager.handle_method(*this, &SessionManager::open_session, std::move(call));
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_SESSION_MANAGER, "close_session", "o", "b", [this](sdbus::MethodCall call) -> void {
-            threads_manager.run_in_thread(*this, &SessionManager::close_session, std::move(call));
+            threads_manager.handle_method(*this, &SessionManager::close_session, std::move(call));
         });
     dbus_object->finishRegistration();
 

--- a/dnfdaemon-server/session_manager.hpp
+++ b/dnfdaemon-server/session_manager.hpp
@@ -51,7 +51,7 @@ private:
     void dbus_register();
     sdbus::MethodReply open_session(sdbus::MethodCall && call);
     sdbus::MethodReply close_session(sdbus::MethodCall && call);
-    void on_name_owner_changed(sdbus::Signal & signal);
+    void on_name_owner_changed(sdbus::Signal && signal);
 };
 
 #endif

--- a/dnfdaemon-server/session_manager.hpp
+++ b/dnfdaemon-server/session_manager.hpp
@@ -35,6 +35,8 @@ public:
     SessionManager(sdbus::IConnection & connection, const std::string & object_path);
     ~SessionManager();
 
+    ThreadsManager & get_threads_manager() { return threads_manager; };
+
 private:
     std::string object_path;
     sdbus::IConnection & connection;
@@ -47,8 +49,8 @@ private:
     std::map<std::string, std::map<std::string, std::unique_ptr<Session>>> sessions;
 
     void dbus_register();
-    void open_session(sdbus::MethodCall call);
-    void close_session(sdbus::MethodCall call);
+    sdbus::MethodReply open_session(sdbus::MethodCall && call);
+    sdbus::MethodReply close_session(sdbus::MethodCall && call);
     void on_name_owner_changed(sdbus::Signal & signal);
 };
 

--- a/dnfdaemon-server/threads_manager.cpp
+++ b/dnfdaemon-server/threads_manager.cpp
@@ -33,7 +33,9 @@ ThreadsManager::ThreadsManager() {
     });
 }
 
-ThreadsManager::~ThreadsManager() {}
+ThreadsManager::~ThreadsManager() {
+    finish();
+}
 
 void ThreadsManager::register_thread(std::thread && thread) {
     std::lock_guard<std::mutex> lock(running_threads_mutex);

--- a/dnfdaemon-server/threads_manager.hpp
+++ b/dnfdaemon-server/threads_manager.hpp
@@ -42,7 +42,7 @@ public:
     void finish();
 
     template <class S>
-    void run_in_thread(S & service, sdbus::MethodReply (S::*method)(sdbus::MethodCall &&), sdbus::MethodCall && call) {
+    void handle_method(S & service, sdbus::MethodReply (S::*method)(sdbus::MethodCall &&), sdbus::MethodCall && call) {
         auto worker = std::thread(
             [&method, &service, this](sdbus::MethodCall call) {
                 try {

--- a/test/dnfdaemon-server/support.py
+++ b/test/dnfdaemon-server/support.py
@@ -72,5 +72,4 @@ class InstallrootCase(unittest.TestCase):
 
 
     def tearDown(self):
-        self.iface_session.close_session(self.session)
         shutil.rmtree(self.installroot)


### PR DESCRIPTION
- added check on the client side
- session manager uses the same handle_method() / handle_signal() wrappers as other dbus methods including catching exceptions and error handling