### PR TITLE
SHA1_* functions are deprecated in OpenSSL 3.0 use EVP_Digest* 

### DIFF
--- a/libdnf/utils/crypto/sha1.cpp
+++ b/libdnf/utils/crypto/sha1.cpp
@@ -8,14 +8,15 @@
 
 SHA1Hash::SHA1Hash()
 {
-    SHA1_Init(&ctx);
+    md_ctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(md_ctx, EVP_sha1(), NULL);
 }
 
 
 void
 SHA1Hash::update(const char * data)
 {
-    SHA1_Update(&ctx, (unsigned char *)data, strlen(data));
+    EVP_DigestUpdate(md_ctx, data, strlen(data));
 }
 
 
@@ -23,12 +24,13 @@ std::string
 SHA1Hash::hexdigest()
 {
     unsigned char md[digestLength];
-    SHA1_Final(md, &ctx);
+    EVP_DigestFinal_ex(md_ctx, md, NULL);
 
     std::stringstream ss;
     for(int i=0; i<digestLength; i++) {
         ss << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(md[i]);
     }
 
+    EVP_MD_CTX_free(md_ctx);
     return ss.str();
 }

--- a/libdnf/utils/crypto/sha1.hpp
+++ b/libdnf/utils/crypto/sha1.hpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 
 /*
@@ -20,5 +21,5 @@ public:
     static constexpr int digestLength = SHA_DIGEST_LENGTH;
 
 private:
-    SHA_CTX ctx;
+    EVP_MD_CTX *md_ctx;
 };

--- a/tests/libdnf/module/ModulePackageContainerTest.cpp
+++ b/tests/libdnf/module/ModulePackageContainerTest.cpp
@@ -17,7 +17,7 @@ void ModulePackageContainerTest::setUp()
     char *retptr = mkdtemp(tmpdir);
     CPPUNIT_ASSERT(retptr);
     char * etc_target = g_strjoin(NULL, tmpdir, "/etc", NULL);
-    dnf_copy_recursive(TESTDATADIR "/modules/etc", etc_target, &error);
+    CPPUNIT_ASSERT(dnf_copy_recursive(TESTDATADIR "/modules/etc", etc_target, &error));
     g_assert_no_error(error);
     g_free(etc_target);
 


### PR DESCRIPTION
Also adds one return value check for a test.

These issues were reported by static analyzers for: `libdnf-0.63.0-2.el9` compared to `libdnf-0.58.0-1.el9`.