### PR TITLE
[dnf5] rpm::Transaction: Use new librpm transaction callbacks

### DIFF
--- a/dnfdaemon-server/callbacks.cpp
+++ b/dnfdaemon-server/callbacks.cpp
@@ -194,22 +194,27 @@ void DbusTransactionCB::install_stop(const libdnf::rpm::TransactionItem & item, 
 
 
 void DbusTransactionCB::script_start(
-    const libdnf::rpm::TransactionItem * /*item*/, libdnf::rpm::Nevra nevra, uint64_t tag) {
+    const libdnf::rpm::TransactionItem * /*item*/,
+    libdnf::rpm::Nevra nevra,
+    libdnf::rpm::TransactionCB::ScriptType type) {
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_START, to_full_nevra_string(nevra));
-        signal << tag;
+        signal << static_cast<int>(type);
         dbus_object->emitSignal(signal);
     } catch (...) {
     }
 }
 
 void DbusTransactionCB::script_stop(
-    const libdnf::rpm::TransactionItem * /*item*/, libdnf::rpm::Nevra nevra, uint64_t tag, uint64_t return_code) {
+    const libdnf::rpm::TransactionItem * /*item*/,
+    libdnf::rpm::Nevra nevra,
+    libdnf::rpm::TransactionCB::ScriptType type,
+    uint64_t return_code) {
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_STOP, to_full_nevra_string(nevra));
-        signal << tag;
+        signal << static_cast<int>(type);
         signal << return_code;
         dbus_object->emitSignal(signal);
     } catch (...) {
@@ -230,11 +235,14 @@ void DbusTransactionCB::elem_progress(const libdnf::rpm::TransactionItem & item,
 }
 
 void DbusTransactionCB::script_error(
-    const libdnf::rpm::TransactionItem * /*item*/, libdnf::rpm::Nevra nevra, uint64_t tag, uint64_t return_code) {
+    const libdnf::rpm::TransactionItem * /*item*/,
+    libdnf::rpm::Nevra nevra,
+    libdnf::rpm::TransactionCB::ScriptType type,
+    uint64_t return_code) {
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_ERROR, to_full_nevra_string(nevra));
-        signal << tag;
+        signal << static_cast<int>(type);
         signal << return_code;
         dbus_object->emitSignal(signal);
     } catch (...) {

--- a/dnfdaemon-server/callbacks.cpp
+++ b/dnfdaemon-server/callbacks.cpp
@@ -196,7 +196,7 @@ void DbusTransactionCB::install_stop(const libdnf::rpm::TransactionItem & item, 
 void DbusTransactionCB::script_start(
     const libdnf::rpm::TransactionItem * /*item*/,
     libdnf::rpm::Nevra nevra,
-    libdnf::rpm::TransactionCB::ScriptType type) {
+    libdnf::rpm::TransactionCallbacks::ScriptType type) {
     try {
         auto signal = create_signal_pkg(
             dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_SCRIPT_START, to_full_nevra_string(nevra));
@@ -209,7 +209,7 @@ void DbusTransactionCB::script_start(
 void DbusTransactionCB::script_stop(
     const libdnf::rpm::TransactionItem * /*item*/,
     libdnf::rpm::Nevra nevra,
-    libdnf::rpm::TransactionCB::ScriptType type,
+    libdnf::rpm::TransactionCallbacks::ScriptType type,
     uint64_t return_code) {
     try {
         auto signal = create_signal_pkg(
@@ -237,7 +237,7 @@ void DbusTransactionCB::elem_progress(const libdnf::rpm::TransactionItem & item,
 void DbusTransactionCB::script_error(
     const libdnf::rpm::TransactionItem * /*item*/,
     libdnf::rpm::Nevra nevra,
-    libdnf::rpm::TransactionCB::ScriptType type,
+    libdnf::rpm::TransactionCallbacks::ScriptType type,
     uint64_t return_code) {
     try {
         auto signal = create_signal_pkg(

--- a/dnfdaemon-server/callbacks.hpp
+++ b/dnfdaemon-server/callbacks.hpp
@@ -103,72 +103,48 @@ public:
     void transaction_stop(uint64_t total) override;
 
     // install a package
-    void install_start(
-        const libdnf::rpm::TransactionItem * item, const libdnf::rpm::RpmHeader & header, uint64_t) override;
-    void install_progress(
-        const libdnf::rpm::TransactionItem * item,
-        const libdnf::rpm::RpmHeader & header,
-        uint64_t amount,
-        uint64_t total) override;
-    void install_stop(
-        const libdnf::rpm::TransactionItem * item,
-        const libdnf::rpm::RpmHeader & header,
-        uint64_t amount,
-        uint64_t total) override;
+    void install_start(const libdnf::rpm::TransactionItem & item, uint64_t)
+    override;
+    void install_progress(const libdnf::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override;
+    void install_stop(const libdnf::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override;
 
     // uninstall a package (the same messages as for install are used)
-    void uninstall_start(
-        const libdnf::rpm::TransactionItem * item, const libdnf::rpm::RpmHeader & header, uint64_t total) override {
-        install_start(item, header, total);
+    void uninstall_start(const libdnf::rpm::TransactionItem & item, uint64_t total) override {
+        install_start(item, total);
     }
-    void uninstall_progress(
-        const libdnf::rpm::TransactionItem * item,
-        const libdnf::rpm::RpmHeader & header,
-        uint64_t amount,
-        uint64_t total) override {
-        install_progress(item, header, amount, total);
+    void uninstall_progress(const libdnf::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override {
+        install_progress(item, amount, total);
     }
-    void uninstall_stop(
-        const libdnf::rpm::TransactionItem * item,
-        const libdnf::rpm::RpmHeader & header,
-        uint64_t amount,
-        uint64_t total) override {
-        install_stop(item, header, amount, total);
+    void uninstall_stop(const libdnf::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override {
+        install_stop(item, amount, total);
     }
 
-    void script_start(
-        const libdnf::rpm::TransactionItem * item, const libdnf::rpm::RpmHeader & header, uint64_t tag) override;
+    void script_start(const libdnf::rpm::TransactionItem * item, libdnf::rpm::Nevra nevra, uint64_t tag) override;
     void script_stop(
         const libdnf::rpm::TransactionItem * item,
-        const libdnf::rpm::RpmHeader & header,
+        libdnf::rpm::Nevra nevra,
         uint64_t tag,
         uint64_t return_code) override;
     void script_error(
         const libdnf::rpm::TransactionItem * item,
-        const libdnf::rpm::RpmHeader & header,
+        libdnf::rpm::Nevra nevra,
         uint64_t tag,
         uint64_t return_code) override;
 
-    void elem_progress(
-        const libdnf::rpm::TransactionItem * item,
-        const libdnf::rpm::RpmHeader & header,
-        uint64_t amount,
-        uint64_t total) override;
+    void elem_progress(const libdnf::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override;
 
     void verify_start(uint64_t total) override;
     void verify_progress(uint64_t amount, uint64_t total) override;
     void verify_stop(uint64_t total) override;
 
-    void unpack_error(const libdnf::rpm::TransactionItem * item, const libdnf::rpm::RpmHeader & header) override;
-    void cpio_error(
-        const libdnf::rpm::TransactionItem * /*item*/, const libdnf::rpm::RpmHeader & /*header*/) override{};
+    void unpack_error(const libdnf::rpm::TransactionItem & item) override;
+    void cpio_error(const libdnf::rpm::TransactionItem & /*item*/) override{};
 
     // whole rpm transaction is finished
     void finish();
 
 private:
-    sdbus::Signal create_signal_pkg(
-        std::string interface, std::string signal_name, const libdnf::rpm::RpmHeader & header);
+    sdbus::Signal create_signal_pkg(std::string interface, std::string signal_name, const std::string & nevra);
 };
 
 #endif

--- a/dnfdaemon-server/callbacks.hpp
+++ b/dnfdaemon-server/callbacks.hpp
@@ -92,7 +92,7 @@ private:
 };
 
 
-class DbusTransactionCB : public libdnf::rpm::TransactionCB, public DbusCallback {
+class DbusTransactionCB : public libdnf::rpm::TransactionCallbacks, public DbusCallback {
 public:
     explicit DbusTransactionCB(Session & session) : DbusCallback(session) {}
     virtual ~DbusTransactionCB() = default;
@@ -122,16 +122,16 @@ public:
     void script_start(
         const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        libdnf::rpm::TransactionCB::ScriptType type) override;
+        libdnf::rpm::TransactionCallbacks::ScriptType type) override;
     void script_stop(
         const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        libdnf::rpm::TransactionCB::ScriptType type,
+        libdnf::rpm::TransactionCallbacks::ScriptType type,
         uint64_t return_code) override;
     void script_error(
         const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        libdnf::rpm::TransactionCB::ScriptType type,
+        libdnf::rpm::TransactionCallbacks::ScriptType type,
         uint64_t return_code) override;
 
     void elem_progress(const libdnf::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override;

--- a/dnfdaemon-server/callbacks.hpp
+++ b/dnfdaemon-server/callbacks.hpp
@@ -119,16 +119,19 @@ public:
         install_stop(item, amount, total);
     }
 
-    void script_start(const libdnf::rpm::TransactionItem * item, libdnf::rpm::Nevra nevra, uint64_t tag) override;
+    void script_start(
+        const libdnf::rpm::TransactionItem * item,
+        libdnf::rpm::Nevra nevra,
+        libdnf::rpm::TransactionCB::ScriptType type) override;
     void script_stop(
         const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        uint64_t tag,
+        libdnf::rpm::TransactionCB::ScriptType type,
         uint64_t return_code) override;
     void script_error(
         const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        uint64_t tag,
+        libdnf::rpm::TransactionCB::ScriptType type,
         uint64_t return_code) override;
 
     void elem_progress(const libdnf::rpm::TransactionItem & item, uint64_t amount, uint64_t total) override;

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -47,6 +47,8 @@ class Transaction;
 
 namespace libdnf::rpm {
 
+class Transaction;
+
 struct PackageId {
 public:
     PackageId() = default;
@@ -447,6 +449,7 @@ private:
     friend class PackageSack;
     friend class libdnf::Goal;
     friend class libdnf::base::Transaction;
+    friend class libdnf::rpm::Transaction;
 
     // TODO(jrohel): Assumes unique `rpmdbid`. Support for opening more rpm databases at once?
     Package(const BaseWeakPtr & base, unsigned long long rpmdbid);

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -448,6 +448,9 @@ private:
     friend class libdnf::Goal;
     friend class libdnf::base::Transaction;
 
+    // TODO(jrohel): Assumes unique `rpmdbid`. Support for opening more rpm databases at once?
+    Package(const BaseWeakPtr & base, unsigned long long rpmdbid);
+
     BaseWeakPtr base;
     PackageId id;
 };

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -65,13 +65,13 @@ private:
 };
 
 
-// suppress "unused-parameter" warnings because TransactionCB is a virtual class
+// suppress "unused-parameter" warnings because TransactionCallbacks is a virtual class
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 /// Base class for Transaction callbacks
 /// User implements Transaction callbacks by inheriting this class and overriding its methods.
-class TransactionCB {
+class TransactionCallbacks {
 public:
 
     /// Scriptlet type
@@ -90,7 +90,7 @@ public:
         TRIGGER_POST_UNINSTALL  // "%triggerpostun"
     };
 
-    virtual ~TransactionCB() = default;
+    virtual ~TransactionCallbacks() = default;
 
     virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
     virtual void install_start(const TransactionItem & item, uint64_t total) {}
@@ -292,7 +292,7 @@ public:
     rpm_tid_t get_id() const;
 
     // Set transaction notify callback.
-    void register_cb(TransactionCB * cb);
+    void register_cb(TransactionCallbacks * cb);
 
     /// Fill the RPM transaction from base::Transaction.
     /// @param transcation The base::Transaction object.

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -73,6 +73,23 @@ private:
 /// User implements Transaction callbacks by inheriting this class and overriding its methods.
 class TransactionCB {
 public:
+
+    /// Scriptlet type
+    // TODO(jrohel): Are all scriptlets types present and correct?
+    enum class ScriptType {
+        UNKNOWN,
+        PRE_INSTALL,            // "%pre"
+        POST_INSTALL,           // "%post"
+        PRE_UNINSTALL,          // "%preun"
+        POST_UNINSTALL,         // "%postun"
+        PRE_TRANSACTION,        // "%pretrans"
+        POST_TRANSACTION,       // "%posttrans"
+        TRIGGER_PRE_INSTALL,    // "%triggerprein"
+        TRIGGER_INSTALL,        // "%triggerin"
+        TRIGGER_UNINSTALL,      // "%triggerun"
+        TRIGGER_POST_UNINSTALL  // "%triggerpostun"
+    };
+
     virtual ~TransactionCB() = default;
 
     virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
@@ -86,9 +103,9 @@ public:
     virtual void uninstall_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
     virtual void unpack_error(const TransactionItem & item) {}
     virtual void cpio_error(const TransactionItem & item) {}
-    virtual void script_error(const TransactionItem * item, Nevra nevra, uint64_t tag, uint64_t return_code) {}
-    virtual void script_start(const TransactionItem * item, Nevra nevra, uint64_t tag) {}
-    virtual void script_stop(const TransactionItem * item, Nevra nevra, uint64_t tag, uint64_t return_code) {}
+    virtual void script_error(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code) {}
+    virtual void script_start(const TransactionItem * item, Nevra nevra, ScriptType type) {}
+    virtual void script_stop(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code) {}
     virtual void elem_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
     virtual void verify_progress(uint64_t amount, uint64_t total) {}
     virtual void verify_start(uint64_t total) {}

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -75,28 +75,21 @@ class TransactionCB {
 public:
     virtual ~TransactionCB() = default;
 
-    virtual void install_progress(
-        const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {}
-    virtual void install_start(const TransactionItem * item, const RpmHeader & header, uint64_t total) {}
-    virtual void install_stop(const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {
-    }
+    virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
+    virtual void install_start(const TransactionItem & item, uint64_t total) {}
+    virtual void install_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
     virtual void transaction_progress(uint64_t amount, uint64_t total) {}
     virtual void transaction_start(uint64_t total) {}
     virtual void transaction_stop(uint64_t total) {}
-    virtual void uninstall_progress(
-        const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {}
-    virtual void uninstall_start(const TransactionItem * item, const RpmHeader & header, uint64_t total) {}
-    virtual void uninstall_stop(
-        const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {}
-    virtual void unpack_error(const TransactionItem * item, const RpmHeader & header) {}
-    virtual void cpio_error(const TransactionItem * item, const RpmHeader & header) {}
-    virtual void script_error(
-        const TransactionItem * item, const RpmHeader & header, uint64_t tag, uint64_t return_code) {}
-    virtual void script_start(const TransactionItem * item, const RpmHeader & header, uint64_t tag) {}
-    virtual void script_stop(
-        const TransactionItem * item, const RpmHeader & header, uint64_t tag, uint64_t return_code) {}
-    virtual void elem_progress(
-        const TransactionItem * item, const RpmHeader & header, uint64_t amount, uint64_t total) {}
+    virtual void uninstall_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
+    virtual void uninstall_start(const TransactionItem & item, uint64_t total) {}
+    virtual void uninstall_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
+    virtual void unpack_error(const TransactionItem & item) {}
+    virtual void cpio_error(const TransactionItem & item) {}
+    virtual void script_error(const TransactionItem * item, Nevra nevra, uint64_t tag, uint64_t return_code) {}
+    virtual void script_start(const TransactionItem * item, Nevra nevra, uint64_t tag) {}
+    virtual void script_stop(const TransactionItem * item, Nevra nevra, uint64_t tag, uint64_t return_code) {}
+    virtual void elem_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
     virtual void verify_progress(uint64_t amount, uint64_t total) {}
     virtual void verify_start(uint64_t total) {}
     virtual void verify_stop(uint64_t total) {}

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -80,7 +80,7 @@ BuildRequires:  pkgconfig(libsolvext) >= %{libsolv_version}
 %if %{with modulemd}
 BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
 %endif
-BuildRequires:  pkgconfig(rpm) >= 4.11.0
+BuildRequires:  pkgconfig(rpm) >= 4.17.0
 BuildRequires:  pkgconfig(sqlite3)
 %if %{with zchunk}
 BuildRequires:  pkgconfig(zck) >= %{zchunk_version}

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -48,7 +48,7 @@ pkg_check_modules(LIBSOLVEXT REQUIRED libsolvext>=0.7.7)
 list(APPEND LIBDNF_PC_REQUIRES_PRIVATE "${LIBSOLVEXT_MODULE_NAME}")
 target_link_libraries(libdnf ${LIBSOLVEXT_LIBRARIES})
 
-pkg_check_modules(RPM REQUIRED rpm>=4.11.0)
+pkg_check_modules(RPM REQUIRED rpm>=4.17.0)
 list(APPEND LIBDNF_PC_REQUIRES "${RPM_MODULE_NAME}")
 target_link_libraries(libdnf ${RPM_LIBRARIES})
 

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -316,4 +316,20 @@ Checksum Package::get_hdr_checksum() const {
     return checksum;
 }
 
+Package::Package(const BaseWeakPtr & base, unsigned long long rpmdbid) : base(base) {
+    Pool * pool = *get_pool(base);
+    auto * installed_repo = pool->installed;
+
+    libdnf_assert(installed_repo, "Installed repo not loaded");
+
+    for (auto candidate_id = installed_repo->start; candidate_id < installed_repo->end; ++candidate_id) {
+        if (rpmdbid == repo_lookup_num(installed_repo, candidate_id, RPM_RPMDBID, 0)) {
+            id.id = candidate_id;
+            return;
+        }
+    }
+
+    throw Exception("Package with rpmdbid was not found");
+}
+
 }  // namespace libdnf::rpm

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -499,6 +499,7 @@ public:
             ignore_set |= RPMPROB_FILTER_OLDPACKAGE;
         }
         if (cb_info.cb) {
+            rpmtsSetNotifyStyle(ts, 1);
             rpmtsSetNotifyCallback(ts, ts_callback, &cb_info);
         }
         auto rc = rpmtsRun(ts, nullptr, ignore_set);
@@ -554,7 +555,7 @@ private:
 
     /// Function triggered by rpmtsNotify()
     ///
-    /// @param hd  related header or NULL
+    /// @param te  related transaction element or NULL
     /// @param what  kind of notification
     /// @param amount  number of bytes/packages already processed or tag of the scriptlet involved
     ///                or 0 or some other number
@@ -562,7 +563,7 @@ private:
     /// @param key  result of rpmteKey() of related rpmte or 0
     /// @param data  user data as passed to rpmtsSetNotifyCallback()
     static void * ts_callback(
-        const void * hd,
+        const void * te,
         const rpmCallbackType what,
         const rpm_loff_t amount,
         const rpm_loff_t total,
@@ -573,7 +574,8 @@ private:
         auto * transaction = cb_info->transaction;
         auto & log = *transaction->base->get_logger();
         auto & cb = *cb_info->cb;
-        auto * hdr = const_cast<headerToken_s *>(static_cast<const headerToken_s *>(hd));
+        auto * trans_element = static_cast<rpmte>(const_cast<void *>(te));
+        auto * hdr = trans_element ? rpmteHeader(trans_element) : nullptr;
         const auto * item = static_cast<const TransactionItem *>(pkg_key);
         if (!item && hdr) {
             auto iter = transaction->items.find(headerGetInstance(hdr));

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -470,7 +470,7 @@ public:
     }
 
     // Set transaction notify callback.
-    void register_cb(TransactionCB * cb) { cb_info.cb = cb; }
+    void register_cb(TransactionCallbacks * cb) { cb_info.cb = cb; }
 
     /// Perform dependency resolution on the transaction set.
     /// Any problems found by rpmtsCheck() can be examined by retrieving the problem set with rpmtsProblems(),
@@ -544,7 +544,7 @@ private:
     friend class Transaction;
 
     struct CallbackInfo {
-        TransactionCB * cb;
+        TransactionCallbacks * cb;
         Impl * transaction;
     };
 
@@ -638,30 +638,30 @@ private:
         return 0;
     }
 
-    static TransactionCB::ScriptType rpm_tag_to_script_type(rpmTag_e tag) noexcept {
+    static TransactionCallbacks::ScriptType rpm_tag_to_script_type(rpmTag_e tag) noexcept {
         switch (tag) {
             case RPMTAG_PREIN:
-                return TransactionCB::ScriptType::PRE_INSTALL;
+                return TransactionCallbacks::ScriptType::PRE_INSTALL;
             case RPMTAG_POSTIN:
-                return TransactionCB::ScriptType::POST_INSTALL;
+                return TransactionCallbacks::ScriptType::POST_INSTALL;
             case RPMTAG_PREUN:
-                return TransactionCB::ScriptType::PRE_UNINSTALL;
+                return TransactionCallbacks::ScriptType::PRE_UNINSTALL;
             case RPMTAG_POSTUN:
-                return TransactionCB::ScriptType::POST_UNINSTALL;
+                return TransactionCallbacks::ScriptType::POST_UNINSTALL;
             case RPMTAG_PRETRANS:
-                return TransactionCB::ScriptType::PRE_TRANSACTION;
+                return TransactionCallbacks::ScriptType::PRE_TRANSACTION;
             case RPMTAG_POSTTRANS:
-                return TransactionCB::ScriptType::POST_TRANSACTION;
+                return TransactionCallbacks::ScriptType::POST_TRANSACTION;
             case RPMTAG_TRIGGERPREIN:
-                return TransactionCB::ScriptType::TRIGGER_PRE_INSTALL;
+                return TransactionCallbacks::ScriptType::TRIGGER_PRE_INSTALL;
             case RPMTAG_TRIGGERIN:
-                return TransactionCB::ScriptType::TRIGGER_INSTALL;
+                return TransactionCallbacks::ScriptType::TRIGGER_INSTALL;
             case RPMTAG_TRIGGERUN:
-                return TransactionCB::ScriptType::TRIGGER_UNINSTALL;
+                return TransactionCallbacks::ScriptType::TRIGGER_UNINSTALL;
             case RPMTAG_TRIGGERPOSTUN:
-                return TransactionCB::ScriptType::TRIGGER_POST_UNINSTALL;
+                return TransactionCallbacks::ScriptType::TRIGGER_POST_UNINSTALL;
             default:
-                return TransactionCB::ScriptType::UNKNOWN;
+                return TransactionCallbacks::ScriptType::UNKNOWN;
         }
     }
 
@@ -886,7 +886,7 @@ rpm_tid_t Transaction::get_id() const {
     return p_impl->get_id();
 }
 
-void Transaction::register_cb(TransactionCB * cb) {
+void Transaction::register_cb(TransactionCallbacks * cb) {
     p_impl->register_cb(cb);
 }
 

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -638,6 +638,33 @@ private:
         return 0;
     }
 
+    static TransactionCB::ScriptType rpm_tag_to_script_type(rpmTag_e tag) noexcept {
+        switch (tag) {
+            case RPMTAG_PREIN:
+                return TransactionCB::ScriptType::PRE_INSTALL;
+            case RPMTAG_POSTIN:
+                return TransactionCB::ScriptType::POST_INSTALL;
+            case RPMTAG_PREUN:
+                return TransactionCB::ScriptType::PRE_UNINSTALL;
+            case RPMTAG_POSTUN:
+                return TransactionCB::ScriptType::POST_UNINSTALL;
+            case RPMTAG_PRETRANS:
+                return TransactionCB::ScriptType::PRE_TRANSACTION;
+            case RPMTAG_POSTTRANS:
+                return TransactionCB::ScriptType::POST_TRANSACTION;
+            case RPMTAG_TRIGGERPREIN:
+                return TransactionCB::ScriptType::TRIGGER_PRE_INSTALL;
+            case RPMTAG_TRIGGERIN:
+                return TransactionCB::ScriptType::TRIGGER_INSTALL;
+            case RPMTAG_TRIGGERUN:
+                return TransactionCB::ScriptType::TRIGGER_UNINSTALL;
+            case RPMTAG_TRIGGERPOSTUN:
+                return TransactionCB::ScriptType::TRIGGER_POST_UNINSTALL;
+            default:
+                return TransactionCB::ScriptType::UNKNOWN;
+        }
+    }
+
     /// Function triggered by rpmtsNotify()
     ///
     /// @param te  related transaction element or NULL
@@ -725,34 +752,16 @@ private:
             case RPMCALLBACK_SCRIPT_ERROR:
                 // amount is script tag
                 // total is return code - if (!RPMSCRIPT_FLAG_CRITICAL) return_code = RPMRC_OK
-                cb.script_error(item, trans_element_to_nevra(trans_element), amount, total);
+                cb.script_error(item, trans_element_to_nevra(trans_element), rpm_tag_to_script_type(static_cast<rpmTag_e>(amount)), total);
                 break;
             case RPMCALLBACK_SCRIPT_START:
                 // amount is script tag
-                // TODO(jrohel): Define enum
-                //   RPMTAG_PREIN; "%pre";
-                //   RPMTAG_POSTIN; "%post";
-                //   RPMTAG_PREUN; "%preun";
-                //   RPMTAG_POSTUN; "%postun";
-                //   RPMTAG_PRETRANS; "%pretrans";
-                //   RPMTAG_POSTTRANS; "%posttrans";
-                //   RPMTAG_VERIFYSCRIPT; "%verifyscript";
-                //   RPMTAG_TRIGGERSCRIPTS; "%triggerprein";
-                //   RPMTAG_TRIGGERSCRIPTS; "%triggerin";
-                //   RPMTAG_TRIGGERSCRIPTS; "%triggerun";
-                //   RPMTAG_TRIGGERSCRIPTS; "%triggerpostun";
-                //   RPMTAG_FILETRIGGERSCRIPTS; "%filetriggerin";
-                //   RPMTAG_FILETRIGGERSCRIPTS; "%filetriggerun";
-                //   RPMTAG_FILETRIGGERSCRIPTS; "%filetriggerpostun";
-                //   RPMTAG_TRANSFILETRIGGERSCRIPTS; "%transfiletriggerin";
-                //   RPMTAG_TRANSFILETRIGGERSCRIPTS; "%transfiletriggerun";
-                //   RPMTAG_TRANSFILETRIGGERSCRIPTS; "%transfiletriggerpostun";
-                cb.script_start(item, trans_element_to_nevra(trans_element), amount);
+                cb.script_start(item, trans_element_to_nevra(trans_element), rpm_tag_to_script_type(static_cast<rpmTag_e>(amount)));
                 break;
             case RPMCALLBACK_SCRIPT_STOP:
                 // amount is script tag
                 // total is return code - if (error && !RPMSCRIPT_FLAG_CRITICAL) return_code = RPMRC_NOTFOUND
-                cb.script_stop(item, trans_element_to_nevra(trans_element), amount, total);
+                cb.script_stop(item, trans_element_to_nevra(trans_element), rpm_tag_to_script_type(static_cast<rpmTag_e>(amount)), total);
                 break;
             case RPMCALLBACK_INST_STOP:
                 libdnf_assert(item != nullptr, "TransactionItem is not set");

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -566,6 +566,34 @@ namespace {
 
 class RpmTransCB : public libdnf::rpm::TransactionCB {
 public:
+    static const char * script_type_to_string(ScriptType type) noexcept {
+        switch (type) {
+            case ScriptType::PRE_INSTALL:
+                return "pre-install";
+            case ScriptType::POST_INSTALL:
+                return "post-install";
+            case ScriptType::PRE_UNINSTALL:
+                return "pre-uninstall";
+            case ScriptType::POST_UNINSTALL:
+                return "post-uninstall";
+            case ScriptType::PRE_TRANSACTION:
+                return "pre-transaction";
+            case ScriptType::POST_TRANSACTION:
+                return "post-transaction";
+            case ScriptType::TRIGGER_PRE_INSTALL:
+                return "trigger-pre-install";
+            case ScriptType::TRIGGER_INSTALL:
+                return "trigger-install";
+            case ScriptType::TRIGGER_UNINSTALL:
+                return "trigger-uninstall";
+            case ScriptType::TRIGGER_POST_UNINSTALL:
+                return "trigger-post-uninstall";
+            case ScriptType::UNKNOWN:
+                return "unknown";
+        }
+        return "unknown";
+    }
+
     ~RpmTransCB() {
         if (active_progress_bar &&
             active_progress_bar->get_state() != libdnf::cli::progressbar::ProgressBarState::ERROR) {
@@ -684,30 +712,36 @@ public:
     void script_error(
         [[maybe_unused]] const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        [[maybe_unused]] uint64_t tag,
+        libdnf::rpm::TransactionCB::ScriptType type,
         uint64_t return_code) override {
         active_progress_bar->add_message(
             libdnf::cli::progressbar::MessageType::ERROR,
-            fmt::format("Error in scriptlet: {} return code {}", to_full_nevra_string(nevra), return_code));
+            fmt::format(
+                "Error in {} scriptlet: {} return code {}",
+                script_type_to_string(type),
+                to_full_nevra_string(nevra),
+                return_code));
         multi_progress_bar.print();
     }
 
     void script_start(
         [[maybe_unused]] const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        [[maybe_unused]] uint64_t tag) override {
+        libdnf::rpm::TransactionCB::ScriptType type) override {
         active_progress_bar->add_message(
-            libdnf::cli::progressbar::MessageType::INFO, "Running scriptlet: " + to_full_nevra_string(nevra));
+            libdnf::cli::progressbar::MessageType::INFO,
+            fmt::format("Running {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
         multi_progress_bar.print();
     }
 
     void script_stop(
         [[maybe_unused]] const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        [[maybe_unused]] uint64_t tag,
+        libdnf::rpm::TransactionCB::ScriptType type,
         [[maybe_unused]] uint64_t return_code) override {
         active_progress_bar->add_message(
-            libdnf::cli::progressbar::MessageType::INFO, "Stop scriptlet: " + to_full_nevra_string(nevra));
+            libdnf::cli::progressbar::MessageType::INFO,
+            fmt::format("Stop {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
         multi_progress_bar.print();
     }
 

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -564,7 +564,7 @@ void download_packages(libdnf::base::Transaction & transaction, const char * des
 
 namespace {
 
-class RpmTransCB : public libdnf::rpm::TransactionCB {
+class RpmTransCB : public libdnf::rpm::TransactionCallbacks {
 public:
     static const char * script_type_to_string(ScriptType type) noexcept {
         switch (type) {
@@ -712,7 +712,7 @@ public:
     void script_error(
         [[maybe_unused]] const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        libdnf::rpm::TransactionCB::ScriptType type,
+        libdnf::rpm::TransactionCallbacks::ScriptType type,
         uint64_t return_code) override {
         active_progress_bar->add_message(
             libdnf::cli::progressbar::MessageType::ERROR,
@@ -727,7 +727,7 @@ public:
     void script_start(
         [[maybe_unused]] const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        libdnf::rpm::TransactionCB::ScriptType type) override {
+        libdnf::rpm::TransactionCallbacks::ScriptType type) override {
         active_progress_bar->add_message(
             libdnf::cli::progressbar::MessageType::INFO,
             fmt::format("Running {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
@@ -737,7 +737,7 @@ public:
     void script_stop(
         [[maybe_unused]] const libdnf::rpm::TransactionItem * item,
         libdnf::rpm::Nevra nevra,
-        libdnf::rpm::TransactionCB::ScriptType type,
+        libdnf::rpm::TransactionCallbacks::ScriptType type,
         [[maybe_unused]] uint64_t return_code) override {
         active_progress_bar->add_message(
             libdnf::cli::progressbar::MessageType::INFO,


### PR DESCRIPTION
The code uses new librpm callbacks for track added elements and to set pointers to the related `libdnf::rpm::TransactionItem` in them:

* Uses new librpm transaction notify callback style.
  It was added into librpm 4.17. Activated by: `rpmtsSetNotifyStyle(rpmts, 1)`
  In this mode, librpm provides the transaction element in the callback. The old style/mode only provides information about the RPM header in the transaction element.
    
* Uses rpmtsNotifyChange callback
  The callback was added into librpm 4.17 to receive notifications of added and deleted transaction elements.
  Activated by: `rpmtsSetChangeCallback(rpmts ts, rpmtsChangeFunction notify, void *data)`    
    
Defines ScriptType enum: PRE_INSTALL, POST_INSTALL, PRE_UNINSTALL, POST_UNINSTALL, PRE_TRANSACTION, POST_TRANSACTION, TRIGGER_PRE_INSTALL, TRIGGER_INSTALL, TRIGGER_UNINSTALL, TRIGGER_POST_UNINSTALL 

TransactionCB was renamed to TransactionCallbacks for code unification.

Uses TransactionItems and rpm::Nevra in TransactionCallbacks. The rpm::rpmHeader was removed from callbacks.

Requires librpm >= 4.17 .