### PR TITLE
CI: Build only for f35 and higher in Package Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build in Copr
         run: |
-          CHROOTS="fedora-33-x86_64, fedora-34-x86_64, fedora-rawhide-x86_64"
+          CHROOTS="fedora-35-x86_64, fedora-rawhide-x86_64"
           PROJECT_NAME="CI-libdnf5-pr${{github.event.pull_request.number}}"
           if [[ -n "${{matrix.compiler}}" ]]; then
             PROJECT_NAME+="-${{matrix.compiler}}"


### PR DESCRIPTION
In preparation for merging new rpm transaction callbacks which require
rpm >= 4.17.

For: https://github.com/rpm-software-management/libdnf/pull/1287