### PR TITLE
Add getLatestModules()

### DIFF
--- a/libdnf/module/ModulePackageContainer.hpp
+++ b/libdnf/module/ModulePackageContainer.hpp
@@ -132,6 +132,15 @@ public:
     std::vector<std::vector<std::vector<ModulePackage *>>> getLatestModulesPerRepo(
         ModuleState moduleFilter, std::vector<ModulePackage *> modulePackages);
 
+    /**
+    * @brief Return all latest ModulePackages for each module Name, stream and architecture. In case of
+    * multiple latest packages, all will be returned. When activeOnly is true, it returns only the latest active
+    * packages.
+    *
+    * @return std::vector<ModulePackage *>
+    */
+    std::vector<ModulePackage *> getLatestModules(const std::vector<ModulePackage *> modulePackages, bool activeOnly);
+
     std::vector<ModulePackage *> requiresModuleEnablement(const libdnf::PackageSet & packages);
 
     /**


### PR DESCRIPTION
It returns latest module packages for each module name, stream, and
architecture.

It is an alternative implementation to code base with
the old modular solver.

Alternative to 73868368120ceea97ada628a1aa42236fb42b89d