### PR TITLE
Run dnfdaemon integration tests and use simpler overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           copr-user: ${{steps.setup-ci.outputs.copr-user}}
           chroot: fedora-35-x86_64
+          overlay: dnf5-ci
 
   integration-tests:
     name: DNF Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
         # A workaround for an undeterministic "OCI not found" error, see
         # https://github.com/containers/podman/issues/10321
         - /var/lib/mycontainer:/var/lib/containers
+    strategy:
+      matrix:
+        extra-run-args: [--tags dnf5 --command microdnf5, --tags dnfdaemon --command dnfdaemon-client]
     steps:
       - name: Check out ci-dnf-stack
         uses: actions/checkout@v2
@@ -104,5 +107,5 @@ jobs:
         uses: ./.github/actions/integration-tests
         with:
           package-urls: ${{needs.copr-build.outputs.package-urls}}
-          extra-run-args: --tags dnf5 --command microdnf5
+          extra-run-args: ${{matrix.extra-run-args}}
           base-image: fedora:35


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/1038

