### PR TITLE
[dnfdaemon] Fix method/signal handling in thread

### DIFF
--- a/dnfdaemon-server/services/base/base.cpp
+++ b/dnfdaemon-server/services/base/base.cpp
@@ -35,14 +35,14 @@ void Base::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_BASE, "read_all_repos", "", "b", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Base::read_all_repos, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Base::read_all_repos, call);
         });
     dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_REPO_LOAD_START, "ss");
     dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_REPO_LOAD_PROGRESS, "suu");
     dbus_object->registerSignal(dnfdaemon::INTERFACE_BASE, dnfdaemon::SIGNAL_REPO_LOAD_END, "s");
 }
 
-sdbus::MethodReply Base::read_all_repos(sdbus::MethodCall && call) {
+sdbus::MethodReply Base::read_all_repos(sdbus::MethodCall & call) {
     bool retval = session.read_all_repos();
     auto reply = call.createReply();
     reply << retval;

--- a/dnfdaemon-server/services/base/base.hpp
+++ b/dnfdaemon-server/services/base/base.hpp
@@ -35,7 +35,7 @@ public:
     void dbus_deregister();
 
 private:
-    sdbus::MethodReply read_all_repos(sdbus::MethodCall && call);
+    sdbus::MethodReply read_all_repos(sdbus::MethodCall & call);
 };
 
 #endif

--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -39,15 +39,15 @@ void Goal::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_GOAL, "resolve", "a{sv}", "a(ua{sv})", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Goal::resolve, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Goal::resolve, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_GOAL, "do_transaction", "a{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Goal::do_transaction, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Goal::do_transaction, call);
         });
 }
 
-sdbus::MethodReply Goal::resolve(sdbus::MethodCall && call) {
+sdbus::MethodReply Goal::resolve(sdbus::MethodCall & call) {
     // read options from dbus call
     dnfdaemon::KeyValueMap options;
     call >> options;
@@ -146,7 +146,7 @@ void download_packages(Session & session, libdnf::base::Transaction & transactio
     libdnf::repo::PackageTarget::download_packages(targets, true);
 }
 
-sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall && call) {
+sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
     if (!session.check_authorization(dnfdaemon::POLKIT_EXECUTE_RPM_TRANSACTION, call.getSender())) {
         throw std::runtime_error("Not authorized");
     }

--- a/dnfdaemon-server/services/goal/goal.hpp
+++ b/dnfdaemon-server/services/goal/goal.hpp
@@ -32,8 +32,8 @@ public:
     void dbus_deregister();
 
 private:
-    sdbus::MethodReply resolve(sdbus::MethodCall && call);
-    sdbus::MethodReply do_transaction(sdbus::MethodCall && call);
+    sdbus::MethodReply resolve(sdbus::MethodCall & call);
+    sdbus::MethodReply do_transaction(sdbus::MethodCall & call);
 };
 
 #endif

--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -205,11 +205,11 @@ void Repo::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPO, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Repo::list, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Repo::list, call);
         });
 }
 
-sdbus::MethodReply Repo::list(sdbus::MethodCall && call) {
+sdbus::MethodReply Repo::list(sdbus::MethodCall & call) {
     dnfdaemon::KeyValueMap options;
     call >> options;
     const std::vector<std::string> empty_list{};

--- a/dnfdaemon-server/services/repo/repo.hpp
+++ b/dnfdaemon-server/services/repo/repo.hpp
@@ -35,7 +35,7 @@ public:
     void dbus_deregister();
 
 private:
-    sdbus::MethodReply list(sdbus::MethodCall && call);
+    sdbus::MethodReply list(sdbus::MethodCall & call);
 };
 
 #endif

--- a/dnfdaemon-server/services/repoconf/repo_conf.cpp
+++ b/dnfdaemon-server/services/repoconf/repo_conf.cpp
@@ -31,19 +31,19 @@ void RepoConf::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &RepoConf::list, std::move(call));
+            session.get_threads_manager().handle_method(*this, &RepoConf::list, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "get", "s", "a{sv}", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &RepoConf::get, std::move(call));
+            session.get_threads_manager().handle_method(*this, &RepoConf::get, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "enable", "as", "as", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &RepoConf::enable, std::move(call));
+            session.get_threads_manager().handle_method(*this, &RepoConf::enable, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_REPOCONF, "disable", "as", "as", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &RepoConf::disable, std::move(call));
+            session.get_threads_manager().handle_method(*this, &RepoConf::disable, call);
         });
 }
 
@@ -75,7 +75,7 @@ dnfdaemon::KeyValueMapList RepoConf::repo_list(const std::vector<std::string> & 
     return out;
 }
 
-sdbus::MethodReply RepoConf::list(sdbus::MethodCall && call) {
+sdbus::MethodReply RepoConf::list(sdbus::MethodCall & call) {
     dnfdaemon::KeyValueMap options;
     std::vector<std::string> default_ids{};
     call >> options;
@@ -87,7 +87,7 @@ sdbus::MethodReply RepoConf::list(sdbus::MethodCall && call) {
     return reply;
 }
 
-sdbus::MethodReply RepoConf::get(sdbus::MethodCall && call) {
+sdbus::MethodReply RepoConf::get(sdbus::MethodCall & call) {
     std::string id;
     call >> id;
     auto ids = std::vector<std::string>{std::move(id)};

--- a/dnfdaemon-server/services/repoconf/repo_conf.hpp
+++ b/dnfdaemon-server/services/repoconf/repo_conf.hpp
@@ -36,11 +36,11 @@ public:
     void dbus_deregister();
 
 private:
-    sdbus::MethodReply list(sdbus::MethodCall && call);
-    sdbus::MethodReply get(sdbus::MethodCall && call);
+    sdbus::MethodReply list(sdbus::MethodCall & call);
+    sdbus::MethodReply get(sdbus::MethodCall & call);
     sdbus::MethodReply enable_disable(sdbus::MethodCall && call, const bool & enable);
-    sdbus::MethodReply enable(sdbus::MethodCall && call) { return enable_disable(std::move(call), true); };
-    sdbus::MethodReply disable(sdbus::MethodCall && call) { return enable_disable(std::move(call), false); };
+    sdbus::MethodReply enable(sdbus::MethodCall & call) { return enable_disable(std::move(call), true); };
+    sdbus::MethodReply disable(sdbus::MethodCall & call) { return enable_disable(std::move(call), false); };
 
     dnfdaemon::KeyValueMapList repo_list(const std::vector<std::string> & ids);
     std::vector<std::string> enable_disable_repos(const std::vector<std::string> & ids, const bool enable);

--- a/dnfdaemon-server/services/rpm/rpm.cpp
+++ b/dnfdaemon-server/services/rpm/rpm.cpp
@@ -34,31 +34,31 @@ void Rpm::dbus_register() {
     auto dbus_object = session.get_dbus_object();
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "downgrade", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Rpm::downgrade, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::downgrade, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Rpm::list, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::list, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "install", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Rpm::install, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::install, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "upgrade", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Rpm::upgrade, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::upgrade, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "reinstall", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Rpm::reinstall, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::reinstall, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_RPM, "remove", "asa{sv}", "", [this](sdbus::MethodCall call) -> void {
-            session.get_threads_manager().handle_method(*this, &Rpm::remove, std::move(call));
+            session.get_threads_manager().handle_method(*this, &Rpm::remove, call);
         });
 }
 
-sdbus::MethodReply Rpm::list(sdbus::MethodCall && call) {
+sdbus::MethodReply Rpm::list(sdbus::MethodCall & call) {
     // read options from dbus call
     dnfdaemon::KeyValueMap options;
     call >> options;
@@ -109,7 +109,7 @@ sdbus::MethodReply Rpm::list(sdbus::MethodCall && call) {
     return reply;
 }
 
-sdbus::MethodReply Rpm::downgrade(sdbus::MethodCall && call) {
+sdbus::MethodReply Rpm::downgrade(sdbus::MethodCall & call) {
     std::vector<std::string> specs;
     call >> specs;
 
@@ -130,7 +130,7 @@ sdbus::MethodReply Rpm::downgrade(sdbus::MethodCall && call) {
     return reply;
 }
 
-sdbus::MethodReply Rpm::install(sdbus::MethodCall && call) {
+sdbus::MethodReply Rpm::install(sdbus::MethodCall & call) {
     std::vector<std::string> specs;
     call >> specs;
 
@@ -160,7 +160,7 @@ sdbus::MethodReply Rpm::install(sdbus::MethodCall && call) {
     return reply;
 }
 
-sdbus::MethodReply Rpm::upgrade(sdbus::MethodCall && call) {
+sdbus::MethodReply Rpm::upgrade(sdbus::MethodCall & call) {
     std::vector<std::string> specs;
     call >> specs;
 
@@ -181,7 +181,7 @@ sdbus::MethodReply Rpm::upgrade(sdbus::MethodCall && call) {
     return reply;
 }
 
-sdbus::MethodReply Rpm::reinstall(sdbus::MethodCall && call) {
+sdbus::MethodReply Rpm::reinstall(sdbus::MethodCall & call) {
     std::vector<std::string> specs;
     call >> specs;
 
@@ -202,7 +202,7 @@ sdbus::MethodReply Rpm::reinstall(sdbus::MethodCall && call) {
     return reply;
 }
 
-sdbus::MethodReply Rpm::remove(sdbus::MethodCall && call) {
+sdbus::MethodReply Rpm::remove(sdbus::MethodCall & call) {
     std::vector<std::string> specs;
     call >> specs;
 

--- a/dnfdaemon-server/services/rpm/rpm.hpp
+++ b/dnfdaemon-server/services/rpm/rpm.hpp
@@ -32,12 +32,12 @@ public:
     void dbus_deregister();
 
 private:
-    sdbus::MethodReply list(sdbus::MethodCall && call);
-    sdbus::MethodReply install(sdbus::MethodCall && call);
-    sdbus::MethodReply upgrade(sdbus::MethodCall && call);
-    sdbus::MethodReply remove(sdbus::MethodCall && call);
-    sdbus::MethodReply downgrade(sdbus::MethodCall && call);
-    sdbus::MethodReply reinstall(sdbus::MethodCall && call);
+    sdbus::MethodReply list(sdbus::MethodCall & call);
+    sdbus::MethodReply install(sdbus::MethodCall & call);
+    sdbus::MethodReply upgrade(sdbus::MethodCall & call);
+    sdbus::MethodReply remove(sdbus::MethodCall & call);
+    sdbus::MethodReply downgrade(sdbus::MethodCall & call);
+    sdbus::MethodReply reinstall(sdbus::MethodCall & call);
 };
 
 #endif

--- a/dnfdaemon-server/session_manager.cpp
+++ b/dnfdaemon-server/session_manager.cpp
@@ -45,11 +45,11 @@ void SessionManager::dbus_register() {
     dbus_object = sdbus::createObject(connection, object_path);
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_SESSION_MANAGER, "open_session", "a{sv}", "o", [this](sdbus::MethodCall call) -> void {
-            threads_manager.handle_method(*this, &SessionManager::open_session, std::move(call));
+            threads_manager.handle_method(*this, &SessionManager::open_session, call);
         });
     dbus_object->registerMethod(
         dnfdaemon::INTERFACE_SESSION_MANAGER, "close_session", "o", "b", [this](sdbus::MethodCall call) -> void {
-            threads_manager.handle_method(*this, &SessionManager::close_session, std::move(call));
+            threads_manager.handle_method(*this, &SessionManager::close_session, call);
         });
     dbus_object->finishRegistration();
 
@@ -57,7 +57,7 @@ void SessionManager::dbus_register() {
     name_changed_proxy = sdbus::createProxy(connection, "org.freedesktop.DBus", "/org/freedesktop/DBus");
     name_changed_proxy->registerSignalHandler(
         "org.freedesktop.DBus", "NameOwnerChanged", [this](sdbus::Signal signal) -> void {
-            threads_manager.handle_signal(*this, &SessionManager::on_name_owner_changed, std::move(signal));
+            threads_manager.handle_signal(*this, &SessionManager::on_name_owner_changed, signal);
         });
     name_changed_proxy->finishRegistration();
 }
@@ -76,7 +76,7 @@ std::string gen_session_id() {
 }
 
 
-void SessionManager::on_name_owner_changed(sdbus::Signal && signal) {
+void SessionManager::on_name_owner_changed(sdbus::Signal & signal) {
     std::string name;
     std::string old_owner;
     std::string new_owner;
@@ -93,7 +93,7 @@ void SessionManager::on_name_owner_changed(sdbus::Signal && signal) {
     }
 }
 
-sdbus::MethodReply SessionManager::open_session(sdbus::MethodCall && call) {
+sdbus::MethodReply SessionManager::open_session(sdbus::MethodCall & call) {
     auto sender = call.getSender();
     dnfdaemon::KeyValueMap configuration;
     call >> configuration;
@@ -113,7 +113,7 @@ sdbus::MethodReply SessionManager::open_session(sdbus::MethodCall && call) {
 }
 
 
-sdbus::MethodReply SessionManager::close_session(sdbus::MethodCall && call) {
+sdbus::MethodReply SessionManager::close_session(sdbus::MethodCall & call) {
     auto sender = call.getSender();
     sdbus::ObjectPath session_id;
     call >> session_id;

--- a/dnfdaemon-server/session_manager.hpp
+++ b/dnfdaemon-server/session_manager.hpp
@@ -49,9 +49,9 @@ private:
     std::map<std::string, std::map<std::string, std::unique_ptr<Session>>> sessions;
 
     void dbus_register();
-    sdbus::MethodReply open_session(sdbus::MethodCall && call);
-    sdbus::MethodReply close_session(sdbus::MethodCall && call);
-    void on_name_owner_changed(sdbus::Signal && signal);
+    sdbus::MethodReply open_session(sdbus::MethodCall & call);
+    sdbus::MethodReply close_session(sdbus::MethodCall & call);
+    void on_name_owner_changed(sdbus::Signal & signal);
 };
 
 #endif


### PR DESCRIPTION
- replace rvalue reference handlers arguments with references
- fix passing reference into worker thread

This patch fixes occasional segfaults of dnfdaemon-server and resolves
problems reported by valgrind.