### PR TITLE
[dnf5] plugin: Remove PluginLibrary class from public header

### DIFF
--- a/include/libdnf/plugin/plugins.hpp
+++ b/include/libdnf/plugin/plugins.hpp
@@ -22,8 +22,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "iplugin.hpp"
 
-#include "libdnf/utils/library.hpp"
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -54,28 +52,6 @@ protected:
     Plugin() = default;
     IPlugin * iplugin_instance{nullptr};
     bool enabled{true};
-};
-
-
-class PluginLibrary : public Plugin {
-public:
-    explicit PluginLibrary(const std::string & library_path);
-    ~PluginLibrary();
-
-#ifndef SWIG
-private:
-    using TGetApiVersionFunc = decltype(&libdnf_plugin_get_api_version);
-    using TGetNameFunc = decltype(&libdnf_plugin_get_name);
-    using TGetVersionFunc = decltype(&libdnf_plugin_get_version);
-    using TNewInstanceFunc = decltype(&libdnf_plugin_new_instance);
-    using TDeleteInstanceFunc = decltype(&libdnf_plugin_delete_instance);
-    TGetApiVersionFunc get_api_version{nullptr};
-    TGetNameFunc get_name{nullptr};
-    TGetVersionFunc get_version{nullptr};
-    TNewInstanceFunc new_instance{nullptr};
-    TDeleteInstanceFunc delete_instance{nullptr};
-    utils::Library library;
-#endif
 };
 
 

--- a/libdnf/plugin/plugins.cpp
+++ b/libdnf/plugin/plugins.cpp
@@ -21,12 +21,36 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/base/base.hpp"
 #include "libdnf/utils/bgettext/bgettext-lib.h"
+#include "libdnf/utils/library.hpp"
+
 
 #include <fmt/format.h>
 
 #include <filesystem>
 
 namespace libdnf::plugin {
+
+// Support for Plugin in the shared library.
+class PluginLibrary : public Plugin {
+public:
+    // Loads a shared library, finds symbols, and instantiates the plugin.
+    explicit PluginLibrary(const std::string & library_path);
+
+    ~PluginLibrary();
+
+private:
+    using TGetApiVersionFunc = decltype(&libdnf_plugin_get_api_version);
+    using TGetNameFunc = decltype(&libdnf_plugin_get_name);
+    using TGetVersionFunc = decltype(&libdnf_plugin_get_version);
+    using TNewInstanceFunc = decltype(&libdnf_plugin_new_instance);
+    using TDeleteInstanceFunc = decltype(&libdnf_plugin_delete_instance);
+    TGetApiVersionFunc get_api_version{nullptr};
+    TGetNameFunc get_name{nullptr};
+    TGetVersionFunc get_version{nullptr};
+    TNewInstanceFunc new_instance{nullptr};
+    TDeleteInstanceFunc delete_instance{nullptr};
+    utils::Library library;
+};
 
 PluginLibrary::PluginLibrary(const std::string & library_path) : library(library_path) {
     get_api_version = reinterpret_cast<TGetApiVersionFunc>(library.get_address("libdnf_plugin_get_api_version"));


### PR DESCRIPTION
`PluginLibrary` does not have to be public.
Resolves an issue with the included private header file in the public header file.