### PR TITLE
[dnf5] Command line argument completion support 

### DIFF
--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -607,6 +607,10 @@ public:
     /// Gets a list of all positional argument stored in the argument parser.
     const std::vector<std::unique_ptr<PositionalArg>> & get_positional_args() const noexcept { return pos_args; }
 
+    /// Prints the completed argument from the `complete_arg_idx` position in the argv array. In case of more than one
+    /// potential completion matches, prints a table with the potential matches along with their short help descriptions.
+    void complete(int argc, const char * const argv[], int complete_arg_idx);
+
 private:
     std::vector<std::unique_ptr<Command>> cmds;
     std::vector<std::unique_ptr<NamedArg>> named_args;
@@ -618,6 +622,7 @@ private:
     Command * root_command{nullptr};
     Command * selected_command{nullptr};
     bool inherit_named_args{false};
+    const char * const * complete_arg_ptr{nullptr};
 };
 
 }  // namespace libdnf::cli

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -22,8 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf-cli/output/argument_parser.hpp"
 
-#include <libdnf/utils/bgettext/bgettext-lib.h>
-#include <libdnf/utils/string.hpp>
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+#include "libdnf/utils/string.hpp"
 
 #include <fmt/format.h>
 

--- a/libdnf-cli/output/argument_parser.hpp
+++ b/libdnf-cli/output/argument_parser.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_CLI_OUTPUT_ARGUMENT_PARSER_HPP
 
 
-#include <libdnf-cli/utils/tty.hpp>
+#include "libdnf-cli/utils/tty.hpp"
 
 #include <libsmartcols/libsmartcols.h>
 
@@ -88,7 +88,7 @@ protected:
 
 class Help : public Usage {
 public:
-    explicit Help() : Usage::Usage() {
+    explicit Help() {
         scols_table_new_column(table, "desc", 40, SCOLS_FL_WRAP);
     }
 


### PR DESCRIPTION
* Adds command line argument completion support to the argument parser.
* Uses command line argument completion in microdnf.

If microdnf argument at position 1 is "--complete=<index>", this is a request to complete the argument at position <index>. The first two arguments are not subject to completion (skip them). The original arguments of the program (including the program name) start from position 2.

Example of bash completion script:
```
_do_microdnf_completion()
{
    mapfile -t COMPREPLY < <($1 "--complete=${COMP_CWORD}" "${COMP_WORDS[@]}")
}
complete -F _do_microdnf_completion -o nosort -o nospace microdn
```