### PR TITLE
[dnf5] microdnf: Help output, prefer to reduce width of description

### DIFF
--- a/libdnf-cli/output/argument_parser.hpp
+++ b/libdnf-cli/output/argument_parser.hpp
@@ -89,7 +89,8 @@ protected:
 class Help : public Usage {
 public:
     explicit Help() {
-        scols_table_new_column(table, "desc", 40, SCOLS_FL_WRAP);
+        // Sets a small relative width. We prefer to reduce the width of the description before reducing the argument.
+        scols_table_new_column(table, "desc", .1, SCOLS_FL_WRAP);
     }
 
     void add_line(const std::string & arg, const std::string & desc, libscols_line * parent = nullptr) {


### PR DESCRIPTION
Without this patch, there is an aggressive wrapping of argument names.

Example on 80 characters wide terminal.
With the patch:
```
# ./microdnf upgrade --help
Usage:
  microdnf upgrade [GLOBAL OPTIONS] [OPTIONS] [ARGUMENTS]
                                
Options:                        
  --minimal                     Upgrade packages only to the lowest versions of 
                                packages that fix the problems affecting the sys
                                tem.
                                
Arguments:                      
  keys_to_match                 List of keys to match
```
Before the patch:
```
# ./microdnf upgrade --help
Usage:
  microdnf upgrade [GLOBAL OPTIONS] [OPTIONS] [ARGUMENTS]
      
Opti  
ons:  
  --  Upgrade packages only to the lowest versions of packages that fix the prob
mini  lems affecting the system.
mal   
      
Argu  
ment  
s:    
  ke  List of keys to match
ys_t  
o_ma  
tch
```