### PR TITLE
CI: Run microdnf5 CI stack tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: DNF 5 CI
 on: pull_request_target
 
 jobs:
-  integration-tests:
+  package-build:
     name: Package Build
     runs-on: ubuntu-latest
     container: ghcr.io/rpm-software-management/dnf-ci-host
@@ -48,3 +48,59 @@ jobs:
             PROJECT_NAME+="-${{matrix.compiler}}"
           fi
           rpm-gitoverlay --gitdir=gits build-overlay -s overlays/dnf5-unstable rpm --with "${{matrix.compiler}}" copr --owner "${{steps.setup-ci.outputs.copr-user}}" --project "$PROJECT_NAME" --chroots "$CHROOTS" --delete-project-after-days=7
+
+  copr-build:
+    name: Copr Build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rpm-software-management/dnf-ci-host
+    outputs:
+      package-urls: ${{steps.copr-build.outputs.package-urls}}
+    steps:
+      - name: Check out ci-dnf-stack
+        uses: actions/checkout@v2
+        with:
+          repository: rpm-software-management/ci-dnf-stack
+
+      - name: Setup CI
+        id: setup-ci
+        uses: ./.github/actions/setup-ci
+        with:
+          copr-user: ${{secrets.COPR_USER}}
+          copr-api-token: ${{secrets.COPR_API_TOKEN}}
+
+      - name: Check out sources
+        uses: actions/checkout@v2
+        with:
+          path: gits/${{github.event.repository.name}}
+          ref: ${{github.event.pull_request.head.sha}}  # check out the PR HEAD
+          fetch-depth: 0
+
+      - name: Run Copr Build
+        id: copr-build
+        uses: ./.github/actions/copr-build
+        with:
+          copr-user: ${{steps.setup-ci.outputs.copr-user}}
+
+  integration-tests:
+    name: DNF Integration Tests
+    needs: copr-build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rpm-software-management/dnf-ci-host
+      options: --privileged
+      volumes:
+        # A workaround for an undeterministic "OCI not found" error, see
+        # https://github.com/containers/podman/issues/10321
+        - /var/lib/mycontainer:/var/lib/containers
+    steps:
+      - name: Check out ci-dnf-stack
+        uses: actions/checkout@v2
+        with:
+          repository: rpm-software-management/ci-dnf-stack
+
+      - name: Run Integration Tests
+        uses: ./.github/actions/integration-tests
+        with:
+          package-urls: ${{needs.copr-build.outputs.package-urls}}
+          extra-run-args: --tags dnf5 --command microdnf5


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/1026