### PR TITLE
[dnf5] Enhance advisory query and remove enums

### DIFF
--- a/include/libdnf/advisory/advisory.hpp
+++ b/include/libdnf/advisory/advisory.hpp
@@ -40,56 +40,6 @@ public:
     int id{0};
 };
 
-
-//TODO(amatej): consider defining these as individual numbers, not as bits in int.
-//              This allows us faster iteration, but all public APIs should accept
-//              only individual values (in a vector) not bitwise ored multiple values.
-//              (here the OR and AND operators are public)
-/// Type of advisory
-enum class AdvisoryType : uint32_t {
-    UNKNOWN = (1 << 0),
-    SECURITY = (1 << 1),
-    BUGFIX = (1 << 2),
-    ENHANCEMENT = (1 << 3),
-    NEWPACKAGE = (1 << 4)
-};
-
-inline AdvisoryType operator|(AdvisoryType lhs, AdvisoryType rhs) {
-    return static_cast<AdvisoryType>(
-        static_cast<std::underlying_type<AdvisoryType>::type>(lhs) |
-        static_cast<std::underlying_type<AdvisoryType>::type>(rhs));
-}
-
-inline AdvisoryType operator&(AdvisoryType lhs, AdvisoryType rhs) {
-    return static_cast<AdvisoryType>(
-        static_cast<std::underlying_type<AdvisoryType>::type>(lhs) &
-        static_cast<std::underlying_type<AdvisoryType>::type>(rhs));
-}
-
-//TODO(amatej): consider defining these as individual numbers, not as bits in int.
-//              This allows us faster iteration, but all public APIs should accept
-//              only individual values (in a vector) not bitwise ored multiple values.
-//              (here the OR and AND operators are public)
-/// Type of advisory reference
-enum class AdvisoryReferenceType : uint32_t {
-    UNKNOWN = (1 << 0),
-    BUGZILLA = (1 << 1),
-    CVE = (1 << 2),
-    VENDOR = (1 << 3),
-};
-
-inline AdvisoryReferenceType operator|(AdvisoryReferenceType lhs, AdvisoryReferenceType rhs) {
-    return static_cast<AdvisoryReferenceType>(
-        static_cast<std::underlying_type<AdvisoryReferenceType>::type>(lhs) |
-        static_cast<std::underlying_type<AdvisoryReferenceType>::type>(rhs));
-}
-
-inline AdvisoryReferenceType operator&(AdvisoryReferenceType lhs, AdvisoryReferenceType rhs) {
-    return static_cast<AdvisoryReferenceType>(
-        static_cast<std::underlying_type<AdvisoryReferenceType>::type>(lhs) &
-        static_cast<std::underlying_type<AdvisoryReferenceType>::type>(rhs));
-}
-
 /// An advisory, represents advisory used to track security updates
 class Advisory {
 public:
@@ -107,8 +57,6 @@ public:
     /// Destroy the Advisory object
     ~Advisory();
 
-    using Type = AdvisoryType;
-
     /// Get name of this advisory.
     ///
     /// @return Name of this advisory as std::string.
@@ -121,13 +69,8 @@ public:
 
     /// Get type of this advisory.
     ///
-    /// @return Type of this advisory.
-    Type get_type() const;
-
-    /// Get type of this advisory.
-    ///
-    /// @return Type of this advisory as const char* !! (temporal values)
-    const char * get_type_cstring() const;
+    /// @return type of this advisory as std::string.
+    std::string get_type() const;
 
     /// Get buildtime of this advisory. Libsolv combines issued and updated dates
     /// into buildtime by always using the newer one.
@@ -172,11 +115,9 @@ public:
 
     /// Get all references of specified type from this advisory.
     ///
-    /// @param ref_type     What type of references to get. If not specified gets all types.
+    /// @param types     What types of references to get. If not specified gets all types.
     /// @return Vector of AdvisoryReference objects.
-    std::vector<AdvisoryReference> get_references(
-        AdvisoryReferenceType ref_type = AdvisoryReferenceType::BUGZILLA | AdvisoryReferenceType::CVE |
-                                         AdvisoryReferenceType::VENDOR) const;
+    std::vector<AdvisoryReference> get_references(std::vector<std::string> types = {}) const;
 
     /// Get all collections from this advisory.
     ///
@@ -187,12 +128,6 @@ public:
     ///
     /// @return True if applicable, False otherwise.
     bool is_applicable() const;
-
-    /// Convert AdvisoryType to c string representation
-    ///
-    /// @param type     AdvisoryType to convert.
-    /// @return Converted AdvisoryType as c string (temporal value).
-    static const char * advisory_type_to_cstring(Type type);
 
 private:
     libdnf::BaseWeakPtr base;

--- a/include/libdnf/advisory/advisory.hpp
+++ b/include/libdnf/advisory/advisory.hpp
@@ -68,6 +68,7 @@ public:
     std::string get_severity() const;
 
     /// Get type of this advisory.
+    /// Possible types are: "security", "bugfix", "enhancement", "newpackage".
     ///
     /// @return type of this advisory as std::string.
     std::string get_type() const;
@@ -114,6 +115,7 @@ public:
     AdvisoryId get_id() const;
 
     /// Get all references of specified type from this advisory.
+    /// Possible refenrece types are: "bugzilla", "cve", "vendor".
     ///
     /// @param types     What types of references to get. If not specified gets all types.
     /// @return Vector of AdvisoryReference objects.

--- a/include/libdnf/advisory/advisory_collection.hpp
+++ b/include/libdnf/advisory/advisory_collection.hpp
@@ -23,6 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "advisory.hpp"
 #include "advisory_module.hpp"
 #include "advisory_package.hpp"
+#include "advisory_set.hpp"
 
 #include <vector>
 
@@ -63,6 +64,7 @@ public:
 private:
     friend Advisory;
     friend AdvisoryQuery;
+    friend AdvisorySet;
     friend AdvisoryPackage;
     friend AdvisoryModule;
 

--- a/include/libdnf/advisory/advisory_package.hpp
+++ b/include/libdnf/advisory/advisory_package.hpp
@@ -108,6 +108,7 @@ public:
 private:
     friend class AdvisoryCollection;
     friend class AdvisoryQuery;
+    friend class AdvisorySet;
     friend class libdnf::rpm::PackageQuery;
 
     class Impl;

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -66,10 +66,6 @@ public:
     AdvisoryQuery & filter_type(
         const std::vector<std::string> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    AdvisoryQuery & filter_reference(
-        const std::vector<std::string> & reference_id,
-        std::vector<std::string> types,
-        sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     //TODO(amatej): What about other reference fitlers (title, url?) - do we want them?
     AdvisoryQuery & filter_CVE(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     AdvisoryQuery & filter_CVE(

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -62,6 +62,10 @@ public:
     AdvisoryQuery & filter_name(
         const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
+    /// Filter Advisories by type
+    ///
+    /// @param type         Possible types are: "security", "bugfix", "enhancement", "newpackage".
+    /// @param cmp_type     What comparator to use with type, allows: EQ.
     AdvisoryQuery & filter_type(const std::string & type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     AdvisoryQuery & filter_type(
         const std::vector<std::string> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -90,9 +90,6 @@ public:
     std::vector<AdvisoryPackage> get_advisory_packages(
         const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    //TODO(amatej): This is only used for conveniece it might possibly be a method on AdvisorySet? Or there might be some other way of accessing AdvisoryPackages
-    std::vector<AdvisoryPackage> get_sorted_advisory_packages(bool only_applicable = false) const;
-
 private:
     explicit AdvisoryQuery(const AdvisorySackWeakPtr & sack);
 

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -62,13 +62,13 @@ public:
     AdvisoryQuery & filter_name(
         const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    AdvisoryQuery & filter_type(const Advisory::Type type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery & filter_type(const std::string & type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     AdvisoryQuery & filter_type(
-        const std::vector<Advisory::Type> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+        const std::vector<std::string> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     AdvisoryQuery & filter_reference(
         const std::vector<std::string> & reference_id,
-        std::vector<AdvisoryReferenceType> types,
+        std::vector<std::string> types,
         sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     //TODO(amatej): What about other reference fitlers (title, url?) - do we want them?
     AdvisoryQuery & filter_CVE(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -29,6 +29,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/sack/query_cmp.hpp"
 #include "libdnf/rpm/package.hpp"
 
+#include <optional>
+
 
 namespace libdnf::advisory {
 
@@ -70,13 +72,19 @@ public:
     AdvisoryQuery & filter_type(
         const std::vector<std::string> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    //TODO(amatej): What about other reference fitlers (title, url?) - do we want them?
-    AdvisoryQuery & filter_CVE(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & filter_CVE(
-        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & filter_bug(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & filter_bug(
-        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    /// Filter Advisories by reference
+    ///
+    /// @param pattern      Pattern to match with reference id.
+    /// @param cmp_type     What comparator to use with pattern, allows: EQ, IEXACT, GLOB, IGLOB, CONTAINS, ICONTAINS.
+    /// @param type         Possible reference types are: "bugzilla", "cve", "vendor". If none is specified it matches all.
+    AdvisoryQuery & filter_reference(
+        const std::string & pattern,
+        sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ,
+        const std::optional<std::string> type = {});
+    AdvisoryQuery & filter_reference(
+        const std::vector<std::string> & pattern,
+        sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ,
+        const std::optional<std::string> type = {});
 
     AdvisoryQuery & filter_severity(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     AdvisoryQuery & filter_severity(

--- a/include/libdnf/advisory/advisory_reference.hpp
+++ b/include/libdnf/advisory/advisory_reference.hpp
@@ -37,6 +37,7 @@ public:
     std::string get_id() const;
 
     /// Get type of this reference.
+    /// Possible reference types are: "bugzilla", "cve", "vendor".
     ///
     /// @return type of this reference as std::string.
     std::string get_type() const;

--- a/include/libdnf/advisory/advisory_reference.hpp
+++ b/include/libdnf/advisory/advisory_reference.hpp
@@ -30,8 +30,6 @@ namespace libdnf::advisory {
 
 class AdvisoryReference {
 public:
-    using Type = AdvisoryReferenceType;
-
     /// Get id of this advisory reference, this id is like a name of this reference
     /// (it is not libsolv id).
     ///
@@ -40,8 +38,8 @@ public:
 
     /// Get type of this reference.
     ///
-    /// @return Type of this reference.
-    Type get_type() const;
+    /// @return type of this reference as std::string.
+    std::string get_type() const;
 
     /// Get type of this reference.
     ///

--- a/include/libdnf/advisory/advisory_set.hpp
+++ b/include/libdnf/advisory/advisory_set.hpp
@@ -36,6 +36,12 @@ class SolvMap;
 
 }  // namespace libdnf::solv
 
+namespace libdnf::rpm {
+
+class PackageQuery;
+
+}  // namespace libdnf::rpm
+
 namespace libdnf::advisory {
 
 class AdvisorySet {
@@ -127,7 +133,9 @@ public:
 private:
     friend AdvisorySetIterator;
     friend class AdvisoryQuery;
+    friend class libdnf::rpm::PackageQuery;
     AdvisorySet(const BaseWeakPtr & base, libdnf::solv::SolvMap & solv_map);
+    std::vector<AdvisoryPackage> get_advisory_packages_sorted_by_id(bool only_applicable = false) const;
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/libdnf-cli/output/advisoryinfo.cpp
+++ b/libdnf-cli/output/advisoryinfo.cpp
@@ -32,7 +32,7 @@ void AdvisoryInfo::add_advisory(libdnf::advisory::Advisory & advisory) {
     add_line("Name", advisory.get_name(), "bold");
     add_line("Title", advisory.get_title());
     add_line("Severity", advisory.get_severity());
-    add_line("Type", advisory.get_type_cstring());
+    add_line("Type", advisory.get_type());
     add_line("Status", advisory.get_status());
     add_line("Vendor", advisory.get_vendor());
     add_line("Buildtime", std::to_string(advisory.get_buildtime()));

--- a/libdnf-cli/output/advisorylist.cpp
+++ b/libdnf-cli/output/advisorylist.cpp
@@ -62,12 +62,12 @@ void print_advisorylist_table(
     for (auto adv_pkg : advisory_package_list) {
         auto advisory = adv_pkg.get_advisory();
         add_line_into_advisorylist_table(
-            table, advisory.get_name().c_str(), advisory.get_type_cstring(), adv_pkg.get_nevra().c_str(), false);
+            table, advisory.get_name().c_str(), advisory.get_type().c_str(), adv_pkg.get_nevra().c_str(), false);
     }
     for (auto adv_pkg : advisory_package_list_installed) {
         auto advisory = adv_pkg.get_advisory();
         add_line_into_advisorylist_table(
-            table, advisory.get_name().c_str(), advisory.get_type_cstring(), adv_pkg.get_nevra().c_str(), true);
+            table, advisory.get_name().c_str(), advisory.get_type().c_str(), adv_pkg.get_nevra().c_str(), true);
     }
     auto cl = scols_table_get_column(table, COL_ADVISORY_NAME);
     scols_sort_table(table, cl);

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -43,233 +43,170 @@ AdvisoryQuery::AdvisoryQuery(Base & base) : AdvisoryQuery(base.get_weak_ptr()) {
 
 AdvisoryQuery::~AdvisoryQuery() = default;
 
+static int libsolv_cmp_flags(libdnf::sack::QueryCmp cmp_type, const char * pattern) {
+    // Remove GLOB when the pattern is not a glob
+    if ((cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB &&
+        !libdnf::utils::is_glob_pattern(pattern)) {
+        cmp_type = (cmp_type - libdnf::sack::QueryCmp::GLOB) | libdnf::sack::QueryCmp::EQ;
+    }
+
+    switch (cmp_type) {
+        case libdnf::sack::QueryCmp::EQ:
+            return SEARCH_STRING;
+        case libdnf::sack::QueryCmp::IEXACT:
+            return SEARCH_NOCASE | SEARCH_STRING;
+        case libdnf::sack::QueryCmp::GLOB:
+            return SEARCH_GLOB;
+        case libdnf::sack::QueryCmp::IGLOB:
+            return SEARCH_NOCASE | SEARCH_GLOB;
+        case libdnf::sack::QueryCmp::CONTAINS:
+            return SEARCH_SUBSTRING;
+        case libdnf::sack::QueryCmp::ICONTAINS:
+            return SEARCH_NOCASE | SEARCH_SUBSTRING;
+        default:
+            throw AdvisoryQuery::NotSupportedCmpType("Used unsupported CmpType");
+    }
+}
+
+static void filter_dataiterator_internal(
+    Pool * pool,
+    Id keyname,
+    libdnf::solv::SolvMap & candidates,
+    libdnf::sack::QueryCmp cmp_type,
+    const std::vector<std::string> & patterns) {
+    libdnf::solv::SolvMap filter_result(pool->nsolvables);
+
+    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
+    if (cmp_not) {
+        // Removal of NOT CmpType makes following comparissons easier and more effective
+        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
+    }
+
+    for (auto & pattern : patterns) {
+        int flags = libsolv_cmp_flags(cmp_type, pattern.c_str());
+
+        Dataiterator di;
+        for (Id candidate_id : candidates) {
+            dataiterator_init(&di, pool, nullptr, candidate_id, keyname, pattern.c_str(), flags);
+            if (dataiterator_step(&di) != 0) {
+                filter_result.add_unsafe(candidate_id);
+            }
+            dataiterator_free(&di);
+        }
+    }
+
+    // Apply filter results to query
+    if (cmp_not) {
+        candidates -= filter_result;
+    } else {
+        candidates &= filter_result;
+    }
+}
+
+static void filter_reference_by_type_and_id(
+    libdnf::solv::Pool & pool,
+    libdnf::solv::SolvMap & candidates,
+    libdnf::sack::QueryCmp cmp_type,
+    const std::vector<std::string> & patterns,
+    std::string type) {
+    libdnf::solv::SolvMap filter_result((*pool)->nsolvables);
+
+    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
+    if (cmp_not) {
+        // Removal of NOT CmpType makes following comparissons easier and more effective
+        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
+    }
+
+    for (auto & pattern : patterns) {
+        int flags = libsolv_cmp_flags(cmp_type, pattern.c_str());
+
+        Dataiterator di;
+
+        for (Id candidate_id : candidates) {
+            dataiterator_init(&di, *pool, nullptr, candidate_id, UPDATE_REFERENCE_ID, pattern.c_str(), flags);
+            dataiterator_prepend_keyname(&di, UPDATE_REFERENCE);
+            while (dataiterator_step(&di) != 0) {
+                dataiterator_setpos_parent(&di);
+                const char * current_type = pool.lookup_str(SOLVID_POS, UPDATE_REFERENCE_TYPE);
+                if (current_type && !strcmp(type.c_str(), current_type)) {
+                    filter_result.add_unsafe(candidate_id);
+                    break;
+                }
+            }
+            dataiterator_free(&di);
+        }
+    }
+
+    // Apply filter results to query
+    if (cmp_not) {
+        candidates -= filter_result;
+    } else {
+        candidates &= filter_result;
+    }
+}
 
 AdvisoryQuery & AdvisoryQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp_type) {
-    const std::vector<std::string> patterns = {pattern};
-    filter_name(patterns, cmp_type);
+    filter_dataiterator_internal(
+        *get_pool(base),
+        SOLVABLE_NAME,
+        *p_impl,
+        cmp_type,
+        {std::string(libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX) + pattern});
+
     return *this;
 }
 
 AdvisoryQuery & AdvisoryQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    auto & pool = get_pool(base);
-    libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
-
-    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
-    if (cmp_not) {
-        // Removal of NOT CmpType makes following comparissons easier and more effective
-        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
+    std::vector<std::string> prefixed_patterns;
+    for (std::string pattern : patterns) {
+        prefixed_patterns.push_back(std::string(libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX) + pattern);
     }
+    filter_dataiterator_internal(*get_pool(base), SOLVABLE_NAME, *p_impl, cmp_type, prefixed_patterns);
 
-    bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
-
-    for (const std::string & pattern : patterns) {
-        libdnf::sack::QueryCmp tmp_cmp_type = cmp_type;
-        const char * c_pattern = pattern.c_str();
-        // Remove GLOB when the pattern is not a glob
-        if (cmp_glob && !libdnf::utils::is_glob_pattern(c_pattern)) {
-            tmp_cmp_type = (tmp_cmp_type - libdnf::sack::QueryCmp::GLOB) | libdnf::sack::QueryCmp::EQ;
-        }
-
-        switch (tmp_cmp_type) {
-            case libdnf::sack::QueryCmp::EQ: {
-                std::string prefixed_name = std::string(libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX) + pattern;
-                Id name_id = pool.str2id(prefixed_name.c_str(), 0);
-                for (Id candidate_id : *p_impl) {
-                    Id candidate_name = pool.lookup_id(candidate_id, SOLVABLE_NAME);
-                    if (candidate_name == name_id) {
-                        filter_result.add_unsafe(candidate_id);
-                    }
-                }
-            } break;
-            case libdnf::sack::QueryCmp::GLOB: {
-                for (Id candidate_id : *p_impl) {
-                    const char * candidate_name = pool.lookup_str(candidate_id, SOLVABLE_NAME);
-                    if (fnmatch(c_pattern, candidate_name + libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX_LENGTH, 0) ==
-                        0) {
-                        filter_result.add_unsafe(candidate_id);
-                    }
-                }
-
-            } break;
-            case libdnf::sack::QueryCmp::IGLOB: {
-                for (Id candidate_id : *p_impl) {
-                    const char * candidate_name = pool.lookup_str(candidate_id, SOLVABLE_NAME);
-                    if (fnmatch(
-                            c_pattern,
-                            candidate_name + libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX_LENGTH,
-                            FNM_CASEFOLD) == 0) {
-                        filter_result.add_unsafe(candidate_id);
-                    }
-                }
-
-            } break;
-            default:
-                throw NotSupportedCmpType("Unsupported CmpType");
-        }
-    }
-
-    // Apply filter results to query
-    if (cmp_not) {
-        *p_impl -= filter_result;
-    } else {
-        *p_impl &= filter_result;
-    }
     return *this;
 }
 
 AdvisoryQuery & AdvisoryQuery::filter_type(const std::string & type, sack::QueryCmp cmp_type) {
-    std::vector<std::string> types = {type};
-    filter_type(types, cmp_type);
+    filter_dataiterator_internal(*get_pool(base), SOLVABLE_PATCHCATEGORY, *p_impl, cmp_type, {type});
+
     return *this;
 }
 
 AdvisoryQuery & AdvisoryQuery::filter_type(const std::vector<std::string> & types, sack::QueryCmp cmp_type) {
-    auto & pool = get_pool(base);
-    libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
-
-    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
-    if (cmp_not) {
-        // Removal of NOT CmpType makes following comparissons easier and more effective
-        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
-    }
-    switch (cmp_type) {
-        case libdnf::sack::QueryCmp::EQ: {
-
-            //TODO(amatej): extract this into solv::advisroy_private once its created
-            for (Id candidate_id : *p_impl) {
-                std::string candidate_type = std::string(pool.lookup_str(candidate_id, SOLVABLE_PATCHCATEGORY));
-                if(types.empty() || std::find(types.begin(), types.end(), candidate_type) != types.end()) {
-                    filter_result.add_unsafe(candidate_id);
-                }
-            }
-        } break;
-        default:
-            throw NotSupportedCmpType("Unsupported CmpType");
-    }
-
-    // Apply filter results to query
-    if (cmp_not) {
-        *p_impl -= filter_result;
-    } else {
-        *p_impl &= filter_result;
-    }
+    filter_dataiterator_internal(*get_pool(base), SOLVABLE_PATCHCATEGORY, *p_impl, cmp_type, types);
 
     return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::filter_reference(
-    const std::vector<std::string> & reference_id, std::vector<std::string> types, sack::QueryCmp cmp_type) {
-    libdnf::solv::SolvMap filter_result(get_pool(base).get_nsolvables());
-
-    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
-    if (cmp_not) {
-        // Removal of NOT CmpType makes following comparissons easier and more effective
-        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
-    }
-
-    bool cmp_glob = (cmp_type & libdnf::sack::QueryCmp::GLOB) == libdnf::sack::QueryCmp::GLOB;
-
-    for (const std::string & pattern : reference_id) {
-        libdnf::sack::QueryCmp tmp_cmp_type = cmp_type;
-        const char * c_pattern = pattern.c_str();
-        // Remove GLOB when the pattern is not a glob
-        if (cmp_glob && !libdnf::utils::is_glob_pattern(c_pattern)) {
-            tmp_cmp_type = (tmp_cmp_type - libdnf::sack::QueryCmp::GLOB) | libdnf::sack::QueryCmp::EQ;
-        }
-
-        switch (tmp_cmp_type) {
-            case libdnf::sack::QueryCmp::EQ: {
-                for (Id candidate_id : *p_impl) {
-                    //TODO(amatej): replace this with solv::advisroy_private (just like for package)
-                    //              So that we don't duplicate code and don't have to create Advisory object (big overhead, has weak pointer)
-                    Advisory a = Advisory(base, AdvisoryId(candidate_id));
-                    for (const auto & cve : a.get_references(types)) {
-                        if (cve.get_id() == pattern) {
-                            filter_result.add_unsafe(candidate_id);
-                        }
-                    }
-                }
-            } break;
-            case libdnf::sack::QueryCmp::GLOB: {
-                for (Id candidate_id : *p_impl) {
-                    Advisory a = Advisory(base, AdvisoryId(candidate_id));
-                    for (const auto & cve : a.get_references(types)) {
-                        if (fnmatch(c_pattern, cve.get_id().c_str(), 0) == 0) {
-                            filter_result.add_unsafe(candidate_id);
-                        }
-                    }
-                }
-            } break;
-            default:
-                throw NotSupportedCmpType("Unsupported CmpType");
-        }
-    }
-
-    // Apply filter results to query
-    if (cmp_not) {
-        *p_impl -= filter_result;
-    } else {
-        *p_impl &= filter_result;
-    }
-    return *this;
-}
 AdvisoryQuery & AdvisoryQuery::filter_CVE(const std::string & pattern, sack::QueryCmp cmp_type) {
-    const std::vector<std::string> patterns = {pattern};
-    filter_reference(patterns, {"cve"}, cmp_type);
+    filter_reference_by_type_and_id(get_pool(base), *p_impl, cmp_type, {pattern}, "cve");
+
     return *this;
 }
 AdvisoryQuery & AdvisoryQuery::filter_CVE(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    filter_reference(patterns, {"cve"}, cmp_type);
+    filter_reference_by_type_and_id(get_pool(base), *p_impl, cmp_type, patterns, "cve");
+
     return *this;
 }
 
 AdvisoryQuery & AdvisoryQuery::filter_bug(const std::string & pattern, sack::QueryCmp cmp_type) {
-    const std::vector<std::string> patterns = {pattern};
-    filter_reference(patterns, {"bugzilla"}, cmp_type);
+    filter_reference_by_type_and_id(get_pool(base), *p_impl, cmp_type, {pattern}, "bugzilla");
+
     return *this;
 }
 AdvisoryQuery & AdvisoryQuery::filter_bug(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    filter_reference(patterns, {"bugzilla"}, cmp_type);
+    filter_reference_by_type_and_id(get_pool(base), *p_impl, cmp_type, patterns, "bugzilla");
+
     return *this;
 }
 
 AdvisoryQuery & AdvisoryQuery::filter_severity(const std::string & pattern, sack::QueryCmp cmp_type) {
-    const std::vector<std::string> patterns = {pattern};
-    filter_severity(patterns, cmp_type);
+    filter_dataiterator_internal(*get_pool(base), UPDATE_SEVERITY, *p_impl, cmp_type, {pattern});
+
     return *this;
 }
 AdvisoryQuery & AdvisoryQuery::filter_severity(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    auto & pool = get_pool(base);
-    libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
-
-    bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
-    if (cmp_not) {
-        // Removal of NOT CmpType makes following comparissons easier and more effective
-        cmp_type = cmp_type - libdnf::sack::QueryCmp::NOT;
-    }
-
-    switch (cmp_type) {
-        case libdnf::sack::QueryCmp::EQ: {
-            for (const std::string & severity : patterns) {
-                for (Id candidate_id : *p_impl) {
-                    const char * candidate_severity = pool.lookup_str(candidate_id, UPDATE_SEVERITY);
-                    if (!strcmp(candidate_severity, severity.c_str())) {
-                        filter_result.add_unsafe(candidate_id);
-                    }
-                }
-            }
-        } break;
-        default:
-            throw NotSupportedCmpType("Unsupported CmpType");
-    }
-
-
-    // Apply filter results to query
-    if (cmp_not) {
-        *p_impl -= filter_result;
-    } else {
-        *p_impl &= filter_result;
-    }
+    filter_dataiterator_internal(*get_pool(base), UPDATE_SEVERITY, *p_impl, cmp_type, patterns);
 
     return *this;
 }

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -215,7 +215,7 @@ AdvisoryQuery & AdvisoryQuery::filter_severity(const std::vector<std::string> & 
 AdvisoryQuery & AdvisoryQuery::filter_packages(const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
     auto & pool = get_pool(base);
     libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
-    std::vector<AdvisoryPackage> adv_pkgs = get_sorted_advisory_packages();
+    std::vector<AdvisoryPackage> adv_pkgs = get_advisory_packages_sorted_by_id();
 
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
@@ -264,7 +264,7 @@ AdvisoryQuery & AdvisoryQuery::filter_packages(const libdnf::rpm::PackageSet & p
 
 std::vector<AdvisoryPackage> AdvisoryQuery::get_advisory_packages(
     const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
-    std::vector<AdvisoryPackage> adv_pkgs = get_sorted_advisory_packages();
+    std::vector<AdvisoryPackage> adv_pkgs = get_advisory_packages_sorted_by_id();
     std::vector<AdvisoryPackage> after_filter;
 
     auto & pool = get_pool(base);
@@ -299,24 +299,6 @@ std::vector<AdvisoryPackage> AdvisoryQuery::get_advisory_packages(
 
     //after_filter contains just advisoryPackages which comply to condition with package_set
     return after_filter;
-}
-
-std::vector<AdvisoryPackage> AdvisoryQuery::get_sorted_advisory_packages(bool only_applicable) const {
-    std::vector<AdvisoryPackage> out;
-    for (Id candidate_id : *p_impl) {
-        Advisory advisory = Advisory(base, AdvisoryId(candidate_id));
-        auto collections = advisory.get_collections();
-        for (auto & collection : collections) {
-            if (only_applicable && !collection.is_applicable()) {
-                continue;
-            }
-            collection.get_packages(out);
-        }
-    }
-
-    std::sort(out.begin(), out.end(), AdvisoryPackage::Impl::nevra_compare_lower_id);
-
-    return out;
 }
 
 }  // namespace libdnf::advisory

--- a/libdnf/advisory/advisory_reference.cpp
+++ b/libdnf/advisory/advisory_reference.cpp
@@ -36,20 +36,8 @@ AdvisoryReference::AdvisoryReference(const libdnf::BaseWeakPtr & base, AdvisoryI
 std::string AdvisoryReference::get_id() const {
     return std::string(get_pool(base).get_str_from_pool(UPDATE_REFERENCE_ID, advisory.id, index));
 }
-AdvisoryReference::Type AdvisoryReference::get_type() const {
-    const char * type = get_pool(base).get_str_from_pool(UPDATE_REFERENCE_TYPE, advisory.id, index);
-
-    if (type == nullptr) {
-        return Type::UNKNOWN;
-    } else if (!strcmp(type, "bugzilla")) {
-        return Type::BUGZILLA;
-    } else if (!strcmp(type, "cve")) {
-        return Type::CVE;
-    } else if (!strcmp(type, "vendor")) {
-        return Type::VENDOR;
-    }
-
-    return Type::UNKNOWN;
+std::string AdvisoryReference::get_type() const {
+    return std::string(get_pool(base).get_str_from_pool(UPDATE_REFERENCE_TYPE, advisory.id, index));
 }
 const char * AdvisoryReference::get_type_cstring() const {
     return get_pool(base).get_str_from_pool(UPDATE_REFERENCE_TYPE, advisory.id, index);

--- a/libdnf/advisory/advisory_set.cpp
+++ b/libdnf/advisory/advisory_set.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 #include "libdnf/advisory/advisory_set.hpp"
+#include "libdnf/advisory/advisory_package_private.hpp"
 
 #include "advisory_set_impl.hpp"
 
@@ -137,5 +138,22 @@ BaseWeakPtr AdvisorySet::get_base() const {
     return p_impl->base;
 }
 
+std::vector<AdvisoryPackage> AdvisorySet::get_advisory_packages_sorted_by_id(bool only_applicable) const {
+    std::vector<AdvisoryPackage> out;
+    for (Id candidate_id : *p_impl) {
+        Advisory advisory2 = Advisory(p_impl->base, AdvisoryId(candidate_id));
+        auto collections = advisory2.get_collections();
+        for (auto & collection : collections) {
+            if (only_applicable && !collection.is_applicable()) {
+                continue;
+            }
+            collection.get_packages(out);
+        }
+    }
+
+    std::sort(out.begin(), out.end(), AdvisoryPackage::Impl::nevra_compare_lower_id);
+
+    return out;
+}
 
 }  // namespace libdnf::advisory

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -1888,7 +1888,7 @@ PackageQuery & PackageQuery::filter_advisories(
     }
 
     libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
-    std::vector<libdnf::advisory::AdvisoryPackage> adv_pkgs = advisory_query.get_sorted_advisory_packages();
+    std::vector<libdnf::advisory::AdvisoryPackage> adv_pkgs = advisory_query.get_advisory_packages_sorted_by_id();
     auto & sorted_solvables = p_impl->base->get_rpm_package_sack()->p_impl->get_sorted_solvables();
 
     switch (cmp_type) {

--- a/test/libdnf/advisory/test_advisory.cpp
+++ b/test/libdnf/advisory/test_advisory.cpp
@@ -41,7 +41,7 @@ void AdvisoryAdvisoryTest::setUp() {
 void AdvisoryAdvisoryTest::test_get_name() {
     // Tests get_name method
     libdnf::advisory::AdvisoryQuery advisories =
-        libdnf::advisory::AdvisoryQuery(base).filter_type(libdnf::advisory::Advisory::Type::SECURITY);
+        libdnf::advisory::AdvisoryQuery(base).filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     CPPUNIT_ASSERT_EQUAL(advisory.get_name(), std::string("DNF-2019-1"));
 }
@@ -49,23 +49,15 @@ void AdvisoryAdvisoryTest::test_get_name() {
 void AdvisoryAdvisoryTest::test_get_type() {
     // Tests get_type method
     libdnf::advisory::AdvisoryQuery advisories =
-        libdnf::advisory::AdvisoryQuery(base).filter_type(libdnf::advisory::Advisory::Type::SECURITY);
+        libdnf::advisory::AdvisoryQuery(base).filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
-    CPPUNIT_ASSERT_EQUAL(advisory.get_type(), libdnf::advisory::Advisory::Type::SECURITY);
-}
-
-void AdvisoryAdvisoryTest::test_get_type_cstring() {
-    // Tests get_type method
-    libdnf::advisory::AdvisoryQuery advisories =
-        libdnf::advisory::AdvisoryQuery(base).filter_type(libdnf::advisory::Advisory::Type::SECURITY);
-    libdnf::advisory::Advisory advisory = *advisories.begin();
-    CPPUNIT_ASSERT(!strcmp(advisory.get_type_cstring(), "security"));
+    CPPUNIT_ASSERT_EQUAL(advisory.get_type(), std::string("security"));
 }
 
 void AdvisoryAdvisoryTest::test_get_severity() {
     // Tests get_severity method
     libdnf::advisory::AdvisoryQuery advisories =
-        libdnf::advisory::AdvisoryQuery(base).filter_type(libdnf::advisory::Advisory::Type::SECURITY);
+        libdnf::advisory::AdvisoryQuery(base).filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     CPPUNIT_ASSERT_EQUAL(advisory.get_severity(), std::string("moderate"));
 }
@@ -73,14 +65,14 @@ void AdvisoryAdvisoryTest::test_get_severity() {
 void AdvisoryAdvisoryTest::test_get_references() {
     // Tests get_references method
     libdnf::advisory::AdvisoryQuery advisories =
-        libdnf::advisory::AdvisoryQuery(base).filter_type(libdnf::advisory::Advisory::Type::SECURITY);
+        libdnf::advisory::AdvisoryQuery(base).filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     std::vector<libdnf::advisory::AdvisoryReference> refs = advisory.get_references();
     CPPUNIT_ASSERT_EQUAL(1lu, refs.size());
 
     libdnf::advisory::AdvisoryReference r = refs[0];
     CPPUNIT_ASSERT_EQUAL(std::string("1111"), r.get_id());
-    CPPUNIT_ASSERT_EQUAL(libdnf::advisory::AdvisoryReference::Type::CVE, r.get_type());
+    CPPUNIT_ASSERT_EQUAL(std::string("cve"), r.get_type());
     CPPUNIT_ASSERT_EQUAL(std::string("CVE-2999"), r.get_title());
     CPPUNIT_ASSERT_EQUAL(std::string("https://foobar/foobarupdate_2"), r.get_url());
 }
@@ -88,7 +80,7 @@ void AdvisoryAdvisoryTest::test_get_references() {
 void AdvisoryAdvisoryTest::test_get_collections() {
     // Tests get_collections method
     libdnf::advisory::AdvisoryQuery advisories =
-        libdnf::advisory::AdvisoryQuery(base).filter_type(libdnf::advisory::Advisory::Type::SECURITY);
+        libdnf::advisory::AdvisoryQuery(base).filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     std::vector<libdnf::advisory::AdvisoryCollection> colls = advisory.get_collections();
     CPPUNIT_ASSERT_EQUAL(1lu, colls.size());

--- a/test/libdnf/advisory/test_advisory.hpp
+++ b/test/libdnf/advisory/test_advisory.hpp
@@ -34,7 +34,6 @@ class AdvisoryAdvisoryTest : public LibdnfTestCase {
 
     CPPUNIT_TEST(test_get_name);
     CPPUNIT_TEST(test_get_type);
-    CPPUNIT_TEST(test_get_type_cstring);
     CPPUNIT_TEST(test_get_severity);
     CPPUNIT_TEST(test_get_references);
     CPPUNIT_TEST(test_get_collections);
@@ -46,7 +45,6 @@ public:
 
     void test_get_name();
     void test_get_type();
-    void test_get_type_cstring();
     void test_get_severity();
     //void test_filter_package();
 

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -62,19 +62,16 @@ void AdvisoryAdvisoryQueryTest::test_filter_name() {
 
 void AdvisoryAdvisoryQueryTest::test_filter_type() {
     // Tests filter_type method
-    libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_type(libdnf::advisory::Advisory::Type::BUGFIX);
+    libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_type("bugfix");
     std::vector<std::string> expected = {"DNF-2020-1", "PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_type(libdnf::advisory::Advisory::Type::ENHANCEMENT);
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_type("enhancement");
     expected = {"PKG-NEWER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
     adv_query = libdnf::advisory::AdvisoryQuery(base).filter_type(
-        std::vector<libdnf::advisory::Advisory::Type>{
-            libdnf::advisory::Advisory::Type::BUGFIX, libdnf::advisory::Advisory::Type::SECURITY},
-        libdnf::sack::QueryCmp::EQ);
+        std::vector<std::string>{"bugfix", "security"}, libdnf::sack::QueryCmp::EQ);
     expected = {"DNF-2019-1", "DNF-2020-1", "PKG-OLDER"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -103,41 +103,60 @@ void AdvisoryAdvisoryQueryTest::test_filter_packages() {
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_cve() {
-    // Tests filter_cve method
+    // Tests filter_reference method with cve
     libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_CVE("3333", libdnf::sack::QueryCmp::EQ);
+        libdnf::advisory::AdvisoryQuery(base).filter_reference("3333", libdnf::sack::QueryCmp::EQ, "cve");
     std::vector<std::string> expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_CVE(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference(
+        std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "cve");
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_CVE(std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ);
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference(
+        std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ, "cve");
     expected = {"DNF-2019-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_CVE("*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB, "cve");
     expected = {"DNF-2019-1", "DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 
-void AdvisoryAdvisoryQueryTest::test_filter_bug() {
-    // Tests filter_bug method
+void AdvisoryAdvisoryQueryTest::test_filter_bugzilla() {
+    // Tests filter_reference method with bugzilla
     libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_bug("2222", libdnf::sack::QueryCmp::EQ);
+        libdnf::advisory::AdvisoryQuery(base).filter_reference("2222", libdnf::sack::QueryCmp::EQ, "bugzilla");
     std::vector<std::string> expected = {"DNF-2020-1"};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_bug(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ);
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference(
+        std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "bugzilla");
     expected = {};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_bug("*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB, "bugzilla");
     expected = {"DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+}
+
+void AdvisoryAdvisoryQueryTest::test_filter_reference() {
+    // Tests filter_reference method without type specified
+    libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("2222");
+    std::vector<std::string> expected = {"DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference(std::vector<std::string>{"1111", "3333"});
+    expected = {"DNF-2019-1", "DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB);
+    expected = {"DNF-2019-1", "DNF-2020-1"};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+
+    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("none*", libdnf::sack::QueryCmp::GLOB);
+    expected = {};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -154,31 +154,22 @@ void AdvisoryAdvisoryQueryTest::test_filter_severity() {
     CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
 }
 
-void AdvisoryAdvisoryQueryTest::test_get_sorted_advisory_packages() {
-    // Tests get_sorted_advisory_packages method
-    std::vector<libdnf::advisory::AdvisoryPackage> adv_pkgs = libdnf::advisory::AdvisoryQuery(base).get_sorted_advisory_packages();
-    CPPUNIT_ASSERT_EQUAL(7lu, adv_pkgs.size());
+void AdvisoryAdvisoryQueryTest::test_get_advisory_packages() {
+    // Tests get_advisory_packages method
+    libdnf::rpm::PackageQuery pkg_query(base);
+    // pkg_query contains: pkg-1.2-3.x86_64, pkg-libs-1:1.3-4.x86_64, unresolvable-1:2-3.noarch
+    std::vector<libdnf::advisory::AdvisoryPackage> adv_pkgs =
+        libdnf::advisory::AdvisoryQuery(base).get_advisory_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
+    CPPUNIT_ASSERT_EQUAL(2lu, adv_pkgs.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[0].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("1.2-3"), adv_pkgs[0].get_evr());
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[1].get_name());
+    CPPUNIT_ASSERT_EQUAL(std::string("4.0-1"), adv_pkgs[1].get_evr());
+
+    adv_pkgs = libdnf::advisory::AdvisoryQuery(base).get_advisory_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
+    CPPUNIT_ASSERT_EQUAL(2lu, adv_pkgs.size());
     CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("1.2-3"), adv_pkgs[0].get_evr());
     CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[1].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("0.1-1"), adv_pkgs[1].get_evr());
-    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[2].get_name());
-    CPPUNIT_ASSERT_EQUAL(std::string("4.0-1"), adv_pkgs[2].get_evr());
-    CPPUNIT_ASSERT_EQUAL(std::string("bitcoin"), adv_pkgs[3].get_name());
-    CPPUNIT_ASSERT_EQUAL(std::string("2.5-1"), adv_pkgs[3].get_evr());
-    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), adv_pkgs[4].get_name());
-    CPPUNIT_ASSERT_EQUAL(std::string("3.9-2.fc29"), adv_pkgs[4].get_evr());
-    CPPUNIT_ASSERT_EQUAL(std::string("wget"), adv_pkgs[5].get_name());
-    CPPUNIT_ASSERT_EQUAL(std::string("1.19.5-5.fc29"), adv_pkgs[5].get_evr());
-    CPPUNIT_ASSERT_EQUAL(std::string("yum"), adv_pkgs[6].get_name());
-    CPPUNIT_ASSERT_EQUAL(std::string("3.4.3-0"), adv_pkgs[6].get_evr());
-
-    adv_pkgs = libdnf::advisory::AdvisoryQuery(base).filter_name("DNF-2020-1").get_sorted_advisory_packages();
-    CPPUNIT_ASSERT_EQUAL(3lu, adv_pkgs.size());
-    CPPUNIT_ASSERT_EQUAL(std::string("bitcoin"), adv_pkgs[0].get_name());
-    CPPUNIT_ASSERT_EQUAL(std::string("2.5-1"), adv_pkgs[0].get_evr());
-    CPPUNIT_ASSERT_EQUAL(std::string("wget"), adv_pkgs[1].get_name());
-    CPPUNIT_ASSERT_EQUAL(std::string("1.19.5-5.fc29"), adv_pkgs[1].get_evr());
-    CPPUNIT_ASSERT_EQUAL(std::string("yum"), adv_pkgs[2].get_name());
-    CPPUNIT_ASSERT_EQUAL(std::string("3.4.3-0"), adv_pkgs[2].get_evr());
 }

--- a/test/libdnf/advisory/test_advisory_query.hpp
+++ b/test/libdnf/advisory/test_advisory_query.hpp
@@ -36,7 +36,8 @@ class AdvisoryAdvisoryQueryTest : public LibdnfTestCase {
     CPPUNIT_TEST(test_filter_type);
     CPPUNIT_TEST(test_filter_packages);
     CPPUNIT_TEST(test_filter_cve);
-    CPPUNIT_TEST(test_filter_bug);
+    CPPUNIT_TEST(test_filter_bugzilla);
+    CPPUNIT_TEST(test_filter_reference);
     CPPUNIT_TEST(test_filter_severity);
     CPPUNIT_TEST(test_get_advisory_packages);
 
@@ -50,7 +51,8 @@ public:
     void test_filter_type();
     void test_filter_packages();
     void test_filter_cve();
-    void test_filter_bug();
+    void test_filter_bugzilla();
+    void test_filter_reference();
     void test_filter_severity();
     void test_get_advisory_packages();
 };

--- a/test/libdnf/advisory/test_advisory_query.hpp
+++ b/test/libdnf/advisory/test_advisory_query.hpp
@@ -38,7 +38,7 @@ class AdvisoryAdvisoryQueryTest : public LibdnfTestCase {
     CPPUNIT_TEST(test_filter_cve);
     CPPUNIT_TEST(test_filter_bug);
     CPPUNIT_TEST(test_filter_severity);
-    CPPUNIT_TEST(test_get_sorted_advisory_packages);
+    CPPUNIT_TEST(test_get_advisory_packages);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -52,7 +52,7 @@ public:
     void test_filter_cve();
     void test_filter_bug();
     void test_filter_severity();
-    void test_get_sorted_advisory_packages();
+    void test_get_advisory_packages();
 };
 
 

--- a/test/libdnf/advisory/test_advisory_reference.cpp
+++ b/test/libdnf/advisory/test_advisory_reference.cpp
@@ -47,7 +47,7 @@ void AdvisoryAdvisoryReferenceTest::test_get_id() {
 
 void AdvisoryAdvisoryReferenceTest::test_get_type() {
     // Tests get_type method
-    CPPUNIT_ASSERT_EQUAL(libdnf::advisory::AdvisoryReference::Type::CVE, references[0].get_type());
+    CPPUNIT_ASSERT_EQUAL(std::string("cve"), references[0].get_type());
 }
 
 void AdvisoryAdvisoryReferenceTest::test_get_title() {


### PR DESCRIPTION
I am conflicted about removing the enums, we are losing the enumeration of possible values but it seems a lot cleaner without them.

Advisory::get_references is most likely slower but it is no longer used in AdvisoryQuery.