### PR TITLE
advisory: Clean up constructors and assignment operators

### DIFF
--- a/include/libdnf/advisory/advisory_module.hpp
+++ b/include/libdnf/advisory/advisory_module.hpp
@@ -29,10 +29,11 @@ namespace libdnf::advisory {
 class AdvisoryModule {
 public:
     AdvisoryModule(const AdvisoryModule & src);
-    AdvisoryModule(AdvisoryModule && src);
-
     AdvisoryModule & operator=(const AdvisoryModule & src);
-    AdvisoryModule & operator=(AdvisoryModule && src) noexcept;
+
+    AdvisoryModule(AdvisoryModule && src) = default;
+    AdvisoryModule & operator=(AdvisoryModule && src) = default;
+
     ~AdvisoryModule();
 
     /// Get name of this AdvisoryModule.

--- a/include/libdnf/advisory/advisory_package.hpp
+++ b/include/libdnf/advisory/advisory_package.hpp
@@ -37,10 +37,11 @@ namespace libdnf::advisory {
 class AdvisoryPackage {
 public:
     AdvisoryPackage(const AdvisoryPackage & src);
-    AdvisoryPackage(AdvisoryPackage && src);
-
     AdvisoryPackage & operator=(const AdvisoryPackage & src);
-    AdvisoryPackage & operator=(AdvisoryPackage && src) noexcept;
+
+    AdvisoryPackage(AdvisoryPackage && src) = default;
+    AdvisoryPackage & operator=(AdvisoryPackage && src) = default;
+
     ~AdvisoryPackage();
 
     /// Get name of this AdvisoryPackage.

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -37,12 +37,14 @@ class AdvisoryQuery {
 public:
     explicit AdvisoryQuery(const BaseWeakPtr & base);
     explicit AdvisoryQuery(Base & base);
-    AdvisoryQuery(const AdvisoryQuery & src);
-    AdvisoryQuery(AdvisoryQuery && src);
-    ~AdvisoryQuery();
 
+    AdvisoryQuery(const AdvisoryQuery & src);
     AdvisoryQuery & operator=(const AdvisoryQuery & src);
-    AdvisoryQuery & operator=(AdvisoryQuery && src) noexcept;
+
+    AdvisoryQuery(AdvisoryQuery && src) = default;
+    AdvisoryQuery & operator=(AdvisoryQuery && src) = default;
+
+    ~AdvisoryQuery();
 
     struct NotSupportedCmpType : public RuntimeError {
         using RuntimeError::RuntimeError;

--- a/include/libdnf/advisory/advisory_sack.hpp
+++ b/include/libdnf/advisory/advisory_sack.hpp
@@ -36,7 +36,6 @@ using AdvisorySackWeakPtr = WeakPtr<AdvisorySack, false>;
 class AdvisorySack {
 public:
     explicit AdvisorySack(const libdnf::BaseWeakPtr & base);
-    ~AdvisorySack();
 
     AdvisorySackWeakPtr get_weak_ptr() { return AdvisorySackWeakPtr(this, &sack_guard); }
 

--- a/libdnf/advisory/advisory_module.cpp
+++ b/libdnf/advisory/advisory_module.cpp
@@ -28,20 +28,14 @@ namespace libdnf::advisory {
 // AdvisoryModule
 AdvisoryModule::AdvisoryModule(AdvisoryModule::Impl * private_module) : p_impl(private_module) {}
 
-AdvisoryModule::~AdvisoryModule() = default;
-
 AdvisoryModule::AdvisoryModule(const AdvisoryModule & src) : p_impl(new Impl(*src.p_impl)) {}
-AdvisoryModule::AdvisoryModule(AdvisoryModule && other) : p_impl(new Impl(std::move(*other.p_impl))) {}
 
 AdvisoryModule & AdvisoryModule::operator=(const AdvisoryModule & src) {
     *p_impl = *src.p_impl;
     return *this;
 }
 
-AdvisoryModule & AdvisoryModule::operator=(AdvisoryModule && src) noexcept {
-    p_impl.swap(src.p_impl);
-    return *this;
-}
+AdvisoryModule::~AdvisoryModule() = default;
 
 
 std::string AdvisoryModule::get_name() const {
@@ -88,49 +82,5 @@ AdvisoryModule::Impl::Impl(
     , version(version)
     , context(context)
     , arch(arch) {}
-
-AdvisoryModule::Impl::Impl(const Impl & other)
-    : base(other.base)
-    , advisory(other.advisory)
-    , owner_collection_index(other.owner_collection_index)
-    , name(other.name)
-    , stream(other.stream)
-    , version(other.version)
-    , context(other.context)
-    , arch(other.arch) {}
-
-AdvisoryModule::Impl::Impl(Impl && other)
-    : base(std::move(other.base))
-    , advisory(std::move(other.advisory))
-    , owner_collection_index(other.owner_collection_index)
-    , name(std::move(other.name))
-    , stream(std::move(other.stream))
-    , version(std::move(other.version))
-    , context(std::move(other.context))
-    , arch(std::move(other.arch)) {}
-
-AdvisoryModule::Impl & AdvisoryModule::Impl::operator=(const Impl & other) {
-    base = other.base;
-    advisory = other.advisory;
-    owner_collection_index = other.owner_collection_index;
-    name = other.name;
-    stream = other.stream;
-    version = other.version;
-    context = other.context;
-    arch = other.arch;
-    return *this;
-}
-
-AdvisoryModule::Impl & AdvisoryModule::Impl::operator=(Impl && other) {
-    base = std::move(other.base);
-    advisory = std::move(other.advisory);
-    owner_collection_index = std::move(other.owner_collection_index);
-    name = std::move(other.name);
-    stream = std::move(other.stream);
-    version = std::move(other.version);
-    context = std::move(other.context);
-    arch = std::move(other.arch);
-    return *this;
-}
 
 }  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_module_private.hpp
+++ b/libdnf/advisory/advisory_module_private.hpp
@@ -31,15 +31,6 @@ namespace libdnf::advisory {
 //              AdvisoryModules (less classes, less overhead), but we would end
 //              up with libsolv ints (Ids) in a public header.
 class AdvisoryModule::Impl {
-public:
-    /// Copy constructor: clone from an existing AdvisoryModule::Impl
-    Impl(const Impl & other);
-    /// Move constructor: clone from an existing AdvisoryModule::Impl
-    Impl(Impl && other);
-
-    Impl & operator=(const Impl & other);
-    Impl & operator=(Impl && other);
-
 private:
     friend class AdvisoryCollection;
     friend AdvisoryModule;

--- a/libdnf/advisory/advisory_package.cpp
+++ b/libdnf/advisory/advisory_package.cpp
@@ -34,20 +34,14 @@ namespace libdnf::advisory {
 // AdvisoryPackage
 AdvisoryPackage::AdvisoryPackage(AdvisoryPackage::Impl * private_pkg) : p_impl(private_pkg) {}
 
-AdvisoryPackage::~AdvisoryPackage() = default;
-
 AdvisoryPackage::AdvisoryPackage(const AdvisoryPackage & src) : p_impl(new Impl(*src.p_impl)) {}
-AdvisoryPackage::AdvisoryPackage(AdvisoryPackage && src) : p_impl(new Impl(std::move(*src.p_impl))) {}
 
 AdvisoryPackage & AdvisoryPackage::operator=(const AdvisoryPackage & src) {
     *p_impl = *src.p_impl;
     return *this;
 }
 
-AdvisoryPackage & AdvisoryPackage::operator=(AdvisoryPackage && src) noexcept {
-    p_impl.swap(src.p_impl);
-    return *this;
-}
+AdvisoryPackage::~AdvisoryPackage() = default;
 
 
 std::string AdvisoryPackage::get_name() const {
@@ -90,47 +84,6 @@ AdvisoryPackage::Impl::Impl(
     , arch(arch)
     , filename(filename)
     , base(base) {}
-
-AdvisoryPackage::Impl::Impl(const Impl & other)
-    : advisory(other.advisory)
-    , owner_collection_index(other.owner_collection_index)
-    , name(other.name)
-    , evr(other.evr)
-    , arch(other.arch)
-    , filename(other.filename)
-    , base(other.base) {}
-
-AdvisoryPackage::Impl::Impl(Impl && other)
-    : advisory(std::move(other.advisory))
-    , owner_collection_index(other.owner_collection_index)
-    , name(std::move(other.name))
-    , evr(std::move(other.evr))
-    , arch(std::move(other.arch))
-    , filename(std::move(other.filename))
-    , base(std::move(other.base)) {}
-
-AdvisoryPackage::Impl & AdvisoryPackage::Impl::operator=(const Impl & other) {
-    advisory = other.advisory;
-    owner_collection_index = other.owner_collection_index;
-    name = other.name;
-    evr = other.evr;
-    arch = other.arch;
-    filename = other.filename;
-    base = other.base;
-    return *this;
-}
-
-AdvisoryPackage::Impl & AdvisoryPackage::Impl::operator=(Impl && other) {
-    advisory = std::move(other.advisory);
-    owner_collection_index = std::move(other.owner_collection_index);
-    name = std::move(other.name);
-    evr = std::move(other.evr);
-    arch = std::move(other.arch);
-    filename = std::move(other.filename);
-    base = std::move(other.base);
-    return *this;
-}
-
 
 std::string AdvisoryPackage::Impl::get_name() const {
     return get_pool(base).id2str(name);

--- a/libdnf/advisory/advisory_package_private.hpp
+++ b/libdnf/advisory/advisory_package_private.hpp
@@ -34,14 +34,6 @@ namespace libdnf::advisory {
 //              up with libsolv ints (Ids) in a public header.
 class AdvisoryPackage::Impl {
 public:
-    /// Copy constructor: clone from an existing AdvisoryPackage::Impl
-    Impl(const Impl & other);
-    /// Move constructor: clone from an existing AdvisoryPackage::Impl
-    Impl(Impl && other);
-
-    Impl & operator=(const Impl & other);
-    Impl & operator=(Impl && other);
-
     std::string get_name() const;
     std::string get_version() const;
     std::string get_evr() const;

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -42,13 +42,7 @@ AdvisoryQuery::AdvisoryQuery(const BaseWeakPtr & base) : base(base) {
 
 AdvisoryQuery::AdvisoryQuery(Base & base) : AdvisoryQuery(base.get_weak_ptr()) {}
 
-AdvisoryQuery::~AdvisoryQuery() = default;
-
 AdvisoryQuery::AdvisoryQuery(const AdvisoryQuery & src) : base(src.base), p_impl(new Impl(*src.p_impl)) {}
-
-AdvisoryQuery::AdvisoryQuery(AdvisoryQuery && src)
-    : base(std::move(src.base)),
-      p_impl(new Impl(std::move(*src.p_impl))) {}
 
 AdvisoryQuery & AdvisoryQuery::operator=(const AdvisoryQuery & src) {
     base = src.base;
@@ -56,11 +50,8 @@ AdvisoryQuery & AdvisoryQuery::operator=(const AdvisoryQuery & src) {
     return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::operator=(AdvisoryQuery && src) noexcept {
-    base = std::move(src.base);
-    p_impl.swap(src.p_impl);
-    return *this;
-}
+AdvisoryQuery::~AdvisoryQuery() = default;
+
 
 AdvisoryQuery & AdvisoryQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp_type) {
     const std::vector<std::string> patterns = {pattern};

--- a/libdnf/advisory/advisory_sack.cpp
+++ b/libdnf/advisory/advisory_sack.cpp
@@ -28,8 +28,6 @@ namespace libdnf::advisory {
 
 AdvisorySack::AdvisorySack(const libdnf::BaseWeakPtr & base) : base(base) {}
 
-AdvisorySack::~AdvisorySack() = default;
-
 void AdvisorySack::load_advisories() {
     auto & pool = get_pool(base);
 


### PR DESCRIPTION
Default implementations should be used when possible. In case of our
pimpls, we only need to define copy constructors and assignment
operators, as unique_ptr isn't copyable. Since we define these, the
compiler won't generate the move variants automatically, but we can
still use the default implementation by declaring them "= default".

For the Impl classes, we don't need to define any of these, the
generated ones are fine.

On a side note the "= default" destructor definition inside the .cpp
files is there because the automatically generated definition is inlined
in the header and the complier fails on incomplete type of the Impl
class in that case.