### PR TITLE
[dnf5] rpm::Transaction: use base::TransactionPackage, fix memory leaks, fill method

### DIFF
--- a/dnfdaemon-client/callbacks.cpp
+++ b/dnfdaemon-client/callbacks.cpp
@@ -341,25 +341,25 @@ void TransactionCB::action_start(sdbus::Signal & signal) {
         signal >> nevra;
         signal >> action_i;
         signal >> total;
-        auto action = static_cast<dnfdaemon::RpmTransactionItem::Actions>(action_i);
+        auto action = static_cast<dnfdaemon::RpmTransactionItemActions>(action_i);
         std::string msg;
         switch (action) {
-            case dnfdaemon::RpmTransactionItem::Actions::INSTALL:
+            case dnfdaemon::RpmTransactionItemActions::INSTALL:
                 msg = "Installing";
                 break;
-            case dnfdaemon::RpmTransactionItem::Actions::ERASE:
+            case dnfdaemon::RpmTransactionItemActions::ERASE:
                 msg = "Erasing";
                 break;
-            case dnfdaemon::RpmTransactionItem::Actions::DOWNGRADE:
+            case dnfdaemon::RpmTransactionItemActions::DOWNGRADE:
                 msg = "Downgrading";
                 break;
-            case dnfdaemon::RpmTransactionItem::Actions::UPGRADE:
+            case dnfdaemon::RpmTransactionItemActions::UPGRADE:
                 msg = "Upgrading";
                 break;
-            case dnfdaemon::RpmTransactionItem::Actions::REINSTALL:
+            case dnfdaemon::RpmTransactionItemActions::REINSTALL:
                 msg = "Reinstalling";
                 break;
-            case dnfdaemon::RpmTransactionItem::Actions::CLEANUP:
+            case dnfdaemon::RpmTransactionItemActions::CLEANUP:
                 msg = "Cleanup";
                 break;
         }

--- a/dnfdaemon-client/wrappers/dbus_goal_wrapper.cpp
+++ b/dnfdaemon-client/wrappers/dbus_goal_wrapper.cpp
@@ -23,7 +23,7 @@ namespace dnfdaemon::client {
 
 DbusGoalWrapper::DbusGoalWrapper(std::vector<dnfdaemon::DbusTransactionItem> transaction) {
     for (auto & ti : transaction) {
-        packages.push_back(DbusTransactionPackageWrapper(ti));
+        transaction_packages.push_back(DbusTransactionPackageWrapper(ti));
     }
 }
 

--- a/dnfdaemon-client/wrappers/dbus_goal_wrapper.hpp
+++ b/dnfdaemon-client/wrappers/dbus_goal_wrapper.hpp
@@ -34,10 +34,10 @@ class DbusGoalWrapper {
 public:
     DbusGoalWrapper(std::vector<dnfdaemon::DbusTransactionItem>);
 
-    std::vector<DbusTransactionPackageWrapper> get_packages() const { return packages; };
+    std::vector<DbusTransactionPackageWrapper> get_transaction_packages() const { return transaction_packages; };
 
 private:
-    std::vector<DbusTransactionPackageWrapper> packages;
+    std::vector<DbusTransactionPackageWrapper> transaction_packages;
 };
 
 }  // namespace dnfdaemon::client

--- a/dnfdaemon-server/callbacks.cpp
+++ b/dnfdaemon-server/callbacks.cpp
@@ -157,14 +157,14 @@ sdbus::Signal DbusTransactionCB::create_signal_pkg(
 void DbusTransactionCB::install_start(
     const libdnf::rpm::TransactionItem * item, const libdnf::rpm::RpmHeader & header, uint64_t total) {
     try {
-        int action;
-        if (auto trans_item = static_cast<const dnfdaemon::RpmTransactionItem *>(item)) {
-            action = static_cast<int>(trans_item->get_action());
+        dnfdaemon::RpmTransactionItemActions action;
+        if (item) {
+            action = dnfdaemon::transaction_package_to_action(*item);
         } else {
-            action = static_cast<int>(dnfdaemon::RpmTransactionItem::Actions::CLEANUP);
+            action = dnfdaemon::RpmTransactionItemActions::CLEANUP;
         }
         auto signal = create_signal_pkg(dnfdaemon::INTERFACE_RPM, dnfdaemon::SIGNAL_TRANSACTION_ACTION_START, header);
-        signal << action;
+        signal << static_cast<int>(action);
         signal << total;
         dbus_object->emitSignal(signal);
     } catch (...) {

--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -67,7 +67,7 @@ sdbus::MethodReply Goal::resolve(sdbus::MethodCall & call) {
 
     std::vector<dnfdaemon::DbusTransactionItem> result;
 
-    for (auto & tspkg : transaction.get_packages()) {
+    for (auto & tspkg : transaction.get_transaction_packages()) {
         result.push_back(dnfdaemon::DbusTransactionItem(
             static_cast<unsigned int>(tspkg.get_action()), package_to_map(tspkg.get_package(), attr)));
     }
@@ -103,7 +103,7 @@ libdnf::transaction::TransactionWeakPtr new_db_transaction(libdnf::Base * base, 
 // TODO (mblaha) callbacks to report the status
 void download_packages(Session & session, libdnf::base::Transaction & transaction) {
     std::vector<libdnf::rpm::Package> download_pkgs;
-    for (auto & tspkg : transaction.get_packages()) {
+    for (auto & tspkg : transaction.get_transaction_packages()) {
         if (tspkg.get_action() == libdnf::transaction::TransactionItemAction::INSTALL ||
             tspkg.get_action() == libdnf::transaction::TransactionItemAction::REINSTALL ||
             tspkg.get_action() == libdnf::transaction::TransactionItemAction::UPGRADE ||
@@ -164,10 +164,10 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
 
     libdnf::rpm::Transaction rpm_transaction(*base);
     std::vector<std::unique_ptr<libdnf::base::TransactionPackage>> transaction_items;
-    rpm_transaction.fill_transaction<libdnf::base::TransactionPackage>(transaction->get_packages(), transaction_items);
+    rpm_transaction.fill_transaction<libdnf::base::TransactionPackage>(transaction->get_transaction_packages(), transaction_items);
 
     auto db_transaction = new_db_transaction(base, comment);
-    db_transaction->fill_transaction_packages(transaction->get_packages());
+    db_transaction->fill_transaction_packages(transaction->get_transaction_packages());
 
     auto time = std::chrono::system_clock::now().time_since_epoch();
     db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());

--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -163,8 +163,7 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
     download_packages(session, *transaction);
 
     libdnf::rpm::Transaction rpm_transaction(*base);
-    std::vector<std::unique_ptr<libdnf::base::TransactionPackage>> transaction_items;
-    rpm_transaction.fill_transaction<libdnf::base::TransactionPackage>(transaction->get_transaction_packages(), transaction_items);
+    rpm_transaction.fill(*transaction);
 
     auto db_transaction = new_db_transaction(base, comment);
     db_transaction->fill_transaction_packages(transaction->get_transaction_packages());

--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -163,8 +163,8 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
     download_packages(session, *transaction);
 
     libdnf::rpm::Transaction rpm_transaction(*base);
-    std::vector<std::unique_ptr<dnfdaemon::RpmTransactionItem>> transaction_items;
-    rpm_transaction.fill_transaction<dnfdaemon::RpmTransactionItem>(transaction->get_packages(), transaction_items);
+    std::vector<std::unique_ptr<libdnf::base::TransactionPackage>> transaction_items;
+    rpm_transaction.fill_transaction<libdnf::base::TransactionPackage>(transaction->get_packages(), transaction_items);
 
     auto db_transaction = new_db_transaction(base, comment);
     db_transaction->fill_transaction_packages(transaction->get_packages());

--- a/dnfdaemon-server/transaction.cpp
+++ b/dnfdaemon-server/transaction.cpp
@@ -24,33 +24,28 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon {
 
-RpmTransactionItem::RpmTransactionItem(const libdnf::base::TransactionPackage & tspkg)
-    : TransactionItem(tspkg.get_package()) {
+RpmTransactionItemActions transaction_package_to_action(const libdnf::base::TransactionPackage & tspkg) {
     switch (tspkg.get_action()) {
-        case libdnf::transaction::TransactionItemAction::INSTALL:
-            action = Actions::INSTALL;
-            break;
+        case libdnf::base::TransactionPackage::Action::INSTALL:
+            return RpmTransactionItemActions::INSTALL;
         case libdnf::transaction::TransactionItemAction::UPGRADE:
-            action = Actions::UPGRADE;
-            break;
-        case libdnf::transaction::TransactionItemAction::DOWNGRADE:
-            action = Actions::DOWNGRADE;
-            break;
-        case libdnf::transaction::TransactionItemAction::REINSTALL:
-            action = Actions::REINSTALL;
-            break;
-        case libdnf::transaction::TransactionItemAction::REMOVE:
-        case libdnf::transaction::TransactionItemAction::OBSOLETED:
-            action = Actions::ERASE;
-            break;
-        case libdnf::transaction::TransactionItemAction::REINSTALLED:
-        case libdnf::transaction::TransactionItemAction::UPGRADED:
-        case libdnf::transaction::TransactionItemAction::DOWNGRADED:
-        case libdnf::transaction::TransactionItemAction::OBSOLETE:
-        case libdnf::transaction::TransactionItemAction::REASON_CHANGE:
+            return RpmTransactionItemActions::UPGRADE;
+        case libdnf::base::TransactionPackage::Action::DOWNGRADE:
+            return RpmTransactionItemActions::DOWNGRADE;
+        case libdnf::base::TransactionPackage::Action::REINSTALL:
+            return RpmTransactionItemActions::REINSTALL;
+        case libdnf::base::TransactionPackage::Action::REMOVE:
+        case libdnf::base::TransactionPackage::Action::OBSOLETED:
+            return RpmTransactionItemActions::ERASE;
+        case libdnf::base::TransactionPackage::Action::REINSTALLED:
+        case libdnf::base::TransactionPackage::Action::UPGRADED:
+        case libdnf::base::TransactionPackage::Action::DOWNGRADED:
+        case libdnf::base::TransactionPackage::Action::OBSOLETE:
+        case libdnf::base::TransactionPackage::Action::REASON_CHANGE:
             // TODO(lukash) handle cases
             throw libdnf::LogicError(fmt::format("Unexpected action in RpmTransactionItem: {}", tspkg.get_action()));
     }
+    throw libdnf::LogicError(fmt::format("Unknown action in RpmTransactionItem: {}", tspkg.get_action()));
 }
 
 }  // namespace dnfdaemon

--- a/dnfdaemon-server/transaction.hpp
+++ b/dnfdaemon-server/transaction.hpp
@@ -28,16 +28,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon {
 
-class RpmTransactionItem : public libdnf::rpm::TransactionItem {
-public:
-    enum class Actions { INSTALL, ERASE, UPGRADE, DOWNGRADE, REINSTALL, CLEANUP };
+enum class RpmTransactionItemActions { INSTALL, ERASE, UPGRADE, DOWNGRADE, REINSTALL, CLEANUP };
 
-    RpmTransactionItem(const libdnf::base::TransactionPackage & tspkg);
-    Actions get_action() const noexcept { return action; }
-
-private:
-    Actions action;
-};
+RpmTransactionItemActions transaction_package_to_action(const libdnf::base::TransactionPackage & tspkg);
 
 }  // namespace dnfdaemon
 

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -48,7 +48,8 @@ public:
     get_resolve_logs();
 
     /// @return the transaction packages.
-    std::vector<libdnf::base::TransactionPackage> get_packages();
+    // TODO(jrohel): Return reference instead of copy?
+    std::vector<libdnf::base::TransactionPackage> get_transaction_packages() const;
 
     /// Convert an element from resolve log to string;
     static std::string format_resolve_log(

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -50,6 +50,12 @@ private:
 /// Class for access RPM header
 class RpmHeader {
 public:
+    RpmHeader(const RpmHeader & src);
+    RpmHeader(RpmHeader && src);
+    ~RpmHeader();
+    RpmHeader & operator=(const RpmHeader & src);
+    RpmHeader & operator=(RpmHeader && src);
+
     std::string get_name() const;
     uint64_t get_epoch() const noexcept;
     std::string get_version() const;
@@ -62,7 +68,7 @@ public:
 
 private:
     friend class Transaction;
-    explicit RpmHeader(void * hdr) : header(hdr) {}
+    explicit RpmHeader(void * hdr);
     void * header;
 };
 

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -310,52 +310,9 @@ public:
     /// @param item  item to be erased
     void erase(TransactionItem & item);
 
-    /// Fill the RPM transaction from transaction packages.
-    /// @param transcation_packages The transaction packages to add.
-    /// @param rpm_transcation_items_out A vector of RPM transaction items of type T which will be filled up.
-    ///                                  TODO(lukash) temporary, needs more code moving around to simplify.
-    template<typename T>
-    void fill_transaction(
-        const std::vector<libdnf::base::TransactionPackage> & transaction_packages,
-        std::vector<std::unique_ptr<T>> & rpm_transaction_items_out) {
-        for (auto & tspkg : transaction_packages) {
-            // The rpm_transaction_items_out argument is a reference to a
-            // vector in which to store the new transaction items that are
-            // being created. They are stored in unique_ptrs so that we can
-            // then pull the raw pointers from them and pass these to RPM. RPM
-            // stores the pointers and passes them into the transaction
-            // callbacks. The lambda therefore creates a new unique_ptr, stores
-            // it into the output vector, and returns the raw pointer, which is
-            // then passed to RPM.
-            auto fiddle_the_ptr = [&rpm_transaction_items_out](const libdnf::base::TransactionPackage & tspkg) {
-                auto item = std::make_unique<T>(tspkg);
-                auto item_ptr = item.get();
-                rpm_transaction_items_out.push_back(std::move(item));
-                return item_ptr;
-            };
-
-            switch (tspkg.get_action()) {
-                case libdnf::transaction::TransactionItemAction::INSTALL:
-                    install(*fiddle_the_ptr(tspkg));
-                    break;
-                case libdnf::transaction::TransactionItemAction::REINSTALL:
-                    reinstall(*fiddle_the_ptr(tspkg));
-                    break;
-                case libdnf::transaction::TransactionItemAction::UPGRADE:
-                    upgrade(*fiddle_the_ptr(tspkg));
-                    break;
-                case libdnf::transaction::TransactionItemAction::DOWNGRADE:
-                    downgrade(*fiddle_the_ptr(tspkg));
-                    break;
-                case libdnf::transaction::TransactionItemAction::REMOVE:
-                case libdnf::transaction::TransactionItemAction::OBSOLETED:
-                    erase(*fiddle_the_ptr(tspkg));
-                    break;
-                default:
-                    ; // TODO(lukash) handle the other cases
-            }
-        }
-    }
+    /// Fill the RPM transaction from base::Transaction.
+    /// @param transcation The base::Transaction object.
+    void fill(const base::Transaction & transaction);
 
     /// Perform a dependency check on the transaction set.
     /// After headers have been added to a transaction set,

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -36,15 +36,7 @@ class RpmProblemSet;
 
 
 /// Class represents one item in transaction set.
-class TransactionItem {
-public:
-    explicit TransactionItem(Package pkg) : pkg(std::move(pkg)) {}
-    const Package & get_pkg() const noexcept { return pkg; }
-    Package & get_pkg() noexcept { return pkg; }
-
-private:
-    Package pkg;
-};
+using TransactionItem = base::TransactionPackage;
 
 
 /// Class for access RPM header

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -284,32 +284,6 @@ public:
     // Set transaction notify callback.
     void register_cb(TransactionCB * cb);
 
-    /// Add package to be installed to transaction set.
-    /// The transaction set is checked for duplicate package names.
-    /// If found, the package with the "newest" EVR will be replaced.
-    /// @param item  item to be installed
-    void install(TransactionItem & item);
-
-    /// Add package to be upgraded to transaction set.
-    /// The transaction set is checked for duplicate package names.
-    /// If found, the package with the "newest" EVR will be replaced.
-    /// @param item  item to be upgraded
-    void upgrade(TransactionItem & item);
-
-    /// Add package to be downgraded to transaction set.
-    /// The transaction set is checked for duplicate package names.
-    /// If found, the package with the "newest" EVR will be replaced.
-    /// @param item  item to be downgraded
-    void downgrade(TransactionItem & item);
-
-    /// Add package to be reinstalled to transaction set.
-    /// @param item  item to be reinstalled
-    void reinstall(TransactionItem & item);
-
-    /// Add package to be erased to transaction set.
-    /// @param item  item to be erased
-    void erase(TransactionItem & item);
-
     /// Fill the RPM transaction from base::Transaction.
     /// @param transcation The base::Transaction object.
     void fill(const base::Transaction & transaction);

--- a/libdnf-cli/output/transaction_table.hpp
+++ b/libdnf-cli/output/transaction_table.hpp
@@ -219,7 +219,7 @@ template <class Transaction>
 bool print_transaction_table(Transaction & transaction) {
     // TODO (nsella) split function into create/print if possible
     //static struct libscols_table * create_transaction_table(bool with_status) {}
-    auto tspkgs = transaction.get_packages();
+    auto tspkgs = transaction.get_transaction_packages();
 
     if (tspkgs.empty()) {
         std::cout << "Nothing to do." << std::endl;

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -207,7 +207,7 @@ GoalProblem Transaction::get_problems() {
     return p_impl->problems;
 }
 
-std::vector<TransactionPackage> Transaction::get_packages() {
+std::vector<TransactionPackage> Transaction::get_transaction_packages() const {
     return p_impl->packages;
 }
 

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -785,26 +785,6 @@ void Transaction::register_cb(TransactionCB * cb) {
     p_impl->register_cb(cb);
 }
 
-void Transaction::install(TransactionItem & item) {
-    p_impl->install(item);
-}
-
-void Transaction::upgrade(TransactionItem & item) {
-    p_impl->upgrade(item);
-}
-
-void Transaction::downgrade(TransactionItem & item) {
-    p_impl->downgrade(item);
-}
-
-void Transaction::reinstall(TransactionItem & item) {
-    p_impl->reinstall(item);
-}
-
-void Transaction::erase(TransactionItem & item) {
-    p_impl->erase(item);
-}
-
 void Transaction::fill(const base::Transaction & transaction) {
     p_impl->fill(transaction.get_transaction_packages());
 }

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -43,6 +43,35 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::rpm {
 
+RpmHeader::RpmHeader(void * hdr) : header(headerLink(static_cast<Header>(hdr))) {}
+
+RpmHeader::RpmHeader(const RpmHeader & src) : header(headerLink(static_cast<Header>(src.header))) {}
+
+RpmHeader::RpmHeader(RpmHeader && src) : header(src.header) {
+    src.header = nullptr;
+}
+
+RpmHeader::~RpmHeader() {
+    headerFree(static_cast<Header>(header));
+}
+
+RpmHeader & RpmHeader::operator=(const RpmHeader & src) {
+    if (&src != this) {
+        headerFree(static_cast<Header>(header));
+        header = headerLink(static_cast<Header>(src.header));
+    }
+    return *this;
+}
+
+RpmHeader & RpmHeader::operator=(RpmHeader && src) {
+    if (&src != this) {
+        headerFree(static_cast<Header>(header));
+        header = src.header;
+        src.header = nullptr;
+    }
+    return *this;
+}
+
 std::string RpmHeader::get_name() const {
     return headerGetString(static_cast<Header>(header), RPMTAG_NAME);
 }

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -374,6 +374,7 @@ public:
         auto file_path = item.get_pkg().get_package_path();
         auto * header = read_pkg_header(file_path);
         auto rc = rpmtsAddReinstallElement(ts, header, &item);
+        headerFree(header);
         if (rc != 0) {
             std::string msg = "Can't reinstall package \"" + file_path + "\"";
             throw Exception(msg);
@@ -668,6 +669,7 @@ void Transaction::Impl::install_up_down(TransactionItem & item, libdnf::transact
     auto file_path = item.get_pkg().get_package_path();
     auto * header = read_pkg_header(file_path);
     auto rc = rpmtsAddInstallElement(ts, header, &item, upgrade ? 1 : 0, nullptr);
+    headerFree(header);
     if (rc != 0) {
         std::string msg = "Can't " + msg_action + " package \"" + file_path + "\"";
         throw Exception(msg);

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -400,7 +400,7 @@ public:
     /// Add package to be reinstalled to transaction set.
     /// @param item  item to be reinstalled
     void reinstall(TransactionItem & item) {
-        auto file_path = item.get_pkg().get_package_path();
+        auto file_path = item.get_package().get_package_path();
         auto * header = read_pkg_header(file_path);
         auto rc = rpmtsAddReinstallElement(ts, header, &item);
         headerFree(header);
@@ -413,7 +413,7 @@ public:
     /// Add package to be erased to transaction set.
     /// @param item  item to be erased
     void erase(TransactionItem & item) {
-        auto rpmdb_id = static_cast<unsigned int>(item.get_pkg().get_rpmdbid());
+        auto rpmdb_id = static_cast<unsigned int>(item.get_package().get_rpmdbid());
         auto * header = get_header(rpmdb_id);
         int unused = -1;
         int rc = rpmtsAddEraseElement(ts, header, unused);
@@ -562,7 +562,7 @@ private:
                 cb.install_start(item, RpmHeader(hdr), total);
                 break;
             case RPMCALLBACK_INST_OPEN_FILE: {
-                auto file_path = item->get_pkg().get_package_path();
+                auto file_path = item->get_package().get_package_path();
                 if (file_path.empty()) {
                     return nullptr;
                 }
@@ -695,7 +695,7 @@ void Transaction::Impl::install_up_down(TransactionItem & item, libdnf::transact
     } else {
         throw LogicError("Unsupported action");
     }
-    auto file_path = item.get_pkg().get_package_path();
+    auto file_path = item.get_package().get_package_path();
     auto * header = read_pkg_header(file_path);
     auto rc = rpmtsAddInstallElement(ts, header, &item, upgrade ? 1 : 0, nullptr);
     headerFree(header);

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -318,10 +318,10 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
 
     libdnf::rpm::Transaction rpm_transaction(base);
     std::vector<std::unique_ptr<libdnf::base::TransactionPackage>> transaction_items;
-    rpm_transaction.fill_transaction<libdnf::base::TransactionPackage>(transaction.get_packages(), transaction_items);
+    rpm_transaction.fill_transaction<libdnf::base::TransactionPackage>(transaction.get_transaction_packages(), transaction_items);
 
     auto db_transaction = new_db_transaction();
-    db_transaction->fill_transaction_packages(transaction.get_packages());
+    db_transaction->fill_transaction_packages(transaction.get_transaction_packages());
 
     auto time = std::chrono::system_clock::now().time_since_epoch();
     db_transaction->set_dt_start(std::chrono::duration_cast<std::chrono::seconds>(time).count());
@@ -330,7 +330,7 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
     run_transaction(rpm_transaction);
 
     auto & system_state = base.get_rpm_package_sack()->get_system_state();
-    for (const auto & tspkg : transaction.get_packages()) {
+    for (const auto & tspkg : transaction.get_transaction_packages()) {
         system_state.set_reason(tspkg.get_package().get_na(), tspkg.get_reason());
     }
 
@@ -502,7 +502,7 @@ void download_packages(const std::vector<libdnf::rpm::Package> & packages, const
 
 void download_packages(libdnf::base::Transaction & transaction, const char * dest_dir) {
     std::vector<libdnf::rpm::Package> downloads;
-    for (auto & tspkg : transaction.get_packages()) {
+    for (auto & tspkg : transaction.get_transaction_packages()) {
         if (tspkg.get_action() == libdnf::transaction::TransactionItemAction::INSTALL || \
             tspkg.get_action() == libdnf::transaction::TransactionItemAction::REINSTALL || \
             tspkg.get_action() == libdnf::transaction::TransactionItemAction::UPGRADE || \

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -317,8 +317,7 @@ void Context::download_and_run(libdnf::base::Transaction & transaction) {
     std::cout << std::endl;
 
     libdnf::rpm::Transaction rpm_transaction(base);
-    std::vector<std::unique_ptr<libdnf::base::TransactionPackage>> transaction_items;
-    rpm_transaction.fill_transaction<libdnf::base::TransactionPackage>(transaction.get_transaction_packages(), transaction_items);
+    rpm_transaction.fill(transaction);
 
     auto db_transaction = new_db_transaction();
     db_transaction->fill_transaction_packages(transaction.get_transaction_packages());

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -65,7 +65,7 @@ void BaseGoalTest::test_install() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_install_not_available() {
@@ -78,7 +78,7 @@ void BaseGoalTest::test_install_not_available() {
     goal.add_rpm_install("not_available");
     auto transaction = goal.resolve(false);
 
-    CPPUNIT_ASSERT(transaction.get_packages().empty());
+    CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 
     auto & log = transaction.get_resolve_logs();
     CPPUNIT_ASSERT_EQUAL(1lu, log.size());
@@ -109,7 +109,7 @@ void BaseGoalTest::test_install_from_cmdline() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_install_multilib_all() {
@@ -135,7 +135,7 @@ void BaseGoalTest::test_install_multilib_all() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_reinstall() {
@@ -161,7 +161,7 @@ void BaseGoalTest::test_reinstall() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_reinstall_user() {
@@ -187,7 +187,7 @@ void BaseGoalTest::test_reinstall_user() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_remove() {
@@ -206,7 +206,7 @@ void BaseGoalTest::test_remove() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_remove_not_installed() {
@@ -216,7 +216,7 @@ void BaseGoalTest::test_remove_not_installed() {
     goal.add_rpm_remove("not_installed");
     auto transaction = goal.resolve(false);
 
-    CPPUNIT_ASSERT(transaction.get_packages().empty());
+    CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 
     auto & log = transaction.get_resolve_logs();
     CPPUNIT_ASSERT_EQUAL(1lu, log.size());
@@ -244,7 +244,7 @@ void BaseGoalTest::test_install_installed_pkg() {
 
     auto transaction = goal.resolve(false);
 
-    CPPUNIT_ASSERT(transaction.get_packages().empty());
+    CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 }
 
 void BaseGoalTest::test_upgrade() {
@@ -272,7 +272,7 @@ void BaseGoalTest::test_upgrade() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_upgrade_not_available() {
@@ -286,7 +286,7 @@ void BaseGoalTest::test_upgrade_not_available() {
 
     auto transaction = goal.resolve(false);
 
-    CPPUNIT_ASSERT(transaction.get_packages().empty());
+    CPPUNIT_ASSERT(transaction.get_transaction_packages().empty());
 
     auto & log = transaction.get_resolve_logs();
     CPPUNIT_ASSERT_EQUAL(1lu, log.size());
@@ -324,7 +324,7 @@ void BaseGoalTest::test_upgrade_all() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_upgrade_user() {
@@ -352,7 +352,7 @@ void BaseGoalTest::test_upgrade_user() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_downgrade() {
@@ -380,7 +380,7 @@ void BaseGoalTest::test_downgrade() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_downgrade_user() {
@@ -408,7 +408,7 @@ void BaseGoalTest::test_downgrade_user() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_distrosync() {
@@ -436,7 +436,7 @@ void BaseGoalTest::test_distrosync() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_distrosync_all() {
@@ -464,7 +464,7 @@ void BaseGoalTest::test_distrosync_all() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }
 
 void BaseGoalTest::test_install_or_reinstall() {
@@ -492,5 +492,5 @@ void BaseGoalTest::test_install_or_reinstall() {
             TransactionItemState::UNKNOWN
         )
     };
-    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_packages());
+    CPPUNIT_ASSERT_EQUAL(expected, transaction.get_transaction_packages());
 }


### PR DESCRIPTION
`rpm::Transaction` improvements:
* better work with rpm header (fix memory leaks,  `rpm::RpmHeader` - Adds increase and decrease rpm header link count. Adds destructor.)
* Use `base::TransactionPackage` as `rpm::TransactionItem`
* Replace `fill_transaction` by `fill` method and use it new `fill` method. The `fill` method uses `base::Transaction` object as input to fill `rpm::Transaction`.
* Remove `install`/`upgrade`/`downgrade`/`reinstall`/`erase` methods from API. User is not allowed to manualy add transaction items. Instead, he can use `fill` method with `base::Transaction` object as input.