### PR TITLE
Headers and includes cleanup

### DIFF
--- a/include/libdnf/advisory/advisory.hpp
+++ b/include/libdnf/advisory/advisory.hpp
@@ -27,13 +27,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::advisory {
 
-class AdvisoryCollection;
 class AdvisoryReference;
 
 struct AdvisoryId {
 public:
     AdvisoryId() = default;
-    explicit AdvisoryId(int id);
+    explicit AdvisoryId(int id) : id(id) {}
 
     bool operator==(const AdvisoryId & other) const noexcept { return id == other.id; };
     bool operator!=(const AdvisoryId & other) const noexcept { return id != other.id; };
@@ -41,7 +40,6 @@ public:
     int id{0};
 };
 
-inline AdvisoryId::AdvisoryId(int id) : id(id) {}
 
 //TODO(amatej): consider defining these as individual numbers, not as bits in int.
 //              This allows us faster iteration, but all public APIs should accept
@@ -160,7 +158,6 @@ private:
     AdvisoryId id;
     libdnf::rpm::PackageSackWeakPtr sack;
 };
-
 
 }  // namespace libdnf::advisory
 

--- a/include/libdnf/advisory/advisory_module.hpp
+++ b/include/libdnf/advisory/advisory_module.hpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_ADVISORY_ADVISORY_MODULE_HPP
 #define LIBDNF_ADVISORY_ADVISORY_MODULE_HPP
 
-#include "libdnf/advisory/advisory.hpp"
+#include "advisory.hpp"
 
 #include <memory>
 

--- a/include/libdnf/advisory/advisory_package.hpp
+++ b/include/libdnf/advisory/advisory_package.hpp
@@ -26,6 +26,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 
+namespace libdnf::rpm {
+
+class PackageQuery;
+
+}
+
 namespace libdnf::advisory {
 
 class AdvisoryPackage {

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -25,16 +25,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/advisory/advisory_package.hpp"
 #include "libdnf/advisory/advisory_reference.hpp"
 #include "libdnf/advisory/advisory_sack.hpp"
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/sack/query_cmp.hpp"
 #include "libdnf/rpm/package.hpp"
-
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}  // namespace libdnf
 
 
 namespace libdnf::advisory {

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -28,12 +28,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/sack/query_cmp.hpp"
 #include "libdnf/rpm/package.hpp"
 
+
 namespace libdnf {
 
 class Base;
 using BaseWeakPtr = WeakPtr<Base, false>;
 
 }  // namespace libdnf
+
 
 namespace libdnf::advisory {
 
@@ -110,7 +112,6 @@ private:
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };
-
 
 }  // namespace libdnf::advisory
 

--- a/include/libdnf/advisory/advisory_sack.hpp
+++ b/include/libdnf/advisory/advisory_sack.hpp
@@ -22,16 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "advisory_query.hpp"
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/solv/solv_map.hpp"
-
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}
 
 
 namespace libdnf::advisory {
@@ -49,7 +42,7 @@ public:
 
     /// @return The `Base` object to which this object belongs.
     /// @since 5.0
-    BaseWeakPtr get_base() const;
+    libdnf::BaseWeakPtr get_base() const;
 
 private:
     friend AdvisoryQuery;

--- a/include/libdnf/advisory/advisory_sack.hpp
+++ b/include/libdnf/advisory/advisory_sack.hpp
@@ -25,15 +25,20 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/solv/solv_map.hpp"
 
+
 namespace libdnf {
+
 class Base;
 using BaseWeakPtr = WeakPtr<Base, false>;
+
 }
+
 
 namespace libdnf::advisory {
 
 class AsdvisorySack;
 using AdvisorySackWeakPtr = WeakPtr<AdvisorySack, false>;
+
 
 class AdvisorySack {
 public:

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_BASE_BASE_HPP
 
 #include "libdnf/advisory/advisory_sack.hpp"
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/comps/comps.hpp"
 #include "libdnf/conf/config_main.hpp"
@@ -35,9 +36,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
 
 using LogRouterWeakPtr = WeakPtr<LogRouter, false>;
 using VarsWeakPtr = WeakPtr<Vars, false>;
@@ -77,7 +75,7 @@ public:
     void load_plugins();
     plugin::Plugins & get_plugins() { return plugins; }
 
-    BaseWeakPtr get_weak_ptr() { return BaseWeakPtr(this, &base_guard); }
+    libdnf::BaseWeakPtr get_weak_ptr() { return BaseWeakPtr(this, &base_guard); }
 
 private:
     WeakPtrGuard<Base, false> base_guard;

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -33,6 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <map>
 
+
 namespace libdnf {
 
 class Base;

--- a/include/libdnf/base/base_weak.hpp
+++ b/include/libdnf/base/base_weak.hpp
@@ -1,0 +1,33 @@
+/*
+Copyright (C) 2020-2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_BASE_BASE_WEAK_HPP
+#define LIBDNF_BASE_BASE_WEAK_HPP
+
+#include "libdnf/common/weak_ptr.hpp"
+
+
+namespace libdnf {
+
+class Base;
+using BaseWeakPtr = WeakPtr<Base, false>;
+
+}  // namespace libdnf
+
+#endif

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -29,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
-
 class Goal {
 public:
     struct UsedDifferentSack : public LogicError {

--- a/include/libdnf/base/goal.hpp
+++ b/include/libdnf/base/goal.hpp
@@ -51,8 +51,8 @@ public:
         REMOVE
     };
 
-    explicit Goal(const BaseWeakPtr & base);
-    explicit Goal(Base & base);
+    explicit Goal(const libdnf::BaseWeakPtr & base);
+    explicit Goal(libdnf::Base & base);
     ~Goal();
     void add_module_enable(const std::string & spec);
     /// Prevent reinstallation by adding of already installed packages with the same NEVRA
@@ -135,7 +135,7 @@ public:
 
     /// @return The `Base` object to which this object belongs.
     /// @since 5.0
-    BaseWeakPtr get_base() const;
+    libdnf::BaseWeakPtr get_base() const;
 
 private:
     rpm::PackageId get_running_kernel_internal();

--- a/include/libdnf/base/goal_elements.hpp
+++ b/include/libdnf/base/goal_elements.hpp
@@ -29,10 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
-// forward declarations
-class Goal;
-
-
 enum class ProblemRules {
     RULE_DISTUPGRADE = 1,
     RULE_INFARCH,

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -21,18 +21,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_BASE_TRANSACTION_HPP
 #define LIBDNF_BASE_TRANSACTION_HPP
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/base/goal_elements.hpp"
 #include "libdnf/base/transaction_package.hpp"
 
 #include <optional>
-
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}  // namespace libdnf
 
 
 namespace libdnf::base {
@@ -50,7 +43,7 @@ public:
 private:
     friend class libdnf::Goal;
 
-    Transaction(const BaseWeakPtr & base);
+    Transaction(const libdnf::BaseWeakPtr & base);
 
     class Impl;
     std::unique_ptr<Impl> p_impl;

--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -20,12 +20,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_UTILS_EXCEPTION_HPP
 #define LIBDNF_UTILS_EXCEPTION_HPP
 
-
 #include <stdexcept>
 
 
 namespace libdnf {
-
 
 /// Base class of libdnf exceptions. Each exception define at least domain_name, name, and description.
 /// These information can be used to serialize exception into a string.

--- a/include/libdnf/common/preserve_order_map.hpp
+++ b/include/libdnf/common/preserve_order_map.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <stdexcept>
 #include <vector>
 
+
 namespace libdnf {
 
 /// PreserveOrderMap is an associative container that contains key-value pairs with unique unique keys.

--- a/include/libdnf/common/proc.hpp
+++ b/include/libdnf/common/proc.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <sys/types.h>
 
+
 namespace libdnf {
 
 constexpr uid_t INVALID_UID = static_cast<uid_t>(-1);

--- a/include/libdnf/common/sack/match_int64.hpp
+++ b/include/libdnf/common/sack/match_int64.hpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_COMMON_SACK_MATCH_INT64_HPP
 #define LIBDNF_COMMON_SACK_MATCH_INT64_HPP
 
-
 #include "query_cmp.hpp"
 
 #include <cstdint>
@@ -29,12 +28,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::sack {
 
-
 bool match_int64(int64_t value, QueryCmp cmp, int64_t pattern);
 bool match_int64(int64_t value, QueryCmp cmp, const std::vector<int64_t> & patterns);
 bool match_int64(const std::vector<int64_t> & values, QueryCmp cmp, int64_t pattern);
 bool match_int64(const std::vector<int64_t> & values, QueryCmp cmp, const std::vector<int64_t> & patterns);
-
 
 }  // namespace libdnf::sack
 

--- a/include/libdnf/common/sack/match_string.hpp
+++ b/include/libdnf/common/sack/match_string.hpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_COMMON_SACK_MATCH_STRING_HPP
 #define LIBDNF_COMMON_SACK_MATCH_STRING_HPP
 
-
 #include "query_cmp.hpp"
 
 #include <string>
@@ -29,12 +28,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::sack {
 
-
 bool match_string(const std::string & value, QueryCmp cmp, const std::string & pattern);
 bool match_string(const std::string & value, QueryCmp cmp, const std::vector<std::string> & patterns);
 bool match_string(const std::vector<std::string> & values, QueryCmp cmp, const std::string & pattern);
 bool match_string(const std::vector<std::string> & values, QueryCmp cmp, const std::vector<std::string> & patterns);
-
 
 }  // namespace libdnf::sack
 

--- a/include/libdnf/common/sack/query.hpp
+++ b/include/libdnf/common/sack/query.hpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_COMMON_SACK_QUERY_HPP
 #define LIBDNF_COMMON_SACK_QUERY_HPP
 
-
 #include "match_int64.hpp"
 #include "match_string.hpp"
 #include "query_cmp.hpp"
@@ -36,7 +35,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::sack {
-
 
 /// Query is a Set with filtering capabilities.
 template <typename T>
@@ -220,8 +218,6 @@ inline void Query<T>::filter(Query<T>::FilterFunctionCString * getter, const std
     }
 }
 
-
 }  // namespace libdnf::sack
-
 
 #endif

--- a/include/libdnf/common/sack/query_cmp.hpp
+++ b/include/libdnf/common/sack/query_cmp.hpp
@@ -17,17 +17,14 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_COMMON_SACK_QUERY_CMP_HPP
 #define LIBDNF_COMMON_SACK_QUERY_CMP_HPP
-
 
 #include <cstdint>
 #include <type_traits>
 
 
 namespace libdnf::sack {
-
 
 /// Match operators used in filter methods of the Query objects.
 //
@@ -145,8 +142,6 @@ inline QueryCmp operator-(QueryCmp lhs, QueryCmp rhs) {
         static_cast<std::underlying_type<QueryCmp>::type>(rhs));
 }
 
-
 }  // namespace libdnf::sack
-
 
 #endif  // LIBDNF_COMMON_SACK_QUERY_CMP_HPP

--- a/include/libdnf/common/sack/sack.hpp
+++ b/include/libdnf/common/sack/sack.hpp
@@ -26,8 +26,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <vector>
 
-namespace libdnf::sack {
 
+namespace libdnf::sack {
 
 template <typename T>
 class Sack {

--- a/include/libdnf/common/set.hpp
+++ b/include/libdnf/common/set.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <set>
 
+
 namespace libdnf {
 
 /// Set represents set of objects (e.g. repositories, or groups)

--- a/include/libdnf/common/weak_ptr.hpp
+++ b/include/libdnf/common/weak_ptr.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <unordered_set>
 
+
 namespace libdnf {
 
 template <typename TPtr, bool ptr_owner>

--- a/include/libdnf/comps/comps.hpp
+++ b/include/libdnf/comps/comps.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_COMPS_COMPS_HPP
 #define LIBDNF_COMPS_COMPS_HPP
 
@@ -28,7 +27,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf {
+
 class Base;
+
 }
 
 
@@ -55,13 +56,11 @@ private:
     class Impl;
     std::unique_ptr<Impl> p_impl;
 
-    friend GroupSack;
-    friend GroupQuery;
-    friend Group;
+    friend class Group;
+    friend class GroupQuery;
+    friend class GroupSack;
 };
 
-
 }  // namespace libdnf::comps
-
 
 #endif  // LIBDNF_COMPS_COMPS_HPP

--- a/include/libdnf/comps/group/group.hpp
+++ b/include/libdnf/comps/group/group.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_COMPS_GROUP_GROUP_HPP
 #define LIBDNF_COMPS_GROUP_GROUP_HPP
 
@@ -31,7 +30,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::comps {
-
 
 struct GroupId {
 public:
@@ -146,8 +144,6 @@ private:
     friend class GroupQuery;
 };
 
-
 }  // namespace libdnf::comps
-
 
 #endif  // LIBDNF_COMPS_GROUP_GROUP_HPP

--- a/include/libdnf/comps/group/package.hpp
+++ b/include/libdnf/comps/group/package.hpp
@@ -17,16 +17,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_COMPS_GROUP_PACKAGE_HPP
 #define LIBDNF_COMPS_GROUP_PACKAGE_HPP
-
 
 #include <string>
 
 
 namespace libdnf::comps {
-
 
 enum class PackageType {MANDATORY, DEFAULT, OPTIONAL, CONDITIONAL};
 
@@ -70,12 +67,6 @@ private:
     std::string condition;
 };
 
-
 }  // namespace libdnf::comps
-
-
-
-//dnf:dnf/comps.py:attribute:Package.option_type
-
 
 #endif

--- a/include/libdnf/comps/group/query.hpp
+++ b/include/libdnf/comps/group/query.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_COMPS_GROUP_QUERY_HPP
 #define LIBDNF_COMPS_GROUP_QUERY_HPP
 
@@ -26,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/comps/group/group.hpp"
 
 #include <memory>
+
 
 namespace libdnf {
 
@@ -130,7 +130,6 @@ inline GroupQuery & GroupQuery::filter_installed(bool value) {
     filter(F::is_installed, value, sack::QueryCmp::EQ);
     return *this;
 }
-
 
 }  // namespace libdnf::comps
 

--- a/include/libdnf/comps/group/query.hpp
+++ b/include/libdnf/comps/group/query.hpp
@@ -20,19 +20,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_COMPS_GROUP_QUERY_HPP
 #define LIBDNF_COMPS_GROUP_QUERY_HPP
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/sack/query.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/comps/group/group.hpp"
 
 #include <memory>
-
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}  // namespace libdnf
 
 
 namespace libdnf::comps {
@@ -49,8 +42,8 @@ class GroupQuery : public libdnf::sack::Query<Group> {
 public:
     // Create new query with newly composed groups (using only solvables from currently enabled repositories)
     explicit GroupQuery(const GroupSackWeakPtr & sack);
-    explicit GroupQuery(const BaseWeakPtr & base);
-    explicit GroupQuery(Base & base);
+    explicit GroupQuery(const libdnf::BaseWeakPtr & base);
+    explicit GroupQuery(libdnf::Base & base);
 
     GroupQuery(const GroupQuery & query);
     ~GroupQuery();

--- a/include/libdnf/comps/group/sack.hpp
+++ b/include/libdnf/comps/group/sack.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_COMPS_GROUP_SACK_HPP
 #define LIBDNF_COMPS_GROUP_SACK_HPP
 
@@ -32,12 +31,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::comps {
 
-
 class Comps;
-
 class Group;
-
-class GroupQuery;
 
 class GroupSack;
 using GroupSackWeakPtr = WeakPtr<GroupSack, false>;
@@ -67,12 +62,11 @@ private:
     std::map<std::string, libdnf::transaction::TransactionItemReason> reasons;
 
     friend Comps;
-    friend GroupQuery;
     friend Group;
+
+    friend class GroupQuery;
 };
 
-
 }  // namespace libdnf::comps
-
 
 #endif  // LIBDNF_COMPS_GROUP_SACK_HPP

--- a/include/libdnf/conf/config.hpp
+++ b/include/libdnf/conf/config.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "vars.hpp"
 #include "../logger/logger.hpp"
 
+
 namespace libdnf {
 
 /// Base class for configurations objects

--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -33,6 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <memory>
 
+
 namespace libdnf {
 
 /// Holds global configuration

--- a/include/libdnf/conf/config_parser.hpp
+++ b/include/libdnf/conf/config_parser.hpp
@@ -31,11 +31,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <utility>
 
+
 namespace libdnf {
 
 /**
 * @class ConfigParser
-* 
+*
 * @brief Class for parsing dnf/yum .ini configuration files.
 *
 * ConfigParser is used for parsing files.

--- a/include/libdnf/conf/const.hpp
+++ b/include/libdnf/conf/const.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+
 namespace libdnf {
 
 constexpr const char * PERSISTDIR = "/var/lib/dnf";

--- a/include/libdnf/conf/option.hpp
+++ b/include/libdnf/conf/option.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <string>
 
+
 namespace libdnf {
 
 /// Option class is an abstract class. Parent of all options. Options are used to store a configuration.

--- a/include/libdnf/conf/option_binds.hpp
+++ b/include/libdnf/conf/option_binds.hpp
@@ -20,11 +20,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_CONF_OPTION_BINDS_HPP
 #define LIBDNF_CONF_OPTION_BINDS_HPP
 
-
 #include "option.hpp"
 
 #include <functional>
 #include <map>
+
 
 namespace libdnf {
 

--- a/include/libdnf/conf/option_bool.hpp
+++ b/include/libdnf/conf/option_bool.hpp
@@ -20,12 +20,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_CONF_OPTION_BOOL_HPP
 #define LIBDNF_CONF_OPTION_BOOL_HPP
 
-
 #include "option.hpp"
 
 #include <array>
 #include <memory>
 #include <vector>
+
 
 namespace libdnf {
 

--- a/include/libdnf/conf/option_child.hpp
+++ b/include/libdnf/conf/option_child.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "option.hpp"
 
+
 namespace libdnf {
 
 /// Option that links option to another option. It uses default value and parameters from linked option.

--- a/include/libdnf/conf/option_enum.hpp
+++ b/include/libdnf/conf/option_enum.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <functional>
 #include <vector>
 
+
 namespace libdnf {
 
 /// Option that stores value from enumeration. The type of value is template parameter.

--- a/include/libdnf/conf/option_number.hpp
+++ b/include/libdnf/conf/option_number.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <functional>
 
+
 namespace libdnf {
 
 /// Option that stores numerical value. The type of value is template parameter.

--- a/include/libdnf/conf/option_path.hpp
+++ b/include/libdnf/conf/option_path.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "option_string.hpp"
 
+
 namespace libdnf {
 
 /// Option that stores file/directory path.

--- a/include/libdnf/conf/option_seconds.hpp
+++ b/include/libdnf/conf/option_seconds.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "option_number.hpp"
 
+
 namespace libdnf {
 
 /// Option that stores an integer value of seconds.

--- a/include/libdnf/conf/option_string.hpp
+++ b/include/libdnf/conf/option_string.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "option.hpp"
 
+
 namespace libdnf {
 
 /// Option that stores string value.

--- a/include/libdnf/conf/option_string_list.hpp
+++ b/include/libdnf/conf/option_string_list.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <vector>
 
+
 namespace libdnf {
 
 /// Option that stores list of strings.

--- a/include/libdnf/conf/vars.hpp
+++ b/include/libdnf/conf/vars.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+
 namespace libdnf {
 
 /// @class Vars
@@ -113,7 +114,6 @@ private:
 
     std::map<std::string, Variable> variables;
 };
-
 
 }  // namespace libdnf
 

--- a/include/libdnf/logger/log_router.hpp
+++ b/include/libdnf/logger/log_router.hpp
@@ -20,14 +20,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_LOGGER_LOG_ROUTER_HPP
 #define LIBDNF_LOGGER_LOG_ROUTER_HPP
 
-
 #include "logger.hpp"
 
 #include <memory>
 #include <vector>
 
-namespace libdnf {
 
+namespace libdnf {
 
 /// LogRouter is an implementation of logging class that forwards incoming logging messages to several other loggers.
 /// Loggers can be addressed via index. Index is serial number of the logger starting from zero.
@@ -55,7 +54,6 @@ public:
 private:
     std::vector<std::unique_ptr<Logger>> loggers;
 };
-
 
 }  // namespace libdnf
 

--- a/include/libdnf/logger/logger.hpp
+++ b/include/libdnf/logger/logger.hpp
@@ -20,15 +20,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_LOGGER_LOGGER_HPP
 #define LIBDNF_LOGGER_LOGGER_HPP
 
-
 #include <unistd.h>
 
 #include <array>
 #include <ctime>
 #include <string>
 
-namespace libdnf {
 
+namespace libdnf {
 
 /// Logger is an abstract interface used for logging.
 /// An implementation (inherited class) can call callbacks, log the messages to memory, file, or somewhere else.
@@ -83,7 +82,6 @@ private:
         "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG", "TRACE"};
 #endif
 };
-
 
 }  // namespace libdnf
 

--- a/include/libdnf/logger/memory_buffer_logger.hpp
+++ b/include/libdnf/logger/memory_buffer_logger.hpp
@@ -20,14 +20,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_LOGGER_MEMORY_BUFFER_LOGGER_HPP
 #define LIBDNF_LOGGER_MEMORY_BUFFER_LOGGER_HPP
 
-
 #include "logger.hpp"
 
 #include <mutex>
 #include <vector>
 
-namespace libdnf {
 
+namespace libdnf {
 
 /// MemoryBufferLogger is an implementation of logging class that stores incoming logging messages into memory buffer.
 /// It is usually used as temporary logger until a final logger is not configured.
@@ -53,7 +52,6 @@ private:
     std::size_t first_item_idx;
     std::vector<Item> items;
 };
-
 
 }  // namespace libdnf
 

--- a/include/libdnf/logger/null_logger.hpp
+++ b/include/libdnf/logger/null_logger.hpp
@@ -20,11 +20,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_LOGGER_NULL_LOGGER_HPP
 #define LIBDNF_LOGGER_NULL_LOGGER_HPP
 
-
 #include "logger.hpp"
 
-namespace libdnf {
 
+namespace libdnf {
 
 /// NullLogger is an implementation of logging class that discards all incoming logging messages.
 /// It can be used in case when no logs are needed.
@@ -38,7 +37,6 @@ public:
     /// @replaces libdnf:utils/logger.hpp:method:NullLogger.write(int , time_t , pid_t , libdnf::Logger::Level , const std::string & )
     void write(time_t /*time*/, pid_t /*pid*/, Level /*level*/, const std::string & /*message*/) noexcept override {}
 };
-
 
 }  // namespace libdnf
 

--- a/include/libdnf/logger/stream_logger.hpp
+++ b/include/libdnf/logger/stream_logger.hpp
@@ -20,15 +20,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_LOGGER_STREAM_LOGGER_HPP
 #define LIBDNF_LOGGER_STREAM_LOGGER_HPP
 
-
 #include "logger.hpp"
 
 #include <memory>
 #include <mutex>
 #include <ostream>
 
-namespace libdnf {
 
+namespace libdnf {
 
 /// StreamLogger is an implementation of logging class that writes messages into a stream.
 class StreamLogger : public Logger {
@@ -40,7 +39,6 @@ private:
     mutable std::mutex stream_mutex;
     std::unique_ptr<std::ostream> log_stream;
 };
-
 
 }  // namespace libdnf
 

--- a/include/libdnf/plugin/iplugin.hpp
+++ b/include/libdnf/plugin/iplugin.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <cstdint>
 
+
 namespace libdnf {
 
 class Base;

--- a/include/libdnf/plugin/plugins.hpp
+++ b/include/libdnf/plugin/plugins.hpp
@@ -28,6 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+
 namespace libdnf::plugin {
 
 class Plugin {

--- a/include/libdnf/repo/config_repo.hpp
+++ b/include/libdnf/repo/config_repo.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <memory>
 
+
 namespace libdnf::repo {
 
 /// Holds repo configuration options. Default values of some options are inherited from ConfigMain.

--- a/include/libdnf/repo/repo.hpp
+++ b/include/libdnf/repo/repo.hpp
@@ -24,18 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "config_repo.hpp"
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/exception.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 
 #include <memory>
-
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}  // namespace libdnf
 
 
 namespace libdnf::rpm {
@@ -135,7 +128,7 @@ public:
     /// @param conf   configuration to use
     /// @param base   reference to Base instance
     /// @param type   type of repo
-    Repo(const std::string & id, Base & base, Repo::Type type = Repo::Type::AVAILABLE);
+    Repo(const std::string & id, libdnf::Base & base, Repo::Type type = Repo::Type::AVAILABLE);
 
     Repo & operator=(Repo && repo) = delete;
 
@@ -372,7 +365,7 @@ public:
 
     /// @return The `Base` object to which this object belongs.
     /// @since 5.0
-    BaseWeakPtr get_base() const;
+    libdnf::BaseWeakPtr get_base() const;
 
     ~Repo();
 

--- a/include/libdnf/repo/repo.hpp
+++ b/include/libdnf/repo/repo.hpp
@@ -29,6 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <memory>
 
+
 namespace libdnf {
 
 class Base;
@@ -36,11 +37,13 @@ using BaseWeakPtr = WeakPtr<Base, false>;
 
 }  // namespace libdnf
 
+
 namespace libdnf::rpm {
 
 class PackageSack;
 
 }
+
 
 namespace libdnf::repo {
 

--- a/include/libdnf/repo/repo_query.hpp
+++ b/include/libdnf/repo/repo_query.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_REPO_REPO_QUERY_HPP
 #define LIBDNF_REPO_REPO_QUERY_HPP
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/sack/query.hpp"
 #include "libdnf/common/sack/query_cmp.hpp"
 #include "libdnf/common/weak_ptr.hpp"
@@ -28,13 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}
 
 namespace libdnf::repo {
 
@@ -60,16 +54,16 @@ public:
     /// Create a new RepoQuery instance.
     ///
     /// @param base     A weak pointer to Base
-    explicit RepoQuery(const BaseWeakPtr & base);
+    explicit RepoQuery(const libdnf::BaseWeakPtr & base);
 
     /// Create a new RepoQuery instance.
     ///
     /// @param base     Reference to Base
-    explicit RepoQuery(Base & base);
+    explicit RepoQuery(libdnf::Base & base);
 
     /// @return Weak pointer to the Base object.
     /// @since 5.0
-    BaseWeakPtr get_base() { return base; }
+    libdnf::BaseWeakPtr get_base() { return base; }
 
     /// Filter repos by their `enabled` state.
     ///

--- a/include/libdnf/repo/repo_query.hpp
+++ b/include/libdnf/repo/repo_query.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_REPO_REPO_QUERY_HPP
 #define LIBDNF_REPO_REPO_QUERY_HPP
-
 
 #include "libdnf/common/sack/query.hpp"
 #include "libdnf/common/sack/query_cmp.hpp"
@@ -32,18 +30,21 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf {
+
 class Base;
 using BaseWeakPtr = WeakPtr<Base, false>;
+
 }
 
 namespace libdnf::repo {
+
 class RepoSack;
 using RepoSackWeakPtr = WeakPtr<RepoSack, false>;
+
 }
 
 
 namespace libdnf::repo {
-
 
 /// Weak pointer to rpm repository. RepoWeakPtr does not own the repository (ptr_owner = false).
 /// Repositories are owned by RepoSack.
@@ -120,8 +121,6 @@ private:
     BaseWeakPtr base;
 };
 
-
 }  // namespace libdnf::repo
-
 
 #endif  // LIBDNF_REPO_REPO_QUERY_HPP

--- a/include/libdnf/repo/repo_sack.hpp
+++ b/include/libdnf/repo/repo_sack.hpp
@@ -27,6 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/logger/logger.hpp"
 
+
 namespace libdnf {
 
 class Base;
@@ -34,11 +35,12 @@ using BaseWeakPtr = WeakPtr<Base, false>;
 
 }  // namespace libdnf
 
+
 namespace libdnf::repo {
 
 class RepoSack;
-
 using RepoSackWeakPtr = WeakPtr<RepoSack, false>;
+
 
 class RepoSack : public sack::Sack<Repo> {
 public:

--- a/include/libdnf/repo/repo_sack.hpp
+++ b/include/libdnf/repo/repo_sack.hpp
@@ -23,17 +23,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repo.hpp"
 #include "repo_query.hpp"
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/sack/sack.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/logger/logger.hpp"
-
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}  // namespace libdnf
 
 
 namespace libdnf::repo {
@@ -44,7 +37,7 @@ using RepoSackWeakPtr = WeakPtr<RepoSack, false>;
 
 class RepoSack : public sack::Sack<Repo> {
 public:
-    explicit RepoSack(Base & base) : base(&base) {}
+    explicit RepoSack(libdnf::Base & base) : base(&base) {}
 
     /// Creates new repository and add it into RepoSack
     RepoWeakPtr new_repo(const std::string & id);
@@ -74,7 +67,7 @@ public:
 
     /// @return The `Base` object to which this object belongs.
     /// @since 5.0
-    BaseWeakPtr get_base() const;
+    libdnf::BaseWeakPtr get_base() const;
 
 private:
     friend class RepoQuery;

--- a/include/libdnf/rpm/checksum.hpp
+++ b/include/libdnf/rpm/checksum.hpp
@@ -17,16 +17,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_RPM_CHECKSUM_HPP
 #define LIBDNF_RPM_CHECKSUM_HPP
 
 #include <string>
 
-namespace libdnf::rpm {
 
-// forward declarations
-class Package;
+namespace libdnf::rpm {
 
 /// Class contains checksum and checksum type
 class Checksum {
@@ -56,7 +53,6 @@ inline Checksum::Checksum(const char * checksum, int libsolv_type) : libsolv_typ
         this->checksum = checksum;
     }
 }
-
 
 }  // namespace libdnf::rpm
 

--- a/include/libdnf/rpm/nevra.hpp
+++ b/include/libdnf/rpm/nevra.hpp
@@ -27,6 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+
 namespace libdnf::rpm {
 
 /// @replaces hawkey:hawkey/__init__.py:class:Nevra
@@ -230,7 +231,6 @@ bool cmp_naevr(const T & lhs, const T & rhs) {
     }
     return false;
 };
-
 
 }  // namespace libdnf::rpm
 

--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -22,7 +22,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_RPM_PACKAGE_HPP
 
 #include "checksum.hpp"
-#include "package_sack.hpp"
 #include "reldep_list.hpp"
 
 #include "libdnf/repo/repo_query.hpp"
@@ -38,6 +37,7 @@ class Goal;
 
 }  // namespace libdnf
 
+
 namespace libdnf::base {
 
 class Transaction;
@@ -47,10 +47,21 @@ class Transaction;
 
 namespace libdnf::rpm {
 
+struct PackageId {
+public:
+    PackageId() = default;
+    explicit PackageId(int id) : id(id) {}
+
+    bool operator==(const PackageId & other) const noexcept { return id == other.id; };
+    bool operator!=(const PackageId & other) const noexcept { return id != other.id; };
+    bool operator<(const PackageId & other) const noexcept { return id < other.id; };
+
+
+    int id{0};
+};
 
 // IMPORTANT: Package methods MUST NOT be 'noexcept'
 // because accessing deleted sack throws an exception.
-
 
 // @replaces libdnf:libdnf/hy-package.h:struct:DnfPackage
 // @replaces dnf:dnf/package.py:class:Package
@@ -482,8 +493,6 @@ inline bool Package::operator!=(const Package & other) const noexcept {
     return id != other.id || sack != other.sack;
 }
 
-
 }  // namespace libdnf::rpm
-
 
 #endif  // LIBDNF_RPM_PACKAGE_HPP

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "package_sack.hpp"
 #include "package_set.hpp"
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/base/goal_elements.hpp"
 #include "libdnf/common/exception.hpp"
 #include "libdnf/common/sack/query_cmp.hpp"
@@ -35,9 +36,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
-class Base;
 class Goal;
-using BaseWeakPtr = WeakPtr<Base, false>;
 
 }  // namespace libdnf
 
@@ -68,8 +67,8 @@ public:
     /// @replaces libdnf/hy-query.h:function:hy_query_create_flags(DnfSack *sack, int flags);
     /// @replaces libdnf/sack/query.hpp:method:Query(DnfSack* sack, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES)
     /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_free(DnfReldep *reldep)
-    explicit PackageQuery(const BaseWeakPtr & base, InitFlags flags = InitFlags::APPLY_EXCLUDES);
-    explicit PackageQuery(Base & base, InitFlags flags = InitFlags::APPLY_EXCLUDES);
+    explicit PackageQuery(const libdnf::BaseWeakPtr & base, InitFlags flags = InitFlags::APPLY_EXCLUDES);
+    explicit PackageQuery(libdnf::Base & base, InitFlags flags = InitFlags::APPLY_EXCLUDES);
     PackageQuery(const PackageQuery & src) = default;
     PackageQuery(PackageQuery && src) noexcept = default;
     ~PackageQuery() = default;

--- a/include/libdnf/rpm/package_sack.hpp
+++ b/include/libdnf/rpm/package_sack.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "package_set.hpp"
 #include "reldep.hpp"
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/exception.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/transaction/transaction_item_reason.hpp"
@@ -36,8 +37,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
 class Goal;
 class Swdb;
 
@@ -113,7 +112,7 @@ public:
         USE_OTHER = 1 << 4,
     };
 
-    explicit PackageSack(Base & base);
+    explicit PackageSack(libdnf::Base & base);
     ~PackageSack();
 
     //TODO(jrohel): Provide/use configuration options for flags?
@@ -149,7 +148,7 @@ public:
 
     /// @return The `Base` object to which this object belongs.
     /// @since 5.0
-    BaseWeakPtr get_base() const;
+    libdnf::BaseWeakPtr get_base() const;
 
     /// Returns number of solvables in pool.
     int get_nsolvables() const noexcept;

--- a/include/libdnf/rpm/package_sack.hpp
+++ b/include/libdnf/rpm/package_sack.hpp
@@ -21,6 +21,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_PACKAGE_SACK_HPP
 #define LIBDNF_RPM_PACKAGE_SACK_HPP
 
+#include "package.hpp"
+#include "package_set.hpp"
+#include "reldep.hpp"
+
 #include "libdnf/common/exception.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/transaction/transaction_item_reason.hpp"
@@ -56,7 +60,7 @@ namespace libdnf::repo {
 class Repo;
 class RepoSack;
 
-}
+}  // namespace libdnf::repo
 
 namespace libdnf::rpm::solv {
 
@@ -72,48 +76,7 @@ class Transaction;
 
 namespace libdnf::rpm {
 
-
-class PackageSet;
-
-
-struct PackageId {
-public:
-    PackageId() = default;
-    explicit PackageId(int id);
-
-    bool operator==(const PackageId & other) const noexcept { return id == other.id; };
-    bool operator!=(const PackageId & other) const noexcept { return id != other.id; };
-    bool operator<(const PackageId & other) const noexcept { return id < other.id; };
-
-
-    int id{0};
-};
-
-struct ReldepId {
-public:
-    ReldepId() = default;
-    explicit ReldepId(int id);
-
-    bool operator==(const ReldepId & other) const noexcept { return id == other.id; };
-    bool operator!=(const ReldepId & other) const noexcept { return id != other.id; };
-
-    int id{0};
-};
-
-inline PackageId::PackageId(int id) : id(id) {}
-
-inline ReldepId::ReldepId(int id) : id(id) {}
-
-
-// forward declarations
-class Package;
-class Reldep;
-class ReldepList;
-class PackageQuery;
-class Transaction;
-
 class PackageSack;
-
 using PackageSackWeakPtr = WeakPtr<PackageSack, false>;
 
 class PackageSack {
@@ -168,7 +131,7 @@ public:
     /// @replaces libdnf/dnf_sack.h:function:dnf_sack_add_cmdline_package(DnfSack *sack, const char *fn)
     /// @replaces libdnf/dnf_sack.h:function:dnf_sack_add_cmdline_package_nochecksum(DnfSack *sack, const char *fn)
     /// @replaces hawkey:hawkey/Sack:method:add_cmdline_package()
-    Package add_cmdline_package(const std::string & fn, bool add_with_hdrid);
+    libdnf::rpm::Package add_cmdline_package(const std::string & fn, bool add_with_hdrid);
 
     // TODO(jmracek) The method is highly experimental, what about to move it somewhere else?
     /// Adds the given .rpm file to the system repo. The function is mostly for testing purpose (not only for unittests)
@@ -176,7 +139,7 @@ public:
     /// It will calculate SHA256 checksum of header and store it in pool => Requires more CPU for loading
     /// When RPM is not accesible or corrupted it raises libdnf::RuntimeError
     /// Return added new Package
-    Package add_system_package(const std::string & fn, bool add_with_hdrid, bool build_cache);
+    libdnf::rpm::Package add_system_package(const std::string & fn, bool add_with_hdrid, bool build_cache);
 
     // TODO (lhrazky): There's an overlap with dumping the debugdata on the Goal class
     void dump_debugdata(const std::string & dir);
@@ -194,17 +157,20 @@ public:
     /// @return Map of resolved reasons why packages were installed: ``{(name, arch) -> reason}``.
     ///         A package can be installed due to multiple reasons, only the most significant is returned.
     /// @since 5.0
-    const std::map<std::pair<std::string, std::string>, libdnf::transaction::TransactionItemReason> & get_reasons() const { return reasons; }
+    const std::map<std::pair<std::string, std::string>, libdnf::transaction::TransactionItemReason> & get_reasons()
+        const {
+        return reasons;
+    }
 
 private:
     friend libdnf::Goal;
     friend Package;
     friend PackageSet;
     friend Reldep;
-    friend ReldepList;
+    friend class ReldepList;
     friend class repo::RepoSack;
-    friend PackageQuery;
-    friend Transaction;
+    friend class PackageQuery;
+    friend class Transaction;
     friend libdnf::Swdb;
     friend solv::SolvPrivate;
     friend libdnf::advisory::Advisory;

--- a/include/libdnf/rpm/package_set.hpp
+++ b/include/libdnf/rpm/package_set.hpp
@@ -23,7 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 #include "package.hpp"
-#include "package_sack.hpp"
 #include "package_set_iterator.hpp"
 
 #include <memory>
@@ -36,11 +35,6 @@ class SolvMap;
 }  // namespace libdnf::rpm::solv
 
 namespace libdnf::rpm {
-
-class PackageSetIterator;
-class PackageQuery;
-class Transaction;
-
 
 /// @replaces libdnf:sack/packageset.hpp:struct:PackageSet
 class PackageSet {
@@ -105,18 +99,15 @@ public:
 
 private:
     friend PackageSetIterator;
-    friend PackageQuery;
-    friend Transaction;
+    friend class PackageQuery;
+    friend class Transaction;
     friend class libdnf::base::Transaction;
     friend libdnf::Goal;
-    friend libdnf::Swdb;
     PackageSet(const PackageSackWeakPtr & sack, libdnf::solv::SolvMap & solv_map);
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };
 
-
 }  // namespace libdnf::rpm
-
 
 #endif  // LIBDNF_RPM_PACKAGE_SET_HPP

--- a/include/libdnf/rpm/package_set_iterator.hpp
+++ b/include/libdnf/rpm/package_set_iterator.hpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_PACKAGE_SET_ITERATOR_HPP
 #define LIBDNF_RPM_PACKAGE_SET_ITERATOR_HPP
 
-
 #include "package.hpp"
 
 #include <cstddef>
@@ -30,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::rpm {
-
 
 class PackageSet;
 
@@ -63,8 +61,6 @@ private:
     std::unique_ptr<Impl> p_impl;
 };
 
-
 }  // namespace libdnf::rpm
-
 
 #endif  // LIBDNF_RPM_PACKAGE_SET_ITERATOR_HPP

--- a/include/libdnf/rpm/reldep.hpp
+++ b/include/libdnf/rpm/reldep.hpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_RELDEP_HPP
 #define LIBDNF_RPM_RELDEP_HPP
 
-#include "package_sack.hpp"
+#include "libdnf/common/weak_ptr.hpp"
 
 #include <memory>
 #include <string>
@@ -29,7 +29,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::rpm {
 
-class ReldepListIterator;
+class PackageSack;
+using PackageSackWeakPtr = WeakPtr<PackageSack, false>;
+
+struct ReldepId {
+public:
+    ReldepId() = default;
+    explicit ReldepId(int id) : id(id) {}
+
+    bool operator==(const ReldepId & other) const noexcept { return id == other.id; };
+    bool operator!=(const ReldepId & other) const noexcept { return id != other.id; };
+
+    int id{0};
+};
 
 /// @brief Represent a relational dependency from libsolv
 ///
@@ -83,8 +95,8 @@ protected:
     Reldep(PackageSack * sack, ReldepId dependency_id);
 
 private:
-    friend ReldepList;
-    friend ReldepListIterator;
+    friend class ReldepList;
+    friend class ReldepListIterator;
 
     /// @brief Creates a reldep from name, version, and comparison type.
     ///

--- a/include/libdnf/rpm/reldep_list.hpp
+++ b/include/libdnf/rpm/reldep_list.hpp
@@ -26,12 +26,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <memory>
 
-namespace libdnf::rpm {
 
-// forward declarations
-class Package;
-class ReldepListIterator;
-class PackageQuery;
+namespace libdnf::rpm {
 
 /// @replaces libdnf/dnf-reldep-list.h:struct:DnfReldepList
 /// @replaces libdnf/repo/solvable/DependencyContainer.hpp:struct:DependencyContainer
@@ -103,8 +99,9 @@ public:
 
 private:
     friend ReldepListIterator;
-    friend Package;
-    friend PackageQuery;
+
+    friend class Package;
+    friend class PackageQuery;
 
     /// @brief Adds a reldep from Char*. It does not support globs.
     ///
@@ -123,7 +120,6 @@ private:
 inline bool ReldepList::add_reldep(const std::string & reldep_str) {
     return add_reldep(reldep_str, 1);
 }
-
 
 }  // namespace libdnf::rpm
 

--- a/include/libdnf/rpm/reldep_list_iterator.hpp
+++ b/include/libdnf/rpm/reldep_list_iterator.hpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_RELDEP_LIST_ITERATOR_HPP
 #define LIBDNF_RPM_RELDEP_LIST_ITERATOR_HPP
 
-
 #include "reldep.hpp"
 
 #include <cstddef>
@@ -30,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::rpm {
-
 
 class ReldepList;
 
@@ -63,8 +61,6 @@ private:
     std::unique_ptr<Impl> p_impl;
 };
 
-
 }  // namespace libdnf::rpm
-
 
 #endif  // LIBDNF_RPM_RELDEP_LIST_ITERATOR_HPP

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -23,19 +23,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "package.hpp"
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/base/transaction_package.hpp"
 #include "libdnf/common/exception.hpp"
-#include "libdnf/common/weak_ptr.hpp"
 
 #include <memory>
 
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}  // namespace libdnf
 
 namespace libdnf::rpm {
 

--- a/include/libdnf/transaction/comps_environment.hpp
+++ b/include/libdnf/transaction/comps_environment.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_COMPS_ENVIRONMENT_HPP
 #define LIBDNF_TRANSACTION_COMPS_ENVIRONMENT_HPP
-
 
 #include "comps_group.hpp"
 
@@ -29,7 +27,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::transaction {
-
 
 class CompsEnvironmentGroup;
 class Transction;
@@ -173,8 +170,6 @@ private:
     CompsEnvironment & environment;
 };
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_COMPS_ENVIRONMENT_HPP

--- a/include/libdnf/transaction/comps_group.hpp
+++ b/include/libdnf/transaction/comps_group.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_COMPS_GROUP_HPP
 #define LIBDNF_TRANSACTION_COMPS_GROUP_HPP
-
 
 #include "transaction_item.hpp"
 
@@ -29,7 +27,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::transaction {
-
 
 class CompsGroupPackage;
 class Transaction;
@@ -191,8 +188,6 @@ private:
     CompsGroup & group;
 };
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_COMPS_GROUP_HPP

--- a/include/libdnf/transaction/query.hpp
+++ b/include/libdnf/transaction/query.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_QUERY_HPP
 #define LIBDNF_TRANSACTION_QUERY_HPP
-
 
 #include "transaction.hpp"
 
@@ -29,6 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <mutex>
 #include <vector>
+
 
 namespace libdnf {
 
@@ -39,7 +38,6 @@ using BaseWeakPtr = WeakPtr<Base, false>;
 
 
 namespace libdnf::transaction {
-
 
 class TransactionSack;
 
@@ -77,8 +75,6 @@ private:
     };
 };
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_QUERY_HPP

--- a/include/libdnf/transaction/query.hpp
+++ b/include/libdnf/transaction/query.hpp
@@ -22,19 +22,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "transaction.hpp"
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/sack/query.hpp"
 #include "libdnf/common/weak_ptr.hpp"
 
 #include <mutex>
 #include <vector>
-
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}  // namespace libdnf
 
 
 namespace libdnf::transaction {
@@ -53,8 +46,8 @@ public:
 
     // create an *empty* query
     // the content is lazily loaded/cached while running the queries
-    explicit TransactionQuery(const BaseWeakPtr & base);
-    explicit TransactionQuery(Base & base);
+    explicit TransactionQuery(const libdnf::BaseWeakPtr & base);
+    explicit TransactionQuery(libdnf::Base & base);
 
     /// @replaces libdnf:transaction/Transaction.hpp:method:Transaction.dbSelect(int64_t transaction_id)
     TransactionQuery & filter_id(int64_t pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);

--- a/include/libdnf/transaction/rpm_package.hpp
+++ b/include/libdnf/transaction/rpm_package.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_RPM_PACKAGE_HPP
 #define LIBDNF_TRANSACTION_RPM_PACKAGE_HPP
-
 
 #include "transaction_item.hpp"
 #include "transaction_item_reason.hpp"
@@ -30,7 +28,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::transaction {
-
 
 class Transaction;
 
@@ -121,8 +118,6 @@ private:
     std::string arch;
 };
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_RPM_PACKAGE_HPP

--- a/include/libdnf/transaction/sack.hpp
+++ b/include/libdnf/transaction/sack.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_SACK_HPP
 #define LIBDNF_TRANSACTION_SACK_HPP
-
 
 #include "query.hpp"
 #include "transaction.hpp"
@@ -38,9 +36,7 @@ using BaseWeakPtr = WeakPtr<Base, false>;
 
 }
 
-
 namespace libdnf::transaction {
-
 
 /// Weak pointer to Transaction. It doesn't own the object (ptr_owner = false).
 /// Transactions are owned by TransactionSack.
@@ -81,6 +77,5 @@ private:
 };
 
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_SACK_HPP

--- a/include/libdnf/transaction/sack.hpp
+++ b/include/libdnf/transaction/sack.hpp
@@ -23,18 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "query.hpp"
 #include "transaction.hpp"
 
+#include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/sack/sack.hpp"
+#include "libdnf/common/weak_ptr.hpp"
 #include "libdnf/transaction/db/db.hpp"
 
 #include <mutex>
 
-
-namespace libdnf {
-
-class Base;
-using BaseWeakPtr = WeakPtr<Base, false>;
-
-}
 
 namespace libdnf::transaction {
 
@@ -63,7 +58,7 @@ public:
 
     /// @return The `Base` object to which this object belongs.
     /// @since 5.0
-    BaseWeakPtr get_base() const;
+    libdnf::BaseWeakPtr get_base() const;
 
 private:
     friend class Transaction;

--- a/include/libdnf/transaction/transaction.hpp
+++ b/include/libdnf/transaction/transaction.hpp
@@ -17,14 +17,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_TRANSACTION_HPP
 #define LIBDNF_TRANSACTION_TRANSACTION_HPP
-
 
 #include "comps_environment.hpp"
 #include "comps_group.hpp"
 #include "rpm_package.hpp"
+#include "transaction_item.hpp"
 
 #include "libdnf/base/transaction_package.hpp"
 
@@ -32,16 +31,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <set>
 #include <string>
 
+
 namespace libdnf::transaction {
+
 class Transaction;
 typedef std::shared_ptr<Transaction> TransactionPtr;
-}  // namespace libdnf::transaction
 
-#include "transaction_item.hpp"
+}  // namespace libdnf::transaction
 
 
 namespace libdnf::transaction {
-
 
 class Item;
 class Transformer;
@@ -268,8 +267,6 @@ private:
     TransactionSack & sack;
 };
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_TRANSACTION_HPP

--- a/include/libdnf/transaction/transaction_item.hpp
+++ b/include/libdnf/transaction/transaction_item.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_TRANSACTION_ITEM_HPP
 #define LIBDNF_TRANSACTION_TRANSACTION_ITEM_HPP
-
 
 #include "transaction_item_action.hpp"
 #include "transaction_item_reason.hpp"
@@ -31,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::transaction {
-
 
 class Transaction;
 
@@ -155,8 +152,6 @@ protected:
     // std::vector< TransactionItemPtr > replacedBy;
 };
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_TRANSACTION_ITEM_HPP

--- a/include/libdnf/transaction/transaction_item_action.hpp
+++ b/include/libdnf/transaction/transaction_item_action.hpp
@@ -17,16 +17,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_ITEM_ACTION_HPP
 #define LIBDNF_TRANSACTION_ITEM_ACTION_HPP
-
 
 #include <string>
 
 
 namespace libdnf::transaction {
-
 
 // Any time you add a new action, change functions that resolve reasons,
 // because removed items (RPMs) must be excluded from reason resolution:
@@ -51,7 +48,6 @@ std::string TransactionItemAction_get_name(TransactionItemAction action);
 std::string TransactionItemAction_get_short(TransactionItemAction action);
 bool TransactionItemAction_is_forward_action(TransactionItemAction action);
 bool TransactionItemAction_is_backward_action(TransactionItemAction action);
-
 
 }  // namespace libdnf::transaction
 

--- a/include/libdnf/transaction/transaction_item_reason.hpp
+++ b/include/libdnf/transaction/transaction_item_reason.hpp
@@ -17,16 +17,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_TRANSACTION_ITEM_REASON_HPP
 #define LIBDNF_TRANSACTION_TRANSACTION_ITEM_REASON_HPP
-
 
 #include <string>
 
 
 namespace libdnf::transaction {
-
 
 enum class TransactionItemReason : int {
     UNKNOWN = 0,
@@ -54,8 +51,6 @@ bool operator<=(TransactionItemReason lhs, TransactionItemReason rhs);
 bool operator>(TransactionItemReason lhs, TransactionItemReason rhs);
 bool operator>=(TransactionItemReason lhs, TransactionItemReason rhs);
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_TRANSACTION_ITEM_REASON_HPP

--- a/include/libdnf/transaction/transaction_item_state.hpp
+++ b/include/libdnf/transaction/transaction_item_state.hpp
@@ -17,16 +17,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
 #define LIBDNF_TRANSACTION_TRANSACTION_ITEM_STATE_HPP
-
 
 #include <string>
 
 
 namespace libdnf::transaction {
-
 
 enum class TransactionItemState : int {
     UNKNOWN = 0,  // default state, must be changed before save
@@ -37,8 +34,6 @@ enum class TransactionItemState : int {
 
 std::string TransactionItemState_to_string(TransactionItemState state);
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_TRANSACTION_ITEM_STATE_HPP

--- a/include/libdnf/transaction/transaction_item_type.hpp
+++ b/include/libdnf/transaction/transaction_item_type.hpp
@@ -17,13 +17,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_TRANSACTION_TRANSACTION_ITEM_TYPE_HPP
 #define LIBDNF_TRANSACTION_TRANSACTION_ITEM_TYPE_HPP
 
 
 namespace libdnf::transaction {
-
 
 enum class TransactionItemType : int {
     UNKNOWN = 0,  // default type, must be changed before save
@@ -32,8 +30,6 @@ enum class TransactionItemType : int {
     ENVIRONMENT = 3
 };
 
-
 }  // namespace libdnf::transaction
-
 
 #endif  // LIBDNF_TRANSACTION_TRANSACTION_ITEM_TYPE_HPP

--- a/libdnf/rpm/package_sack_impl.hpp
+++ b/libdnf/rpm/package_sack_impl.hpp
@@ -20,14 +20,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_PACKAGE_SACK_IMPL_HPP
 #define LIBDNF_RPM_PACKAGE_SACK_IMPL_HPP
 
-#include "../utils/utils_internal.hpp"
-#include "../repo/repo_impl.hpp"
+#include "libdnf/base/base.hpp"
+#include "libdnf/repo/repo_impl.hpp"
+#include "libdnf/rpm/package.hpp"
 #include "libdnf/solv/id_queue.hpp"
 #include "libdnf/solv/solv_map.hpp"
-
-#include "libdnf/base/base.hpp"
-#include "libdnf/rpm/package.hpp"
-#include "libdnf/rpm/package_sack.hpp"
+#include "libdnf/utils/utils_internal.hpp"
 
 extern "C" {
 #include <solv/pool.h>
@@ -59,10 +57,6 @@ static inline bool nevra_solvable_cmp_icase_key(
 }
 
 namespace libdnf::rpm {
-
-
-class PackageSet;
-
 
 class PackageSack::Impl {
 public:
@@ -167,7 +161,8 @@ private:
     friend PackageSet;
     friend Reldep;
     friend ReldepList;
-    friend Transaction;
+
+    friend class Transaction;
 };
 
 

--- a/libdnf/rpm/reldep_list_impl.hpp
+++ b/libdnf/rpm/reldep_list_impl.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/solv/id_queue.hpp"
 
+
 namespace libdnf::rpm {
 
 class ReldepList::Impl {
@@ -39,7 +40,7 @@ public:
 
 private:
     friend class ReldepList;
-    friend Package;
+    friend class Package;
     PackageSackWeakPtr sack;
     libdnf::solv::IdQueue queue;
 };

--- a/libdnf/utils/fs.hpp
+++ b/libdnf/utils/fs.hpp
@@ -1,12 +1,10 @@
 #ifndef LIBDNF_UTILS_FS_HPP
 #define LIBDNF_UTILS_FS_HPP
 
-
 #include <string>
 
 
 namespace libdnf::utils::fs {
-
 
 /// Create directories for a specified path to a file.
 /// Make sure trailing '/' is present if a file name is not specified.
@@ -17,8 +15,6 @@ void makedirs_for_file(const std::string & file_path);
 /// If content differs or error occurred (file doesn't exist, not readable, ...) returns "false".
 bool have_files_same_content_noexcept(const char * file_path1, const char * file_path2) noexcept;
 
-
 }  // namespace libdnf::utils::fs
-
 
 #endif  // LIBDNF_UTILS_FS_HPP

--- a/libdnf/utils/iniparser.hpp
+++ b/libdnf/utils/iniparser.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <string>
 
+
 namespace libdnf {
 
 /// @class IniParser

--- a/libdnf/utils/library.hpp
+++ b/libdnf/utils/library.hpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <string>
 
+
 namespace libdnf::utils {
 
 class Library {

--- a/libdnf/utils/span.hpp
+++ b/libdnf/utils/span.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <iterator>
 #include <type_traits>
 
+
 namespace libdnf {
 
 inline constexpr std::size_t DYNAMIC_EXTENT = static_cast<std::size_t>(-1);

--- a/libdnf/utils/sqlite3/sqlite3.hpp
+++ b/libdnf/utils/sqlite3/sqlite3.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_UTILS_SQLITE3_SQLITE3_HPP
 #define LIBDNF_UTILS_SQLITE3_SQLITE3_HPP
-
 
 #include "libdnf/common/exception.hpp"
 
@@ -34,7 +32,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::utils {
-
 
 class SQLite3 {
 public:
@@ -325,8 +322,6 @@ protected:
 
 using SQLite3Ptr = std::shared_ptr<SQLite3>;
 
-
 }  // namespace libdnf::utils
-
 
 #endif  // LIBDNF_UTILS_SQLITE3_SQLITE3_HPP

--- a/libdnf/utils/string.hpp
+++ b/libdnf/utils/string.hpp
@@ -17,17 +17,14 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_UTILS_STRING_HPP
 #define LIBDNF_UTILS_STRING_HPP
-
 
 #include <algorithm>
 #include <string>
 
 
 namespace libdnf::utils::string {
-
 
 /// Determine if a string starts with a pattern
 inline bool starts_with(const std::string & value, const std::string & pattern) {
@@ -82,8 +79,6 @@ std::vector<std::string> rsplit(const std::string & str, const std::string & del
 std::vector<std::string> split(
     const std::string & str, const std::string & delimiter, std::size_t limit = std::string::npos);
 
-
 }  // namespace libdnf::utils::string
-
 
 #endif  // LIBDNF_UTILS_STRING_HPP

--- a/libdnf/utils/temp.hpp
+++ b/libdnf/utils/temp.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef LIBDNF_UTILS_TEMP_HPP
 #define LIBDNF_UTILS_TEMP_HPP
-
 
 #include <filesystem>
 #include <vector>
@@ -28,7 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 namespace libdnf::utils {
-
 
 /// Object that creates and holds a temp directory.
 /// The directory gets removed when the object is deleted.
@@ -45,8 +42,6 @@ private:
     std::filesystem::path path;
 };
 
-
 }  // namespace libdnf::utils
-
 
 #endif  // LIBDNF_UTILS_TEMP_HPP

--- a/libdnf/utils/xml.hpp
+++ b/libdnf/utils/xml.hpp
@@ -1,12 +1,10 @@
 #ifndef LIBDNF_UTILS_XML_HPP
 #define LIBDNF_UTILS_XML_HPP
 
-
 #include <libxml/tree.h>
 
 
 namespace libdnf::utils::xml {
-
 
 xmlNodePtr add_subnode_with_text(xmlNodePtr parent, std::string child_name, std::string child_text) {
     xmlNodePtr node = xmlNewNode(NULL, BAD_CAST child_name.c_str());
@@ -15,8 +13,6 @@ xmlNodePtr add_subnode_with_text(xmlNodePtr parent, std::string child_name, std:
     return node;
 }
 
-
 }  // namespace libdnf::utils::xml
-
 
 #endif  // LIBDNF_UTILS_XML_HPP


### PR DESCRIPTION
Attempts to clean up some directions of includes, as well as forward declarations and coding style improvements (not comprehensive).

The `base_weak.hpp` header is up for dicussion, if we want to go that way I'll add the same headers for the other `WeakPtr`s that are used in more than one place.