### PR TITLE
[dnf5] New exception structure and more std::filesystem usage

### DIFF
--- a/bindings/libdnf/common.i
+++ b/bindings/libdnf/common.i
@@ -31,7 +31,7 @@
 %exception {
     try {
         $action
-    } catch (const libdnf::InvalidPointer & e) {
+    } catch (const libdnf::InvalidPointerError & e) {
         SWIG_exception(SWIG_NullReferenceError, e.what());
     } catch (const std::out_of_range & e) {
         SWIG_exception(SWIG_IndexError, e.what());

--- a/bindings/libdnf/conf.i
+++ b/bindings/libdnf/conf.i
@@ -16,7 +16,7 @@
 %exception {
     try {
         $action
-    } catch (const libdnf::InvalidPointer & e) {
+    } catch (const libdnf::InvalidPointerError & e) {
         SWIG_exception(SWIG_NullReferenceError, e.what());
     } catch (const libdnf::RuntimeError & e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
@@ -27,6 +27,7 @@
     #include "libdnf/conf/option_child.hpp"
     #include "libdnf/conf/config_main.hpp"
     #include "libdnf/conf/config_parser.hpp"
+    #include "libdnf/common/weak_ptr.hpp"
 %}
 
 #define CV __perl_CV

--- a/bindings/libdnf/repo.i
+++ b/bindings/libdnf/repo.i
@@ -18,7 +18,7 @@
 %exception {
     try {
         $action
-    } catch (const libdnf::InvalidPointer & e) {
+    } catch (const libdnf::InvalidPointerError & e) {
         SWIG_exception(SWIG_NullReferenceError, e.what());
     } catch (const libdnf::RuntimeError & e) {
         SWIG_exception(SWIG_RuntimeError, e.what());

--- a/bindings/libdnf/rpm.i
+++ b/bindings/libdnf/rpm.i
@@ -18,7 +18,7 @@
 %exception {
     try {
         $action
-    } catch (const libdnf::InvalidPointer & e) {
+    } catch (const libdnf::InvalidPointerError & e) {
         SWIG_exception(SWIG_NullReferenceError, e.what());
     } catch (const libdnf::RuntimeError & e) {
         SWIG_exception(SWIG_RuntimeError, e.what());

--- a/include/libdnf/repo/package_downloader.hpp
+++ b/include/libdnf/repo/package_downloader.hpp
@@ -55,6 +55,13 @@ public:
 };
 
 
+class PackageDownloadError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf::repo"; }
+    const char * get_name() const noexcept override { return "PackageDownloadError"; }
+};
+
+
 class PackageDownloader {
 public:
     PackageDownloader();

--- a/include/libdnf/repo/repo.hpp
+++ b/include/libdnf/repo/repo.hpp
@@ -28,6 +28,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/base_weak.hpp"
 #include "libdnf/common/exception.hpp"
 #include "libdnf/common/weak_ptr.hpp"
+#include "libdnf/repo/repo_errors.hpp"
 
 #include <memory>
 
@@ -293,7 +294,9 @@ public:
 
     /// Downloads file from URL into given opened file descriptor.
     /// @replaces libdnf:repo/Repo.hpp:method:Repo.downloadUrl(const char * url, int fd)
-    void download_url(const char * url, int fd);
+    /// TODO(lukash) fd seems like an inconvenient API for this function, use target path instead?
+    ///              It also needs defining what it means downloading an URL through a particular repo
+    //void download_url(const char * url, int fd);
 
     /// Set http headers.
     /// @param headers A vector of full headers ("header: value")

--- a/include/libdnf/repo/repo_errors.hpp
+++ b/include/libdnf/repo/repo_errors.hpp
@@ -1,0 +1,59 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_RPM_REPO_ERRORS_HPP
+#define LIBDNF_RPM_REPO_ERRORS_HPP
+
+#include "libdnf/common/exception.hpp"
+
+
+namespace libdnf::repo {
+
+class RepoError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf::repo"; }
+    const char * get_name() const noexcept override { return "RepoError"; }
+};
+
+
+class RepoDownloadError : public RepoError {
+public:
+    using RepoError::RepoError;
+    const char * get_domain_name() const noexcept override { return "libdnf::repo"; }
+    const char * get_name() const noexcept override { return "RepoDownloadError"; }
+};
+
+
+class RepoGpgError : public RepoError {
+public:
+    using RepoError::RepoError;
+    const char * get_domain_name() const noexcept override { return "libdnf::repo"; }
+    const char * get_name() const noexcept override { return "RepoGpgError"; }
+};
+
+
+class RepoRpmError : public RepoError {
+    using RepoError::RepoError;
+    const char * get_domain_name() const noexcept override { return "libdnf::repo"; }
+    const char * get_name() const noexcept override { return "RepoRpmError"; }
+};
+
+}  // namespace libdnf::repo
+
+#endif

--- a/libdnf/repo/repo_downloader.cpp
+++ b/libdnf/repo/repo_downloader.cpp
@@ -352,7 +352,7 @@ RepoDownloader::~RepoDownloader() = default;
 
 void RepoDownloader::download_metadata(const std::string & destdir) {
     std::filesystem::create_directories(destdir);
-    libdnf::utils::TempDir tmpdir(destdir, "tmpdir.");
+    libdnf::utils::TempDir tmpdir(destdir, "tmpdir");
 
     std::unique_ptr<LrHandle> h(init_remote_handle(tmpdir.get_path().c_str()));
     auto r = perform(h.get(), tmpdir.get_path(), config.repo_gpgcheck().get_value());
@@ -373,7 +373,7 @@ void RepoDownloader::download_metadata(const std::string & destdir) {
 bool RepoDownloader::is_metalink_in_sync() {
     auto & logger = *base->get_logger();
 
-    libdnf::utils::TempDir tmpdir("tmpdir.");
+    libdnf::utils::TempDir tmpdir("tmpdir");
 
     std::unique_ptr<LrHandle> h(init_remote_handle(tmpdir.get_path().c_str()));
 
@@ -440,7 +440,7 @@ bool RepoDownloader::is_repomd_in_sync() {
     auto & logger = *base->get_logger();
     LrYumRepo * yum_repo;
 
-    libdnf::utils::TempDir tmpdir("tmpdir.");
+    libdnf::utils::TempDir tmpdir("tmpdir");
 
     const char * dlist[] = LR_YUM_REPOMDONLY;
 

--- a/libdnf/repo/repo_gpgme.cpp
+++ b/libdnf/repo/repo_gpgme.cpp
@@ -157,7 +157,7 @@ static void gpg_import_key(gpgme_ctx_t context, std::vector<char> key) {
 static std::vector<Key> rawkey2infos(int fd) {
     gpg_error_t gpg_err;
 
-    libdnf::utils::TempDir tmpdir("tmpdir.");
+    libdnf::utils::TempDir tmpdir("tmpdir");
 
     auto context = create_context(tmpdir.get_path());
 

--- a/libdnf/repo/repo_gpgme.hpp
+++ b/libdnf/repo/repo_gpgme.hpp
@@ -28,23 +28,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+
 namespace libdnf::repo {
 
-class GpgError : public RuntimeError {
-public:
-    using RuntimeError::RuntimeError;
-
-    const char * get_domain_name() const noexcept override { return "repo"; }
-    const char * get_name() const noexcept override { return "GpgError"; }
-    const char * get_description() const noexcept override { return "Gpg error"; }
-};
-
-
+/// Wraps gpgme in a higher-level interface.
+/// @exception RepoGpgError (public) Thrown on any gpgme-related error.
 class RepoGpgme {
 public:
     RepoGpgme(const BaseWeakPtr & base, const ConfigRepo & config);
 
-    void set_callbacks(RepoCallbacks * callbacks) { this->callbacks = callbacks; }
+    void set_callbacks(RepoCallbacks * callbacks) noexcept { this->callbacks = callbacks; }
 
     std::string get_keyring_dir() { return config.get_cachedir() + "/pubring"; }
 

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -330,7 +330,7 @@ Package::Package(const BaseWeakPtr & base, unsigned long long rpmdbid) : base(ba
         }
     }
 
-    throw Exception("Package with rpmdbid was not found");
+    throw RuntimeError("Package with rpmdbid was not found");
 }
 
 }  // namespace libdnf::rpm

--- a/libdnf/rpm/package_sack_impl.hpp
+++ b/libdnf/rpm/package_sack_impl.hpp
@@ -134,7 +134,10 @@ private:
     void rewrite_repos(libdnf::solv::IdQueue & addedfileprovides, libdnf::solv::IdQueue & addedfileprovides_inst);
 
     /// Constructs libsolv repository cache filename for given repository id and optional extension.
-    std::string give_repo_solv_cache_fn(const std::string & repoid, const char * ext = nullptr);
+    std::string repo_solv_cache_fn(const std::string & repoid, const char * ext = nullptr);
+
+    /// Constructs libsolv repository cache file path for given repository id and optional extension.
+    std::string repo_solv_cache_path(const std::string & repoid, const char * ext = nullptr);
 
     bool considered_uptodate{true};
     bool provides_ready{false};

--- a/libdnf/utils/sqlite3/sqlite3.cpp
+++ b/libdnf/utils/sqlite3/sqlite3.cpp
@@ -29,7 +29,7 @@ void SQLite3::open() {
         auto result = sqlite3_open(path.c_str(), &db);
         if (result != SQLITE_OK) {
             sqlite3_close(db);
-            throw Error(*this, result, "Open failed");
+            throw SQLError(*this, result, "Open failed");
         }
 
         // the busy timeout must be set before executing *any* statements
@@ -66,7 +66,7 @@ void SQLite3::close() {
         result = sqlite3_close(db);
     }
     if (result != SQLITE_OK) {
-        throw Error(*this, result, "Close failed");
+        throw SQLError(*this, result, "Close failed");
     }
     db = nullptr;
 }
@@ -78,7 +78,7 @@ void SQLite3::backup(const std::string & output_file) {
     auto result = sqlite3_open(output_file.c_str(), &backup_db);
     if (result != SQLITE_OK) {
         sqlite3_close(backup_db);
-        throw Error(*this, result, "Failed to open backup database: \"" + output_file + "\"");
+        throw SQLError(*this, result, "Failed to open backup database: \"" + output_file + "\"");
     }
 
     sqlite3_backup * backup_handle = sqlite3_backup_init(backup_db, "main", db, "main");
@@ -93,7 +93,7 @@ void SQLite3::backup(const std::string & output_file) {
     sqlite3_close(backup_db);
 
     if (result != SQLITE_OK) {
-        throw Error(*this, result, "Database backup failed");
+        throw SQLError(*this, result, "Database backup failed");
     }
 }
 
@@ -104,7 +104,7 @@ void SQLite3::restore(const std::string & input_file) {
     auto result = sqlite3_open(input_file.c_str(), &backup_db);
     if (result != SQLITE_OK) {
         sqlite3_close(backup_db);
-        throw Error(*this, result, "Failed to open backup database: \"" + input_file + "\"");
+        throw SQLError(*this, result, "Failed to open backup database: \"" + input_file + "\"");
     }
 
     sqlite3_backup * backup_handle = sqlite3_backup_init(db, "main", backup_db, "main");
@@ -119,7 +119,7 @@ void SQLite3::restore(const std::string & input_file) {
     sqlite3_close(backup_db);
 
     if (result != SQLITE_OK) {
-        throw Error(*this, result, "Database restore failed");
+        throw SQLError(*this, result, "Database restore failed");
     }
 }
 

--- a/libdnf/utils/sqlite3/sqlite3.hpp
+++ b/libdnf/utils/sqlite3/sqlite3.hpp
@@ -35,11 +35,20 @@ namespace libdnf::utils {
 
 class SQLite3 {
 public:
-    class Error : public libdnf::Exception {
+    class Error : public libdnf::Error {
     public:
-        explicit Error(const SQLite3 & s, int code, const std::string & msg)
-            : libdnf::Exception("SQLite error on \"" + s.get_path() + "\": " + msg + ": " + s.get_error())
-            , ecode{code} {}
+        using libdnf::Error::Error;
+        const char * get_domain_name() const noexcept override { return "libdnf::utils::SQLite3"; }
+        const char * get_name() const noexcept override { return "Error"; }
+    };
+
+    class SQLError : public Error {
+    public:
+        explicit SQLError(const SQLite3 & s, int code, const std::string & msg)
+            : Error("SQLite error on \"{}\": {}: {}", s.get_path(), msg, s.get_error()),
+              ecode{code} {}
+        const char * get_domain_name() const noexcept override { return "libdnf::utils::SQLite3"; }
+        const char * get_name() const noexcept override { return "SQLError"; }
 
         int code() const noexcept { return ecode; }
         const char * code_str() const noexcept { return sqlite3_errstr(ecode); }
@@ -56,13 +65,15 @@ public:
     class Statement {
     public:
         /// An error class that will log the SQL statement in its constructor.
-        class Error : public SQLite3::Error {
+        class SQLError : public SQLite3::SQLError {
         public:
-            Error(Statement & stmt, int code, const std::string & msg) : SQLite3::Error(stmt.db, code, msg) {
+            SQLError(Statement & stmt, int code, const std::string & msg) : SQLite3::SQLError(stmt.db, code, msg) {
                 // TODO(dmach): replace with a new logger
                 // auto logger(libdnf::Log::getLogger());
                 // logger->debug(std::string("SQL statement being executed: ") + stmt.getExpandedSql());
             }
+            const char * get_domain_name() const noexcept override { return "libdnf::utils::SQLite3::Statement"; }
+            const char * get_name() const noexcept override { return "SQLError"; }
         };
 
         enum class StepResult { DONE, ROW, BUSY };
@@ -73,25 +84,25 @@ public:
         Statement(SQLite3 & db, const char * sql) : db(db) {
             auto result = sqlite3_prepare_v2(db.db, sql, -1, &stmt, nullptr);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Statement failed");
+                throw SQLError(*this, result, "Statement failed");
         };
 
         Statement(SQLite3 & db, const std::string & sql) : db(db) {
             auto result = sqlite3_prepare_v2(db.db, sql.c_str(), static_cast<int>(sql.length()) + 1, &stmt, nullptr);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Statement failed");
+                throw SQLError(*this, result, "Statement failed");
         };
 
         void bind(int pos, int val) {
             auto result = sqlite3_bind_int(stmt, pos, val);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Integer bind failed");
+                throw SQLError(*this, result, "Integer bind failed");
         }
 
         void bind(int pos, std::int64_t val) {
             auto result = sqlite3_bind_int64(stmt, pos, val);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Integer64 bind failed");
+                throw SQLError(*this, result, "Integer64 bind failed");
         }
 
         void bind(int pos, std::uint32_t val) {
@@ -100,43 +111,43 @@ public:
             // signed INTEGER type in the DB
             auto result = sqlite3_bind_int64(stmt, pos, static_cast<int64_t>(val));
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Unsigned integer bind failed");
+                throw SQLError(*this, result, "Unsigned integer bind failed");
         }
 
         void bind(int pos, double val) {
             auto result = sqlite3_bind_double(stmt, pos, val);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Double bind failed");
+                throw SQLError(*this, result, "Double bind failed");
         }
 
         void bind(int pos, bool val) {
             auto result = sqlite3_bind_int(stmt, pos, val ? 1 : 0);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Bool bind failed");
+                throw SQLError(*this, result, "Bool bind failed");
         }
 
         void bind(int pos, const char * val) {
             auto result = sqlite3_bind_text(stmt, pos, val, -1, SQLITE_TRANSIENT);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Text bind failed");
+                throw SQLError(*this, result, "Text bind failed");
         }
 
         void bind(int pos, const std::string & val) {
             auto result = sqlite3_bind_text(stmt, pos, val.c_str(), -1, SQLITE_TRANSIENT);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Text bind failed");
+                throw SQLError(*this, result, "Text bind failed");
         }
 
         void bind(int pos, const Blob & val) {
             auto result = sqlite3_bind_blob(stmt, pos, val.data, static_cast<int>(val.size), SQLITE_TRANSIENT);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Blob bind failed");
+                throw SQLError(*this, result, "Blob bind failed");
         }
 
         void bind(int pos, const std::vector<unsigned char> & val) {
             auto result = sqlite3_bind_blob(stmt, pos, val.data(), static_cast<int>(val.size()), SQLITE_TRANSIENT);
             if (result != SQLITE_OK)
-                throw Error(*this, result, "Blob bind failed");
+                throw SQLError(*this, result, "Blob bind failed");
         }
 
         template <typename... Args>
@@ -157,7 +168,7 @@ public:
                 case SQLITE_BUSY:
                     return StepResult::BUSY;
                 default:
-                    throw Error(*this, result, "Reading a row failed");
+                    throw SQLError(*this, result, "Reading a row failed");
             }
         }
 
@@ -180,9 +191,7 @@ public:
 #else
             expanded_sql = sqlite3_expanded_sql(stmt);
             if (!expanded_sql) {
-                throw libdnf::Exception(
-                    "get_expanded_sql(): insufficient memory or result "
-                    "exceed the maximum SQLite3 string length");
+                throw Error("Insufficient memory or result exceed maximum SQLite3 string length");
             }
             return expanded_sql;
 #endif
@@ -261,7 +270,7 @@ public:
         int get_column_index(const std::string & col_name) {
             auto it = cols_name_to_index.find(col_name);
             if (it == cols_name_to_index.end())
-                throw libdnf::Exception("get() column \"" + col_name + "\" not found");
+                throw Error("Column \"{}\" not found", col_name);
             return it->second;
         }
 
@@ -300,7 +309,7 @@ public:
     void exec(const char * sql) {
         auto result = sqlite3_exec(db, sql, nullptr, nullptr, nullptr);
         if (result != SQLITE_OK) {
-            throw Error(*this, result, "Executing an SQL statement failed");
+            throw SQLError(*this, result, "Executing an SQL statement failed");
         }
     }
 

--- a/libdnf/utils/temp.cpp
+++ b/libdnf/utils/temp.cpp
@@ -31,12 +31,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::utils {
 
 
-TempDir::TempDir(const std::string & prefix) : TempDir(std::filesystem::temp_directory_path(), prefix) {}
+TempDir::TempDir(const std::string & name_prefix) : TempDir(std::filesystem::temp_directory_path(), name_prefix) {}
 
 
-TempDir::TempDir(const std::string & destdir, const std::string & prefix) {
+TempDir::TempDir(const std::string & destdir, const std::string & name_prefix) {
     std::filesystem::path dir = destdir;
-    dir /= prefix + "XXXXXX";
+    dir /= name_prefix + ".XXXXXX";
 
     const char * temp_path = mkdtemp(const_cast<char *>(dir.native().c_str()));
     if (temp_path == nullptr) {

--- a/libdnf/utils/temp.cpp
+++ b/libdnf/utils/temp.cpp
@@ -34,15 +34,16 @@ namespace libdnf::utils {
 TempDir::TempDir(const std::string & name_prefix) : TempDir(std::filesystem::temp_directory_path(), name_prefix) {}
 
 
-TempDir::TempDir(const std::string & destdir, const std::string & name_prefix) {
-    std::filesystem::path dir = destdir;
-    dir /= name_prefix + ".XXXXXX";
+TempDir::TempDir(std::filesystem::path destdir, const std::string & name_prefix) {
+    destdir /= name_prefix + ".XXXXXX";
 
-    const char * temp_path = mkdtemp(const_cast<char *>(dir.native().c_str()));
+    // mkdtemp modifies the dest's char * in-place
+    std::string dest = destdir;
+    const char * temp_path = mkdtemp(dest.data());
     if (temp_path == nullptr) {
         throw std::filesystem::filesystem_error(
             "cannot create temporary directory",
-            dir,
+            destdir,
             std::error_code(errno, std::system_category()));
     }
     path = temp_path;

--- a/libdnf/utils/temp.cpp
+++ b/libdnf/utils/temp.cpp
@@ -40,9 +40,10 @@ TempDir::TempDir(const std::string & destdir, const std::string & prefix) {
 
     const char * temp_path = mkdtemp(const_cast<char *>(dir.native().c_str()));
     if (temp_path == nullptr) {
-        // TODO(lukash) use a specific exception class
-        throw RuntimeError(
-            fmt::format(_("Cannot create temporary directory \"{}\": {}"), dir.native().c_str(), strerror(errno)));
+        throw std::filesystem::filesystem_error(
+            "cannot create temporary directory",
+            dir,
+            std::error_code(errno, std::system_category()));
     }
     path = temp_path;
 }

--- a/libdnf/utils/temp.hpp
+++ b/libdnf/utils/temp.hpp
@@ -32,10 +32,10 @@ namespace libdnf::utils {
 class TempDir {
 public:
     /// Creates a temporary directory in the system temporary directory path.
-    explicit TempDir(const std::string & prefix);
+    explicit TempDir(const std::string & name_prefix);
 
     /// Creates a temporary directory in `destdir`.
-    TempDir(const std::string & destdir, const std::string & prefix);
+    TempDir(const std::string & destdir, const std::string & name_prefix);
 
     TempDir(const TempDir &) = delete;
     TempDir & operator=(const TempDir &) = delete;

--- a/libdnf/utils/temp.hpp
+++ b/libdnf/utils/temp.hpp
@@ -35,7 +35,7 @@ public:
     explicit TempDir(const std::string & name_prefix);
 
     /// Creates a temporary directory in `destdir`.
-    TempDir(const std::string & destdir, const std::string & name_prefix);
+    TempDir(std::filesystem::path destdir, const std::string & name_prefix);
 
     TempDir(const TempDir &) = delete;
     TempDir & operator=(const TempDir &) = delete;

--- a/test/libdnf/base/test_base.cpp
+++ b/test/libdnf/base/test_base.cpp
@@ -45,6 +45,6 @@ void BaseTest::test_weak_ptr() {
     base.reset();
 
     // Base object is invalid. -> Both WeakPtr are invalid. The code must throw an exception.
-    CPPUNIT_ASSERT_THROW(vars->get_value("test_variable"), libdnf::VarsWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(vars2->get_value("test_variable"), libdnf::VarsWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(vars->get_value("test_variable"), libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(vars2->get_value("test_variable"), libdnf::InvalidPointerError);
 }

--- a/test/libdnf/repo/test_repo.cpp
+++ b/test/libdnf/repo/test_repo.cpp
@@ -32,7 +32,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(RepoTest);
 
 void RepoTest::setUp() {
     TestCaseFixture::setUp();
-    temp = new libdnf::utils::TempDir("libdnf_unittest_");
+    temp = new libdnf::utils::TempDir("libdnf_unittest");
     std::filesystem::create_directory(temp->get_path() / "installroot");
     std::filesystem::create_directory(temp->get_path() / "cache");
 }

--- a/test/libdnf/support.cpp
+++ b/test/libdnf/support.cpp
@@ -129,7 +129,7 @@ libdnf::rpm::Package LibdnfTestCase::first_query_pkg(libdnf::rpm::PackageQuery &
 void LibdnfTestCase::setUp() {
     TestCaseFixture::setUp();
 
-    temp = std::make_unique<libdnf::utils::TempDir>("libdnf_unittest_");
+    temp = std::make_unique<libdnf::utils::TempDir>("libdnf_unittest");
     std::filesystem::create_directory(temp->get_path() / "installroot");
 
     // set installroot to a temp directory
@@ -139,7 +139,7 @@ void LibdnfTestCase::setUp() {
     auto class_name = typeid(*this).name();
     auto it = cache_dirs.find(class_name);
     if (it == cache_dirs.end()) {
-        cache_dirs.insert({class_name, std::make_unique<libdnf::utils::TempDir>("libdnf_unittest_")});
+        cache_dirs.insert({class_name, std::make_unique<libdnf::utils::TempDir>("libdnf_unittest")});
     }
     base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cache_dirs.at(class_name)->get_path());
 

--- a/test/libdnf/system/test_state.cpp
+++ b/test/libdnf/system/test_state.cpp
@@ -33,7 +33,7 @@ void StateTest::setUp() {
     LibdnfTestCase::setUp();
     add_repo_repomd("repomd-repo1");
 
-    temp_dir = std::make_unique<libdnf::utils::TempDir>("libdnf_test_state_");
+    temp_dir = std::make_unique<libdnf::utils::TempDir>("libdnf_test_state");
 
     std::ofstream toml(temp_dir->get_path() / "userinstalled.toml");
     toml << "userinstalled = [\n"

--- a/test/libdnf/transaction/transaction_test_base.cpp
+++ b/test/libdnf/transaction/transaction_test_base.cpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 void TransactionTestBase::setUp() {
-    persistdir = std::make_unique<libdnf::utils::TempDir>("libdnf_unittest_");
+    persistdir = std::make_unique<libdnf::utils::TempDir>("libdnf_unittest");
 }
 
 

--- a/test/libdnf/utils/test_fs.cpp
+++ b/test/libdnf/utils/test_fs.cpp
@@ -32,7 +32,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(UtilsFsTest);
 
 
 void UtilsFsTest::setUp() {
-    temp = new libdnf::utils::TempDir("libdnf_unittest_");
+    temp = new libdnf::utils::TempDir("libdnf_unittest");
     std::filesystem::create_directory(temp->get_path() / "already-exists");
 }
 

--- a/test/libdnf/weak_ptr/test_weak_ptr.cpp
+++ b/test/libdnf/weak_ptr/test_weak_ptr.cpp
@@ -83,8 +83,8 @@ void WeakPtrTest::test_weak_ptr() {
     // data from sack1 must be still accesible, but access to data from sack2 must throw exception
     CPPUNIT_ASSERT(*item1_weak_ptr.get() == "sack1_item1");
     CPPUNIT_ASSERT(item2_weak_ptr->compare("sack1_item2") == 0);
-    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get() == "sack2_item1", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW((item4_weak_ptr->compare("sack2_item2") == 0), Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get() == "sack2_item1", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW((item4_weak_ptr->compare("sack2_item2") == 0), libdnf::InvalidPointerError);
 
     // test is_valid() method
     CPPUNIT_ASSERT(item1_weak_ptr.is_valid());
@@ -138,12 +138,12 @@ void WeakPtrTest::test_weak_ptr() {
     sack1->data_guard.clear();
     CPPUNIT_ASSERT(sack1->data_guard.empty());
     CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(0));
-    CPPUNIT_ASSERT_THROW(*item1_weak_ptr.get() == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item2_weak_ptr.get() == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get() == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item4_weak_ptr.get() == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item5_weak_ptr.get() == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item6_weak_ptr.get() == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item1_weak_ptr.get() == "sack1_item1", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item2_weak_ptr.get() == "sack1_item2", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get() == "sack1_item2", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item4_weak_ptr.get() == "sack1_item1", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item5_weak_ptr.get() == "sack1_item1", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item6_weak_ptr.get() == "sack1_item1", libdnf::InvalidPointerError);
 }
 
 
@@ -200,8 +200,8 @@ void WeakPtrTest::test_weak_ptr_is_owner() {
     // data from sack1 must be still accesible, but access to data from sack2 must throw exception
     CPPUNIT_ASSERT(*item1_weak_ptr.get()->remote_data == "sack1_item1");
     CPPUNIT_ASSERT(*item2_weak_ptr->remote_data == "sack1_item2");
-    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get()->remote_data == "sack2_item1", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item4_weak_ptr->remote_data == "sack2_item2", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item3_weak_ptr.get()->remote_data == "sack2_item1", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item4_weak_ptr->remote_data == "sack2_item2", libdnf::InvalidPointerError);
 
     // test is_valid() method
     CPPUNIT_ASSERT(item1_weak_ptr.is_valid());
@@ -218,7 +218,7 @@ void WeakPtrTest::test_weak_ptr_is_owner() {
     // there move constructor
     auto item6_weak_ptr(std::move(item5_weak_ptr));
     CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(3));
-    CPPUNIT_ASSERT_THROW(*item5_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item5_weak_ptr->remote_data == "sack1_item1", libdnf::InvalidPointerError);
     CPPUNIT_ASSERT(*item6_weak_ptr->remote_data == "sack1_item1");
 
     // test copy assignment operator =
@@ -235,7 +235,7 @@ void WeakPtrTest::test_weak_ptr_is_owner() {
     // test move assignment operator =
     item4_weak_ptr = std::move(item2_weak_ptr);
     CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(4));
-    CPPUNIT_ASSERT_THROW(*item2_weak_ptr->remote_data == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item2_weak_ptr->remote_data == "sack1_item2", libdnf::InvalidPointerError);
     CPPUNIT_ASSERT(*item4_weak_ptr->remote_data == "sack1_item2");
 
     // test move self-assignment operator =
@@ -273,8 +273,8 @@ void WeakPtrTest::test_weak_ptr_is_owner() {
     sack1->data_guard.clear();
     CPPUNIT_ASSERT(sack1->data_guard.empty());
     CPPUNIT_ASSERT_EQUAL(sack1->data_guard.size(), static_cast<std::size_t>(0));
-    CPPUNIT_ASSERT_THROW(*item1_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item3_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item4_weak_ptr->remote_data == "sack1_item1", Sack::DataItemWeakPtr::InvalidPtr);
-    CPPUNIT_ASSERT_THROW(*item6_weak_ptr->remote_data == "sack1_item2", Sack::DataItemWeakPtr::InvalidPtr);
+    CPPUNIT_ASSERT_THROW(*item1_weak_ptr->remote_data == "sack1_item1", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item3_weak_ptr->remote_data == "sack1_item1", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item4_weak_ptr->remote_data == "sack1_item1", libdnf::InvalidPointerError);
+    CPPUNIT_ASSERT_THROW(*item6_weak_ptr->remote_data == "sack1_item2", libdnf::InvalidPointerError);
 }

--- a/test/perl5/libdnf/base/test_base.t
+++ b/test/perl5/libdnf/base/test_base.t
@@ -59,8 +59,8 @@ use libdnf::base;
     $base = 0;
 
     # Base object is invalid. -> Both WeakPtr are invalid. The code must throw an exception.
-    throws_ok( sub { $vars->get_value('test_variable') }, '/InvalidPtr/', 'detected');
-    throws_ok( sub { $vars2->get_value('test_variable') }, '/InvalidPtr/', 'detected');
+    throws_ok( sub { $vars->get_value('test_variable') }, '/Dereferencing an invalidated WeakPtr/', 'detected');
+    throws_ok( sub { $vars2->get_value('test_variable') }, '/Dereferencing an invalidated WeakPtr/', 'detected');
 }
 
 done_testing()

--- a/test/python3/libdnf/base/test_base.py
+++ b/test/python3/libdnf/base/test_base.py
@@ -48,7 +48,7 @@ class TestBase(unittest.TestCase):
         base = None
 
         # Base object is invalid. -> Both WeakPtr are invalid. The code must throw an exception.
-        with self.assertRaisesRegex(RuntimeError, '.*InvalidPtr.*'):
+        with self.assertRaisesRegex(RuntimeError, 'Dereferencing an invalidated WeakPtr'):
             vars.get_value("test_variable")
-        with self.assertRaisesRegex(RuntimeError, '.*InvalidPtr.*'):
+        with self.assertRaisesRegex(RuntimeError, 'Dereferencing an invalidated WeakPtr'):
             vars2.get_value("test_variable")

--- a/test/tutorial/test_tutorial.cpp
+++ b/test/tutorial/test_tutorial.cpp
@@ -27,7 +27,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TutorialTest);
 
 
 void TutorialTest::setUp() {
-    temp = std::make_unique<libdnf::utils::TempDir>("libdnf_unittest_");
+    temp = std::make_unique<libdnf::utils::TempDir>("libdnf_unittest");
     installroot = temp->get_path().native() + "/installroot";
 }
 


### PR DESCRIPTION
Reworks the exception base class to support formatting during the handling of the exception (as opposed to during creation). Uses a lambda closure to store the actual format arguments, as otherwise a naive solution would be to store them in a tuple member, which would propagate the argument types into the type of the error (making it a template) and which is not practically usable. However the closure, while working well, is likely not a good solution either.

The PR also contains a number of commits improving working with the filesystem which are not necessarily tied to the exception work and can be separated into another PR in case it passes the review and the exceptions need changes.