### PR TITLE
[dnf5] Exceptions: sync with new style and localization support

### DIFF
--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -49,13 +49,6 @@ public:
 
     ~AdvisoryQuery();
 
-    struct NotSupportedCmpType : public RuntimeError {
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::advisory::AdvisoryQuery"; }
-        const char * get_name() const noexcept override { return "NotSupportedCmpType"; }
-        const char * get_description() const noexcept override { return "AdvisoryQuery exception"; }
-    };
-
     /// Filter Advisories by name
     ///
     /// @param pattern      Pattern used when matching agains advisory names.

--- a/include/libdnf/advisory/advisory_set.hpp
+++ b/include/libdnf/advisory/advisory_set.hpp
@@ -46,14 +46,6 @@ namespace libdnf::advisory {
 
 class AdvisorySet {
 public:
-    // TODO(dmach): move to common/exception.hpp, share across multiple sets/queries
-    struct UsedDifferentSack : public RuntimeError {
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::advisory::AdvisorySet"; }
-        const char * get_name() const noexcept override { return "UsedDifferentSack"; }
-        const char * get_description() const noexcept override { return "AdvisorySet exception"; }
-    };
-
     explicit AdvisorySet(const libdnf::BaseWeakPtr & base);
     explicit AdvisorySet(libdnf::Base & base);
 

--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -17,8 +17,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIBDNF_UTILS_EXCEPTION_HPP
-#define LIBDNF_UTILS_EXCEPTION_HPP
+#ifndef LIBDNF_COMMON_EXCEPTION_HPP
+#define LIBDNF_COMMON_EXCEPTION_HPP
 
 #include <fmt/format.h>
 
@@ -171,7 +171,7 @@ public:
 
 /// Formats the error message of an exception.
 /// If the exception is nested, recurses to format the message of the exception it holds.
-std::string format(const std::exception & e, std::size_t level = 0);
+std::string format(const std::exception & e, bool with_domain);
 
 }  // namespace libdnf
 

--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -128,9 +128,7 @@ public:
     /// message from the system error description.
     ///
     /// @param error_code The `errno` of the error.
-    SystemError(int error_code)
-        : Error("({}) - {}", error_code, std::system_category().default_error_condition(error_code).message()),
-          error_code(error_code) {}
+    SystemError(int error_code) : Error("System error"), error_code(error_code), has_user_message(false) {}
 
     /// Constructs the error from the `errno` error code and a formatted message.
     /// The formatted message is prepended to the generated system error message.
@@ -138,14 +136,13 @@ public:
     /// @param error_code The `errno` of the error.
     /// @param format The format string for the message.
     /// @param args The format arguments.
-    template<typename... Ss>
-    SystemError(int error_code, const std::string & format, Ss&&... args)
-        : Error(
-            "{}: ({}) - {}",
-            fmt::format(format, std::forward<Ss>(args)...),
-            error_code,
-            std::system_category().default_error_condition(error_code).message()),
-          error_code(error_code) {}
+    template <typename... Ss>
+    SystemError(int error_code, const std::string & format, Ss &&... args)
+        : Error(format, std::forward<Ss>(args)...),
+          error_code(error_code),
+          has_user_message(true) {}
+
+    const char * what() const noexcept override;
 
     const char * get_domain_name() const noexcept override { return "libdnf"; }
     const char * get_name() const noexcept override { return "SystemError"; }
@@ -158,6 +155,7 @@ public:
 
 private:
     int error_code;
+    bool has_user_message;
 };
 
 
@@ -167,7 +165,7 @@ class RuntimeError : public Error {
 public:
     using Error::Error;
     const char * get_name() const noexcept override { return "RuntimeError"; }
-    virtual const char * get_description() const noexcept { return "General RuntimeError exception"; }
+    virtual const char * get_description() const noexcept;
 };
 
 

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -56,14 +56,6 @@ public:
         EMPTY = 1 << 2
     };
 
-    // TODO(dmach): move to common/exception.hpp, share across multiple queries
-    struct NotSupportedCmpType : public RuntimeError {
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::rpm::PackageQuery"; }
-        const char * get_name() const noexcept override { return "NotSupportedCmpType"; }
-        const char * get_description() const noexcept override { return "PackageQuery exception"; }
-    };
-
     // @replaces libdnf/hy-query.h:function:hy_query_create(DnfSack *sack);
     // @replaces libdnf/hy-query.h:function:hy_query_create_flags(DnfSack *sack, int flags);
     // @replaces libdnf/sack/query.hpp:method:Query(DnfSack* sack, ExcludeFlags flags = ExcludeFlags::APPLY_EXCLUDES)

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/rpm/package_set.hpp"
 #include "libdnf/solv/pool.hpp"
 #include "libdnf/solv/solv_map.hpp"
+#include "libdnf/common/sack/query_cmp_private.hpp"
 #include "libdnf/utils/utils_internal.hpp"
 
 #include <solv/evr.h>
@@ -64,7 +65,7 @@ static int libsolv_cmp_flags(libdnf::sack::QueryCmp cmp_type, const char * patte
         case libdnf::sack::QueryCmp::ICONTAINS:
             return SEARCH_NOCASE | SEARCH_SUBSTRING;
         default:
-            throw AdvisoryQuery::NotSupportedCmpType("Used unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 }
 
@@ -245,7 +246,7 @@ AdvisoryQuery & AdvisoryQuery::filter_packages(const libdnf::rpm::PackageSet & p
 
         } break;
         default:
-            throw NotSupportedCmpType("Unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 
     // Apply filter results to query
@@ -290,7 +291,7 @@ std::vector<AdvisoryPackage> AdvisoryQuery::get_advisory_packages(
             }
         } break;
         default:
-            throw NotSupportedCmpType("Unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 
     //after_filter contains just advisoryPackages which comply to condition with package_set

--- a/libdnf/advisory/advisory_set.cpp
+++ b/libdnf/advisory/advisory_set.cpp
@@ -25,7 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/advisory/advisory_set_iterator.hpp"
 #include "libdnf/solv/solv_map.hpp"
-
+#include "libdnf/base/base_private.hpp"
 
 namespace libdnf::advisory {
 
@@ -70,30 +70,21 @@ AdvisorySet::iterator AdvisorySet::end() const {
 
 
 AdvisorySet & AdvisorySet::operator|=(const AdvisorySet & other) {
-    if (p_impl->base != other.p_impl->base) {
-        throw UsedDifferentSack(
-            "Cannot perform the action with AdvisorySet instances initialized with different Base");
-    }
+    libdnf_assert_same_base(p_impl->base, other.p_impl->base);
     *p_impl |= *other.p_impl;
     return *this;
 }
 
 
 AdvisorySet & AdvisorySet::operator-=(const AdvisorySet & other) {
-    if (p_impl->base != other.p_impl->base) {
-        throw UsedDifferentSack(
-            "Cannot perform the action with AdvisorySet instances initialized with different Base");
-    }
+    libdnf_assert_same_base(p_impl->base, other.p_impl->base);
     *p_impl -= *other.p_impl;
     return *this;
 }
 
 
 AdvisorySet & AdvisorySet::operator&=(const AdvisorySet & other) {
-    if (p_impl->base != other.p_impl->base) {
-        throw UsedDifferentSack(
-            "Cannot perform the action with AdvisorySet instances initialized with different Base");
-    }
+    libdnf_assert_same_base(p_impl->base, other.p_impl->base);
     *p_impl &= *other.p_impl;
     return *this;
 }

--- a/libdnf/common/sack/match_int64.cpp
+++ b/libdnf/common/sack/match_int64.cpp
@@ -21,6 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/common/exception.hpp"
 
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
 #include <stdexcept>
 
 
@@ -65,11 +67,11 @@ bool match_int64(int64_t value, QueryCmp cmp, int64_t pattern) {
         case QueryCmp::ENDSWITH:
         case QueryCmp::IENDSWITH:
         case QueryCmp::ISNULL:
-            throw std::runtime_error("Unsupported operator");
+            throw RuntimeError(M_("Unsupported operator"));
             break;
         case QueryCmp::NOT:
         case QueryCmp::ICASE:
-            throw std::runtime_error("Operator flag cannot be used standalone");
+            throw RuntimeError(M_("Operator flag cannot be used standalone"));
             break;
     }
     return result;

--- a/libdnf/common/sack/match_string.cpp
+++ b/libdnf/common/sack/match_string.cpp
@@ -19,6 +19,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/common/sack/match_string.hpp"
 
+#include "libdnf/common/exception.hpp"
+
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
 #include <fnmatch.h>
 
 #include <regex>
@@ -72,18 +76,18 @@ bool match_string(const std::string & value, QueryCmp cmp, const std::string & p
         case QueryCmp::ISTARTSWITH:
         case QueryCmp::ENDSWITH:
         case QueryCmp::IENDSWITH:
-            throw std::runtime_error("Not implemented yet");
+            throw RuntimeError(M_("Not implemented yet"));
             break;
         case QueryCmp::ISNULL:
         case QueryCmp::LT:
         case QueryCmp::LTE:
         case QueryCmp::GT:
         case QueryCmp::GTE:
-            throw std::runtime_error("Unsupported operator");
+            throw RuntimeError(M_("Unsupported operator"));
             break;
         case QueryCmp::NOT:
         case QueryCmp::ICASE:
-            throw std::runtime_error("Operator flag cannot be used standalone");
+            throw RuntimeError(M_("Operator flag cannot be used standalone"));
             break;
     }
     return result;

--- a/libdnf/common/sack/query_cmp_private.hpp
+++ b/libdnf/common/sack/query_cmp_private.hpp
@@ -1,0 +1,29 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef LIBDNF_COMMON_SACK_QUERY_CMP_PRIVATE_HPP
+#define LIBDNF_COMMON_SACK_QUERY_CMP_PRIVATE_HPP
+
+#include <libdnf/common/exception.hpp>
+
+#define libdnf_throw_assert_unsupported_query_cmp_type(cmp_type) \
+    libdnf_throw_assertion("Unsupported sack::QueryCmp type {}", cmp_type)
+
+#endif  // LIBDNF_COMMON_SACK_QUERY_CMP_PRIVATE_HPP

--- a/libdnf/comps/group/group.cpp
+++ b/libdnf/comps/group/group.cpp
@@ -348,7 +348,7 @@ void Group::dump(const std::string & path) {
 
     // Save the document
     if (xmlSaveFile(path.c_str(), doc) == -1) {
-        throw std::runtime_error("failed to save xml document for comps");
+        throw RuntimeError(M_("failed to save xml document for comps"));
     }
 
     // Memory free

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -24,6 +24,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/conf/config_parser.hpp"
 #include "libdnf/conf/const.hpp"
 
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
 #include <fmt/format.h>
 #include <glob.h>
 
@@ -86,7 +88,7 @@ static int str_to_bytes(const std::string & str) {
 static void add_from_file(std::ostream & out, const std::string & file_path) {
     std::ifstream ifs(file_path);
     if (!ifs) {
-        throw std::runtime_error("add_from_file(): Can't open file");
+        throw RuntimeError(M_("add_from_file(): Can't open file"));
     }
     ifs.exceptions(std::ifstream::badbit);
 

--- a/libdnf/conf/vars.cpp
+++ b/libdnf/conf/vars.cpp
@@ -18,6 +18,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "libdnf/conf/vars.hpp"
+#include "libdnf/common/exception.hpp"
+
+#include "libdnf/utils/bgettext/bgettext-lib.h"
 
 #include <dirent.h>
 #include <sys/types.h>
@@ -102,7 +105,7 @@ static void init_lib_rpm() {
     static bool lib_rpm_initiated{false};
     if (!lib_rpm_initiated) {
         if (rpmReadConfigFiles(nullptr, nullptr) != 0) {
-            throw std::runtime_error("failed to read rpm config files\n");
+            throw RuntimeError(M_("failed to read rpm config files"));
         }
         lib_rpm_initiated = true;
     }

--- a/libdnf/plugin/plugins.cpp
+++ b/libdnf/plugin/plugins.cpp
@@ -83,7 +83,7 @@ void Plugins::load_plugin(const std::string & file_path) {
 void Plugins::load_plugins(const std::string & dir_path) {
     auto & logger = *base->get_logger();
     if (dir_path.empty())
-        throw std::runtime_error(_("Plugins::loadPlugins() dirPath cannot be empty"));
+        throw RuntimeError(M_("Plugins::loadPlugins() dirPath cannot be empty"));
 
     std::vector<std::filesystem::path> lib_names;
     for (auto & p : std::filesystem::directory_iterator(dir_path)) {
@@ -105,7 +105,7 @@ void Plugins::load_plugins(const std::string & dir_path) {
     }
 
     if (!error_msgs.empty()) {
-        throw std::runtime_error(error_msgs);
+        throw RuntimeError(M_("Can't load plugins"));
     }
 }
 

--- a/libdnf/repo/config_repo.cpp
+++ b/libdnf/repo/config_repo.cpp
@@ -19,9 +19,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/repo/config_repo.hpp"
 
-#include "../conf/config_utils.hpp"
 
 #include "libdnf/conf/const.hpp"
+
+#include "libdnf/conf/config_utils.hpp"
+#include "libdnf/utils/bgettext/bgettext-lib.h"
 
 #include <solv/chksum.h>
 #include <solv/util.h>
@@ -564,7 +566,7 @@ std::string ConfigRepo::get_unique_id() const {
     static constexpr int USE_CHECKSUM_BYTES = 8;
     if (chksum_len < USE_CHECKSUM_BYTES) {
         solv_chksum_free(chksum_obj, nullptr);
-        throw RuntimeError("getCachedir(): Computation of SHA256 failed");
+        throw RuntimeError(M_("get_unique_id(): Computation of SHA256 failed"));
     }
     char chksum_cstr[USE_CHECKSUM_BYTES * 2 + 1];
     solv_bin2hex(chksum, USE_CHECKSUM_BYTES, chksum_cstr);

--- a/libdnf/repo/package_downloader.cpp
+++ b/libdnf/repo/package_downloader.cpp
@@ -162,7 +162,7 @@ void PackageDownloader::download(bool fail_fast, bool resume) try {
         throw LibrepoError(std::unique_ptr<GError>(err));
     }
 } catch (const std::runtime_error & e) {
-    throw_with_nested(PackageDownloadError(_("Failed to download packages")));
+    throw_with_nested(PackageDownloadError(M_("Failed to download packages")));
 }
 
 }  // namespace libdnf::repo

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -67,11 +67,11 @@ namespace libdnf::repo {
 
 static void is_readable_rpm(const std::string & fn) {
     if (std::filesystem::path(fn).extension() != ".rpm") {
-        throw RepoRpmError(_("Failed to load RPM \"{}\": doesn't have the \".rpm\" extension"), fn);
+        throw RepoRpmError(M_("Failed to load RPM \"{}\": doesn't have the \".rpm\" extension"), fn);
     }
 
     if (access(fn.c_str(), R_OK) != 0) {
-        throw RepoRpmError(_("Failed to access RPM \"{}\": {}"), fn, strerror(errno));
+        throw RepoRpmError(M_("Failed to access RPM \"{}\": {}"), fn, strerror(errno));
     }
 }
 
@@ -131,7 +131,7 @@ Repo::Repo(const std::string & id, Base & base, Repo::Type type) {
     if (type == Type::AVAILABLE) {
         auto idx = verify_id(id);
         if (idx != std::string::npos) {
-            throw RepoError(_("Invalid repository id \"{}\": unexpected character '{}'"), id, id[idx]);
+            throw RepoError(M_("Invalid repository id \"{}\": unexpected character '{}'"), id, id[idx]);
         }
     }
     p_impl.reset(new Impl(*this, id, type, base));
@@ -152,7 +152,7 @@ void Repo::verify() const {
         (p_impl->config.metalink().empty() || p_impl->config.metalink().get_value().empty()) &&
         (p_impl->config.mirrorlist().empty() || p_impl->config.mirrorlist().get_value().empty())) {
         throw RepoError(
-            _("Repository \"{}\" has no source (baseurl, mirrorlist or metalink) set."), p_impl->config.get_id());
+            M_("Repository \"{}\" has no source (baseurl, mirrorlist or metalink) set."), p_impl->config.get_id());
     }
 
     const auto & type = p_impl->config.type().get_value();
@@ -163,7 +163,7 @@ void Repo::verify() const {
                 return;
             }
         }
-        throw RepoError(_("Repository \"{}\" has unsupported type \"{}\", skipping."), p_impl->config.get_id(), type);
+        throw RepoError(M_("Repository \"{}\" has unsupported type \"{}\", skipping."), p_impl->config.get_id(), type);
     }
 }
 
@@ -320,7 +320,7 @@ bool Repo::Impl::load() {
         }
     }
     if (sync_strategy == SyncStrategy::ONLY_CACHE) {
-        throw RepoError(_("Cache-only enabled but no cache for repository \"{}\""), config.get_id());
+        throw RepoError(M_("Cache-only enabled but no cache for repository \"{}\""), config.get_id());
     }
 
     logger.debug(fmt::format(_("repo: downloading from remote: {}"), config.get_id()));
@@ -478,7 +478,7 @@ Id Repo::Impl::add_rpm_package(const std::string & fn, bool add_with_hdrid) {
 
     Id new_id = repo_add_rpm(libsolv_repo_ext.repo, fn.c_str(), flags);
     if (new_id == 0) {
-        throw RepoRpmError(_("Failed to load RPM \"{}\": {}"), fn, pool_errstr(libsolv_repo_ext.repo->pool));
+        throw RepoRpmError(M_("Failed to load RPM \"{}\": {}"), fn, pool_errstr(libsolv_repo_ext.repo->pool));
     }
     libsolv_repo_ext.set_needs_internalizing();
     return new_id;
@@ -590,7 +590,7 @@ long LibrepoLog::add_handler(const std::string & file_path, bool debug) {
     // Open the file
     FILE * fd = fopen(file_path.c_str(), "ae");
     if (!fd) {
-        throw RuntimeError(fmt::format(_("Cannot open {}: {}"), file_path, g_strerror(errno)));
+        throw RuntimeError(fmt::format(M_("Cannot open {}: {}"), file_path, g_strerror(errno)));
     }
 
     // Setup user data
@@ -634,7 +634,7 @@ void LibrepoLog::remove_handler(long uid) {
         ++it;
     }
     if (it == lr_log_datas.end()) {
-        throw RuntimeError(fmt::format(_("Log handler with id {} doesn't exist"), uid));
+        throw RuntimeError(fmt::format(M_("Log handler with id {} doesn't exist"), uid));
     }
 
     // Remove the handler and free the data

--- a/libdnf/repo/repo_downloader.cpp
+++ b/libdnf/repo/repo_downloader.cpp
@@ -246,7 +246,7 @@ static std::unique_ptr<LrHandle> new_remote_handle(const C & config) {
     if (maxspeed != 0 && maxspeed < static_cast<float>(minrate)) {
         // TODO(lukash) not the best class for the error, possibly check in config parser?
         throw libdnf::repo::RepoDownloadError(
-            _("Maximum download speed is lower than minimum, "
+            M_("Maximum download speed is lower than minimum, "
               "please change configuration of minrate or throttle"));
     }
     handle_set_opt(h, LRO_LOWSPEEDLIMIT, static_cast<int64_t>(minrate));
@@ -357,7 +357,7 @@ void RepoDownloader::download_metadata(const std::string & destdir) try {
 } catch (const std::runtime_error & e) {
     auto src = get_source_info();
     throw_with_nested(RepoDownloadError(
-        _("Failed to download metadata ({}: \"{}\") for repository \"{}\""), src.first, src.second, config.get_id()));
+        M_("Failed to download metadata ({}: \"{}\") for repository \"{}\""), src.first, src.second, config.get_id()));
 }
 
 
@@ -426,7 +426,7 @@ bool RepoDownloader::is_metalink_in_sync() try {
     return true;
 } catch (const std::runtime_error & e) {
     throw_with_nested(RepoDownloadError(
-        _("Error checking if metalink \"{}\" is in sync for repository \"{}\""),
+        M_("Error checking if metalink \"{}\" is in sync for repository \"{}\""),
         get_source_info().second,
         config.get_id()));
 }
@@ -456,7 +456,7 @@ bool RepoDownloader::is_repomd_in_sync() try {
 } catch (const std::runtime_error & e) {
     auto src = get_source_info();
     throw_with_nested(RepoDownloadError(
-        _("Error checking if repomd ({}: \"{}\") is in sync for repository \"{}\""),
+        M_("Error checking if repomd ({}: \"{}\") is in sync for repository \"{}\""),
         src.first,
         src.second,
         config.get_id()));
@@ -484,7 +484,7 @@ void RepoDownloader::load_local() try {
 
     g_strfreev(lr_mirrors);
 } catch (const std::runtime_error & e) {
-    throw_with_nested(RepoDownloadError(_("Error loading local metadata for repository \"{}\""), config.get_id()));
+    throw_with_nested(RepoDownloadError(M_("Error loading local metadata for repository \"{}\""), config.get_id()));
 }
 
 
@@ -502,7 +502,7 @@ LrHandle * RepoDownloader::get_cached_handle() {
 std::string RepoDownloader::get_revision() const try {
     return libdnf::utils::string::c_to_str(get_yum_repomd(lr_result)->revision);
 } catch (const std::runtime_error & e) {
-    throw_with_nested(RepoDownloadError(_("Error retrieving revision from repository \"{}\""), config.get_id()));
+    throw_with_nested(RepoDownloadError(M_("Error retrieving revision from repository \"{}\""), config.get_id()));
 }
 
 
@@ -516,7 +516,7 @@ int RepoDownloader::get_max_timestamp() const try {
     return res;
 } catch (const std::runtime_error & e) {
     throw_with_nested(
-        RepoDownloadError(_("Error retrieving maximum timestamp from repository \"{}\""), config.get_id()));
+        RepoDownloadError(M_("Error retrieving maximum timestamp from repository \"{}\""), config.get_id()));
 }
 
 std::map<std::string, std::string> RepoDownloader::get_metadata_paths() const try {
@@ -531,7 +531,7 @@ std::map<std::string, std::string> RepoDownloader::get_metadata_paths() const tr
 
     return res;
 } catch (const std::runtime_error & e) {
-    throw_with_nested(RepoDownloadError(_("Error retrieving metadata paths from repository \"{}\""), config.get_id()));
+    throw_with_nested(RepoDownloadError(M_("Error retrieving metadata paths from repository \"{}\""), config.get_id()));
 }
 
 std::vector<std::string> RepoDownloader::get_content_tags() const try {
@@ -545,7 +545,7 @@ std::vector<std::string> RepoDownloader::get_content_tags() const try {
 
     return res;
 } catch (const std::runtime_error & e) {
-    throw_with_nested(RepoDownloadError(_("Error retrieving content tags from repository \"{}\""), config.get_id()));
+    throw_with_nested(RepoDownloadError(M_("Error retrieving content tags from repository \"{}\""), config.get_id()));
 }
 
 std::vector<std::pair<std::string, std::string>> RepoDownloader::get_distro_tags() const try {
@@ -562,7 +562,7 @@ std::vector<std::pair<std::string, std::string>> RepoDownloader::get_distro_tags
 
     return res;
 } catch (const std::runtime_error & e) {
-    throw_with_nested(RepoDownloadError(_("Error retrieving distro tags from repository \"{}\""), config.get_id()));
+    throw_with_nested(RepoDownloadError(M_("Error retrieving distro tags from repository \"{}\""), config.get_id()));
 }
 
 std::vector<std::pair<std::string, std::string>> RepoDownloader::get_metadata_locations() const try {
@@ -578,7 +578,7 @@ std::vector<std::pair<std::string, std::string>> RepoDownloader::get_metadata_lo
     return res;
 } catch (const std::runtime_error & e) {
     throw_with_nested(
-        RepoDownloadError(_("Error retrieving metadata locations from repository \"{}\""), config.get_id()));
+        RepoDownloadError(M_("Error retrieving metadata locations from repository \"{}\""), config.get_id()));
 }
 
 
@@ -648,7 +648,7 @@ std::unique_ptr<LrHandle> RepoDownloader::init_remote_handle(const char * destdi
         handle_set_opt(h.get(), LRO_URLS, urls);
     } else {
         throw RepoDownloadError(
-            _("No valid source (baseurl, mirrorlist or metalink) found for repository \"{}\""), config.get_id());
+            M_("No valid source (baseurl, mirrorlist or metalink) found for repository \"{}\""), config.get_id());
     }
 
     handle_set_opt(h.get(), LRO_PROGRESSCB, static_cast<LrProgressCb>(progress_cb));

--- a/libdnf/repo/repo_gpgme.cpp
+++ b/libdnf/repo/repo_gpgme.cpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/base.hpp"
 #include "libdnf/logger/logger.hpp"
 #include "libdnf/repo/repo_errors.hpp"
+
 #include "libdnf/utils/bgettext/bgettext-lib.h"
 #include "libdnf/utils/temp.hpp"
 
@@ -103,7 +104,7 @@ static std::unique_ptr<std::remove_pointer<gpgme_ctx_t>::type> create_context(co
     gpgme_ctx_t ctx;
     gpg_err = gpgme_new(&ctx);
     if (gpg_err != GPG_ERR_NO_ERROR) {
-        throw RepoGpgError(_("Error creating gpgme context: {}"), gpgme_strerror(gpg_err));
+        throw RepoGpgError(M_("Error creating gpgme context: {}"), gpgme_strerror(gpg_err));
     }
 
     std::unique_ptr<std::remove_pointer<gpgme_ctx_t>::type> context(ctx);
@@ -111,7 +112,7 @@ static std::unique_ptr<std::remove_pointer<gpgme_ctx_t>::type> create_context(co
     // set GPG home dir
     gpg_err = gpgme_ctx_set_engine_info(ctx, GPGME_PROTOCOL_OpenPGP, nullptr, homedir.c_str());
     if (gpg_err != GPG_ERR_NO_ERROR) {
-        throw RepoGpgError(_("Failed to set gpgme home directory to \"{}\": {}"), homedir, gpgme_strerror(gpg_err));
+        throw RepoGpgError(M_("Failed to set gpgme home directory to \"{}\": {}"), homedir, gpgme_strerror(gpg_err));
     }
 
     return context;
@@ -124,13 +125,13 @@ static void gpg_import_key(gpgme_ctx_t context, int key_fd) {
 
     gpg_err = gpgme_data_new_from_fd(&key_data, key_fd);
     if (gpg_err != GPG_ERR_NO_ERROR) {
-        throw RepoGpgError(_("Failed to create gpgme data from file descriptor: {}"), gpgme_strerror(gpg_err));
+        throw RepoGpgError(M_("Failed to create gpgme data from file descriptor: {}"), gpgme_strerror(gpg_err));
     }
 
     gpg_err = gpgme_op_import(context, key_data);
     gpgme_data_release(key_data);
     if (gpg_err != GPG_ERR_NO_ERROR) {
-        throw RepoGpgError(_("Failed to import gpgme keys: {}"), gpgme_strerror(gpg_err));
+        throw RepoGpgError(M_("Failed to import gpgme keys: {}"), gpgme_strerror(gpg_err));
     }
 }
 
@@ -141,13 +142,13 @@ static void gpg_import_key(gpgme_ctx_t context, std::vector<char> key) {
 
     gpg_err = gpgme_data_new_from_mem(&key_data, key.data(), key.size(), 0);
     if (gpg_err != GPG_ERR_NO_ERROR) {
-        throw RepoGpgError(_("Failed to create gpgme data from a buffer: {}"), gpgme_strerror(gpg_err));
+        throw RepoGpgError(M_("Failed to create gpgme data from a buffer: {}"), gpgme_strerror(gpg_err));
     }
 
     gpg_err = gpgme_op_import(context, key_data);
     gpgme_data_release(key_data);
     if (gpg_err != GPG_ERR_NO_ERROR) {
-        throw RepoGpgError(_("Failed to import gpgme keys: {}"), gpgme_strerror(gpg_err));
+        throw RepoGpgError(M_("Failed to import gpgme keys: {}"), gpgme_strerror(gpg_err));
     }
 }
 
@@ -180,7 +181,7 @@ static std::vector<Key> rawkey2infos(int fd) {
         gpgme_key_release(key);
     }
     if (gpg_err_code(gpg_err) != GPG_ERR_EOF) {
-        throw RepoGpgError(_("Failed to list gpg keys: {}"), gpgme_strerror(gpg_err));
+        throw RepoGpgError(M_("Failed to list gpg keys: {}"), gpgme_strerror(gpg_err));
     }
     gpgme_set_armor(context.get(), 1);
     for (auto & key_info : key_infos) {
@@ -234,7 +235,7 @@ RepoGpgme::RepoGpgme(const BaseWeakPtr & base, const ConfigRepo & config) : base
         }
 
         if (gpg_err_code(gpg_err) != GPG_ERR_EOF) {
-            throw RepoGpgError(_("Failed to list gpg keys: {}"), gpgme_strerror(gpg_err));
+            throw RepoGpgError(M_("Failed to list gpg keys: {}"), gpgme_strerror(gpg_err));
         }
     }
 }

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -27,6 +27,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/conf/option_bool.hpp"
 #include "libdnf/rpm/package_sack_impl.hpp"
 
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
 #include <fmt/format.h>
 
 extern "C" {
@@ -62,11 +64,7 @@ static void libsolv_repo_free(LibsolvRepo * libsolv_repo) {
 RepoWeakPtr RepoSack::new_repo_from_libsolv_testcase(const std::string & repoid, const std::string & path) {
     std::unique_ptr<std::FILE, decltype(&std::fclose)> testcase_file(solv_xfopen(path.c_str(), "r"), &std::fclose);
     if (!testcase_file) {
-        try {
-            throw SystemError(errno ? errno : EIO, path);
-        } catch (...) {
-            std::throw_with_nested(RuntimeError("Unable to open libsolv testcase file"));
-        }
+        throw SystemError(errno ? errno : EIO, M_("Unable to open libsolv testcase file \"{}\""), path);
     }
 
     auto repo = new_repo(repoid);

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/base.hpp"
 #include "libdnf/base/base_private.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/common/sack/query_cmp_private.hpp"
 #include "libdnf/utils/utils_internal.hpp"
 
 extern "C" {
@@ -55,7 +56,7 @@ inline bool is_valid_candidate(libdnf::sack::QueryCmp cmp_type, const char * c_p
             return fnmatch(c_pattern, candidate, FNM_CASEFOLD) == 0;
         } break;
         default:
-            throw libdnf::rpm::PackageQuery::NotSupportedCmpType("Unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 }
 
@@ -330,7 +331,7 @@ PackageQuery & PackageQuery::filter_name(const std::vector<std::string> & patter
                 filter_glob_internal<&libdnf::solv::Pool::get_name>(pool, c_pattern, *p_impl, filter_result, 0);
                 break;
             default:
-                throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
     }
 
@@ -345,7 +346,7 @@ PackageQuery & PackageQuery::filter_name(const std::vector<std::string> & patter
 
 PackageQuery & PackageQuery::filter_name(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
-        throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+        libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
     auto sack = p_impl->base->get_rpm_package_sack();
     auto &  pool = get_pool(p_impl->base);
@@ -376,7 +377,7 @@ PackageQuery & PackageQuery::filter_name(const PackageSet & package_set, libdnf:
 
 PackageQuery & PackageQuery::filter_name_arch(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
-        throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+        libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
     auto sack = p_impl->base->get_rpm_package_sack();
     auto &  pool = get_pool(p_impl->base);
@@ -463,7 +464,7 @@ PackageQuery & PackageQuery::filter_evr(const std::vector<std::string> & pattern
             filter_evr_internal<cmp_eq>(pool, patterns, *p_impl);
             break;
         default:
-            throw NotSupportedCmpType("Used unsupported CmpType");
+             libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
     return *this;
 }
@@ -504,7 +505,7 @@ PackageQuery & PackageQuery::filter_arch(const std::vector<std::string> & patter
                 filter_glob_internal<&libdnf::solv::Pool::get_arch>(pool, c_pattern, *p_impl, filter_result, 0);
                 break;
             default:
-                throw NotSupportedCmpType("Unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
     }
 
@@ -691,7 +692,7 @@ PackageQuery & PackageQuery::filter_nevra(const libdnf::rpm::Nevra & pattern, li
 
 PackageQuery & PackageQuery::filter_nevra(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
-        throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+        libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
     auto sack = p_impl->base->get_rpm_package_sack();
     auto & pool = get_pool(p_impl->base);
@@ -774,7 +775,7 @@ PackageQuery & PackageQuery::filter_version(const std::vector<std::string> & pat
                 filter_version_internal<cmp_lte>(pool, c_pattern, *p_impl, filter_result);
                 break;
             default:
-                throw NotSupportedCmpType("Used unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
     }
 
@@ -841,7 +842,7 @@ PackageQuery & PackageQuery::filter_release(const std::vector<std::string> & pat
                 filter_release_internal<cmp_lte>(pool, c_pattern, *p_impl, filter_result);
                 break;
             default:
-                throw NotSupportedCmpType("Used unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
     }
 
@@ -897,7 +898,7 @@ PackageQuery & PackageQuery::filter_repo_id(const std::vector<std::string> & pat
                 }
                 break;
             default:
-                throw NotSupportedCmpType("Used unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
     }
     for (Id candidate_id : *p_impl) {
@@ -963,7 +964,7 @@ PackageQuery & PackageQuery::filter_sourcerpm(const std::vector<std::string> & p
                 }
                 break;
             default:
-                throw NotSupportedCmpType("Used unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
     }
 
@@ -1039,7 +1040,7 @@ PackageQuery & PackageQuery::filter_epoch(const std::vector<unsigned long> & pat
             }
             break;
         default:
-            throw NotSupportedCmpType("Used unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 
     // Apply filter results to query
@@ -1090,7 +1091,7 @@ PackageQuery & PackageQuery::filter_epoch(const std::vector<std::string> & patte
                 }
                 break;
             default:
-                throw NotSupportedCmpType("Used unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
     }
 
@@ -1168,7 +1169,7 @@ static void filter_dataiterator_internal(
                 flags = SEARCH_FILES | SEARCH_COMPLETE_FILELIST | SEARCH_NOCASE | SEARCH_SUBSTRING;
                 break;
             default:
-                throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
         filter_dataiterator(pool, keyname, flags, candidates, filter_result, c_pattern);
     }
@@ -1229,7 +1230,7 @@ PackageQuery & PackageQuery::filter_location(const std::vector<std::string> & pa
             }
         } break;
         default:
-            throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 
     // Apply filter results to query
@@ -1284,7 +1285,7 @@ void PackageQuery::Impl::str2reldep_internal(
             break;
 
         default:
-            throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 }
 
@@ -1330,7 +1331,7 @@ void PackageQuery::Impl::filter_provides(
             break;
         }
         default:
-            throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 }
 
@@ -1363,7 +1364,7 @@ void PackageQuery::Impl::filter_reldep(
             break;
 
         default:
-            throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 
     auto base = pkg_set.get_base();
@@ -1415,7 +1416,7 @@ void PackageQuery::Impl::filter_reldep(
             break;
 
         default:
-            throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 
     auto base = pkg_set.get_base();
@@ -1631,7 +1632,7 @@ void PackageQuery::Impl::filter_nevra(
                 }
             } break;
             default:
-                throw NotSupportedCmpType("Unsupported CmpType");
+                libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
         }
     } else if (!epoch.empty() || !version.empty() || !release.empty() || !arch.empty()) {
         for (Id candidate_id : *pkg_set.p_impl) {
@@ -1716,7 +1717,7 @@ void PackageQuery::Impl::filter_nevra(
             }
         } break;
         default:
-            throw NotSupportedCmpType("Unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 }
 
@@ -1772,7 +1773,7 @@ PackageQuery & PackageQuery::filter_obsoletes(const PackageSet & package_set, li
             break;
 
         default:
-            throw PackageQuery::NotSupportedCmpType("Used unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 
     auto & spool = get_pool(p_impl->base);
@@ -1932,7 +1933,7 @@ PackageQuery & PackageQuery::filter_advisories(
             }
         } break;
         default:
-            throw NotSupportedCmpType("Unsupported CmpType");
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
 
     // Apply filter results to query

--- a/libdnf/rpm/package_sack.cpp
+++ b/libdnf/rpm/package_sack.cpp
@@ -157,7 +157,7 @@ void PackageSack::Impl::write_main(repo::LibsolvRepoExt & libsolv_repo_ext, bool
     int ret = repo_write(libsolv_repo, fp);
     ret |= checksum_write(libsolv_repo_ext.checksum, fp);
     if (ret) {
-        throw Exception(_("write_main() failed writing data"));
+        throw Exception(M_("write_main() failed writing data"));
         // g_set_error (error, DNF_ERROR, DNF_ERROR_FILE_INVALID, _("write_main() failed writing data: %i"), rc);
     }
 
@@ -171,7 +171,7 @@ void PackageSack::Impl::write_main(repo::LibsolvRepoExt & libsolv_repo_ext, bool
             int ret = repo_add_solv(libsolv_repo, fp.get(), 0);
             if (ret) {
                 /* this is pretty fatal */
-                throw Exception(_("write_main() failed to re-load written solv file"));
+                throw Exception(M_("write_main() failed to re-load written solv file"));
                 // g_set_error_literal (error, DNF_ERROR, DNF_ERROR_FILE_INVALID, _("write_main() failed to re-load " "written solv file"));
             }
         }
@@ -220,7 +220,7 @@ void PackageSack::Impl::write_ext(
     }
     ret |= checksum_write(libsolv_repo_ext.checksum, fp);
     if (ret) {
-        throw Exception(_("write_ext() has failed"));
+        throw Exception(M_("write_ext() has failed"));
         // g_set_error(error, DNF_ERROR, DNF_ERROR_FAILED, _("write_ext(%1$d) has failed: %2$d"), which_repodata, ret);
     }
 
@@ -322,7 +322,7 @@ PackageSack::Impl::RepodataState PackageSack::Impl::load_repo_main(repo::Repo & 
         //const char *chksum = pool_checksum_str(pool, repoImpl->checksum);
         //logger.debug("using cached %s (0x%s)", name, chksum);
         if (repo_add_solv(libsolv_repo.get(), fp_cache.get(), 0)) {
-            throw Exception(_("repo_add_solv() has failed."));
+            throw Exception(M_("repo_add_solv() has failed."));
             // g_set_error (error, DNF_ERROR, DNF_ERROR_INTERNAL_ERROR, _("repo_add_solv() has failed."));
         }
         data_state = RepodataState::LOADED_CACHE;
@@ -331,7 +331,7 @@ PackageSack::Impl::RepodataState PackageSack::Impl::load_repo_main(repo::Repo & 
         if (primary.empty()) {
             // It could happen when repomd file has no "primary" data or they are in unsupported
             // format like zchunk
-            throw Exception(_("loading of MD_FILENAME_PRIMARY has failed."));
+            throw Exception(M_("loading of MD_FILENAME_PRIMARY has failed."));
             // g_set_error (error, DNF_ERROR, DNF_ERROR_INTERNAL_ERROR, _("loading of MD_FILENAME_PRIMARY has failed."));
         }
         std::unique_ptr<std::FILE, decltype(&close_file)> fp_primary(solv_xfopen(primary.c_str(), "r"), &close_file);
@@ -344,7 +344,7 @@ PackageSack::Impl::RepodataState PackageSack::Impl::load_repo_main(repo::Repo & 
         logger.debug(std::string("fetching ") + id);
         if (repo_add_repomdxml(libsolv_repo.get(), fp_repomd.get(), 0) ||
             repo_add_rpmmd(libsolv_repo.get(), fp_primary.get(), 0, 0)) {
-            throw Exception(_("repo_add_repomdxml/rpmmd() has failed."));
+            throw Exception(M_("repo_add_repomdxml/rpmmd() has failed."));
             // g_set_error (error, DNF_ERROR,  DNF_ERROR_INTERNAL_ERROR, _("repo_add_repomdxml/rpmmd() has failed."));
         }
         data_state = RepodataState::LOADED_FETCH;
@@ -367,7 +367,7 @@ PackageSack::Impl::RepodataInfo PackageSack::Impl::load_repo_ext(
     auto fn = repo.get_metadata_path(which_filename);
     if (fn.empty()) {
         // g_set_error (error, DNF_ERROR, DNF_ERROR_NO_CAPABILITY, _("no %1$s string for %2$s"), which_filename, repo_id);
-        throw NoCapability(fmt::format(_("no {0} string for {1}"), which_filename, repo_id));
+        throw NoCapability(M_("no {0} string for {1}"), which_filename, repo_id);
     }
 
     auto fn_cache = repo_solv_cache_path(repo_id, suffix);
@@ -376,7 +376,7 @@ PackageSack::Impl::RepodataInfo PackageSack::Impl::load_repo_ext(
         logger.debug(fmt::format("{}: using cache file: {}", __func__, fn_cache));
         if (repo_add_solv(libsolv_repo, fp.get(), flags) != 0) {
             // g_set_error_literal (error, DNF_ERROR, DNF_ERROR_INTERNAL_ERROR, _("failed to add solv"));
-            throw Exception(_("repo_add_solv() has failed."));
+            throw Exception(M_("repo_add_solv() has failed."));
         }
         info.state = RepodataState::LOADED_CACHE;
         info.id = libsolv_repo->nrepodata - 1;
@@ -386,7 +386,7 @@ PackageSack::Impl::RepodataInfo PackageSack::Impl::load_repo_ext(
     fp.reset(solv_xfopen(fn.c_str(), "r"));
     if (!fp) {
         // g_set_error (error, DNF_ERROR, DNF_ERROR_FILE_INVALID, _("failed to open: %s"), fn.c_str());
-        throw Exception(fmt::format(_("failed to open: {}"), fn));
+        throw Exception(M_("failed to open: {}"), fn);
     }
     logger.debug(fmt::format("{}: loading: {}", __func__, fn.c_str()));
 

--- a/libdnf/rpm/reldep.cpp
+++ b/libdnf/rpm/reldep.cpp
@@ -88,14 +88,14 @@ ReldepId Reldep::get_reldep_id(const BaseWeakPtr & base, const std::string & rel
         Id id = pool_parserpmrichdep(*get_pool(base), reldep_str.c_str());
         // TODO(jmracek) Replace runtime_error. Do we need to throw an error?
         if (id == 0) {
-            throw std::runtime_error("Cannot parse a dependency string");
+            throw RuntimeError(M_("Cannot parse a dependency string"));
         }
         return ReldepId(id);
     }
 
     libdnf::solv::ReldepParser dep_splitter;
     if (!dep_splitter.parse(reldep_str)) {
-        throw std::runtime_error("Cannot parse a dependency string");
+        throw RuntimeError(M_("Cannot parse a dependency string"));
     }
     return get_reldep_id(
         base, dep_splitter.get_name_cstr(), dep_splitter.get_evr_cstr(), dep_splitter.get_cmp_type(), create);

--- a/libdnf/rpm/solv/goal_private.cpp
+++ b/libdnf/rpm/solv/goal_private.cpp
@@ -290,7 +290,7 @@ libdnf::solv::IdQueue GoalPrivate::list_results(Id type_filter1, Id type_filter2
         //}
 
         // TODO(lukash) replace with a proper and descriptive exception
-        throw std::runtime_error("no solution possible");
+        throw RuntimeError(M_("no solution possible"));
     }
 
     libdnf::solv::IdQueue result_ids;
@@ -411,7 +411,7 @@ void GoalPrivate::write_debugdata(const std::string & dir) {
 
     if (!ret) {
         // TODO(jmracek) replace error with Goal Error
-        throw std::runtime_error("failed writing debugdata");
+        throw RuntimeError(M_("failed writing debugdata"));
     }
     //         std::string msg = tfm::format(_("failed writing debugdata to %1$s: %2$s"),
     //                                       absdir, strerror(errno));
@@ -653,7 +653,7 @@ transaction::TransactionItemReason GoalPrivate::get_reason(Id id) {
 
 libdnf::solv::IdQueue GoalPrivate::list_obsoleted_by_package(Id id) {
     if (!libsolv_transaction) {
-        throw std::runtime_error("no solution possible");
+        throw RuntimeError(M_("no solution possible"));
     }
     libdnf::solv::IdQueue obsoletes;
     transaction_all_obs_pkgs(libsolv_transaction, id, &obsoletes.get_queue());

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -409,7 +409,7 @@ public:
         auto rc = rpmtsAddReinstallElement(ts, header, &item);
         headerFree(header);
         if (rc != 0) {
-            throw Exception(fmt::format(_("Can't reinstall package \"{}\""), item.get_package().get_full_nevra()));
+            throw Exception(M_("Can't reinstall package \"{}\""), item.get_package().get_full_nevra());
         }
         libdnf_assert(
             last_item_added_ts_element,
@@ -428,7 +428,7 @@ public:
         int rc = rpmtsAddEraseElement(ts, header, unused);
         headerFree(header);
         if (rc != 0) {
-            throw Exception(fmt::format(_("Can't remove package \"{}\""), item.get_package().get_full_nevra()));
+            throw Exception(M_("Can't remove package \"{}\""), item.get_package().get_full_nevra());
         }
         if (!last_item_added_ts_element) {
             auto it = implicit_ts_elements.find(rpmdb_id);
@@ -530,11 +530,11 @@ public:
         // rec_offset must be unsigned int
         auto * iter = rpmtsInitIterator(ts, RPMDBI_PACKAGES, &rec_offset, sizeof(rec_offset));
         if (!iter) {
-            throw Exception(_("Fatal error, run database recovery"));
+            throw Exception(M_("Fatal error, run database recovery"));
         }
         hdr = rpmdbNextIterator(iter);
         if (!hdr) {
-            throw Exception(_("failed to find package"));
+            throw Exception(M_("Failed to find package"));
         }
         headerLink(hdr);
         rpmdbFreeIterator(iter);
@@ -835,7 +835,7 @@ void Transaction::Impl::install_up_down(TransactionItem & item, libdnf::transact
     auto rc = rpmtsAddInstallElement(ts, header, &item, upgrade ? 1 : 0, nullptr);
     headerFree(header);
     if (rc != 0) {
-        throw Exception(fmt::format(_("Can't {} package \"{}\""), msg_action, item.get_package().get_full_nevra()));
+        throw Exception(M_("Can't {} package \"{}\""), msg_action, item.get_package().get_full_nevra());
     }
     libdnf_assert(
         last_item_added_ts_element,

--- a/libdnf/solv/pool.hpp
+++ b/libdnf/solv/pool.hpp
@@ -25,6 +25,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/base.hpp"
 #include "libdnf/repo/repo.hpp"
 
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
 #include <fmt/format.h>
 
 #include <climits>
@@ -187,7 +189,7 @@ public:
 
             if (converted == ULONG_MAX || *endptr != '\0') {
                 // TODO(lukash) throw proper exception class
-                throw RuntimeError(fmt::format("Failed to convert epoch \"{}\" to number", evr.e));
+                throw RuntimeError(M_("Failed to convert epoch \"{}\" to number"), evr.e);
             }
 
             return converted;

--- a/libdnf/transaction/db/comps_environment_group.cpp
+++ b/libdnf/transaction/db/comps_environment_group.cpp
@@ -92,7 +92,7 @@ void comps_environment_groups_insert(libdnf::utils::SQLite3 & conn, CompsEnviron
             env.get_item_id(), grp->get_group_id(), grp->get_installed(), static_cast<int>(grp->get_group_type()));
         if (query->step() != libdnf::utils::SQLite3::Statement::StepResult::DONE) {
             // TODO(dmach): replace with a better exception class
-            throw std::runtime_error("");
+            throw RuntimeError("");
         }
         grp->set_id(query->last_insert_rowid());
         query->reset();

--- a/libdnf/transaction/db/db.cpp
+++ b/libdnf/transaction/db/db.cpp
@@ -22,6 +22,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/base/base.hpp"
 
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
 #include <filesystem>
 
 
@@ -66,7 +68,7 @@ void transaction_db_create(libdnf::utils::SQLite3 & conn) {
     if (query_get_schema_version.step() == libdnf::utils::SQLite3::Statement::StepResult::ROW) {
         schema_version = query_get_schema_version.get<std::string>(0);
     } else {
-        throw std::runtime_error("Unable to get 'version' from table 'config'");
+        throw RuntimeError(M_("Unable to get 'version' from table 'config'"));
     }
 
     // TODO(dmach): migrations

--- a/libdnf/transaction/db/item.cpp
+++ b/libdnf/transaction/db/item.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<libdnf::utils::SQLite3::Statement> item_insert_new_query(
 int64_t item_insert(libdnf::utils::SQLite3::Statement & query) {
     if (query.step() != libdnf::utils::SQLite3::Statement::StepResult::DONE) {
         // TODO(dmach): replace with a better exception class
-        throw std::runtime_error("");
+        throw RuntimeError("");
     }
     return query.last_insert_rowid();
 }

--- a/libdnf/transaction/query.cpp
+++ b/libdnf/transaction/query.cpp
@@ -32,6 +32,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/transaction/rpm_package.hpp"
 #include "libdnf/transaction/sack.hpp"
 
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
 #include <vector>
 
 
@@ -75,7 +77,7 @@ TransactionQuery & TransactionQuery::filter_id(const std::vector<int64_t> & patt
         case libdnf::sack::QueryCmp::IGLOB:
         case libdnf::sack::QueryCmp::NOT_IGLOB:
             // TODO(dmach): Replace with a different exception class
-            throw std::runtime_error("Unsupported comparison operator");
+            throw RuntimeError(M_("Unsupported comparison operator"));
             break;
     }
 

--- a/libdnf/utils/xdg.cpp
+++ b/libdnf/utils/xdg.cpp
@@ -21,6 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/common/exception.hpp"
 
+#include "libdnf/utils/bgettext/bgettext-lib.h"
+
 #include <pwd.h>
 #include <unistd.h>
 
@@ -39,7 +41,7 @@ std::filesystem::path get_user_home_dir() {
     if (struct passwd * pw = getpwuid(getuid())) {
         return std::filesystem::path(pw->pw_dir);
     }
-    throw RuntimeError("get_home_dir(): Can't determine the user's home directory");
+    throw RuntimeError(M_("get_user_home_dir(): Can't determine the user's home directory"));
 }
 
 std::filesystem::path get_user_cache_dir() {
@@ -83,7 +85,7 @@ std::filesystem::path get_user_runtime_dir() {
             return ret;
         }
     }
-    throw RuntimeError("get_user_runtime_dir(): Can't determine the user's runtime directory");
+    throw RuntimeError(M_("get_user_runtime_dir(): Can't determine the user's runtime directory"));
 }
 
 }  // namespace libdnf::utils::xdg

--- a/test/libdnf/rpm/test_package_query.cpp
+++ b/test/libdnf/rpm/test_package_query.cpp
@@ -195,7 +195,7 @@ void RpmPackageQueryTest::test_filter_name() {
 
     // unsupported comparison type (operator)
     CPPUNIT_ASSERT_THROW(
-        query8.filter_name({"pkg"}, libdnf::sack::QueryCmp::GT), libdnf::rpm::PackageQuery::NotSupportedCmpType);
+        query8.filter_name({"pkg"}, libdnf::sack::QueryCmp::GT), libdnf::AssertionError);
 
     // ---
 


### PR DESCRIPTION
Exceptions localization:
* Error and SystemError: Added support for messages localization
The message is stored unlocalized/untranslated in the exception. Localization is done when a user requests a message - for example, he calls `what()`.
This allows to get the message in several languages. The user can request a message - for example, call `what()`, then change the locale and request the message again.

* Replaces throwing `std::runtime_error` with `libdnf::RuntimeError`.

* AssertionError for "Unsupported sack::QueryCmp value" in AdvisoryQuery and PackageQuery

* Use `libdnf_assert_same_base` in AdvisorySet
