### PR TITLE
[dnf5] Fix: PreserveOrderMap reverse iterators, assertion_traits in tests

### DIFF
--- a/include/libdnf/common/preserve_order_map.hpp
+++ b/include/libdnf/common/preserve_order_map.hpp
@@ -82,8 +82,8 @@ public:
     };
     using iterator = MyBidirIterator<value_type, typename container_type::iterator>;
     using const_iterator = MyBidirIterator<const value_type, typename container_type::const_iterator>;
-    using reverse_iterator = std::reverse_iterator<iterator>;
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using reverse_iterator =  MyBidirIterator<value_type, typename container_type::reverse_iterator>;
+    using const_reverse_iterator =  MyBidirIterator<value_type, typename container_type::const_reverse_iterator>;
 
     bool empty() const noexcept { return items.empty(); }
     size_type size() const noexcept { return items.size(); }

--- a/test/libdnf/utils.hpp
+++ b/test/libdnf/utils.hpp
@@ -59,10 +59,10 @@ struct assertion_traits<C<T>> {
         return os.str();
     }
 
-    assertion_traits<C<T>>() = delete;
-    ~assertion_traits<C<T>>() = delete;
-    assertion_traits<C<T>>(const assertion_traits<C<T>>&) = delete;
-    assertion_traits<C<T>>& operator=(const assertion_traits<C<T>>&) = delete;
+    assertion_traits() = delete;
+    ~assertion_traits() = delete;
+    assertion_traits(const assertion_traits &) = delete;
+    assertion_traits & operator=(const assertion_traits &) = delete;
 };
 
 template <>


### PR DESCRIPTION
* Fix reverse iterators in `libdnf::PreserveOrderMap`.
* Fix `assertion_traits` in "test/libdnf/utils.hpp".

This is part of the fixes needed to compile with C++20.
