### PR TITLE
spec: systemd scriptlets for dnfdaemon-server

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -363,6 +363,7 @@ License:        GPLv2+
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       libdnf-cli%{?_isa} = %{version}-%{release}
 Requires:       dnf-data
+%{?systemd_requires}
 BuildRequires:  pkgconfig(sdbus-c++) >= 0.8.1
 %if %{with dnfdaemon_tests}
 BuildRequires:  dbus-daemon
@@ -373,6 +374,15 @@ BuildRequires:  python3dist(dbus-python)
 
 %description -n dnfdaemon-server
 Package management service with a DBus interface
+
+%post -n dnfdaemon-server
+%systemd_post dnfdaemon-server.service
+
+%preun -n dnfdaemon-server
+%systemd_preun dnfdaemon-server.service
+
+%postun -n dnfdaemon-server
+%systemd_postun_with_restart dnfdaemon-server.service
 
 %files -n dnfdaemon-server
 %{_bindir}/dnfdaemon-server


### PR DESCRIPTION
There is a problem that dnfdaemon-server process remains running even after removal of dnfdaemon-server package.
This PR fixes this but unfortunately doesn't work in our CI testing containers.

```
# rpm --eval "%systemd_preun dnfdaemon-server.service"

if [ $1 -eq 0 ] && [ -x /usr/bin/systemctl ]; then 
    # Package removal, not upgrade 
    if [ -d /run/systemd/system ]; then 
          /usr/bin/systemctl --no-reload disable --now dnfdaemon-server.service || : 
    else 
          /usr/bin/systemctl --no-reload disable dnfdaemon-server.service || : 
    fi 
fi

# /usr/bin/systemctl --no-reload disable --now dnfdaemon-server.service
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
```
