### PR TITLE
[dnf5] Modify the code to be compatible with C++20

### DIFF
--- a/dnfdaemon-client/commands/repoquery/repoquery.cpp
+++ b/dnfdaemon-client/commands/repoquery/repoquery.cpp
@@ -25,7 +25,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf-cli/output/repoquery.hpp"
 
 #include <dnfdaemon-server/dbus.hpp>
-#include <fmt/format.h>
 #include <libdnf/conf/option_string.hpp>
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>

--- a/dnfdaemon-client/main.cpp
+++ b/dnfdaemon-client/main.cpp
@@ -29,7 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnfdaemon-server/dbus.hpp>
 #include <fcntl.h>
-#include <fmt/format.h>
+#include <libdnf/common/format.hpp>
 #include <libdnf-cli/exit-codes.hpp>
 #include <libdnf-cli/session.hpp>
 #include <libdnf/base/base.hpp>
@@ -141,7 +141,7 @@ static bool parse_args(Context & ctx, int argc, char * argv[]) {
     installroot->set_parse_hook_func(
         [](libdnf::cli::ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             if (value[0] != '/') {
-                throw std::runtime_error(fmt::format("--{}: Absolute path must be used.", arg->get_long_name()));
+                throw std::runtime_error(libdnf::format("--{}: Absolute path must be used.", arg->get_long_name()));
             }
             return true;
         });
@@ -257,7 +257,7 @@ int main(int argc, char * argv[]) {
         std::cout << ex.what() << std::endl;
         return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
     } catch (std::exception & ex) {
-        std::cerr << fmt::format("Command returned error: {}", ex.what()) << std::endl;
+        std::cerr << libdnf::format("Command returned error: {}", ex.what()) << std::endl;
         return static_cast<int>(libdnf::cli::ExitCode::ERROR);
     }
 

--- a/dnfdaemon-server/package.cpp
+++ b/dnfdaemon-server/package.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "package.hpp"
 
-#include <fmt/format.h>
+#include <libdnf/common/format.hpp>
 
 #include <map>
 
@@ -53,7 +53,7 @@ dnfdaemon::KeyValueMap package_to_map(
     for (auto & attr : attributes) {
         auto it = package_attributes.find(attr);
         if (it == package_attributes.end()) {
-            throw std::runtime_error(fmt::format("Package attribute '{}' not supported", attr));
+            throw std::runtime_error(libdnf::format("Package attribute '{}' not supported", attr));
         }
         switch (it->second) {
             case PackageAttribute::name:

--- a/dnfdaemon-server/services/base/base.cpp
+++ b/dnfdaemon-server/services/base/base.cpp
@@ -22,7 +22,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "dnfdaemon-server/dbus.hpp"
 #include "dnfdaemon-server/utils.hpp"
 
-#include <fmt/format.h>
 #include <libdnf/repo/repo.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 #include <unistd.h>

--- a/dnfdaemon-server/services/comps/group.cpp
+++ b/dnfdaemon-server/services/comps/group.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "dnfdaemon-server/dbus.hpp"
 
+#include <libdnf/common/format.hpp>
 #include <libdnf/comps/group/group.hpp>
 #include <libdnf/comps/group/query.hpp>
 #include <sdbus-c++/sdbus-c++.h>
@@ -64,7 +65,7 @@ dnfdaemon::KeyValueMap group_to_map(libdnf::comps::Group & libdnf_group, const s
     for (auto & attr : attributes) {
         auto it = group_attributes.find(attr);
         if (it == group_attributes.end()) {
-            throw std::runtime_error(fmt::format("Group attribute '{}' not supported", attr));
+            throw std::runtime_error(libdnf::format("Group attribute '{}' not supported", attr));
         }
         switch (it->second) {
             case GroupAttribute::groupid:

--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -25,7 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "dnfdaemon-server/transaction.hpp"
 #include "dnfdaemon-server/utils.hpp"
 
-#include <fmt/format.h>
+#include <libdnf/common/format.hpp>
 #include <libdnf/rpm/transaction.hpp>
 #include <libdnf/transaction/transaction_item.hpp>
 #include <sdbus-c++/sdbus-c++.h>
@@ -175,7 +175,7 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
     rpm_transaction.register_cb(nullptr);
     if (rpm_result != 0) {
         throw sdbus::Error(
-            dnfdaemon::ERROR_TRANSACTION, fmt::format("rpm transaction failed with code {}.", rpm_result));
+            dnfdaemon::ERROR_TRANSACTION, libdnf::format("rpm transaction failed with code {}.", rpm_result));
     }
 
     time = std::chrono::system_clock::now().time_since_epoch();

--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "dnfdaemon-server/dbus.hpp"
 #include "dnfdaemon-server/utils.hpp"
 
-#include <fmt/format.h>
+#include <libdnf/common/format.hpp>
 #include <libdnf/repo/repo.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
@@ -223,7 +223,7 @@ sdbus::MethodReply Repo::list(sdbus::MethodCall & call) {
     bool fill_sack_needed = false;
     for (auto & attr_str : repo_attrs) {
         if (repo_attributes.count(attr_str) == 0) {
-            throw std::runtime_error(fmt::format("Repo attribute '{}' not supported", attr_str));
+            throw std::runtime_error(libdnf::format("Repo attribute '{}' not supported", attr_str));
         }
         if (!fill_sack_needed) {
             fill_sack_needed = std::find(

--- a/dnfdaemon-server/services/repoconf/configuration.cpp
+++ b/dnfdaemon-server/services/repoconf/configuration.cpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "configuration.hpp"
 
-#include <fmt/format.h>
+#include <libdnf/common/format.hpp>
 #include <glob.h>
 #include <rpm/rpmlib.h>
 
@@ -54,7 +54,7 @@ void Configuration::read_main_config() {
         // store the parser so it can be used for saving the config file later on
         config_parsers[std::move(main_config_path)] = std::move(main_parser);
     } catch (const std::exception & e) {
-        logger.warning(fmt::format("Error parsing config file \"{}\": {}", main_config_path, e.what()));
+        logger.warning(libdnf::format("Error parsing config file \"{}\": {}", main_config_path, e.what()));
     }
 }
 
@@ -91,7 +91,7 @@ void Configuration::read_repo_configs() {
             pattern = std::filesystem::canonical(repos_dir).string() + "/*.repo";
         } catch (std::filesystem::filesystem_error & e) {
             logger.debug(
-                fmt::format("Error reading repository configuration directory \"{}\": {}", repos_dir, e.what()));
+                libdnf::format("Error reading repository configuration directory \"{}\": {}", repos_dir, e.what()));
             continue;
         }
         glob_t glob_result;
@@ -102,7 +102,7 @@ void Configuration::read_repo_configs() {
             try {
                 repo_parser->read(file_path);
             } catch (libdnf::ConfigParser::Exception & e) {
-                logger.warning(fmt::format("Error parsing config file \"{}\": {}", file_path, e.what()));
+                logger.warning(libdnf::format("Error parsing config file \"{}\": {}", file_path, e.what()));
                 continue;
             }
             read_repos(repo_parser.get(), file_path);

--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -29,6 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "services/rpm/rpm.hpp"
 #include "utils.hpp"
 
+#include <libdnf/common/format.hpp>
 #include <libdnf/logger/logger.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
@@ -81,7 +82,7 @@ Session::Session(
         if (bind != opt_binds.end()) {
             bind->second.new_string(libdnf::Option::Priority::RUNTIME, value);
         } else {
-            logger.warning(fmt::format("Unknown config option: {}", key));
+            logger.warning(libdnf::format("Unknown config option: {}", key));
         }
     }
 

--- a/dnfdaemon-server/session.hpp
+++ b/dnfdaemon-server/session.hpp
@@ -24,7 +24,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "threads_manager.hpp"
 #include "utils.hpp"
 
-#include <fmt/format.h>
 #include <libdnf/base/base.hpp>
 #include <libdnf/base/goal.hpp>
 #include <sdbus-c++/sdbus-c++.h>

--- a/dnfdaemon-server/threads_manager.hpp
+++ b/dnfdaemon-server/threads_manager.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "dbus.hpp"
 
-#include <fmt/format.h>
+#include <libdnf/common/format.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
 #include <atomic>
@@ -66,7 +66,7 @@ public:
                     error_msg = "Unknown exception caught";
                 }
                 if (!success) {
-                    std::cerr << fmt::format(
+                    std::cerr << libdnf::format(
                                      "Error sending D-Bus reply to {}:{}() call: {}",
                                      call.getInterfaceName(),
                                      call.getMemberName(),
@@ -96,7 +96,7 @@ public:
                     error_msg = "Unknown exception caught";
                 }
                 if (!success) {
-                    std::cerr << fmt::format(
+                    std::cerr << libdnf::format(
                                      "Error handling signal {}:{}: {}",
                                      signal.getInterfaceName(),
                                      signal.getMemberName(),

--- a/dnfdaemon-server/transaction.cpp
+++ b/dnfdaemon-server/transaction.cpp
@@ -19,8 +19,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "transaction.hpp"
 
-#include <fmt/format.h>
-
 
 namespace dnfdaemon {
 

--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -20,7 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_UTILS_EXCEPTION_HPP
 #define LIBDNF_UTILS_EXCEPTION_HPP
 
-#include <fmt/format.h>
+#include "format.hpp"
 
 #include <stdexcept>
 
@@ -38,8 +38,8 @@ public:
     /// @param format The format string for the message.
     /// @param args The format arguments.
     template<typename... Ss>
-    AssertionError(const std::string & format, Ss&&... args)
-        : std::logic_error(fmt::format(format, std::forward<Ss>(args)...)) {}
+    AssertionError(std::string_view format_string, Ss&&... args)
+        : std::logic_error(format_runtime(format_string, std::forward<Ss>(args)...)) {}
 };
 
 /// An assert function that throws `libdnf::AssertionError` when `condition`
@@ -50,9 +50,9 @@ public:
 /// @param args The format arguments.
 /// @exception libdnf::AssertionError Thrown when condition is not met.
 template<typename... Ss>
-void libdnf_assert(bool condition, const std::string & format, Ss&&... args) {
+void libdnf_assert(bool condition, std::string_view format_string, Ss&&... args) {
     if (!condition) {
-        throw AssertionError(format, std::forward<Ss>(args)...);
+        throw AssertionError(format_string, std::forward<Ss>(args)...);
     }
 }
 

--- a/include/libdnf/common/format.hpp
+++ b/include/libdnf/common/format.hpp
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_COMMON_FORMAT_HPP
+#define LIBDNF_COMMON_FORMAT_HPP
+
+#if __has_include(<format>)
+#include <format>
+#endif
+
+#ifdef __cpp_lib_format
+
+namespace libdnf {
+    using std::format;
+    using std::vformat;
+    using std::make_format_args;
+}
+
+#else
+
+// If the compiler does not support `std::format`, use the fmt library.
+#include <fmt/format.h>
+namespace libdnf {
+    using fmt::format;
+    using fmt::vformat;
+    using fmt::make_format_args;
+}
+
+#endif  // __cpp_lib_format
+
+namespace libdnf {
+
+/// Format `args` according to the `runtime_format_string`, and return the result as a string.
+template <typename... Args>
+inline std::string format_runtime(std::string_view runtime_format_string, Args&&... args) {
+    return vformat(runtime_format_string, make_format_args(args...));
+}
+
+}
+
+#endif  // LIBDNF_COMMON_FORMAT_HPP

--- a/include/libdnf/common/preserve_order_map.hpp
+++ b/include/libdnf/common/preserve_order_map.hpp
@@ -82,8 +82,8 @@ public:
     };
     using iterator = MyBidirIterator<value_type, typename container_type::iterator>;
     using const_iterator = MyBidirIterator<const value_type, typename container_type::const_iterator>;
-    using reverse_iterator = std::reverse_iterator<iterator>;
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using reverse_iterator =  MyBidirIterator<value_type, typename container_type::reverse_iterator>;
+    using const_reverse_iterator =  MyBidirIterator<value_type, typename container_type::const_reverse_iterator>;
 
     bool empty() const noexcept { return items.empty(); }
     size_type size() const noexcept { return items.size(); }

--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -22,10 +22,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf-cli/output/argument_parser.hpp"
 
+#include "libdnf/common/format.hpp"
 #include "libdnf/utils/bgettext/bgettext-lib.h"
 #include "libdnf/utils/string.hpp"
 
-#include <fmt/format.h>
 
 #include <cstring>
 #include <iomanip>
@@ -74,11 +74,11 @@ std::string ArgumentParser::Argument::get_conflict_arg_msg(const Argument * conf
         if (named_arg->get_short_name() != '\0') {
             conflict = std::string("\"-") + named_arg->get_short_name() + "\"";
         }
-        msg = fmt::format("not allowed with argument {}", conflict);
+        msg = format_runtime("not allowed with argument {}", conflict);
     } else if (dynamic_cast<const Command *>(conflict_arg)) {
-        msg = fmt::format("not allowed with command {}", conflict_arg->id);
+        msg = format_runtime("not allowed with command {}", conflict_arg->id);
     } else {
-        msg = fmt::format("not allowed with positional argument {}", conflict_arg->id);
+        msg = format_runtime("not allowed with positional argument {}", conflict_arg->id);
     }
     return msg;
 }
@@ -116,7 +116,7 @@ void ArgumentParser::PositionalArg::set_store_value(bool enable) {
 int ArgumentParser::PositionalArg::parse(const char * option, int argc, const char * const argv[]) {
     if (const auto * arg = get_conflict_argument()) {
         auto conflict = get_conflict_arg_msg(arg);
-        auto msg = fmt::format("positional argument \"{}\": {}", option, conflict);
+        auto msg = format_runtime("positional argument \"{}\": {}", option, conflict);
         throw Conflict(msg);
     }
     if (owner.complete_arg_ptr) {
@@ -176,7 +176,7 @@ int ArgumentParser::PositionalArg::parse(const char * option, int argc, const ch
 int ArgumentParser::NamedArg::parse_long(const char * option, int argc, const char * const argv[]) {
     if (const auto * arg = get_conflict_argument()) {
         auto conflict = get_conflict_arg_msg(arg);
-        auto msg = fmt::format("argument \"--{}\": {}", option, conflict);
+        auto msg = format_runtime("argument \"--{}\": {}", option, conflict);
         throw Conflict(msg);
     }
     const char * arg_value;
@@ -214,7 +214,7 @@ int ArgumentParser::NamedArg::parse_long(const char * option, int argc, const ch
 int ArgumentParser::NamedArg::parse_short(const char * option, int argc, const char * const argv[]) {
     if (const auto * arg = get_conflict_argument()) {
         auto conflict = get_conflict_arg_msg(arg);
-        auto msg = fmt::format("argument \"-{}\": {:.1}", option, conflict);
+        auto msg = format_runtime("argument \"-{}\": {:.1}", option, conflict);
         throw Conflict(msg);
     }
     const char * arg_value;
@@ -465,7 +465,7 @@ void ArgumentParser::Command::parse(
                 if (cmd->id == argv[i]) {
                     if (const auto * arg = get_conflict_argument()) {
                         auto conflict = get_conflict_arg_msg(arg);
-                        auto msg = fmt::format("command \"{}\": {}", option, conflict);
+                        auto msg = format_runtime("command \"{}\": {}", option, conflict);
                         throw Conflict(msg);
                     }
                     // the last subcommand wins

--- a/libdnf-cli/output/transaction_table.hpp
+++ b/libdnf-cli/output/transaction_table.hpp
@@ -24,9 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf-cli/utils/tty.hpp"
 #include "libdnf-cli/utils/units.hpp"
 
+#include <libdnf/common/format.hpp>
 #include <libdnf/rpm/nevra.hpp>
 
-#include <fmt/format.h>
 #include <libsmartcols/libsmartcols.h>
 
 #include <iostream>
@@ -176,22 +176,22 @@ public:
     void print() {
         std::cout << "\nTransaction Summary:\n";
         if (installs != 0) {
-            std::cout << fmt::format(" {:15} {:4} packages\n", "Installing:", installs);
+            std::cout << format_runtime(" {:15} {:4} packages\n", "Installing:", installs);
         }
         if (reinstalls != 0) {
-            std::cout << fmt::format(" {:15} {:4} packages\n", "Reinstalling:", reinstalls);
+            std::cout << format_runtime(" {:15} {:4} packages\n", "Reinstalling:", reinstalls);
         }
         if (upgrades != 0) {
-            std::cout << fmt::format(" {:15} {:4} packages\n", "Upgrading:", upgrades);
+            std::cout << format_runtime(" {:15} {:4} packages\n", "Upgrading:", upgrades);
         }
         if ( replaced != 0) {
-            std::cout << fmt::format(" {:15} {:4} packages\n", "Replacing:", replaced );
+            std::cout << format_runtime(" {:15} {:4} packages\n", "Replacing:", replaced );
         }
         if (removes != 0) {
-            std::cout << fmt::format(" {:15} {:4} packages\n", "Removing:", removes);
+            std::cout << format_runtime(" {:15} {:4} packages\n", "Removing:", removes);
         }
         if (downgrades != 0) {
-            std::cout << fmt::format(" {:15} {:4} packages\n", "Downgrading:", downgrades);
+            std::cout << format_runtime(" {:15} {:4} packages\n", "Downgrading:", downgrades);
         }
         std::cout << std::endl;
     }

--- a/libdnf-cli/progressbar/widgets/common.cpp
+++ b/libdnf-cli/progressbar/widgets/common.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf-cli/utils/units.hpp"
 
-#include <fmt/format.h>
+#include "libdnf/common/format.hpp"
 
 
 namespace libdnf::cli::progressbar {
@@ -48,25 +48,25 @@ std::string format_time(int64_t num, bool negative) {
     int64_t seconds = std::abs(num) % 60;
     int64_t minutes = std::abs(num) / 60;
     if (minutes < 60) {
-        return fmt::format("{0}{1:02d}m{2:02d}s", negative_sign, minutes, seconds);
+        return format("{0}{1:02d}m{2:02d}s", negative_sign, minutes, seconds);
     }
 
     // display [ -]HHhMMm
     int64_t hours = minutes / 60;
     minutes = minutes % 60;
     if (hours < 24) {
-        return fmt::format("{0}{1:02d}h{2:02d}m", negative_sign, hours, minutes);
+        return format("{0}{1:02d}h{2:02d}m", negative_sign, hours, minutes);
     }
 
     // display [ -]DDdHHh
     int64_t days = hours / 24;
     hours = hours % 24;
     if (days < 100) {
-        return fmt::format("{0}{1:02d}d{2:02d}h", negative_sign, days, hours);
+        return format("{0}{1:02d}d{2:02d}h", negative_sign, days, hours);
     }
 
     // display [ -]?
-    return fmt::format("{0}?     ", negative_sign);
+    return format("{0}?     ", negative_sign);
 }
 
 

--- a/libdnf-cli/utils/units.cpp
+++ b/libdnf-cli/utils/units.cpp
@@ -20,8 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "units.hpp"
 
+#include "libdnf/common/format.hpp"
+
 #include <cstring>
-#include <fmt/format.h>
 
 
 namespace libdnf::cli::utils::units {
@@ -47,7 +48,7 @@ std::string format_size(int64_t num) {
         i /= 1024;
         index++;
     }
-    return fmt::format("{0:.1f} {1:>3s}", i, SIZE_UNITS[index]);
+    return format("{0:.1f} {1:>3s}", i, SIZE_UNITS[index]);
 }
 
 

--- a/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -18,7 +18,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include <Python.h>
-#include <fmt/format.h>
+#include <libdnf/common/format.hpp>
 #include <libdnf/base/base.hpp>
 
 #include <cstdlib>
@@ -261,7 +261,7 @@ void PythonPluginLoader::load_plugins_from_dir(const fs::path & dir_path) {
         try {
             load_plugin_file(p);
         } catch (const std::exception & ex) {
-            std::string msg = fmt::format("Can't load plugin \"{}\": {}", p.string(), ex.what());
+            std::string msg = libdnf::format("Can't load plugin \"{}\": {}", p.string(), ex.what());
             logger.error(msg);
             error_msgs += msg + '\n';
         }
@@ -330,7 +330,7 @@ Version libdnf_plugin_get_version(void) {
 
 IPlugin * libdnf_plugin_new_instance(Version api_version) {
     if (api_version.major != PLUGIN_API_VERSION.major || api_version.minor != PLUGIN_API_VERSION.minor) {
-        auto msg = fmt::format(
+        auto msg = libdnf::format(
             "Unsupported API combination. API version implemented by plugin = \"{}.{}.{}\"."
             " API version in libdnf = \"{}.{}.{}\".",
             PLUGIN_API_VERSION.major,

--- a/libdnf/advisory/advisory.cpp
+++ b/libdnf/advisory/advisory.cpp
@@ -22,9 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/advisory/advisory_collection.hpp"
 #include "libdnf/advisory/advisory_reference.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/common/format.hpp"
 #include "libdnf/solv/pool.hpp"
-
-#include <fmt/format.h>
 
 namespace libdnf::advisory {
 
@@ -39,7 +38,7 @@ std::string Advisory::get_name() const {
     if (strncmp(
             libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX, name, libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX_LENGTH) !=
         0) {
-        auto msg = fmt::format(
+        auto msg = format_runtime(
             R"**(Bad libsolv id for advisory "{}", solvable name "{}" doesn't have advisory prefix "{}")**",
             id.id,
             name,

--- a/libdnf/advisory/advisory_module_private.hpp
+++ b/libdnf/advisory/advisory_module_private.hpp
@@ -23,7 +23,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/advisory/advisory.hpp"
 #include "libdnf/advisory/advisory_module.hpp"
 
+#define requires require
 #include <solv/pooltypes.h>
+#undef requires
 
 namespace libdnf::advisory {
 

--- a/libdnf/advisory/advisory_package.cpp
+++ b/libdnf/advisory/advisory_package.cpp
@@ -24,10 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/logger/logger.hpp"
 #include "libdnf/rpm/nevra.hpp"
 
+#define requires require
 #include <solv/chksum.h>
 #include <solv/repo.h>
 #include <solv/util.h>
-
+#undef requires
 
 namespace libdnf::advisory {
 

--- a/libdnf/advisory/advisory_package_private.hpp
+++ b/libdnf/advisory/advisory_package_private.hpp
@@ -24,8 +24,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/rpm/package_sack_impl.hpp"
 #include "libdnf/solv/pool.hpp"
 
+#define requires require
 #include <solv/pooltypes.h>
 #include <solv/solvable.h>
+#undef requires
 
 namespace libdnf::advisory {
 

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -28,7 +28,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/solv_map.hpp"
 #include "libdnf/utils/utils_internal.hpp"
 
+#define requires require
 #include <solv/evr.h>
+#undef requires
 
 // For glob support
 #include <fnmatch.h>

--- a/libdnf/advisory/advisory_reference.cpp
+++ b/libdnf/advisory/advisory_reference.cpp
@@ -22,9 +22,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/logger/logger.hpp"
 #include "libdnf/rpm/package_sack_impl.hpp"
 
+#define requires require
 #include <solv/chksum.h>
 #include <solv/repo.h>
 #include <solv/util.h>
+#undef requires
 
 namespace libdnf::advisory {
 

--- a/libdnf/advisory/advisory_sack.cpp
+++ b/libdnf/advisory/advisory_sack.cpp
@@ -22,7 +22,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/pool.hpp"
 #include "libdnf/solv/solv_map.hpp"
 
+#define requires require
 #include <solv/dataiterator.h>
+#undef requires
 
 namespace libdnf::advisory {
 

--- a/libdnf/advisory/advisory_set_impl.hpp
+++ b/libdnf/advisory/advisory_set_impl.hpp
@@ -26,10 +26,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/pool.hpp"
 #include "libdnf/solv/solv_map.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/pool.h>
 }
-
+#undef requires
 
 namespace libdnf::advisory {
 

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -23,8 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/conf/const.hpp"
 #include "libdnf/solv/pool.hpp"
 
-#include <fmt/format.h>
-
 #include <algorithm>
 #include <atomic>
 #include <cstdlib>

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -32,7 +32,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/id_queue.hpp"
 #include "libdnf/solv/pool.hpp"
 
-#include <fmt/format.h>
 #include <sys/utsname.h>
 
 #include <iostream>

--- a/libdnf/base/log_event.cpp
+++ b/libdnf/base/log_event.cpp
@@ -20,10 +20,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/base/log_event.hpp"
 
+#include "libdnf/common/format.hpp"
 #include "libdnf/utils/bgettext/bgettext-lib.h"
 #include "libdnf/utils/string.hpp"
-
-#include <fmt/format.h>
 
 namespace libdnf::base {
 
@@ -51,48 +50,48 @@ std::string LogEvent::to_string(
         // TODO(jmracek) Improve messages => Each message can contain also an action
         case GoalProblem::NOT_FOUND:
             if (action == GoalAction::REMOVE) {
-                return ret.append(fmt::format(_("No packages to remove for argument: {}"), *spec));
+                return ret.append(format_runtime(_("No packages to remove for argument: {}"), *spec));
             }
-            return ret.append(fmt::format(_("No match for argument: {}"), *spec));
+            return ret.append(format_runtime(_("No match for argument: {}"), *spec));
         case GoalProblem::NOT_FOUND_IN_REPOSITORIES:
-            return ret.append(fmt::format(
+            return ret.append(format_runtime(
                 _("No match for argument '{0}' in repositories '{1}'"),
                 *spec,
                 utils::string::join(settings->to_repo_ids, ", ")));
         case GoalProblem::NOT_INSTALLED:
-            return ret.append(fmt::format(_("Packages for argument '{}' available, but not installed."), *spec));
+            return ret.append(format_runtime(_("Packages for argument '{}' available, but not installed."), *spec));
         case GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE:
-            return ret.append(fmt::format(
+            return ret.append(format_runtime(
                 _("Packages for argument '{}' available, but installed for a different architecture."), *spec));
         case GoalProblem::ONLY_SRC:
-            return ret.append(fmt::format(_("Argument '{}' matches only source packages."), *spec));
+            return ret.append(format_runtime(_("Argument '{}' matches only source packages."), *spec));
         case GoalProblem::EXCLUDED:
-            return ret.append(fmt::format(_("Argument '{}' matches only excluded packages."), *spec));
+            return ret.append(format_runtime(_("Argument '{}' matches only excluded packages."), *spec));
         case GoalProblem::HINT_ICASE:
-            return ret.append(fmt::format(_("  * Maybe you meant: {}"), *spec));
+            return ret.append(format_runtime(_("  * Maybe you meant: {}"), *spec));
         case GoalProblem::HINT_ALTERNATIVES: {
             auto elements = utils::string::join(*additional_data, ", ");
-            return ret.append(fmt::format(_("There are following alternatives for '{0}': {1}"), *spec, elements));
+            return ret.append(format_runtime(_("There are following alternatives for '{0}': {1}"), *spec, elements));
         }
         case GoalProblem::INSTALLED_LOWEST_VERSION: {
             if (additional_data->size() != 1) {
                 throw std::invalid_argument("Incorrect number of elements for INSTALLED_LOWEST_VERSION");
             }
-            return ret.append(fmt::format(
+            return ret.append(format_runtime(
                 _("Package \"{}\" of lowest version already installed, cannot downgrade it."),
                 *additional_data->begin()));
         }
         case GoalProblem::INSTALLED_IN_DIFFERENT_VERSION:
             if (action == GoalAction::REINSTALL) {
-                return ret.append(fmt::format(
+                return ret.append(format_runtime(
                     _("Packages for argument '{}' installed and available, but in a different version => cannot "
                       "reinstall"),
                     *spec));
             }
-            return ret.append(fmt::format(
+            return ret.append(format_runtime(
                 _("Packages for argument '{}' installed and available, but in a different version."), *spec));
         case GoalProblem::NOT_AVAILABLE:
-            return ret.append(fmt::format(_("Packages for argument '{}' installed, but not available."), *spec));
+            return ret.append(format_runtime(_("Packages for argument '{}' installed, but not available."), *spec));
         case GoalProblem::NO_PROBLEM:
         case GoalProblem::SOLVER_ERROR:
             throw std::invalid_argument("Unsupported elements for a goal problem");
@@ -100,7 +99,7 @@ std::string LogEvent::to_string(
             if (additional_data->size() != 1) {
                 throw std::invalid_argument("Incorrect number of elements for ALREADY_INSTALLED");
             }
-            return ret.append(fmt::format(_("Package \"{}\" is already installed."), *additional_data->begin()));
+            return ret.append(format_runtime(_("Package \"{}\" is already installed."), *additional_data->begin()));
     }
     return ret;
 }

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -21,13 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "transaction_impl.hpp"
 
 #include "libdnf/base/base.hpp"
+#include "libdnf/common/format.hpp"
 #include "libdnf/rpm/package_query.hpp"
 #include "libdnf/rpm/package_set_impl.hpp"
 #include "libdnf/solv/pool.hpp"
 #include "libdnf/utils/bgettext/bgettext-lib.h"
 #include "libdnf/utils/string.hpp"
 
-#include <fmt/format.h>
 
 #include <iostream>
 
@@ -240,7 +240,7 @@ GoalProblem Transaction::Impl::report_not_found(
                 }
             }
             rpm::PackageQuery alternatives(hints);
-            std::string alternatives_provide = fmt::format("alternative-for({})", pkg_spec);
+            std::string alternatives_provide = format_runtime("alternative-for({})", pkg_spec);
             alternatives.filter_provides({alternatives_provide});
             if (!alternatives.empty()) {
                 std::set<std::string> hints;
@@ -307,7 +307,7 @@ std::string Transaction::package_solver_problem_to_string(
             if (raw.second.size() != 1) {
                 throw std::invalid_argument("Incorrect number of elements for a problem rule");
             }
-            return fmt::format(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0]);
+            return format_runtime(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0]);
         case ProblemRules::RULE_JOB:
         case ProblemRules::RULE_JOB_UNSUPPORTED:
         case ProblemRules::RULE_PKG:
@@ -323,7 +323,7 @@ std::string Transaction::package_solver_problem_to_string(
             if (raw.second.size() != 2) {
                 throw std::invalid_argument("Incorrect number of elements for a problem rule");
             }
-            return fmt::format(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0], raw.second[1]);
+            return format_runtime(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0], raw.second[1]);
         case ProblemRules::RULE_PKG_CONFLICTS:
         case ProblemRules::RULE_PKG_OBSOLETES:
         case ProblemRules::RULE_PKG_INSTALLED_OBSOLETES:
@@ -332,7 +332,7 @@ std::string Transaction::package_solver_problem_to_string(
             if (raw.second.size() != 3) {
                 throw std::invalid_argument("Incorrect number of elements for a problem rule");
             }
-            return fmt::format(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0], raw.second[1], raw.second[2]);
+            return format_runtime(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0], raw.second[1], raw.second[2]);
         case ProblemRules::RULE_UNKNOWN:
             if (raw.second.size() != 0) {
                 throw std::invalid_argument("Incorrect number of elements for a problem rule");
@@ -341,7 +341,7 @@ std::string Transaction::package_solver_problem_to_string(
         case ProblemRules::RULE_PKG_REMOVAL_OF_PROTECTED:
         case ProblemRules::RULE_PKG_REMOVAL_OF_RUNNING_KERNEL:
             auto elements = utils::string::join(raw.second, ", ");
-            return fmt::format(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), elements);
+            return format_runtime(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), elements);
     }
     return {};
 }
@@ -358,14 +358,14 @@ std::string Transaction::all_package_solver_problems_to_string() {
     }
     const char * problem_prefix = _("Problem {}: ");
 
-    output.append(fmt::format(problem_prefix, 1));
+    output.append(format_runtime(problem_prefix, 1));
     output.append(string_join(*p_impl->package_solver_problems.begin(), "\n  - "));
 
     int index = 2;
     for (auto iter = std::next(p_impl->package_solver_problems.begin()); iter != p_impl->package_solver_problems.end();
          ++iter) {
         output.append("\n ");
-        output.append(fmt::format(problem_prefix, index));
+        output.append(format_runtime(problem_prefix, index));
         output.append(string_join(*iter, "\n  - "));
         ++index;
     }

--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -25,8 +25,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/base/transaction.hpp"
 
+#define requires require
 #include <solv/transaction.h>
-
+#undef requires
 
 namespace libdnf::base {
 

--- a/libdnf/common/proc.cpp
+++ b/libdnf/common/proc.cpp
@@ -19,9 +19,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/common/proc.hpp"
 
+#include "libdnf/common/format.hpp"
+
 #include <errno.h>
 #include <fcntl.h>
-#include <fmt/format.h>
 #include <unistd.h>
 
 #include <cstdlib>
@@ -29,7 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf {
 
 uid_t read_login_uid_from_proc(pid_t pid) noexcept {
-    auto in = open(fmt::format("/proc/{}/loginuid", pid).c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    auto in = open(format("/proc/{}/loginuid", pid).c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
     if (in == -1) {
         return INVALID_UID;
     }

--- a/libdnf/comps/comps.cpp
+++ b/libdnf/comps/comps.cpp
@@ -22,12 +22,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/solv/pool.hpp>
 #include "libdnf/repo/repo_impl.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/pool.h>
 #include <solv/repo.h>
 #include <solv/repo_comps.h>
 #include <solv/solv_xfopen.h>
 }
+#undef requires
 
 #include <filesystem>
 

--- a/libdnf/comps/group/group-private.hpp
+++ b/libdnf/comps/group/group-private.hpp
@@ -24,9 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf/comps/group/group.hpp>
 
+#define requires require
 extern "C" {
 #include <solv/pool.h>
 }
+#undef requires
 
 namespace libdnf::comps {
 

--- a/libdnf/comps/group/group.cpp
+++ b/libdnf/comps/group/group.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/solv/pool.hpp>
 #include <libdnf/utils/xml.hpp>
 
+#define requires require
 extern "C" {
 #include <solv/knownid.h>
 #include <solv/pool.h>
@@ -33,6 +34,7 @@ extern "C" {
 #include <solv/solvable.h>
 #include <solv/dataiterator.h>
 }
+#undef requires
 
 #include <string>
 #include <iostream>
@@ -213,8 +215,8 @@ std::vector<Package> Group::get_packages() {
     Solvable * solvable = pool.id2solvable(group_ids[0].id);
 
     // Load MANDATORY pacakges from solvable->requires
-    if (solvable->requires) {
-        for (Id * r_id = solvable->repo->idarraydata + solvable->requires; *r_id; ++r_id) {
+    if (solvable->require) {
+        for (Id * r_id = solvable->repo->idarraydata + solvable->require; *r_id; ++r_id) {
             packages.push_back(Package(pool.id2str(*r_id), PackageType::MANDATORY, ""));
         }
     }

--- a/libdnf/comps/group/query.cpp
+++ b/libdnf/comps/group/query.cpp
@@ -25,10 +25,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/comps/comps.hpp"
 #include <libdnf/solv/pool.hpp>
 
+#define requires require
 extern "C" {
 #include <solv/pool.h>
 #include <solv/repo.h>
 }
+#undef requires
 
 namespace libdnf::comps {
 

--- a/libdnf/comps/group/sack.cpp
+++ b/libdnf/comps/group/sack.cpp
@@ -24,12 +24,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/comps/group/query.hpp"
 #include "libdnf/comps/comps.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/knownid.h>
 #include <solv/pool.h>
 #include <solv/repo.h>
 #include <solv/solvable.h>
 }
+#undef requires
 
 #include <map>
 

--- a/libdnf/conf/config.cpp
+++ b/libdnf/conf/config.cpp
@@ -19,7 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/config.hpp"
 
-#include <fmt/format.h>
+#include "libdnf/common/format.hpp"
 
 namespace libdnf {
 
@@ -38,7 +38,7 @@ void Config<default_priority>::load_from_parser(
                 try {
                     opt_binds_iter->second.new_string(default_priority, vars.substitute(opt.second));
                 } catch (const Option::Exception & ex) {
-                    logger.warning(fmt::format(
+                    logger.warning(format_runtime(
                         R"**(Config error in section "{}" key "{}": {}: {})**",
                         section,
                         opt.first,

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -21,10 +21,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "config_utils.hpp"
 
+#include "libdnf/common/format.hpp"
 #include "libdnf/conf/config_parser.hpp"
 #include "libdnf/conf/const.hpp"
 
-#include <fmt/format.h>
 #include <glob.h>
 
 #include <algorithm>
@@ -55,12 +55,12 @@ static int str_to_bytes(const std::string & str) {
     std::size_t idx;
     auto res = std::stod(str, &idx);
     if (res < 0) {
-        throw Option::InvalidValue(fmt::format("seconds value '{}' must not be negative", str));
+        throw Option::InvalidValue(format_runtime("seconds value '{}' must not be negative", str));
     }
 
     if (idx < str.length()) {
         if (idx < str.length() - 1) {
-            throw Option::InvalidValue(fmt::format("could not convert '{}' to bytes", str));
+            throw Option::InvalidValue(format_runtime("could not convert '{}' to bytes", str));
         }
         switch (str.back()) {
             case 'k':
@@ -76,7 +76,7 @@ static int str_to_bytes(const std::string & str) {
                 res *= 1024 * 1024 * 1024;
                 break;
             default:
-                throw Option::InvalidValue(fmt::format("unknown unit '{}'", str.back()));
+                throw Option::InvalidValue(format_runtime("unknown unit '{}'", str.back()));
         }
     }
 

--- a/libdnf/plugin/plugins.cpp
+++ b/libdnf/plugin/plugins.cpp
@@ -20,9 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/plugin/plugins.hpp"
 
 #include "libdnf/base/base.hpp"
+#include "libdnf/common/format.hpp"
 #include "libdnf/utils/bgettext/bgettext-lib.h"
-
-#include <fmt/format.h>
 
 #include <filesystem>
 
@@ -56,28 +55,28 @@ void Plugins::register_plugin(std::unique_ptr<Plugin> && plugin) {
     plugins.emplace_back(std::move(plugin));
     auto name = iplugin->get_name();
     auto version = iplugin->get_version();
-    logger.debug(fmt::format(
+    logger.debug(format_runtime(
         _("Added plugin name=\"{}\", version=\"{}.{}.{}\""), name, version.major, version.minor, version.micro));
 
-    logger.debug(fmt::format(_("Trying to load more plugins using the \"{}\" plugin."), name));
+    logger.debug(format_runtime(_("Trying to load more plugins using the \"{}\" plugin."), name));
     iplugin->load_plugins(base);
-    logger.debug(fmt::format(_("End of loading plugins using the \"{}\" plugin."), name));
+    logger.debug(format_runtime(_("End of loading plugins using the \"{}\" plugin."), name));
 }
 
 void Plugins::load_plugin(const std::string & file_path) {
     auto & logger = *base->get_logger();
-    logger.debug(fmt::format(_("Loading plugin file=\"{}\""), file_path));
+    logger.debug(format_runtime(_("Loading plugin file=\"{}\""), file_path));
     auto plugin = std::make_unique<PluginLibrary>(file_path);
     auto * iplugin = plugin->get_iplugin();
     plugins.emplace_back(std::move(plugin));
     auto name = iplugin->get_name();
     auto version = iplugin->get_version();
-    logger.debug(fmt::format(
+    logger.debug(format_runtime(
         _("Loaded plugin name=\"{}\", version=\"{}.{}.{}\""), name, version.major, version.minor, version.micro));
 
-    logger.debug(fmt::format(_("Trying to load more plugins using the \"{}\" plugin."), name));
+    logger.debug(format_runtime(_("Trying to load more plugins using the \"{}\" plugin."), name));
     iplugin->load_plugins(base);
-    logger.debug(fmt::format(_("End of loading plugins using the \"{}\" plugin."), name));
+    logger.debug(format_runtime(_("End of loading plugins using the \"{}\" plugin."), name));
 }
 
 void Plugins::load_plugins(const std::string & dir_path) {
@@ -98,7 +97,7 @@ void Plugins::load_plugins(const std::string & dir_path) {
         try {
             load_plugin(p);
         } catch (const std::exception & ex) {
-            std::string msg = fmt::format(_("Can't load plugin \"{}\": {}"), p.string(), ex.what());
+            std::string msg = format_runtime(_("Can't load plugin \"{}\": {}"), p.string(), ex.what());
             logger.error(msg);
             error_msgs += msg + '\n';
         }

--- a/libdnf/repo/config_repo.cpp
+++ b/libdnf/repo/config_repo.cpp
@@ -23,8 +23,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/const.hpp"
 
+#define requires require
 #include <solv/chksum.h>
 #include <solv/util.h>
+#undef requires
 
 #include <filesystem>
 

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -20,10 +20,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/repo/package_downloader.hpp"
 
 #include "libdnf/common/exception.hpp"
+#include "libdnf/common/format.hpp"
 #include "libdnf/repo/repo_impl.hpp"
 #include "libdnf/utils/bgettext/bgettext-lib.h"
 
-#include <fmt/format.h>
 #include <librepo/librepo.h>
 
 #include <filesystem>

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -28,9 +28,11 @@ constexpr const char * REPOID_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmno
 #include "libdnf/utils/string.hpp"
 #include "libdnf/utils/temp.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/repo_rpmdb.h>
 }
+#undef requires
 
 #include <fcntl.h>
 #include <glib.h>

--- a/libdnf/repo/repo_downloader.cpp
+++ b/libdnf/repo/repo_downloader.cpp
@@ -27,8 +27,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/utils/temp.hpp"
 
 #include <librepo/librepo.h>
+
+#define requires require
 #include <solv/chksum.h>
 #include <solv/util.h>
+#undef requires
 
 #include <filesystem>
 #include <fstream>

--- a/libdnf/repo/repo_impl.hpp
+++ b/libdnf/repo/repo_impl.hpp
@@ -25,9 +25,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/repo/repo.hpp"
 
 #include <gpgme.h>
+
+#define requires require
 #include <solv/chksum.h>
 #include <solv/repo.h>
 #include <solv/util.h>
+#undef requires
+
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -23,11 +23,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/base/base.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/common/format.hpp"
 #include "libdnf/conf/config_parser.hpp"
 #include "libdnf/conf/option_bool.hpp"
 #include "libdnf/rpm/package_sack_impl.hpp"
 
-#include <fmt/format.h>
 
 extern "C" {
 #include <solv/repo.h>
@@ -92,7 +92,7 @@ void RepoSack::new_repos_from_file(const std::string & path) {
         }
         auto repo_id = base->get_vars()->substitute(section);
 
-        logger.debug(fmt::format(
+        logger.debug(format_runtime(
             R"**(Start of loading configuration of repository "{}" from file "{}" section "{}")**",
             repo_id,
             path,
@@ -100,7 +100,7 @@ void RepoSack::new_repos_from_file(const std::string & path) {
 
         auto bad_char_idx = Repo::verify_id(repo_id);
         if (bad_char_idx != std::string::npos) {
-            auto msg = fmt::format(
+            auto msg = format_runtime(
                 R"**(Bad id for repo "{}" section "{}", char = {} at pos {})**",
                 repo_id,
                 section,
@@ -112,10 +112,10 @@ void RepoSack::new_repos_from_file(const std::string & path) {
         auto repo = new_repo(repo_id);
         auto & repo_cfg = repo->get_config();
         repo_cfg.load_from_parser(parser, section, *base->get_vars(), *base->get_logger());
-        logger.trace(fmt::format(R"**(Loading configuration of repository "{}" from file "{}" done)**", repo_id, path));
+        logger.trace(format_runtime(R"**(Loading configuration of repository "{}" from file "{}" done)**", repo_id, path));
 
         if (repo_cfg.name().get_priority() == Option::Priority::DEFAULT) {
-            logger.warning(fmt::format(
+            logger.warning(format_runtime(
                 "Repository \"{}\" is missing name in configuration file \"{}\", using id.", repo_id, path));
             repo_cfg.name().set(Option::Priority::REPOCONFIG, repo_id);
         }

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -28,12 +28,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/conf/option_bool.hpp"
 #include "libdnf/rpm/package_sack_impl.hpp"
 
-
+#define requires require
 extern "C" {
 #include <solv/repo.h>
 #include <solv/solv_xfopen.h>
 #include <solv/testcase.h>
 }
+#undef requires
 
 #include <cerrno>
 #include <filesystem>

--- a/libdnf/rpm/checksum.cpp
+++ b/libdnf/rpm/checksum.cpp
@@ -19,9 +19,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/rpm/checksum.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/chksum.h>
 }
+#undef requires
 
 namespace libdnf::rpm {
 

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -26,11 +26,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/base_private.hpp"
 #include "libdnf/utils/utils_internal.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/evr.h>
 #include <solv/selection.h>
 #include <solv/solver.h>
 }
+#undef requires
 
 #include <fnmatch.h>
 

--- a/libdnf/rpm/package_query_impl.hpp
+++ b/libdnf/rpm/package_query_impl.hpp
@@ -24,9 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/rpm/package_query.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/solvable.h>
 }
+#undef requires
 
 namespace libdnf::rpm {
 

--- a/libdnf/rpm/package_sack.cpp
+++ b/libdnf/rpm/package_sack.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/id_queue.hpp"
 #include "libdnf/solv/solv_map.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/chksum.h>
 #include <solv/repo.h>
@@ -41,6 +42,7 @@ extern "C" {
 #include <solv/solver.h>
 #include <solv/testcase.h>
 }
+#undef requires
 
 #include <filesystem>
 

--- a/libdnf/rpm/package_sack_impl.hpp
+++ b/libdnf/rpm/package_sack_impl.hpp
@@ -27,9 +27,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/pool.hpp"
 #include "libdnf/solv/solv_map.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/pool.h>
 }
+#undef requires
 
 #include <vector>
 

--- a/libdnf/rpm/package_set_impl.hpp
+++ b/libdnf/rpm/package_set_impl.hpp
@@ -26,10 +26,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/pool.hpp"
 #include "libdnf/solv/solv_map.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/pool.h>
 }
-
+#undef requires
 
 namespace libdnf::rpm {
 

--- a/libdnf/rpm/reldep.cpp
+++ b/libdnf/rpm/reldep.cpp
@@ -23,11 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/reldep_parser.hpp"
 
 // workaround, libsolv lacks 'extern "C"' in its header file
+#define requires require
 extern "C" {
 #include <solv/pool.h>
 #include <solv/pool_parserpmrichdep.h>
 #include <solv/util.h>
 }
+#undef requires
 
 #include <stdexcept>
 

--- a/libdnf/rpm/reldep_list.cpp
+++ b/libdnf/rpm/reldep_list.cpp
@@ -26,11 +26,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/rpm/reldep.hpp"
 
 // libsolv
+#define requires require
 extern "C" {
 #include <solv/dataiterator.h>
 #include <solv/queue.h>
 }
-
+#undef requires
 
 namespace libdnf::rpm {
 

--- a/libdnf/rpm/solv/goal_private.cpp
+++ b/libdnf/rpm/solv/goal_private.cpp
@@ -21,10 +21,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/solv/pool.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/evr.h>
 #include <solv/testcase.h>
 }
+#undef requires
 
 namespace {
 
@@ -98,11 +100,11 @@ void init_solver(Pool * pool, Solver ** solver) {
 
 /// @brief return false when does not depend on anything from b
 bool can_depend_on(Pool * pool, Solvable * sa, Id b) {
-    libdnf::solv::IdQueue requires;
+    libdnf::solv::IdQueue require;
 
-    solvable_lookup_idarray(sa, SOLVABLE_REQUIRES, &requires.get_queue());
-    for (int i = 0; i < requires.size(); ++i) {
-        Id req_dep = requires[i];
+    solvable_lookup_idarray(sa, SOLVABLE_REQUIRES, &require.get_queue());
+    for (int i = 0; i < require.size(); ++i) {
+        Id req_dep = require[i];
         Id p, pp;
 
         FOR_PROVIDES(p, pp, req_dep)

--- a/libdnf/rpm/solv/goal_private.hpp
+++ b/libdnf/rpm/solv/goal_private.hpp
@@ -27,7 +27,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/solv/solv_map.hpp"
 #include "libdnf/transaction/transaction_item_reason.hpp"
 
+#define requires require
 #include <solv/solver.h>
+#undef requires
 
 namespace libdnf::rpm::solv {
 

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 #include "libdnf/base/transaction.hpp"
+#include "libdnf/common/format.hpp"
 #include "libdnf/rpm/transaction.hpp"
 
 #include "../libdnf/utils/bgettext/bgettext-lib.h"
@@ -28,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/transaction/transaction_item_action.hpp"
 
 #include <fcntl.h>
-#include <fmt/format.h>
 #include <rpm/rpmbuild.h>
 #include <rpm/rpmdb.h>
 #include <rpm/rpmlib.h>
@@ -408,7 +408,7 @@ public:
         auto rc = rpmtsAddReinstallElement(ts, header, &item);
         headerFree(header);
         if (rc != 0) {
-            throw Exception(fmt::format(_("Can't reinstall package \"{}\""), item.get_package().get_full_nevra()));
+            throw Exception(format_runtime(_("Can't reinstall package \"{}\""), item.get_package().get_full_nevra()));
         }
         libdnf_assert(
             last_item_added_ts_element,
@@ -427,7 +427,7 @@ public:
         int rc = rpmtsAddEraseElement(ts, header, unused);
         headerFree(header);
         if (rc != 0) {
-            throw Exception(fmt::format(_("Can't remove package \"{}\""), item.get_package().get_full_nevra()));
+            throw Exception(format_runtime(_("Can't remove package \"{}\""), item.get_package().get_full_nevra()));
         }
         if (!last_item_added_ts_element) {
             auto it = implicit_ts_elements.find(rpmdb_id);
@@ -601,7 +601,7 @@ private:
             // action caused by librpm itself
             auto trigger_nevra = transaction->last_added_item->get_package().get_full_nevra();
             auto te_rpmdb_record_number = rpmteDBOffset(te);
-            auto te_nevra = fmt::format(
+            auto te_nevra = format_runtime(
                 "{}-{}:{}-{}.{}", rpmteN(te), rpmteE(te) ? rpmteE(te) : "0", rpmteV(te), rpmteR(te), rpmteA(te));
             auto & log = *transaction->base->get_logger();
             const char * te_type;
@@ -625,7 +625,7 @@ private:
             switch (event) {
                 case RPMTS_EVENT_ADD: {
                     transaction->implicit_ts_elements.insert({te_rpmdb_record_number, te});
-                    log.debug(fmt::format(
+                    log.debug(format_runtime(
                         "Implicitly added element {} type {} (caused by {})", te_nevra, te_type, trigger_nevra));
                     break;
                 }
@@ -831,7 +831,7 @@ void Transaction::Impl::install_up_down(TransactionItem & item, libdnf::transact
     auto rc = rpmtsAddInstallElement(ts, header, &item, upgrade ? 1 : 0, nullptr);
     headerFree(header);
     if (rc != 0) {
-        throw Exception(fmt::format(_("Can't {} package \"{}\""), msg_action, item.get_package().get_full_nevra()));
+        throw Exception(format_runtime(_("Can't {} package \"{}\""), msg_action, item.get_package().get_full_nevra()));
     }
     libdnf_assert(
         last_item_added_ts_element,

--- a/libdnf/solv/id_queue.hpp
+++ b/libdnf/solv/id_queue.hpp
@@ -24,11 +24,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <utility>
 
+#define requires require
 extern "C" {
 #include <solv/queue.h>
 #include <solv/util.h>
 }
-
+#undef requires
 
 namespace libdnf::solv {
 

--- a/libdnf/solv/pool.cpp
+++ b/libdnf/solv/pool.cpp
@@ -21,13 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/rpm/solv/solv_private.hpp"
 
+#define requires require
 extern "C" {
 #include "solv/pool.h"
-
 #include <solv/queue.h>
 #include <solv/util.h>
 }
-
+#undef requires
 
 namespace libdnf::solv {
 

--- a/libdnf/solv/pool.hpp
+++ b/libdnf/solv/pool.hpp
@@ -29,6 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <climits>
 #include <memory>
 
+#define requires require
 extern "C" {
 #include <solv/evr.h>
 #include <solv/dataiterator.h>
@@ -38,7 +39,7 @@ extern "C" {
 #include <solv/repo.h>
 #include <solv/util.h>
 }
-
+#undef requires
 
 namespace libdnf::solv {
 

--- a/libdnf/solv/pool.hpp
+++ b/libdnf/solv/pool.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "id_queue.hpp"
 
 #include "libdnf/base/base.hpp"
+#include "libdnf/common/format.hpp"
 #include "libdnf/repo/repo.hpp"
 
 #include <climits>
@@ -181,7 +182,7 @@ public:
 
             if (converted == ULONG_MAX || *endptr != '\0') {
                 // TODO(lukash) throw proper exception class
-                throw RuntimeError(fmt::format("Failed to convert epoch \"{}\" to number", evr.e));
+                throw RuntimeError(format_runtime("Failed to convert epoch \"{}\" to number", evr.e));
             }
 
             return converted;

--- a/libdnf/solv/solv_map.hpp
+++ b/libdnf/solv/solv_map.hpp
@@ -21,9 +21,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_SOLV_MAP_HPP
 #define LIBDNF_SOLV_MAP_HPP
 
-
+#define requires require
 #include <solv/bitmap.h>
 #include <solv/pooltypes.h>
+#undef requires
 
 #include <iterator>
 

--- a/libdnf/transaction/transaction.cpp
+++ b/libdnf/transaction/transaction.cpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/transaction/transaction.hpp"
 
+#include "libdnf/common/format.hpp"
 #include "libdnf/transaction/comps_environment.hpp"
 #include "libdnf/transaction/comps_group.hpp"
 #include "libdnf/transaction/db/comps_environment.hpp"
@@ -33,8 +34,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/transaction/sack.hpp"
 #include "libdnf/transaction/transaction_item.hpp"
 #include "libdnf/utils/bgettext/bgettext-lib.h"
-
-#include <fmt/format.h>
 
 
 namespace libdnf::transaction {
@@ -108,7 +107,7 @@ void Transaction::finish(TransactionState state) {
     for (auto i : getItems()) {
         if (i->get_state() == TransactionItemState::UNKNOWN) {
             throw std::runtime_error(
-                fmt::format(_("TransactionItem state is not set: {}"), i->getItem()->toStr()));
+                format_runtime(_("TransactionItem state is not set: {}"), i->getItem()->toStr()));
         }
     }
     */

--- a/libdnf/utils/temp.cpp
+++ b/libdnf/utils/temp.cpp
@@ -21,9 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "temp.hpp"
 
 #include "libdnf/common/exception.hpp"
+#include "libdnf/common/format.hpp"
 #include "libdnf/utils/bgettext/bgettext-lib.h"
-
-#include <fmt/format.h>
 
 #include <cstdlib>
 
@@ -42,7 +41,7 @@ TempDir::TempDir(const std::string & destdir, const std::string & prefix) {
     if (temp_path == nullptr) {
         // TODO(lukash) use a specific exception class
         throw RuntimeError(
-            fmt::format(_("Cannot create temporary directory \"{}\": {}"), dir.native().c_str(), strerror(errno)));
+            format_runtime(_("Cannot create temporary directory \"{}\": {}"), dir.native().c_str(), strerror(errno)));
     }
     path = temp_path;
 }

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf-cli/progressbar/multi_progress_bar.hpp>
 #include <libdnf-cli/utils/tty.hpp>
 #include <libdnf/base/goal.hpp>
+#include <libdnf/common/format.hpp>
 #include <libdnf/repo/package_downloader.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
@@ -33,7 +34,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <atomic>
 #include <condition_variable>
 #include <filesystem>
-#include <fmt/format.h>
 #include <iostream>
 #include <mutex>
 #include <string>
@@ -716,7 +716,7 @@ public:
         uint64_t return_code) override {
         active_progress_bar->add_message(
             libdnf::cli::progressbar::MessageType::ERROR,
-            fmt::format(
+            libdnf::format(
                 "Error in {} scriptlet: {} return code {}",
                 script_type_to_string(type),
                 to_full_nevra_string(nevra),
@@ -730,7 +730,8 @@ public:
         libdnf::rpm::TransactionCallbacks::ScriptType type) override {
         active_progress_bar->add_message(
             libdnf::cli::progressbar::MessageType::INFO,
-            fmt::format("Running {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
+            libdnf::format(
+                "Running {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
         multi_progress_bar.print();
     }
 
@@ -741,7 +742,7 @@ public:
         [[maybe_unused]] uint64_t return_code) override {
         active_progress_bar->add_message(
             libdnf::cli::progressbar::MessageType::INFO,
-            fmt::format("Stop {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
+            libdnf::format("Stop {} scriptlet: {}", script_type_to_string(type), to_full_nevra_string(nevra)));
         multi_progress_bar.print();
     }
 

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -46,9 +46,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf-cli/exit-codes.hpp>
 #include <libdnf-cli/session.hpp>
+#include <libdnf/common/format.hpp>
 
 #include <fcntl.h>
-#include <fmt/format.h>
 #include <libdnf/base/base.hpp>
 #include <libdnf/logger/memory_buffer_logger.hpp>
 #include <libdnf/logger/stream_logger.hpp>
@@ -178,7 +178,7 @@ static void set_commandline_args(Context & ctx) {
                                     const char * value) {
         auto val = strchr(value + 1, '=');
         if (!val) {
-            throw std::runtime_error(fmt::format("setopt: Badly formated argument value \"{}\"", value));
+            throw std::runtime_error(libdnf::format("setopt: Badly formated argument value \"{}\"", value));
         }
         auto key = std::string(value, val);
         auto dot_pos = key.rfind('.');
@@ -213,7 +213,7 @@ static void set_commandline_args(Context & ctx) {
             [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
             auto val = strchr(value + 1, '=');
             if (!val) {
-                throw std::runtime_error(fmt::format("setvar: Badly formated argument value \"{}\"", value));
+                throw std::runtime_error(libdnf::format("setvar: Badly formated argument value \"{}\"", value));
             }
             auto name = std::string(value, val);
             ctx.base.get_vars()->set(name, val + 1, libdnf::Vars::Priority::COMMANDLINE);
@@ -547,7 +547,7 @@ int main(int argc, char * argv[]) try {
         return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
     } catch (std::exception & ex) {
         std::cout << ex.what() << std::endl;
-        log_router.error(fmt::format("Command returned error: {}", ex.what()));
+        log_router.error(libdnf::format("Command returned error: {}", ex.what()));
         return static_cast<int>(libdnf::cli::ExitCode::ERROR);
     }
 

--- a/test/libdnf/comps/test_group.cpp
+++ b/test/libdnf/comps/test_group.cpp
@@ -23,9 +23,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/comps/group/query.hpp"
 #include "libdnf/comps/group/package.hpp"
 
+#define requires require
 extern "C" {
 #include <solv/repo.h>
 }
+#undef requires
 
 #include <filesystem>
 #include <fstream>

--- a/test/libdnf/solv/test_solv_map.hpp
+++ b/test/libdnf/solv/test_solv_map.hpp
@@ -24,7 +24,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/solv/solv_map.hpp"
 
+#define requires require
 #include <solv/pool.h>
+#undef requires
 
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>

--- a/test/libdnf/utils.hpp
+++ b/test/libdnf/utils.hpp
@@ -59,10 +59,10 @@ struct assertion_traits<C<T>> {
         return os.str();
     }
 
-    assertion_traits<C<T>>() = delete;
-    ~assertion_traits<C<T>>() = delete;
-    assertion_traits<C<T>>(const assertion_traits<C<T>>&) = delete;
-    assertion_traits<C<T>>& operator=(const assertion_traits<C<T>>&) = delete;
+    assertion_traits() = delete;
+    ~assertion_traits() = delete;
+    assertion_traits(const assertion_traits &) = delete;
+    assertion_traits & operator=(const assertion_traits &) = delete;
 };
 
 template <>


### PR DESCRIPTION
The code can now only be compiled with C++17. PR modifies the code to be more compatible with C++20.

* `fmt::format`
In C++20, the `format` function template requires that the format argument be convertible to std::string_view or std::wstring_view, **and the conversion results in a constant expression** and a valid format string for the arguments. Usually we do not know the format string at compile time because we use text translation at runtime. The commit adds `format_runtime` function template, which accepts the runtime computed format string.

* `requires`
Libsolv has a member named `requires` in the structure `Solvable`. But `requires` is a keyword in C++20. We cannot change the libsolv API. However, we can create a preprocessor macro that performs the renaming.

* Fix reverse iterators in `libdnf::PreserveOrderMap`.

* Fix `assertion_traits` in "test/libdnf/utils.hpp"