### PR TITLE
[dnf5] Iterator and improvements for `Set`, more unittest for `Set` and `RepoQuery` 

### DIFF
--- a/bindings/libdnf/common.i
+++ b/bindings/libdnf/common.i
@@ -24,6 +24,13 @@
     #include "libdnf/common/weak_ptr.hpp"
 %}
 %include "libdnf/common/weak_ptr.hpp"
+#if defined(SWIGPYTHON)
+%extend libdnf::WeakPtr {
+    intptr_t __hash__() const {
+        return reinterpret_cast<intptr_t>($self->get());
+    }
+}
+#endif
 
 // Cant use %include <catch_error.i> here, SWIG includes each file only once,
 // but the exception handler actually doesnt get registered when this file is
@@ -136,6 +143,13 @@ del ClassName##__iter__
 %include "libdnf/common/sack/sack.hpp"
 %include "libdnf/common/sack/match_int64.hpp"
 %include "libdnf/common/sack/match_string.hpp"
+
+%rename(next) libdnf::SetConstIterator::operator++();
+%rename(prev) libdnf::SetConstIterator::operator--();
+%rename(value) libdnf::SetConstIterator::operator*() const;
+%ignore libdnf::SetConstIterator::operator++(int);
+%ignore libdnf::SetConstIterator::operator--(int);
+%ignore libdnf::SetConstIterator::operator->() const;
 %include "libdnf/common/set.hpp"
 
 %{

--- a/bindings/libdnf/common.i
+++ b/bindings/libdnf/common.i
@@ -151,6 +151,13 @@ del ClassName##__iter__
 %ignore libdnf::SetConstIterator::operator--(int);
 %ignore libdnf::SetConstIterator::operator->() const;
 %include "libdnf/common/set.hpp"
+#if defined(SWIGPYTHON)
+%extend libdnf::Set {
+    size_type __len__() const noexcept {
+        return $self->size();
+    }
+}
+#endif
 
 %{
     #include "libdnf/common/preserve_order_map.hpp"

--- a/bindings/libdnf/repo.i
+++ b/bindings/libdnf/repo.i
@@ -38,6 +38,7 @@
 %include "libdnf/repo/repo.hpp"
 
 %template(RepoWeakPtr) libdnf::WeakPtr<libdnf::repo::Repo, false>;
+%template(SetConstIteratorRepoWeakPtr) libdnf::SetConstIterator<libdnf::repo::RepoWeakPtr>;
 %template(SetRepoWeakPtr) libdnf::Set<libdnf::repo::RepoWeakPtr>;
 %template(SackQueryRepoWeakPtr) libdnf::sack::Query<libdnf::repo::RepoWeakPtr>;
 
@@ -45,3 +46,5 @@
 %template(SackRepoRepoQuery) libdnf::sack::Sack<libdnf::repo::Repo>;
 %include "libdnf/repo/repo_sack.hpp"
 %template(RepoSackWeakPtr) libdnf::WeakPtr<libdnf::repo::RepoSack, false>;
+
+add_iterator(SetRepoWeakPtr)

--- a/test/libdnf/repo/test_repo_query.cpp
+++ b/test/libdnf/repo/test_repo_query.cpp
@@ -74,4 +74,12 @@ void RepoQueryTest::test_query_basics() {
     libdnf::repo::RepoQuery repo_query2(base);
     repo_query2.filter_local(false);
     CPPUNIT_ASSERT((repo_query2 == libdnf::Set{repo2, repo1_updates, repo2_updates}));
+
+    // Tests iteration over RepoQuery object
+    libdnf::repo::RepoQuery repo_query3(base);
+    libdnf::Set<libdnf::repo::RepoWeakPtr> result;
+    for (auto repo : repo_query3) {
+        result.add(repo);
+    }
+    CPPUNIT_ASSERT((result == libdnf::Set{repo1, repo2, repo1_updates, repo2_updates}));
 }

--- a/test/libdnf/set/test_set.cpp
+++ b/test/libdnf/set/test_set.cpp
@@ -29,7 +29,7 @@ void SetTest::setUp() {}
 
 void SetTest::tearDown() {}
 
-// Test constructors, empty(), size(), contains(), clear(), add(), and remove()
+// Test constructors, empty(), size(), contains(), clear(), add(), remove(), and find()
 void SetTest::test_set_basics() {
     // test default constructor
     libdnf::Set<int> s1;
@@ -59,16 +59,25 @@ void SetTest::test_set_basics() {
     CPPUNIT_ASSERT(s1.empty());
 
     s1 = {1, 4, 6};
-    s1.add(2);
+    CPPUNIT_ASSERT(s1.add(2));
     CPPUNIT_ASSERT((s1 == libdnf::Set<int>{1, 2, 4, 6}));
 
     s1 = {1, 4, 6};
-    s1.add(4);
+    CPPUNIT_ASSERT(!s1.add(4));
     CPPUNIT_ASSERT((s1 == libdnf::Set<int>{1, 4, 6}));
 
     s1 = {1, 4, 6};
-    s1.remove(4);
+    CPPUNIT_ASSERT(s1.remove(4));
     CPPUNIT_ASSERT((s1 == libdnf::Set<int>{1, 6}));
+
+    s1 = {1, 4, 6};
+    CPPUNIT_ASSERT(!s1.remove(5));
+    CPPUNIT_ASSERT((s1 == libdnf::Set<int>{1, 4, 6}));
+
+    s1 = {1, 4, 6};
+    libdnf::Set<int>::iterator it = s1.find(4);
+    CPPUNIT_ASSERT_EQUAL(*it, 4);
+    CPPUNIT_ASSERT(s1.find(5) == s1.end());
 }
 
 // test operator ==()
@@ -151,4 +160,44 @@ void SetTest::test_set_binary_operators() {
     CPPUNIT_ASSERT(((s1 & s2) == libdnf::Set<int>{4}));
     CPPUNIT_ASSERT(((s1 - s2) == libdnf::Set<int>{1, 6}));
     CPPUNIT_ASSERT(((s1 ^ s2) == libdnf::Set<int>{1, 2, 6}));
+}
+
+// test iterator
+void SetTest::test_set_iterator() {
+
+    libdnf::Set<int> s1{1, 4, 5, 6};
+
+    // check if begin() points to the first package
+    auto it1 = s1.begin();
+    CPPUNIT_ASSERT_EQUAL(*it1, 1);
+
+    // test pre-increment operator
+    auto it2 = ++it1;
+    CPPUNIT_ASSERT_EQUAL(*it1, 4);
+    CPPUNIT_ASSERT_EQUAL(*it2, 4);
+
+    // test post-increment operator
+    auto it3 = it2++;
+    CPPUNIT_ASSERT_EQUAL(*it2, 5);
+    CPPUNIT_ASSERT_EQUAL(*it3, 4);
+
+    // test pre-decrement operator
+    auto it4 = --it2;
+    CPPUNIT_ASSERT_EQUAL(*it2, 4);
+    CPPUNIT_ASSERT_EQUAL(*it4, 4);
+
+    // test post-decrement operator
+    auto it5 = it4--;
+    CPPUNIT_ASSERT_EQUAL(*it4, 1);
+    CPPUNIT_ASSERT_EQUAL(*it5, 4);
+
+    // test loop
+    {
+        std::vector<int> expected{1, 4, 5, 6};
+        std::vector<int> result;
+        for (auto value : s1) {
+            result.push_back(value);
+        }
+        CPPUNIT_ASSERT(result == expected);
+    }
 }

--- a/test/libdnf/set/test_set.hpp
+++ b/test/libdnf/set/test_set.hpp
@@ -33,6 +33,7 @@ class SetTest : public CppUnit::TestCase {
     CPPUNIT_TEST(test_set_unary_operators);
     CPPUNIT_TEST(test_set_unary_operators);
     CPPUNIT_TEST(test_set_binary_operators);
+    CPPUNIT_TEST(test_set_iterator);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -45,6 +46,7 @@ public:
     void test_set_unary_operators();
     void test_set_unary_methods();
     void test_set_binary_operators();
+    void test_set_iterator();
 
 private:
 };

--- a/test/python3/libdnf/repo/test_repo_query.py
+++ b/test/python3/libdnf/repo/test_repo_query.py
@@ -1,0 +1,72 @@
+# Copyright Contributors to the libdnf project.
+#
+# This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+#
+# Libdnf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Libdnf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import libdnf
+
+class TestRepQueryo(unittest.TestCase):
+    def test_repo_query(self):
+        base = libdnf.base.Base()
+
+        repo_sack = base.get_repo_sack()
+
+        # TODO(lukash) repo initialization requires to have the cachedir set; do it differently?
+        base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, base.get_config().system_cachedir().get_value())
+
+        # Creates new repositories in the repo_sack
+        repo1 = repo_sack.new_repo("repo1")
+        repo2 = repo_sack.new_repo("repo2")
+        repo1_updates = repo_sack.new_repo("repo1_updates")
+        repo2_updates = repo_sack.new_repo("repo2_updates")
+
+        # Tunes configuration of repositories
+        repo1.enable();
+        repo2.disable();
+        repo1_updates.disable();
+        repo2_updates.enable();
+        repo1.get_config().baseurl().set(libdnf.conf.Option.Priority_RUNTIME, "file:///path/to/repo1")
+        repo2.get_config().baseurl().set(libdnf.conf.Option.Priority_RUNTIME, "https://host/path/to/repo2")
+        repo1_updates.get_config().baseurl().set(libdnf.conf.Option.Priority_RUNTIME, "https://host/path/to/repo1_updates")
+        repo2_updates.get_config().baseurl().set(libdnf.conf.Option.Priority_RUNTIME, "https://host/path/to/repo2_updates")
+
+        # create a RepoQuery and test that it contains expected repos
+        repo_query = libdnf.repo.RepoQuery(base)
+        self.assertEqual(repo_query.size(), 4)
+        self.assertEqual(len(repo_query), 4)
+        self.assertEqual(set(repo_query), {repo1, repo2, repo1_updates, repo2_updates})
+
+        # Tests filter_enabled method
+        repo_query.filter_enabled(True);
+        self.assertEqual(set(repo_query), {repo1, repo2_updates})
+
+        # Tests filter_id method
+        repo_query1 = libdnf.repo.RepoQuery(base)
+        repo_query1.filter_id("*updates", libdnf.common.QueryCmp_GLOB);
+        self.assertEqual(set(repo_query1), {repo1_updates, repo2_updates})
+
+        # Tests filter_local method
+        repo_query2 = libdnf.repo.RepoQuery(base)
+        repo_query2.filter_local(False);
+        self.assertEqual(set(repo_query2), {repo2, repo1_updates, repo2_updates})
+
+        # Tests iteration over RepoQuery object
+        repo_query3 = libdnf.repo.RepoQuery(base)
+        result = set()
+        for repo in repo_query3:
+            result.add(repo.get_id())
+        self.assertEqual(result, {"repo1", "repo2", "repo1_updates", "repo2_updates"})


### PR DESCRIPTION
* Adds iterator for `Set` class - new `SetConstIterator` class
* Adds methods `begin()`, `end()`, `find()`.
* Improves methods `add(const T & obj)`, `add(T && obj)`, `remove(const T & obj)`. Now them returns a `bool` value. Returns `true` if the item was added/deleted otherwise `false`.
* Defines types for better STL compatibility.
* swig: Basic iterator support for `Set` and `RepoQuery`
* swig: Python: `len` support for `Set`, hash for `WeakPtr`
* C++ unittest: Added tests for `Set` iterators and improvements, and for `RepoQuery` iterator
* Python unittests: Added tests for `RepoQuery`
