### PR TITLE
[dnf5] microdnf: Add more command line arguments 

### DIFF
--- a/microdnf/context.hpp
+++ b/microdnf/context.hpp
@@ -49,6 +49,8 @@ public:
 
     libdnf::Base base;
     std::vector<std::pair<std::string, std::string>> setopts;
+    std::vector<std::string> enable_plugins_patterns;
+    std::vector<std::string> disable_plugins_patterns;
 
     /// Gets program arguments.
     libdnf::Span<const char * const> get_prg_arguments() const { return prg_args; }

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -166,7 +166,7 @@ static void set_commandline_args(Context & ctx) {
     auto setopt = ctx.get_argument_parser().add_new_named_arg("setopt");
     setopt->set_long_name("setopt");
     setopt->set_has_value(true);
-    setopt->set_arg_value_help("KEY=VALUE");
+    setopt->set_arg_value_help("[REPO_ID.]OPTION=VALUE");
     setopt->set_short_description("set arbitrary config and repo options");
     setopt->set_description(
         R"**(Override a configuration option from the configuration file. To override configuration options for repositories, use repoid.option for  the
@@ -206,7 +206,7 @@ static void set_commandline_args(Context & ctx) {
     auto setvar = ctx.get_argument_parser().add_new_named_arg("setvar");
     setvar->set_long_name("setvar");
     setvar->set_has_value(true);
-    setvar->set_arg_value_help("NAME=VALUE");
+    setvar->set_arg_value_help("VAR_NAME=VALUE");
     setvar->set_short_description("set arbitrary variable");
     setvar->set_parse_hook_func(
         [&ctx](

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -333,6 +333,22 @@ static void set_commandline_args(Context & ctx) {
             new std::vector<ArgumentParser::Argument *>{enable_repoids, disable_repo_ids}));
     repo_ids->set_conflict_arguments(repo_conflict_args);
 
+    auto no_gpgchecks = ctx.get_argument_parser().add_new_named_arg("no-gpgchecks");
+    no_gpgchecks->set_long_name("no-gpgchecks");
+    no_gpgchecks->set_short_description("disable gpg signature checking (if RPM policy allows)");
+    no_gpgchecks->set_parse_hook_func([&ctx](
+                                         [[maybe_unused]] ArgumentParser::NamedArg * arg,
+                                         [[maybe_unused]] const char * option,
+                                         [[maybe_unused]] const char * value) {
+        ctx.base.get_config().gpgcheck().set(libdnf::Option::Priority::COMMANDLINE, 0);
+        ctx.base.get_config().repo_gpgcheck().set(libdnf::Option::Priority::COMMANDLINE, 0);
+        // Store to vector. Use it later when repositories configuration will be loaded.
+        ctx.setopts.emplace_back("*.gpgcheck", "0");
+        ctx.setopts.emplace_back("*.repo_gpgcheck", "0");
+        return true;
+    });
+    microdnf->register_named_arg(no_gpgchecks);
+
     auto comment = ctx.get_argument_parser().add_new_named_arg("comment");
     comment->set_long_name("comment");
     comment->set_has_value(true);


### PR DESCRIPTION
Adds `--enable-repo`, `--disable-repo`, `--repo`, `--enable-plugin`, `--disable-plugin`, `--no-plugins`, `--no-gpgchecks`

* `--enable-repo`, `--disable-repo` options accept a list of repository IDs, globs are supported
* `--enable-repo`, `--disable-repo` conflict with `--repo`

* `--enable-plugin`, `--disable-plugin` options accept a list of plugins names, globs are supported
* `--enable-plugin`, `--disable-plugin` conflict with `--no-plugins`

Consistency and DNF4 incompatibility:
Using prefix `no` with `-`:
- `--nogpgcheck` -> `--no-gpgcheck` (and plural `--no-gpgchecks`)
- `--noplugins` -> `--no-plugins`

And what about the prefixes `--enable` and `--disable`? 
- `--enablerepo` or  `--enable-repo`; `--disablerepo` or `--disable-repo`
- `--enableplugin` or `--enable-plugin`; `--disableplugin` or `--disable-plugin`

Repositories are defined by IDs (may contain globs).
- `--enablerepo` or `--enablerepoid` or `--enablerepoids`; `--disablerepo` or `--disablerepoid` or `--disablerepoids`
- `--repo` or `--repoid` or `--repoids`