### PR TITLE
[dnf5] reinstall exits nicely when transaction is empty

### DIFF
--- a/dnfdaemon-client/commands/command.cpp
+++ b/dnfdaemon-client/commands/command.cpp
@@ -25,6 +25,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../wrappers/dbus_goal_wrapper.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
+#include "dnfdaemon-server/utils.hpp"
+
+#include <libdnf/base/goal.hpp>
 
 #include <iostream>
 #include <vector>
@@ -39,11 +42,43 @@ void TransactionCommand::run_transaction(Context & ctx) {
     // resolve the transaction
     options["allow_erasing"] = ctx.allow_erasing.get_value();
     std::vector<dnfdaemon::DbusTransactionItem> transaction;
+    dnfdaemon::KeyValueMap dbus_goal_resolve_results;
     ctx.session_proxy->callMethod("resolve")
         .onInterface(dnfdaemon::INTERFACE_GOAL)
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(options)
-        .storeResultsTo(transaction);
+        .storeResultsTo(transaction, dbus_goal_resolve_results);
+
+    // TODO (nsella): handle localization
+    if (!key_value_map_get<std::string>(dbus_goal_resolve_results, "transaction_solver_problems").empty()) {
+        std::cout << key_value_map_get<std::string>(dbus_goal_resolve_results, "transaction_solver_problems") << std::endl;
+    }
+    dnfdaemon::KeyValueMapList goal_resolve_log_list = key_value_map_get<dnfdaemon::KeyValueMapList>(dbus_goal_resolve_results, "goal_problems");
+
+    for (const auto & e : goal_resolve_log_list) {
+        libdnf::GoalAction action = static_cast<libdnf::GoalAction>(key_value_map_get<uint32_t>(e, "action"));
+        libdnf::GoalProblem problem = static_cast<libdnf::GoalProblem>(key_value_map_get<uint32_t>(e, "problem"));
+        libdnf::GoalJobSettings job_settings;
+        job_settings.to_repo_ids = key_value_map_get<dnfdaemon::KeyValueMap>(e, "goal_job_settings").at("to_repo_ids");
+        std::string report = key_value_map_get<std::string>(e, "report");
+        std::vector<std::string> report_list = key_value_map_get<std::vector<std::string>>(e, "report_list");
+        std::set<std::string> report_set { report_list.begin(), report_list.end() };
+
+        std::string format_log = libdnf::base::Transaction::format_resolve_log(
+                action,
+                problem,
+                job_settings,
+                report,
+                report_set);
+        if (!format_log.empty()) {
+            std::cout << format_log << std::endl;
+        }
+    }
+    if (static_cast<libdnf::GoalProblem>(
+            key_value_map_get<uint32_t>(dbus_goal_resolve_results, "transaction_problems")
+            ) != libdnf::GoalProblem::NO_PROBLEM) {
+        return;
+    }
     if (transaction.empty()) {
         std::cout << "Nothing to do." << std::endl;
         return;

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -37,7 +37,7 @@ public:
 
     libdnf::GoalProblem get_problems();
 
-    /// @returns <libdnf::Goal::Action, libdnf::GoalProblem, libdnf::GoalSettings settings, std::string spec>.
+    /// @returns <libdnf::GoalAction, libdnf::GoalProblem, libdnf::GoalSettings settings, std::string spec>.
     /// Returs information about resolvement of Goal except problemes related to solver
     const std::vector<std::tuple<
         libdnf::GoalAction,

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -97,12 +97,12 @@ private:
     friend class Goal;
     BaseWeakPtr base;
     std::vector<std::string> module_enable_specs;
-    /// <libdnf::Goal::Action, std::string pkg_spec, libdnf::GoalJobSettings settings>
+    /// <libdnf::GoalAction, std::string pkg_spec, libdnf::GoalJobSettings settings>
     std::vector<std::tuple<GoalAction, std::string, GoalJobSettings>> rpm_specs;
-    /// <libdnf::Goal::Action, rpm Ids, libdnf::GoalJobSettings settings>
+    /// <libdnf::GoalAction, rpm Ids, libdnf::GoalJobSettings settings>
     std::vector<std::tuple<GoalAction, libdnf::solv::IdQueue, GoalJobSettings>> rpm_ids;
 
-    /// <libdnf::Goal::Action, libdnf::GoalProblem, libdnf::GoalJobSettings settings, std::string spec, std::set<std::string> additional_data>
+    /// <libdnf::GoalAction, libdnf::GoalProblem, libdnf::GoalJobSettings settings, std::string spec, std::set<std::string> additional_data>
     std::vector<std::tuple<GoalAction, GoalProblem, GoalJobSettings, std::string, std::set<std::string>>>
         rpm_goal_reports;
 

--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -66,7 +66,7 @@ private:
 
     std::vector<TransactionPackage> packages;
 
-    /// <libdnf::Goal::Action, libdnf::GoalProblem, libdnf::GoalJobSettings settings, std::string spec, std::set<std::string> additional_data>
+    /// <libdnf::GoalAction, libdnf::GoalProblem, libdnf::GoalJobSettings settings, std::string spec, std::set<std::string> additional_data>
     std::vector<std::tuple<GoalAction, GoalProblem, GoalJobSettings, std::string, std::set<std::string>>> resolve_logs;
 
     std::vector<std::vector<std::pair<libdnf::ProblemRules, std::vector<std::string>>>> package_solver_problems;

--- a/test/dnfdaemon-server/test_downgrade.py
+++ b/test/dnfdaemon-server/test_downgrade.py
@@ -34,7 +34,7 @@ class DowngradeTest(support.InstallrootCase):
         # remove an installed package
         self.iface_rpm.downgrade(['one'], dbus.Dictionary({}, signature='sv'))
 
-        resolved = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
 
         # id of package depends on order of the repos in the sack which varies
         # between runs so we can't rely on the value
@@ -74,6 +74,16 @@ class DowngradeTest(support.InstallrootCase):
                 ], signature=dbus.Signature('(ua{sv})'))
             )
 
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(0, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    ], signature=dbus.Signature('a{sv}', variant_level=1))
+                }, signature=dbus.Signature('sv'))
+        )
+
         self.iface_goal.do_transaction(dbus.Dictionary({}, signature='sv'))
 
     def test_downgrade_fromrepo(self):
@@ -82,8 +92,31 @@ class DowngradeTest(support.InstallrootCase):
         empty transaction
         '''
         self.iface_rpm.downgrade(['one'], dbus.Dictionary({'repo_ids': ['rpm-repo2']}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
         self.assertCountEqual(
-            self.iface_goal.resolve(dbus.Dictionary({}, signature='sv')),
+            resolved,
             dbus.Array([
                 ], signature=dbus.Signature('(ua{sv})'))
             )
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(0, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    dbus.Dictionary({
+                        dbus.String('action'): dbus.UInt32(7, variant_level=1),
+                        dbus.String('problem'): dbus.UInt32(32, variant_level=1),
+                        dbus.String('goal_job_settings'): dbus.Dictionary({
+                            dbus.String('to_repo_ids'): dbus.Array([
+                                dbus.String('rpm-repo2', variant_level=1)
+                                ], signature=dbus.Signature('s'), variant_level=1)
+                            }, signature=dbus.Signature('sv'), variant_level=1),
+                        dbus.String('report'): dbus.String('one', variant_level=1),
+                        dbus.String('report_list'): dbus.Array([
+                            ], signature=dbus.Signature('s'), variant_level=1)
+                        }, signature=dbus.Signature('sv'))
+                    ], signature=dbus.Signature('a{sv}'), variant_level=1),
+                }, signature=dbus.Signature('sv'), variant_level=1)
+        )

--- a/test/dnfdaemon-server/test_install.py
+++ b/test/dnfdaemon-server/test_install.py
@@ -25,7 +25,7 @@ class InstallTest(support.InstallrootCase):
         # install a package
         self.iface_rpm.install(['one'], dbus.Dictionary({}, signature='sv'))
 
-        resolved = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
 
         # id of package depends on order of the repos in the sack which varies
         # between runs so we can't rely on the value
@@ -52,13 +52,48 @@ class InstallTest(support.InstallrootCase):
                 ], signature=dbus.Signature('(ua{sv})'))
             )
 
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(0, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    ], signature=dbus.Signature('a{sv}', variant_level=1))
+                }, signature=dbus.Signature('sv'))
+        )
+
         self.iface_goal.do_transaction(dbus.Dictionary({}, signature='sv'))
 
     def test_install_strict(self):
         '''with strict=True attempt to install nonexistent package returns error'''
         self.iface_rpm.install(['no_one'], dbus.Dictionary({'strict': True}, signature='sv'))
-        with self.assertRaises(dbus.exceptions.DBusException) as exc:
-            resolved = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        self.assertCountEqual(
+            resolved,
+            dbus.Array([
+                ], signature=dbus.Signature('(ua{sv})'))
+            )
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(4, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    dbus.Dictionary({
+                        dbus.String('action'): dbus.UInt32(0, variant_level=1),
+                        dbus.String('problem'): dbus.UInt32(4, variant_level=1),
+                        dbus.String('goal_job_settings'): dbus.Dictionary({
+                            dbus.String('to_repo_ids'): dbus.Array([
+                                ], signature=dbus.Signature('s'), variant_level=1)
+                            }, signature=dbus.Signature('sv'), variant_level=1),
+                        dbus.String('report'): dbus.String('no_one', variant_level=1),
+                        dbus.String('report_list'): dbus.Array([
+                            ], signature=dbus.Signature('s'), variant_level=1)
+                        }, signature=dbus.Signature('sv'))
+                    ], signature=dbus.Signature('a{sv}'), variant_level=1),
+                }, signature=dbus.Signature('sv'), variant_level=1)
+        )
 
     def test_install_nostrict(self):
         '''
@@ -66,16 +101,66 @@ class InstallTest(support.InstallrootCase):
         transaction
         '''
         self.iface_rpm.install(['no_one'], dbus.Dictionary({'strict': False}, signature='sv'))
+
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
         self.assertCountEqual(
-            self.iface_goal.resolve(dbus.Dictionary({}, signature='sv')),
+            resolved,
             dbus.Array([
                 ], signature=dbus.Signature('(ua{sv})'))
             )
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(0, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    dbus.Dictionary({
+                        dbus.String('action'): dbus.UInt32(0, variant_level=1),
+                        dbus.String('problem'): dbus.UInt32(4, variant_level=1),
+                        dbus.String('goal_job_settings'): dbus.Dictionary({
+                            dbus.String('to_repo_ids'): dbus.Array([
+                                ], signature=dbus.Signature('s'), variant_level=1)
+                            }, signature=dbus.Signature('sv'), variant_level=1),
+                        dbus.String('report'): dbus.String('no_one', variant_level=1),
+                        dbus.String('report_list'): dbus.Array([
+                            ], signature=dbus.Signature('s'), variant_level=1)
+                        }, signature=dbus.Signature('sv'))
+                    ], signature=dbus.Signature('a{sv}'), variant_level=1),
+                }, signature=dbus.Signature('sv'), variant_level=1)
+        )
 
     def test_install_fromrepo(self):
         '''
         attempt to install package from repo that does not contain it return error
         '''
         self.iface_rpm.install(['one'], dbus.Dictionary({'repo_ids': ['rpm-repo2']}, signature='sv'))
-        with self.assertRaises(dbus.exceptions.DBusException) as exc:
-            self.iface_goal.resolve(dbus.Dictionary({}, signature='sv')),
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+
+        self.assertCountEqual(
+            resolved,
+            dbus.Array([
+                ], signature=dbus.Signature("(ua{sv})")),
+            )
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(32, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    dbus.Dictionary({
+                        dbus.String('action'): dbus.UInt32(0, variant_level=1),
+                        dbus.String('problem'): dbus.UInt32(32, variant_level=1),
+                        dbus.String('goal_job_settings'): dbus.Dictionary({
+                            dbus.String('to_repo_ids'): dbus.Array([
+                                dbus.String('rpm-repo2', variant_level=1)
+                                ], signature=dbus.Signature('s'), variant_level=1)
+                            }, signature=dbus.Signature('sv'), variant_level=1),
+                        dbus.String('report'): dbus.String('one', variant_level=1),
+                        dbus.String('report_list'): dbus.Array([
+                            ], signature=dbus.Signature('s'), variant_level=1)
+                        }, signature=dbus.Signature('sv'))
+                    ], signature=dbus.Signature('a{sv}'), variant_level=1),
+                }, signature=dbus.Signature('sv'), variant_level=1)
+        )

--- a/test/dnfdaemon-server/test_reinstall.py
+++ b/test/dnfdaemon-server/test_reinstall.py
@@ -31,10 +31,10 @@ class ReinstallTest(support.InstallrootCase):
         self.assertEqual(res.returncode, 0, "Installation of test package '{}' failed.".format(pkg_file))
 
     def test_reinstall_package(self):
-        # remove an installed package
+        # reinstall an installed package
         self.iface_rpm.reinstall(['one'], dbus.Dictionary({}, signature='sv'))
 
-        resolved = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
 
         # id of package depends on order of the repos in the sack which varies
         # between runs so we can't rely on the value
@@ -59,7 +59,7 @@ class ReinstallTest(support.InstallrootCase):
                         }, signature=dbus.Signature('sv'))),
                     signature=None),
                 dbus.Struct((
-                    dbus.UInt32(10),   # action reinstalled
+                    dbus.UInt32(10),  # action reinstalled
                     dbus.Dictionary({ # package
                         dbus.String('evr'): dbus.String('1-1', variant_level=1),
                         dbus.String('name'): dbus.String('one', variant_level=1),
@@ -71,8 +71,122 @@ class ReinstallTest(support.InstallrootCase):
                         dbus.String('repo'): dbus.String('@System', variant_level=1),
                         }, signature=dbus.Signature('sv'))),
                     signature=None)
-                ], signature=dbus.Signature('(ua{sv})'))
-            )
+                ], signature=dbus.Signature('(ua{sv})')),
+        )
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(0, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    ], signature=dbus.Signature('a{sv}', variant_level=1))
+                }, signature=dbus.Signature('sv'))
+        )
 
         self.iface_goal.do_transaction(dbus.Dictionary({}, signature='sv'))
 
+    def test_reinstall_fromrepo(self):
+        '''
+        attempt to reinstall package from repo that does not contain it returns
+        empty transaction
+        '''
+        self.iface_rpm.reinstall(['one'], dbus.Dictionary({'repo_ids': ['rpm-repo2']}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        self.assertCountEqual(
+            resolved,
+            dbus.Array([
+                ], signature=dbus.Signature('(ua{sv})'))
+            )
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(32, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    dbus.Dictionary({
+                        dbus.String('action'): dbus.UInt32(2, variant_level=1),
+                        dbus.String('problem'): dbus.UInt32(32, variant_level=1),
+                        dbus.String('goal_job_settings'): dbus.Dictionary({
+                            dbus.String('to_repo_ids'): dbus.Array([
+                                dbus.String('rpm-repo2')
+                                ], signature=dbus.Signature('s'), variant_level=1)
+                            }, signature=dbus.Signature('sv'), variant_level=1),
+                        dbus.String('report'): dbus.String('one', variant_level=1),
+                        dbus.String('report_list'): dbus.Array([
+                            ], signature=dbus.Signature('s'), variant_level=1)
+                        }, signature=dbus.Signature('sv'))
+                    ], signature=dbus.Signature('a{sv}'), variant_level=1),
+                }, signature=dbus.Signature('sv'), variant_level=1)
+        )
+
+    def test_reinstall_not_installed(self):
+        '''
+        attempt to reinstall package available but not installed returns empty
+        transaction
+        '''
+        self.iface_rpm.reinstall(['two'], dbus.Dictionary({'repo_ids': ['rpm-repo2']}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        self.assertCountEqual(
+            resolved,
+            dbus.Array([
+                ], signature=dbus.Signature('(ua{sv})'))
+            )
+
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(64, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    dbus.Dictionary({
+                        dbus.String('action'): dbus.UInt32(2, variant_level=1),
+                        dbus.String('problem'): dbus.UInt32(64, variant_level=1),
+                        dbus.String('goal_job_settings'): dbus.Dictionary({
+                            dbus.String('to_repo_ids'): dbus.Array([
+                                dbus.String('rpm-repo2')
+                                ], signature=dbus.Signature('s'), variant_level=1)
+                            }, signature=dbus.Signature('sv'), variant_level=1),
+                        dbus.String('report'): dbus.String('two', variant_level=1),
+                        dbus.String('report_list'): dbus.Array([
+                            ], signature=dbus.Signature('s'), variant_level=1)
+                        }, signature=dbus.Signature('sv'))
+                    ], signature=dbus.Signature('a{sv}'), variant_level=1),
+                }, signature=dbus.Signature('sv'), variant_level=1)
+        )
+
+    def test_reinstall_non_existent_fromrepo(self):
+        '''
+        attempt to reinstall package from repo that does not exist it returns
+        empty transaction
+        '''
+        self.iface_rpm.reinstall(['three'], dbus.Dictionary({}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        self.assertCountEqual(
+            resolved,
+            dbus.Array([
+                ], signature=dbus.Signature('(ua{sv})'))
+            )
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(4, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    dbus.Dictionary({
+                        dbus.String('action'): dbus.UInt32(2, variant_level=1),
+                        dbus.String('problem'): dbus.UInt32(4, variant_level=1),
+                        dbus.String('goal_job_settings'): dbus.Dictionary({
+                            dbus.String('to_repo_ids'): dbus.Array([
+                                ], signature=dbus.Signature('s'), variant_level=1)
+                            }, signature=dbus.Signature('sv'), variant_level=1),
+                        dbus.String('report'): dbus.String('three', variant_level=1),
+                        dbus.String('report_list'): dbus.Array([
+                            ], signature=dbus.Signature('s'), variant_level=1)
+                        }, signature=dbus.Signature('sv'))
+                    ], signature=dbus.Signature('a{sv}'), variant_level=1),
+                }, signature=dbus.Signature('sv'), variant_level=1)
+        )

--- a/test/dnfdaemon-server/test_remove.py
+++ b/test/dnfdaemon-server/test_remove.py
@@ -34,7 +34,7 @@ class RemoveTest(support.InstallrootCase):
         # remove an installed package
         self.iface_rpm.remove(['one'], dbus.Dictionary({}, signature='sv'))
 
-        resolved = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
+        resolved, errors = self.iface_goal.resolve(dbus.Dictionary({}, signature='sv'))
 
         # id of package depends on order of the repos in the sack which varies
         # between runs so we can't rely on the value
@@ -60,5 +60,15 @@ class RemoveTest(support.InstallrootCase):
                     signature=None)
                 ], signature=dbus.Signature('(ua{sv})'))
             )
+
+        self.assertDictEqual(
+            errors,
+            dbus.Dictionary({
+                dbus.String('transaction_problems'): dbus.UInt32(0, variant_level=1),
+                dbus.String('transaction_solver_problems'): dbus.String('', variant_level=1),
+                dbus.String('goal_problems'): dbus.Array([
+                    ], signature=dbus.Signature('a{sv}', variant_level=1))
+                }, signature=dbus.Signature('sv'))
+        )
 
         self.iface_goal.do_transaction(dbus.Dictionary({}, signature='sv'))


### PR DESCRIPTION
dnfdaemon-server sends libdnf's rpm_resolve_log and
get_formatted_all_problems to the client.

This solves:
 - dnfdaemon-client reinstall <package_not_installed>
 - dnfdaemon-client reinstall <no_matching_package>