### PR TITLE
DnfContext: document dnf_context_reset* functions and fix dnf_context_module_disable_all

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -3098,6 +3098,7 @@ recompute_modular_filtering(DnfContext * context, DnfSack * sack, GError ** erro
     return TRUE;
 }
 
+/* See header docstring; you likely want dnf_context_module_reset instead. */
 gboolean
 dnf_context_reset_modules(DnfContext * context, DnfSack * sack, const char ** module_names, GError ** error) try
 {

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -280,13 +280,41 @@ bool             dnf_context_plugin_hook                (DnfContext     *context
                                                          DnfPluginError *error);
 /// String must be dealocated by g_free()
 gchar *          dnf_context_get_module_report          (DnfContext * context);
+
+/**
+ * dnf_context_reset_modules:
+ * @context: DnfContext
+ * @sack: DnfSack
+ * @module_names: Names of modules to reset
+ * @error: Error
+ *
+ * Reset modules, commit modular changes, and recalculate module filtration.
+ * Note you likely want to use dnf_context_module_reset instead which matches
+ * the behaviour of other modular APIs to not commit modular changes to disk
+ * until dnf_context_run(). Returns FALSE when an error is set.
+ *
+ * Since: 0.38.1
+ **/
 gboolean         dnf_context_reset_modules              (DnfContext * context,
                                                          DnfSack * sack,
                                                          const char ** module_names,
                                                          GError ** error);
+
+/**
+ * dnf_context_reset_all_modules:
+ * @context: DnfContext
+ * @sack: DnfSack
+ * @error: Error
+ *
+ * Reset all modules and recalculate module filtration.
+ * Returns FALSE when an error is set.
+ *
+ * Since: 0.46.2
+ **/
 gboolean         dnf_context_reset_all_modules          (DnfContext * context,
                                                          DnfSack * sack,
                                                          GError ** error);
+
 /**
  * dnf_context_module_enable:
  * @context: DnfContext

--- a/tests/libdnf/module/ContextTest.cpp
+++ b/tests/libdnf/module/ContextTest.cpp
@@ -153,7 +153,21 @@ void ContextTest::testLoadModules()
     g_assert(strstr(error->message, "No profile found matching 'nonexistent'"));
     g_clear_pointer(&error, g_error_free);
 
-    // install default profile from modulemd-defaults
+    // disable all modules
+    g_assert(dnf_context_module_disable_all(context, &error));
+    g_assert_no_error(error);
+
+    // installing a modular package should fail
+    g_assert(!dnf_context_install(context, "httpd-2.4.25-8.x86_64", &error));
+    g_assert(error);
+    g_assert(strstr(error->message, "No package matches 'httpd-2.4.25-8.x86_64'"));
+    g_clear_pointer(&error, g_error_free);
+
+    // reset all modules
+    g_assert(dnf_context_reset_all_modules(context, sack, &error));
+    g_assert_no_error(error);
+
+    // enable and install default profile from modulemd-defaults
     module_specs[0] = "httpd:2.4";
     g_assert(dnf_context_module_install(context, module_specs, &error));
     g_assert_no_error(error);


### PR DESCRIPTION
```
DnfContext: document dnf_context_reset* functions

Add docstrings for these functions. Notably, `dnf_context_reset_modules`
commits modular changes back to disk, which is a crucial difference from
the other modular APIs, which all make transient changes until
`dnf_context_run`.

Instead, recommend the similarly named `dnf_context_module_reset` which
matches the expected semantics.
```
---
```
DnfContext: fix dnf_context_module_disable_all

There are two versions of `recompute_modular_filtering`: one which nukes
the modular container and reloads it, and another which doesn't. We want
to use the latter, otherwise the transient `container->disable()`
changes we made beforehand will have no effect.

I'm not sure how I got this to work before. I think I might've been
mistakenly testing against repo metadata where all the repos start off
disabled by default anyway.
```