### PR TITLE
dnfdaemon: Add Group dbus interface, refactor dnfdaemon-client commands and implement group list/info

### DIFF
--- a/dnfdaemon-client/commands/command.hpp
+++ b/dnfdaemon-client/commands/command.hpp
@@ -21,28 +21,24 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNFDAEMON_CLIENT_COMMANDS_COMMAND_HPP
 
 #include <dnfdaemon-server/dbus.hpp>
+#include <libdnf-cli/session.hpp>
+
 
 namespace dnfdaemon::client {
 
-class Context;
-
-class Command {
+class DaemonCommand : public libdnf::cli::session::Command {
 public:
-    virtual void set_argument_parser(Context &) {}
-    virtual dnfdaemon::KeyValueMap session_config(Context &) {
+    explicit DaemonCommand(Command & parent, const std::string & name) : Command(parent, name){};
+    virtual dnfdaemon::KeyValueMap session_config() {
         dnfdaemon::KeyValueMap cfg = {};
         return cfg;
     }
-    virtual void pre_configure(Context &) {}
-    virtual void configure(Context &) {}
-    virtual void run(Context &) {}
-    virtual ~Command() = default;
 };
 
-class TransactionCommand : public Command {
+class TransactionCommand : public DaemonCommand {
 public:
-    void print_transaction(std::vector<dnfdaemon::DbusTransactionItem> transaction);
-    void run_transaction(Context & ctx);
+    explicit TransactionCommand(Command & parent, const std::string & name) : DaemonCommand(parent, name){};
+    void run_transaction();
 };
 
 

--- a/dnfdaemon-client/commands/downgrade/downgrade.hpp
+++ b/dnfdaemon-client/commands/downgrade/downgrade.hpp
@@ -23,14 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../command.hpp"
 
 #include <libdnf/conf/option.hpp>
-#include <libdnf/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
-class CmdDowngrade : public TransactionCommand {
+class DowngradeCommand : public TransactionCommand {
 public:
-    void set_argument_parser(Context & ctx) override;
-    void run(Context & ctx) override;
+    explicit DowngradeCommand(Command & parent);
+    void run() override;
 
 private:
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};

--- a/dnfdaemon-client/commands/group/group.cpp
+++ b/dnfdaemon-client/commands/group/group.cpp
@@ -1,0 +1,48 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "group.hpp"
+
+#include "../../context.hpp"
+#include "group_list.hpp"
+
+namespace dnfdaemon::client {
+
+using namespace libdnf::cli;
+
+GroupCommand::GroupCommand(Command & parent) : DaemonCommand(parent, "group") {
+    auto & ctx = static_cast<Context &>(get_session());
+    auto & parser = ctx.get_argument_parser();
+
+    auto & cmd = *get_argument_parser_command();
+    cmd.set_short_description("Manage comps groups");
+
+    // query commands
+    auto * query_commands_group = parser.add_new_group("group_query_commands");
+    query_commands_group->set_header("Query Commands:");
+    cmd.register_group(query_commands_group);
+    register_subcommand(std::make_unique<GroupListCommand>(*this, "list"), query_commands_group);
+    register_subcommand(std::make_unique<GroupListCommand>(*this, "info"), query_commands_group);
+}
+
+void GroupCommand::run() {
+    get_argument_parser_command()->help();
+}
+
+}  // namespace dnfdaemon::client

--- a/dnfdaemon-client/commands/group/group.hpp
+++ b/dnfdaemon-client/commands/group/group.hpp
@@ -1,0 +1,40 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNFDAEMON_CLIENT_COMMANDS_GROUP_GROUP_HPP
+#define DNFDAEMON_CLIENT_COMMANDS_GROUP_GROUP_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_enum.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace dnfdaemon::client {
+
+class GroupCommand : public DaemonCommand {
+public:
+    explicit GroupCommand(Command & parent);
+    void run() override;
+};
+
+}  // namespace dnfdaemon::client
+
+#endif

--- a/dnfdaemon-client/commands/group/group_list.cpp
+++ b/dnfdaemon-client/commands/group/group_list.cpp
@@ -1,0 +1,102 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "group_list.hpp"
+
+#include "../../context.hpp"
+#include "../../wrappers/dbus_group_wrapper.hpp"
+
+#include <libdnf-cli/output/groupinfo.hpp>
+#include <libdnf-cli/output/grouplist.hpp>
+#include <libdnf/conf/option.hpp>
+#include <libdnf/conf/option_string.hpp>
+
+#include <iostream>
+
+namespace dnfdaemon::client {
+
+using namespace libdnf::cli;
+
+GroupListCommand::GroupListCommand(Command & parent, const char * command)
+    : DaemonCommand(parent, command),
+      command(command) {
+    auto & ctx = static_cast<Context &>(get_session());
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_short_description("search for packages matching keyword");
+
+    patterns_options = parser.add_new_values();
+    auto keys = parser.add_new_positional_arg(
+        "keys_to_match",
+        ArgumentParser::PositionalArg::UNLIMITED,
+        parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        patterns_options);
+    keys->set_short_description("List of keys to match");
+    cmd.register_positional_arg(keys);
+}
+
+void GroupListCommand::run() {
+    auto & ctx = static_cast<Context &>(get_session());
+
+    // query groups
+    dnfdaemon::KeyValueMap options = {};
+
+    std::vector<std::string> patterns;
+    if (patterns_options->size() > 0) {
+        patterns.reserve(patterns_options->size());
+        for (auto & pattern : *patterns_options) {
+            auto option = dynamic_cast<libdnf::OptionString *>(pattern.get());
+            patterns.emplace_back(option->get_value());
+        }
+    }
+    options["patterns"] = patterns;
+
+    std::vector<std::string> attributes{"groupid", "name", "installed"};
+    if (command == "info") {
+        std::vector<std::string> more_attributes{
+            "description", "order", "langonly", "uservisible", "repos", "packages"};
+        attributes.reserve(attributes.size() + more_attributes.size());
+        std::move(std::begin(more_attributes), std::end(more_attributes), std::back_inserter(attributes));
+    }
+    options["attributes"] = attributes;
+
+    dnfdaemon::KeyValueMapList raw_groups;
+    ctx.session_proxy->callMethod("list")
+        .onInterface(dnfdaemon::INTERFACE_GROUP)
+        .withTimeout(static_cast<uint64_t>(-1))
+        .withArguments(options)
+        .storeResultsTo(raw_groups);
+
+    std::vector<DbusGroupWrapper> groups{};
+    for (auto & group : raw_groups) {
+        groups.push_back(DbusGroupWrapper(group));
+    }
+
+    if (command == "info") {
+        for (auto & group : groups) {
+            libdnf::cli::output::print_groupinfo_table(group);
+            std::cout << '\n';
+        }
+    } else {
+        libdnf::cli::output::print_grouplist_table(groups);
+    }
+}
+
+}  // namespace dnfdaemon::client

--- a/dnfdaemon-client/commands/group/group_list.hpp
+++ b/dnfdaemon-client/commands/group/group_list.hpp
@@ -1,0 +1,44 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNFDAEMON_CLIENT_COMMANDS_GROUP_GROUP_LIST_HPP
+#define DNFDAEMON_CLIENT_COMMANDS_GROUP_GROUP_LIST_HPP
+
+#include "../command.hpp"
+
+#include <libdnf/conf/option_enum.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace dnfdaemon::client {
+
+class GroupListCommand : public DaemonCommand {
+public:
+    explicit GroupListCommand(Command & parent, const char * command);
+    void run() override;
+
+private:
+    std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
+    const std::string command;
+};
+
+}  // namespace dnfdaemon::client
+
+#endif

--- a/dnfdaemon-client/commands/install/install.cpp
+++ b/dnfdaemon-client/commands/install/install.cpp
@@ -23,8 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../../utils.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
-#include <libdnf-cli/argument_parser.hpp>
-#include <libdnf/conf/option_bool.hpp>
 #include <libdnf/conf/option_string.hpp>
 
 #include <iostream>
@@ -32,42 +30,37 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon::client {
 
-void CmdInstall::set_argument_parser(Context & ctx) {
-    auto install = ctx.arg_parser.add_new_command("install");
-    install->set_short_description("install packages on the system");
-    install->set_description("");
-    install->set_named_args_help_header("Optional arguments:");
-    install->set_positional_args_help_header("Positional arguments:");
-    install->set_parse_hook_func([this, &ctx](
-                                     [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
-                                     [[maybe_unused]] const char * option,
-                                     [[maybe_unused]] int argc,
-                                     [[maybe_unused]] const char * const argv[]) {
-        ctx.select_command(this);
-        return true;
-    });
-    ctx.arg_parser.get_root_command()->register_command(install);
+using namespace libdnf::cli;
 
-    auto strict = ctx.arg_parser.add_new_named_arg("strict");
+InstallCommand::InstallCommand(Command & parent) : TransactionCommand(parent, "install") {
+    auto & ctx = static_cast<Context &>(get_session());
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_short_description("install packages on the system");
+
+    auto strict = parser.add_new_named_arg("strict");
     strict->set_long_name("strict");
     strict->set_short_description(
         "Broken or unavailable packages cause the transaction to fail (yes) or will be skipped (no).");
     strict->set_has_value(true);
     strict->set_arg_value_help("<yes|no>");
     strict->link_value(&strict_option);
-    install->register_named_arg(strict);
+    cmd.register_named_arg(strict);
 
-    patterns_options = ctx.arg_parser.add_new_values();
-    auto keys = ctx.arg_parser.add_new_positional_arg(
+    patterns_options = parser.add_new_values();
+    auto keys = parser.add_new_positional_arg(
         "keys_to_match",
         libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
         patterns_options);
     keys->set_short_description("List of packages to install");
-    install->register_positional_arg(keys);
+    cmd.register_positional_arg(keys);
 }
 
-void CmdInstall::run(Context & ctx) {
+void InstallCommand::run() {
+    auto & ctx = static_cast<Context &>(get_session());
+
     if (!am_i_root()) {
         std::cout << "This command has to be run with superuser privileges (under the root user on most systems)."
                   << std::endl;
@@ -95,7 +88,7 @@ void CmdInstall::run(Context & ctx) {
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(patterns, options);
 
-    run_transaction(ctx);
+    run_transaction();
 }
 
 }  // namespace dnfdaemon::client

--- a/dnfdaemon-client/commands/install/install.hpp
+++ b/dnfdaemon-client/commands/install/install.hpp
@@ -27,10 +27,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon::client {
 
-class CmdInstall : public TransactionCommand {
+class InstallCommand : public TransactionCommand {
 public:
-    void set_argument_parser(Context & ctx) override;
-    void run(Context & ctx) override;
+    explicit InstallCommand(Command & parent);
+    void run() override;
 
 private:
     libdnf::OptionBool strict_option{false};

--- a/dnfdaemon-client/commands/reinstall/reinstall.cpp
+++ b/dnfdaemon-client/commands/reinstall/reinstall.cpp
@@ -23,8 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../../utils.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
-#include <libdnf-cli/argument_parser.hpp>
-#include <libdnf/conf/option_bool.hpp>
 #include <libdnf/conf/option_string.hpp>
 
 #include <iostream>
@@ -32,33 +30,28 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon::client {
 
-void CmdReinstall::set_argument_parser(Context & ctx) {
-    auto reinstall = ctx.arg_parser.add_new_command("reinstall");
-    reinstall->set_short_description("reinstall packages on the system");
-    reinstall->set_description("");
-    reinstall->set_named_args_help_header("Optional arguments:");
-    reinstall->set_positional_args_help_header("Positional arguments:");
-    reinstall->set_parse_hook_func([this, &ctx](
-                                       [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
-                                       [[maybe_unused]] const char * option,
-                                       [[maybe_unused]] int argc,
-                                       [[maybe_unused]] const char * const argv[]) {
-        ctx.select_command(this);
-        return true;
-    });
-    ctx.arg_parser.get_root_command()->register_command(reinstall);
+using namespace libdnf::cli;
 
-    patterns_options = ctx.arg_parser.add_new_values();
-    auto keys = ctx.arg_parser.add_new_positional_arg(
+ReinstallCommand::ReinstallCommand(Command & parent) : TransactionCommand(parent, "reinstall") {
+    auto & ctx = static_cast<Context &>(get_session());
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_short_description("reinstall packages on the system");
+
+    patterns_options = parser.add_new_values();
+    auto keys = parser.add_new_positional_arg(
         "keys_to_match",
         libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
         patterns_options);
     keys->set_short_description("List of packages to reinstall");
-    reinstall->register_positional_arg(keys);
+    cmd.register_positional_arg(keys);
 }
 
-void CmdReinstall::run(Context & ctx) {
+void ReinstallCommand::run() {
+    auto & ctx = static_cast<Context &>(get_session());
+
     if (!am_i_root()) {
         std::cout << "This command has to be run with superuser privileges (under the root user on most systems)."
                   << std::endl;
@@ -82,8 +75,7 @@ void CmdReinstall::run(Context & ctx) {
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(patterns, options);
 
-    run_transaction(ctx);
+    run_transaction();
 }
 
 }  // namespace dnfdaemon::client
-

--- a/dnfdaemon-client/commands/reinstall/reinstall.hpp
+++ b/dnfdaemon-client/commands/reinstall/reinstall.hpp
@@ -23,14 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../command.hpp"
 
 #include <libdnf/conf/option.hpp>
-#include <libdnf/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
-class CmdReinstall : public TransactionCommand {
+class ReinstallCommand : public TransactionCommand {
 public:
-    void set_argument_parser(Context & ctx) override;
-    void run(Context & ctx) override;
+    explicit ReinstallCommand(Command & parent);
+    void run() override;
 
 private:
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};
@@ -39,4 +38,3 @@ private:
 }  // namespace dnfdaemon::client
 
 #endif  // DNFDAEMON_CLIENT_COMMANDS_REINSTALL_REINSTALL_HPP
-

--- a/dnfdaemon-client/commands/remove/remove.hpp
+++ b/dnfdaemon-client/commands/remove/remove.hpp
@@ -23,14 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../command.hpp"
 
 #include <libdnf/conf/option.hpp>
-#include <libdnf/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
-class CmdRemove : public TransactionCommand {
+class RemoveCommand : public TransactionCommand {
 public:
-    void set_argument_parser(Context & ctx) override;
-    void run(Context & ctx) override;
+    explicit RemoveCommand(Command & parent);
+    void run() override;
 
 private:
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};

--- a/dnfdaemon-client/commands/repolist/repolist.cpp
+++ b/dnfdaemon-client/commands/repolist/repolist.cpp
@@ -20,85 +20,82 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "repolist.hpp"
 
 #include "../../context.hpp"
-#include "../../wrappers/dbus_repo_wrapper.hpp"
 #include "../../wrappers/dbus_query_repo_wrapper.hpp"
-#include "libdnf-cli/output/repolist.hpp"
+#include "../../wrappers/dbus_repo_wrapper.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
-#include <libdnf/conf/option_string.hpp>
 #include <libdnf-cli/output/repo_info.hpp>
+#include <libdnf-cli/output/repolist.hpp>
+#include <libdnf/conf/option_string.hpp>
 
 #include <iostream>
 #include <numeric>
 
 namespace dnfdaemon::client {
 
-void CmdRepolist::set_argument_parser(Context & ctx) {
+using namespace libdnf::cli;
+
+RepolistCommand::RepolistCommand(Command & parent, const char * command)
+    : DaemonCommand(parent, command),
+      command(command) {
+    auto & ctx = static_cast<Context &>(get_session());
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+
     enable_disable_option = dynamic_cast<libdnf::OptionEnum<std::string> *>(
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::OptionEnum<std::string>>(
+        parser.add_init_value(std::unique_ptr<libdnf::OptionEnum<std::string>>(
             new libdnf::OptionEnum<std::string>("enabled", {"all", "enabled", "disabled"}))));
 
-    auto all = ctx.arg_parser.add_new_named_arg("all");
+    auto all = parser.add_new_named_arg("all");
     all->set_long_name("all");
     all->set_short_description("show all repos");
     all->set_const_value("all");
     all->link_value(enable_disable_option);
 
-    auto enabled = ctx.arg_parser.add_new_named_arg("enabled");
+    auto enabled = parser.add_new_named_arg("enabled");
     enabled->set_long_name("enabled");
     enabled->set_short_description("show enabled repos (default)");
     enabled->set_const_value("enabled");
     enabled->link_value(enable_disable_option);
 
-    auto disabled = ctx.arg_parser.add_new_named_arg("disabled");
+    auto disabled = parser.add_new_named_arg("disabled");
     disabled->set_long_name("disabled");
     disabled->set_short_description("show disabled repos");
     disabled->set_const_value("disabled");
     disabled->link_value(enable_disable_option);
 
-    patterns_options = ctx.arg_parser.add_new_values();
-    auto repos = ctx.arg_parser.add_new_positional_arg(
+    patterns_options = parser.add_new_values();
+    auto repos = parser.add_new_positional_arg(
         "repos_to_show",
         libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
         patterns_options);
     repos->set_short_description("List of repos to show");
 
     auto conflict_args =
-        ctx.arg_parser.add_conflict_args_group(std::unique_ptr<std::vector<libdnf::cli::ArgumentParser::Argument *>>(
+        parser.add_conflict_args_group(std::unique_ptr<std::vector<libdnf::cli::ArgumentParser::Argument *>>(
             new std::vector<libdnf::cli::ArgumentParser::Argument *>{all, enabled, disabled}));
 
     all->set_conflict_arguments(conflict_args);
     enabled->set_conflict_arguments(conflict_args);
     disabled->set_conflict_arguments(conflict_args);
 
-    auto repolist = ctx.arg_parser.add_new_command(command);
-    repolist->set_short_description("display the configured software repositories");
-    repolist->set_description("");
-    repolist->set_named_args_help_header("Optional arguments:");
-    repolist->set_positional_args_help_header("Positional arguments:");
-    repolist->set_parse_hook_func([this, &ctx](
-                                      [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
-                                      [[maybe_unused]] const char * option,
-                                      [[maybe_unused]] int argc,
-                                      [[maybe_unused]] const char * const argv[]) {
-        ctx.select_command(this);
-        return true;
-    });
+    cmd.set_short_description("display the configured software repositories");
 
-    repolist->register_named_arg(all);
-    repolist->register_named_arg(enabled);
-    repolist->register_named_arg(disabled);
-    repolist->register_positional_arg(repos);
-
-    ctx.arg_parser.get_root_command()->register_command(repolist);
+    cmd.register_named_arg(all);
+    cmd.register_named_arg(enabled);
+    cmd.register_named_arg(disabled);
+    cmd.register_positional_arg(repos);
 }
 
 /// Joins vector of strings to a single string using given separator
 /// ["a", "b", "c"] -> "a b c"
 std::string join(const std::vector<std::string> & str_list, const std::string & separator) {
     return std::accumulate(
-        str_list.begin(), str_list.end(), std::string(),
+        str_list.begin(),
+        str_list.end(),
+        std::string(),
         [&](const std::string & a, const std::string & b) -> std::string {
             return a + (a.length() > 0 ? separator : "") + b;
         });
@@ -107,15 +104,20 @@ std::string join(const std::vector<std::string> & str_list, const std::string & 
 /// Joins vector of string pairs to a single string. Pairs are joined using
 /// field_separator, records using record_separator
 /// [("a", "1"), ("b", "2")] -> "a: 1, b: 2"
-std::string join_pairs(const std::vector<std::pair<std::string, std::string>> & pair_list, const std::string & field_separator, const std::string & record_separator) {
-    std::vector<std::string> records {};
-    for (auto & pair: pair_list) {
+std::string join_pairs(
+    const std::vector<std::pair<std::string, std::string>> & pair_list,
+    const std::string & field_separator,
+    const std::string & record_separator) {
+    std::vector<std::string> records{};
+    for (auto & pair : pair_list) {
         records.emplace_back(pair.first + field_separator + pair.second);
     }
     return join(records, record_separator);
 }
 
-void CmdRepolist::run(Context & ctx) {
+void RepolistCommand::run() {
+    auto & ctx = static_cast<Context &>(get_session());
+
     // prepare options from command line arguments
     dnfdaemon::KeyValueMap options = {};
     options["enable_disable"] = enable_disable_option->get_value();
@@ -130,12 +132,23 @@ void CmdRepolist::run(Context & ctx) {
     }
     options["patterns"] = patterns;
 
-    std::vector<std::string> attrs {"id", "name", "enabled"};
+    std::vector<std::string> attrs{"id", "name", "enabled"};
     if (command == "repoinfo") {
-        std::vector<std::string> repoinfo_attrs {
-            "size", "revision", "content_tags", "distro_tags", "updated",
-            "pkgs", "available_pkgs", "metalink", "mirrorlist", "baseurl",
-            "metadata_expire", "excludepkgs", "includepkgs", "repofile"};
+        std::vector<std::string> repoinfo_attrs{
+            "size",
+            "revision",
+            "content_tags",
+            "distro_tags",
+            "updated",
+            "pkgs",
+            "available_pkgs",
+            "metalink",
+            "mirrorlist",
+            "baseurl",
+            "metadata_expire",
+            "excludepkgs",
+            "includepkgs",
+            "repofile"};
         attrs.insert(attrs.end(), repoinfo_attrs.begin(), repoinfo_attrs.end());
     }
     options["repo_attrs"] = attrs;
@@ -151,8 +164,7 @@ void CmdRepolist::run(Context & ctx) {
         // print the output table
         bool with_status = enable_disable_option->get_value() == "all";
         libdnf::cli::output::print_repolist_table(
-            DbusQueryRepoWrapper(repositories), with_status,
-            libdnf::cli::output::COL_REPO_ID);
+            DbusQueryRepoWrapper(repositories), with_status, libdnf::cli::output::COL_REPO_ID);
     } else {
         // repoinfo command
 

--- a/dnfdaemon-client/commands/repolist/repolist.hpp
+++ b/dnfdaemon-client/commands/repolist/repolist.hpp
@@ -22,18 +22,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../command.hpp"
 
+#include <libdnf/conf/option.hpp>
 #include <libdnf/conf/option_enum.hpp>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace dnfdaemon::client {
 
-class CmdRepolist : public Command {
+class RepolistCommand : public DaemonCommand {
 public:
-    CmdRepolist(const char * command) : command(command) {};
-    void set_argument_parser(Context & ctx) override;
-    void run(Context & ctx) override;
+    explicit RepolistCommand(Command & parent, const char * command);
+    void run() override;
 
 private:
     libdnf::OptionEnum<std::string> * enable_disable_option{nullptr};

--- a/dnfdaemon-client/commands/repoquery/repoquery.hpp
+++ b/dnfdaemon-client/commands/repoquery/repoquery.hpp
@@ -22,6 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "../command.hpp"
 
+#include <libdnf-cli/session.hpp>
+#include <libdnf/conf/option.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -29,11 +31,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon::client {
 
-class CmdRepoquery : public Command {
+class RepoqueryCommand : public DaemonCommand {
 public:
-    void set_argument_parser(Context & ctx) override;
-    void run(Context & ctx) override;
-    dnfdaemon::KeyValueMap session_config(Context &) override;
+    explicit RepoqueryCommand(Command & parent);
+    void run() override;
+    dnfdaemon::KeyValueMap session_config() override;
 
 private:
     libdnf::OptionBool * available_option{nullptr};

--- a/dnfdaemon-client/commands/upgrade/upgrade.cpp
+++ b/dnfdaemon-client/commands/upgrade/upgrade.cpp
@@ -23,8 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../../utils.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
-#include <libdnf-cli/argument_parser.hpp>
-#include <libdnf/conf/option_bool.hpp>
 #include <libdnf/conf/option_string.hpp>
 
 #include <iostream>
@@ -32,33 +30,28 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace dnfdaemon::client {
 
-void CmdUpgrade::set_argument_parser(Context & ctx) {
-    auto upgrade = ctx.arg_parser.add_new_command("upgrade");
-    upgrade->set_short_description("upgrade packages on the system");
-    upgrade->set_description("");
-    upgrade->set_named_args_help_header("Optional arguments:");
-    upgrade->set_positional_args_help_header("Positional arguments:");
-    upgrade->set_parse_hook_func([this, &ctx](
-                                     [[maybe_unused]] libdnf::cli::ArgumentParser::Argument * arg,
-                                     [[maybe_unused]] const char * option,
-                                     [[maybe_unused]] int argc,
-                                     [[maybe_unused]] const char * const argv[]) {
-        ctx.select_command(this);
-        return true;
-    });
-    ctx.arg_parser.get_root_command()->register_command(upgrade);
+using namespace libdnf::cli;
 
-    patterns_options = ctx.arg_parser.add_new_values();
-    auto keys = ctx.arg_parser.add_new_positional_arg(
+UpgradeCommand::UpgradeCommand(Command & parent) : TransactionCommand(parent, "upgrade") {
+    auto & ctx = static_cast<Context &>(get_session());
+    auto & parser = ctx.get_argument_parser();
+    auto & cmd = *get_argument_parser_command();
+
+    cmd.set_short_description("upgrade packages on the system");
+
+    patterns_options = parser.add_new_values();
+    auto keys = parser.add_new_positional_arg(
         "keys_to_match",
         libdnf::cli::ArgumentParser::PositionalArg::UNLIMITED,
-        ctx.arg_parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
+        parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
         patterns_options);
     keys->set_short_description("List of packages to upgrade");
-    upgrade->register_positional_arg(keys);
+    cmd.register_positional_arg(keys);
 }
 
-void CmdUpgrade::run(Context & ctx) {
+void UpgradeCommand::run() {
+    auto & ctx = static_cast<Context &>(get_session());
+
     if (!am_i_root()) {
         std::cout << "This command has to be run with superuser privileges (under the root user on most systems)."
                   << std::endl;
@@ -82,7 +75,7 @@ void CmdUpgrade::run(Context & ctx) {
         .withTimeout(static_cast<uint64_t>(-1))
         .withArguments(patterns, options);
 
-    run_transaction(ctx);
+    run_transaction();
 }
 
 }  // namespace dnfdaemon::client

--- a/dnfdaemon-client/commands/upgrade/upgrade.hpp
+++ b/dnfdaemon-client/commands/upgrade/upgrade.hpp
@@ -23,14 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "../command.hpp"
 
 #include <libdnf/conf/option.hpp>
-#include <libdnf/conf/option_bool.hpp>
 
 namespace dnfdaemon::client {
 
-class CmdUpgrade : public TransactionCommand {
+class UpgradeCommand : public TransactionCommand {
 public:
-    void set_argument_parser(Context & ctx) override;
-    void run(Context & ctx) override;
+    explicit UpgradeCommand(Command & parent);
+    void run() override;
 
 private:
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_options{nullptr};

--- a/dnfdaemon-client/context.cpp
+++ b/dnfdaemon-client/context.cpp
@@ -24,15 +24,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package_set.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
-#include <iostream>
 #include <filesystem>
+#include <iostream>
 #include <string>
 
 namespace dnfdaemon::client {
 
 void Context::init_session() {
     // open dnfdaemon-server session
-    auto cfg = selected_command->session_config(*this);
+    auto cfg = static_cast<DaemonCommand *>(get_selected_command())->session_config();
     auto session_manager_proxy = sdbus::createProxy(connection, dnfdaemon::DBUS_NAME, dnfdaemon::DBUS_OBJECT_PATH);
     session_manager_proxy->finishRegistration();
 
@@ -42,7 +42,7 @@ void Context::init_session() {
     std::filesystem::path ir{installroot.get_value()};
     config["installroot"] = ir.string();
     config["cachedir"] = (ir / "var/cache/dnf").string();
-    for (auto & opt: setopts) {
+    for (auto & opt : setopts) {
         config[opt.first] = opt.second;
     }
     cfg["config"] = config;

--- a/dnfdaemon-client/context.hpp
+++ b/dnfdaemon-client/context.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnfdaemon-server/dbus.hpp>
 #include <libdnf-cli/argument_parser.hpp>
+#include <libdnf-cli/session.hpp>
 #include <libdnf/base/base.hpp>
 #include <libdnf/conf/config.hpp>
 #include <libdnf/repo/repo.hpp>
@@ -35,21 +36,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 #include <vector>
 
-// TODO(mblaha) remove after microdnf is merged
-namespace libdnf::repo {
-using RepoWeakPtr = WeakPtr<Repo, false>;
-using RepoSet = Set<RepoWeakPtr>;
-}  // namespace libdnf::repo
 
 namespace dnfdaemon::client {
 
 constexpr const char * VERSION = "0.1.0";
 
-class Context {
+class Context : public libdnf::cli::session::Session {
 public:
     Context(sdbus::IConnection & connection)
-        : connection(connection)
-        , repositories_status(dnfdaemon::RepoStatus::NOT_READY){};
+        : connection(connection),
+          repositories_status(dnfdaemon::RepoStatus::NOT_READY){};
 
     /// Initialize dbus connection and server session
     void init_session();
@@ -60,12 +56,6 @@ public:
     // signal handlers
     void on_repositories_ready(const bool & result);
 
-    /// Select command to execute
-    void select_command(Command * cmd) { selected_command = cmd; }
-
-    std::vector<std::unique_ptr<Command>> commands;
-    Command * selected_command{nullptr};
-    libdnf::cli::ArgumentParser arg_parser;
     /// proxy to dnfdaemon session
     std::unique_ptr<sdbus::IProxy> session_proxy;
 

--- a/dnfdaemon-client/main.cpp
+++ b/dnfdaemon-client/main.cpp
@@ -18,12 +18,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "commands/downgrade/downgrade.hpp"
+#include "commands/group/group.hpp"
 #include "commands/install/install.hpp"
+#include "commands/reinstall/reinstall.hpp"
 #include "commands/remove/remove.hpp"
 #include "commands/repolist/repolist.hpp"
 #include "commands/repoquery/repoquery.hpp"
 #include "commands/upgrade/upgrade.hpp"
-#include "commands/reinstall/reinstall.hpp"
 #include "context.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
@@ -76,6 +77,12 @@ inline RootCommand::RootCommand(session::Session & session) : Command(session, "
     query_commands_group->set_header("Query Commands:");
     cmd.register_group(query_commands_group);
     register_subcommand(std::make_unique<RepoqueryCommand>(*this), query_commands_group);
+
+    // subcommands
+    auto * subcommands_group = session.get_argument_parser().add_new_group("subcommands");
+    subcommands_group->set_header("Subcommands:");
+    cmd.register_group(subcommands_group);
+    register_subcommand(std::make_unique<GroupCommand>(*this), subcommands_group);
 }
 
 inline void RootCommand::run() {

--- a/dnfdaemon-client/wrappers/dbus_group_wrapper.cpp
+++ b/dnfdaemon-client/wrappers/dbus_group_wrapper.cpp
@@ -1,0 +1,40 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "dbus_group_wrapper.hpp"
+
+namespace dnfdaemon::client {
+
+DbusGroupWrapper::DbusGroupWrapper(dnfdaemon::KeyValueMap & rawdata) : rawdata(rawdata) {
+    auto packages_iter = rawdata.find("packages");
+    if (packages_iter != rawdata.end()) {
+        dnfdaemon::KeyValueMapList raw_packages = packages_iter->second;
+        for (auto & raw_package : raw_packages) {
+            packages.push_back(DbusGroupPackageWrapper(raw_package));
+        }
+    }
+};
+
+std::set<std::string> DbusGroupWrapper::get_repos() const {
+    std::vector<std::string> repos_vector = rawdata.at("repos");
+    std::set<std::string> repos_set(repos_vector.begin(), repos_vector.end());
+    return repos_set;
+};
+
+}  // namespace dnfdaemon::client

--- a/dnfdaemon-client/wrappers/dbus_group_wrapper.hpp
+++ b/dnfdaemon-client/wrappers/dbus_group_wrapper.hpp
@@ -1,0 +1,66 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNFDAEMON_CLIENT_WRAPPERS_DBUS_GROUP_WRAPPER_HPP
+#define DNFDAEMON_CLIENT_WRAPPERS_DBUS_GROUP_WRAPPER_HPP
+
+#include <dnfdaemon-server/dbus.hpp>
+#include <dnfdaemon-server/utils.hpp>
+#include <libdnf/comps/group/package.hpp>
+
+#include <set>
+#include <vector>
+
+namespace dnfdaemon::client {
+
+class DbusGroupWrapper {
+public:
+    class DbusGroupPackageWrapper {
+    public:
+        explicit DbusGroupPackageWrapper(dnfdaemon::KeyValueMap & rawdata) : rawdata(rawdata) {}
+        std::string get_name() const { return rawdata.at("name"); }
+        libdnf::comps::PackageType get_type() const {
+            return static_cast<libdnf::comps::PackageType>(key_value_map_get<int>(rawdata, "type"));
+        }
+
+    private:
+        dnfdaemon::KeyValueMap rawdata;
+    };
+
+    explicit DbusGroupWrapper(dnfdaemon::KeyValueMap & rawdata);
+
+    std::string get_groupid() const { return rawdata.at("groupid"); }
+    std::string get_name() const { return rawdata.at("name"); }
+    std::string get_description() const { return rawdata.at("description"); }
+    std::string get_order() const { return rawdata.at("order"); }
+    std::string get_langonly() const { return rawdata.at("langonly"); }
+    // TODO(mblaha) proper installed value
+    bool get_installed() const { return false; }
+    bool get_uservisible() const { return rawdata.at("uservisible"); }
+    std::set<std::string> get_repos() const;
+    std::vector<DbusGroupPackageWrapper> get_packages() const { return packages; }
+
+private:
+    dnfdaemon::KeyValueMap rawdata{};
+    std::vector<DbusGroupPackageWrapper> packages{};
+};
+
+}  // namespace dnfdaemon::client
+
+#endif  // DNFDAEMON_CLIENT_WRAPPERS_DBUS_GROUP_WRAPPER_HPP

--- a/dnfdaemon-server/dbus.hpp
+++ b/dnfdaemon-server/dbus.hpp
@@ -48,6 +48,7 @@ const char * const INTERFACE_REPO = "org.rpm.dnf.v0.rpm.Repo";
 const char * const INTERFACE_REPOCONF = "org.rpm.dnf.v0.rpm.RepoConf";
 const char * const INTERFACE_RPM = "org.rpm.dnf.v0.rpm.Rpm";
 const char * const INTERFACE_GOAL = "org.rpm.dnf.v0.Goal";
+const char * const INTERFACE_GROUP = "org.rpm.dnf.v0.comps.Group";
 const char * const INTERFACE_SESSION_MANAGER = "org.rpm.dnf.v0.SessionManager";
 
 // signals

--- a/dnfdaemon-server/package.cpp
+++ b/dnfdaemon-server/package.cpp
@@ -21,6 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <fmt/format.h>
 
+#include <map>
+
 
 // map string package attribute name to actual attribute
 const std::map<std::string, PackageAttribute> package_attributes{
@@ -33,6 +35,11 @@ const std::map<std::string, PackageAttribute> package_attributes{
     {"is_installed", PackageAttribute::is_installed},
     {"install_size", PackageAttribute::install_size},
     {"package_size", PackageAttribute::package_size},
+    {"sourcerpm", PackageAttribute::sourcerpm},
+    {"summary", PackageAttribute::summary},
+    {"url", PackageAttribute::url},
+    {"license", PackageAttribute::license},
+    {"description", PackageAttribute::description},
     {"evr", PackageAttribute::evr},
     {"nevra", PackageAttribute::nevra},
     {"full_nevra", PackageAttribute::full_nevra}};
@@ -76,6 +83,21 @@ dnfdaemon::KeyValueMap package_to_map(
             case PackageAttribute::package_size:
                 dbus_package.emplace(attr, static_cast<uint64_t>(libdnf_package.get_package_size()));
                 break;
+            case PackageAttribute::sourcerpm:
+                dbus_package.emplace(attr, libdnf_package.get_sourcerpm());
+                break;
+            case PackageAttribute::summary:
+                dbus_package.emplace(attr, libdnf_package.get_summary());
+                break;
+            case PackageAttribute::url:
+                dbus_package.emplace(attr, libdnf_package.get_url());
+                break;
+            case PackageAttribute::license:
+                dbus_package.emplace(attr, libdnf_package.get_license());
+                break;
+            case PackageAttribute::description:
+                dbus_package.emplace(attr, libdnf_package.get_description());
+                break;
             case PackageAttribute::evr:
                 dbus_package.emplace(attr, libdnf_package.get_evr());
                 break;
@@ -89,4 +111,3 @@ dnfdaemon::KeyValueMap package_to_map(
     }
     return dbus_package;
 }
-

--- a/dnfdaemon-server/package.hpp
+++ b/dnfdaemon-server/package.hpp
@@ -26,7 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <string>
 #include <vector>
-#include <map>
 
 // TODO(mblaha): add all other package attributes
 // package attributes available to be retrieved
@@ -40,6 +39,11 @@ enum class PackageAttribute {
     is_installed,
     install_size,
     package_size,
+    sourcerpm,
+    summary,
+    url,
+    license,
+    description,
 
     evr,
     nevra,

--- a/dnfdaemon-server/services/comps/group.cpp
+++ b/dnfdaemon-server/services/comps/group.cpp
@@ -1,0 +1,156 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "group.hpp"
+
+#include "dnfdaemon-server/dbus.hpp"
+
+#include <libdnf/comps/group/group.hpp>
+#include <libdnf/comps/group/query.hpp>
+#include <sdbus-c++/sdbus-c++.h>
+
+#include <iostream>
+#include <string>
+
+enum class GroupAttribute {
+    groupid,
+    name,
+    description,
+    // TODO(mblaha): translated name / translated description
+    order,
+    langonly,
+    uservisible,
+    is_default,
+    packages,
+    installed,
+    repos,
+};
+
+// map string group attribute name to actual attribute
+const std::map<std::string, GroupAttribute> group_attributes{
+    {"groupid", GroupAttribute::groupid},
+    {"name", GroupAttribute::name},
+    {"description", GroupAttribute::description},
+    {"order", GroupAttribute::order},
+    {"langonly", GroupAttribute::langonly},
+    {"uservisible", GroupAttribute::uservisible},
+    {"default", GroupAttribute::is_default},
+    {"packages", GroupAttribute::packages},
+    {"installed", GroupAttribute::installed},
+    {"repos", GroupAttribute::repos},
+};
+
+dnfdaemon::KeyValueMap group_to_map(libdnf::comps::Group & libdnf_group, const std::vector<std::string> & attributes) {
+    dnfdaemon::KeyValueMap dbus_group;
+    // add group id by default
+    dbus_group.emplace(std::make_pair("groupid", libdnf_group.get_groupid()));
+    // attributes required by client
+    for (auto & attr : attributes) {
+        auto it = group_attributes.find(attr);
+        if (it == group_attributes.end()) {
+            throw std::runtime_error(fmt::format("Group attribute '{}' not supported", attr));
+        }
+        switch (it->second) {
+            case GroupAttribute::groupid:
+                // groupid is always included
+                break;
+            case GroupAttribute::name:
+                dbus_group.emplace(attr, libdnf_group.get_name());
+                break;
+            case GroupAttribute::description:
+                dbus_group.emplace(attr, libdnf_group.get_description());
+                break;
+            case GroupAttribute::order:
+                dbus_group.emplace(attr, libdnf_group.get_order());
+                break;
+            case GroupAttribute::langonly:
+                dbus_group.emplace(attr, libdnf_group.get_langonly());
+                break;
+            case GroupAttribute::uservisible:
+                dbus_group.emplace(attr, libdnf_group.get_uservisible());
+                break;
+            case GroupAttribute::is_default:
+                dbus_group.emplace(attr, libdnf_group.get_default());
+                break;
+            case GroupAttribute::installed:
+                dbus_group.emplace(attr, libdnf_group.get_installed());
+                break;
+            case GroupAttribute::repos: {
+                auto repos_set = libdnf_group.get_repos();
+                std::vector<std::string> repos(repos_set.begin(), repos_set.end());
+                dbus_group.emplace(attr, repos);
+                break;
+            }
+            case GroupAttribute::packages: {
+                dnfdaemon::KeyValueMapList packages;
+                for (auto pkg : libdnf_group.get_packages()) {
+                    dnfdaemon::KeyValueMap package;
+                    package.emplace("name", pkg.get_name());
+                    package.emplace("type", static_cast<int>(pkg.get_type()));
+                    package.emplace("condition", pkg.get_condition());
+                    packages.push_back(std::move(package));
+                }
+                dbus_group.emplace(attr, packages);
+                break;
+            }
+        }
+    }
+    return dbus_group;
+}
+
+
+void Group::dbus_register() {
+    auto dbus_object = session.get_dbus_object();
+    dbus_object->registerMethod(
+        dnfdaemon::INTERFACE_GROUP, "list", "a{sv}", "aa{sv}", [this](sdbus::MethodCall call) -> void {
+            session.get_threads_manager().handle_method(*this, &Group::list, call);
+        });
+}
+
+sdbus::MethodReply Group::list(sdbus::MethodCall & call) {
+    // read options from dbus call
+    dnfdaemon::KeyValueMap options;
+    call >> options;
+
+    session.fill_sack();
+    auto base = session.get_base();
+
+    // patterns to search
+    std::vector<std::string> patterns =
+        key_value_map_get<std::vector<std::string>>(options, "patterns", std::vector<std::string>());
+
+    libdnf::comps::GroupQuery query(base->get_comps()->get_group_sack());
+    if (patterns.size() > 0) {
+        auto query_names = libdnf::comps::GroupQuery(query);
+        query.filter_groupid(patterns, libdnf::sack::QueryCmp::IGLOB);
+        query |= query_names.filter_name(patterns, libdnf::sack::QueryCmp::IGLOB);
+    }
+
+    // create reply from the query
+    dnfdaemon::KeyValueMapList out_groups;
+    std::vector<std::string> attributes =
+        key_value_map_get<std::vector<std::string>>(options, "attributes", std::vector<std::string>{});
+    for (auto grp : query.list()) {
+        out_groups.push_back(group_to_map(grp, attributes));
+    }
+
+    auto reply = call.createReply();
+    reply << out_groups;
+    return reply;
+}

--- a/dnfdaemon-server/services/comps/group.hpp
+++ b/dnfdaemon-server/services/comps/group.hpp
@@ -1,0 +1,38 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DNFDAEMON_SERVER_SERVICES_COMPS_GROUP_HPP
+#define DNFDAEMON_SERVER_SERVICES_COMPS_GROUP_HPP
+
+#include "dnfdaemon-server/session.hpp"
+
+#include <sdbus-c++/sdbus-c++.h>
+
+class Group : public IDbusSessionService {
+public:
+    using IDbusSessionService::IDbusSessionService;
+    ~Group() = default;
+    void dbus_register();
+    void dbus_deregister();
+
+private:
+    sdbus::MethodReply list(sdbus::MethodCall & call);
+};
+
+#endif

--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "callbacks.hpp"
 #include "dbus.hpp"
 #include "services/base/base.hpp"
+#include "services/comps/group.hpp"
 #include "services/goal/goal.hpp"
 #include "services/repo/repo.hpp"
 #include "services/repoconf/repo_conf.hpp"
@@ -108,6 +109,7 @@ Session::Session(
     services.emplace_back(std::make_unique<Repo>(*this));
     services.emplace_back(std::make_unique<Rpm>(*this));
     services.emplace_back(std::make_unique<Goal>(*this));
+    services.emplace_back(std::make_unique<Group>(*this));
 
     dbus_object = sdbus::createObject(connection, object_path);
     // Register all provided services on d-bus

--- a/libdnf-cli/output/groupinfo.hpp
+++ b/libdnf-cli/output/groupinfo.hpp
@@ -22,11 +22,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_CLI_OUTPUT_GROUPINFO_HPP
 
 #include "libdnf-cli/utils/tty.hpp"
-#include <libdnf/utils/string.hpp>
 
-#include <libsmartcols/libsmartcols.h>
 #include <libdnf/comps/group/package.hpp>
-
+#include <libdnf/utils/string.hpp>
+#include <libsmartcols/libsmartcols.h>
 #include <string.h>
 
 
@@ -46,13 +45,14 @@ static void add_line_into_groupinfo_table(
 }
 
 
-static void add_line_into_groupinfo_table(
-    struct libscols_table * table, const char * key, const char * value) {
+static void add_line_into_groupinfo_table(struct libscols_table * table, const char * key, const char * value) {
     add_line_into_groupinfo_table(table, key, value, "");
 }
 
 
-static void add_packages(struct libscols_table * table, libdnf::comps::Group & group, libdnf::comps::PackageType pkg_type, const char * pkg_type_desc) {
+template <typename GroupType>
+static void add_packages(
+    struct libscols_table * table, GroupType & group, libdnf::comps::PackageType pkg_type, const char * pkg_type_desc) {
     std::set<std::string> packages;
 
     // we don't mind iterating through all packages in every add_packages() call,
@@ -84,7 +84,8 @@ static void add_packages(struct libscols_table * table, libdnf::comps::Group & g
 }
 
 
-static struct libscols_table * create_groupinfo_table(libdnf::comps::Group & group) {
+template <typename GroupType>
+static struct libscols_table * create_groupinfo_table(GroupType & group) {
     struct libscols_table * table = scols_new_table();
     scols_table_enable_noheadings(table, 1);
     scols_table_set_column_separator(table, " : ");
@@ -118,7 +119,8 @@ static struct libscols_table * create_groupinfo_table(libdnf::comps::Group & gro
     return table;
 }
 
-void print_groupinfo_table(libdnf::comps::Group & group) {
+template <typename GroupType>
+void print_groupinfo_table(GroupType & group) {
     struct libscols_table * table = create_groupinfo_table(group);
     scols_print_table(table);
     scols_unref_table(table);

--- a/libdnf-cli/output/grouplist.hpp
+++ b/libdnf-cli/output/grouplist.hpp
@@ -58,7 +58,8 @@ static void add_line_into_grouplist_table(
 }
 
 
-void print_grouplist_table(const std::set<libdnf::comps::Group> & group_list) {
+template <class Query>
+void print_grouplist_table(Query & group_list) {
     struct libscols_table * table = create_grouplist_table();
     for (auto group: group_list) {
         add_line_into_grouplist_table(


### PR DESCRIPTION
Implements `dnfdaemon-client group list` and `dnfdaemon-client group info` commands.
Also all the command classes were refactored to use new libdnf-cli::Session.