### PR TITLE
[dnf5] Exceptions: Sync with new style exceptions, mark messages for translation

### DIFF
--- a/bindings/libdnf/conf.i
+++ b/bindings/libdnf/conf.i
@@ -33,24 +33,15 @@
 #define CV __perl_CV
 #define final
 
-%ignore libdnf::Option::Exception;
-%ignore libdnf::Option::InvalidValue;
+%ignore libdnf::OptionError;
+%ignore libdnf::OptionInvalidValueError;
+%ignore libdnf::OptionValueNotAllowedError;
+%ignore libdnf::OptionValueNotSetError;
 %include "libdnf/conf/option.hpp"
-
-%ignore libdnf::OptionBool::InvalidValue;
 %include "libdnf/conf/option_bool.hpp"
-
-%ignore libdnf::OptionString::InvalidValue;
-%ignore libdnf::OptionString::NotAllowedValue;
-%ignore libdnf::OptionString::ValueNotSet;
-
-%ignore libdnf::OptionEnum::InvalidValue;
-%ignore libdnf::OptionEnum::NotAllowedValue;
 %include "libdnf/conf/option_enum.hpp"
 %template(OptionEnumString) libdnf::OptionEnum<std::string>;
 
-%ignore libdnf::OptionNumber::InvalidValue;
-%ignore libdnf::OptionNumber::NotAllowedValue;
 %include "libdnf/conf/option_number.hpp"
 %template(OptionNumberInt32) libdnf::OptionNumber<std::int32_t>;
 %template(OptionNumberUInt32) libdnf::OptionNumber<std::uint32_t>;
@@ -61,6 +52,8 @@
 %include "libdnf/conf/option_seconds.hpp"
 %include "libdnf/conf/option_string.hpp"
 %include "libdnf/conf/option_string_list.hpp"
+
+%ignore libdnf::OptionPathNotFoundError;
 %include "libdnf/conf/option_path.hpp"
 
 %include "libdnf/conf/option_child.hpp"
@@ -75,9 +68,9 @@
 
 
 %rename (OptionBinds_Item) libdnf::OptionBinds::Item;
-%ignore libdnf::OptionBinds::Exception;
-%ignore libdnf::OptionBinds::OptionNotFound;
-%ignore libdnf::OptionBinds::OptionAlreadyExists;
+%ignore libdnf::OptionBindsError;
+%ignore libdnf::OptionBindsOptionNotFoundError;
+%ignore libdnf::OptionBindsOptionAlreadyExistsError;
 %ignore libdnf::OptionBinds::add(const std::string & id, Option & option,
     Item::NewStringFunc new_string_func, Item::GetValueStringFunc get_value_string_func, bool add_value);
 %ignore libdnf::OptionBinds::begin;
@@ -90,6 +83,9 @@
 %include "libdnf/conf/config.hpp"
 %include "libdnf/conf/config_main.hpp"
 
+%ignore libdnf::ConfigParserError;
+%ignore ConfigParserSectionNotFoundError;
+%ignore ConfigParserOptionNotFoundError;
 %include "libdnf/conf/config_parser.hpp"
 
 %include "libdnf/conf/vars.hpp"

--- a/bindings/libdnf/rpm.i
+++ b/bindings/libdnf/rpm.i
@@ -44,6 +44,8 @@
 #define CV __perl_CV
 
 %include "libdnf/rpm/checksum.hpp"
+
+%ignore NevraIncorrectInputError;
 %include "libdnf/rpm/nevra.hpp"
 
 %template(VectorNevra) std::vector<libdnf::rpm::Nevra>;

--- a/dnfdaemon-client/main.cpp
+++ b/dnfdaemon-client/main.cpp
@@ -248,12 +248,12 @@ int main(int argc, char * argv[]) {
     // Run selected command
     try {
         context.get_selected_command()->run();
-    } catch (libdnf::cli::ArgumentParser::MissingCommand & ex) {
+    } catch (libdnf::cli::ArgumentParserMissingCommandError & ex) {
         // print help if no command is provided
         std::cout << ex.what() << std::endl;
         context.get_argument_parser().get_selected_command()->help();
         return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
-    } catch (libdnf::cli::ArgumentParser::Exception & ex) {
+    } catch (libdnf::cli::ArgumentParserError & ex) {
         std::cout << ex.what() << std::endl;
         return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
     } catch (std::exception & ex) {

--- a/dnfdaemon-server/services/repoconf/configuration.cpp
+++ b/dnfdaemon-server/services/repoconf/configuration.cpp
@@ -101,7 +101,7 @@ void Configuration::read_repo_configs() {
             std::string file_path = glob_result.gl_pathv[i];
             try {
                 repo_parser->read(file_path);
-            } catch (libdnf::ConfigParser::Exception & e) {
+            } catch (libdnf::ConfigParserError & e) {
                 logger.warning(fmt::format("Error parsing config file \"{}\": {}", file_path, e.what()));
                 continue;
             }

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -30,61 +30,100 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::cli {
 
+/// Parent for all ArgumentsParser runtime errors.
+class ArgumentParserError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf::cli"; }
+    const char * get_name() const noexcept override { return "ArgumentParserError"; }
+};
+
+/// Exception is thrown when conflicting arguments are used together.
+class ArgumentParserConflictingArgumentsError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserConflictingArgumentsError"; }
+};
+
+/// Exception is thrown when no command is found.
+class ArgumentParserMissingCommandError : public ArgumentParserError {
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserMissingCommandError"; }
+};
+
+/// Exception is thrown when a command requires a positional argument that was not found.
+class ArgumentParserMissingPositionalArgumentError : public ArgumentParserError {
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserMissingPositionalArgumentError"; }
+};
+
+/// Exception is generated in the case of an unexpected argument.
+class ArgumentParserUnknownArgumentError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserUnknownArgumentError"; }
+};
+
+
+/// Exception is thrown when an argument with the same ID is already registered.
+class ArgumentParserGroupArgumentIdRegisteredError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserGroupArgumentIdRegisteredError"; }
+};
+
+
+/// Exception is thrown when the Argument `id` contains not allowed '.' character.
+class ArgumentParserArgumentInvalidIdError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserArgumentInvalidIdError"; }
+};
+
+
+/// Exception is thrown when there are too few values for the positional argument.
+class ArgumentParserPositionalArgFewValuesError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserPositionalArgFewValuesError"; }
+};
+
+
+/// Exception is thrown if the named argument requires a value and the value is missing.
+class ArgumentParserNamedArgMissingValueError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserNamedArgMissingValueError"; }
+};
+
+/// Exception is thrown if the named argument is defined without a value and a value is present.
+class ArgumentParserNamedArgValueNotExpectedError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserNamedArgValueNotExpectedError"; }
+};
+
+
+/// Exception is thrown when the command, named_argument, or positional argument was not found.
+class ArgumentParserNotFoundError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserNotFoundError"; }
+};
+
+/// Exception is thrown when the command, named argument, positional argument, or group with the same ID is already registered.
+class ArgumentParserIdAlreadyRegisteredError : public ArgumentParserError {
+public:
+    using ArgumentParserError::ArgumentParserError;
+    const char * get_name() const noexcept override { return "ArgumentParserIdAlreadyRegisteredError"; }
+};
+
+
 class ArgumentParser {
 public:
-    /// Parent for all ArgumentsParser runtime errors.
-    class Exception : public RuntimeError {
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser"; }
-        const char * get_name() const noexcept override { return "Exception"; }
-        const char * get_description() const noexcept override { return "ArgumentParser exception"; }
-    };
-
-    /// Exception is generated when conflicting arguments are used together.
-    class Conflict : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "Conflict"; }
-        const char * get_description() const noexcept override { return "Conflicting arguments"; }
-    };
-
-    /// Excepion is thrown when no command is found.
-    class MissingCommand : public Exception {
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "MissingCommand"; }
-        const char * get_description() const noexcept override { return "Command not specified"; }
-    };
-
-    /// Exception is thrown when a command requires a positional argument that was not found.
-    class MissingPositionalArgument : public Exception {
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "MissingPositionalArgument"; }
-        const char * get_description() const noexcept override { return "Missing positional argument"; }
-    };
-
-    /// Exception is generated in the case of an unexpected argument.
-    class UnknownArgument : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "UnknownArgument"; }
-        const char * get_description() const noexcept override { return "Unknown argument"; }
-    };
-
     class Argument;
 
     class Group {
     public:
-        /// Exception is thrown when a an argument with the same ID is already registered.
-        class ArgumentIdExists : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Group"; }
-            const char * get_name() const noexcept override { return "ArgumentIdExists"; }
-            const char * get_description() const noexcept override {
-                return "An argument with the same ID is already registered";
-            }
-        };
-
         /// Sets group header.
         void set_header(std::string header) noexcept { this->header = std::move(header); }
 
@@ -113,15 +152,6 @@ public:
 
     class Argument {
     public:
-        /// Exception is generated when the Argument `id` contains not allowed '.' character.
-        class InvalidId : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Argument"; }
-            const char * get_name() const noexcept override { return "InvalidId"; }
-            const char * get_description() const noexcept override { return "Invalid id"; }
-        };
-
         Argument(const Argument &) = delete;
         Argument(Argument &&) = delete;
         Argument & operator=(const Argument &) = delete;
@@ -176,7 +206,7 @@ public:
         friend class ArgumentParser;
 
         Argument(ArgumentParser & owner, std::string id);
-        static std::string get_conflict_arg_msg(const Argument * conflict_arg);
+        static std::pair<std::string, std::string> get_conflict_arg_msg(const Argument * conflict_arg);
 
         ArgumentParser & owner;
         std::string id;
@@ -192,17 +222,6 @@ public:
         constexpr static int OPTIONAL{0};
         constexpr static int UNLIMITED{-1};
         constexpr static int AT_LEAST_ONE{-2};
-
-        /// Exception is generated when there are insufficient values for the positional argument.
-        class FewValues : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override {
-                return "libdnf::cli::ArgumentParser::PositionalArg";
-            }
-            const char * get_name() const noexcept override { return "FewValues"; }
-            const char * get_description() const noexcept override { return "Few values"; }
-        };
 
         using ParseHookFunc = std::function<bool(PositionalArg * arg, int argc, const char * const argv[])>;
         using CompleteHookFunc = std::function<std::vector<std::string>(const char * arg_to_complete)>;
@@ -261,24 +280,6 @@ public:
 
     class NamedArg : public Argument {
     public:
-        /// Exception is generated if the argument requires a value and the value is missing.
-        class MissingValue : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::NamedArg"; }
-            const char * get_name() const noexcept override { return "MissingValue"; }
-            const char * get_description() const noexcept override { return "Missing argument value"; }
-        };
-
-        /// Exception is generated if the argument is defined without a value and a value is present.
-        class UnexpectedValue : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::NamedArg"; }
-            const char * get_name() const noexcept override { return "UnexpectedValue"; }
-            const char * get_description() const noexcept override { return "Unexpected argument value"; }
-        };
-
         using ParseHookFunc = std::function<bool(NamedArg * arg, const char * option, const char * value)>;
 
         /// Sets long name of argument. Long name is prefixed with two dashes on the command line (e.g. "--help").
@@ -364,77 +365,6 @@ public:
 
     class Command : public Argument {
     public:
-        /// Exception is generated when a command was not found.
-        class CommandNotFound : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
-            const char * get_name() const noexcept override { return "CommandNotFound"; }
-            const char * get_description() const noexcept override { return "Commnand not found"; }
-        };
-
-        /// Exception is generated when a named argument was not found.
-        class NamedArgNotFound : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
-            const char * get_name() const noexcept override { return "NamedArgNotFound"; }
-            const char * get_description() const noexcept override { return "Named argument not found"; }
-        };
-
-        /// Exception is generated when a positional argument was not found.
-        class PositionalArgNotFound : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
-            const char * get_name() const noexcept override { return "PositionalArgNotFound"; }
-            const char * get_description() const noexcept override { return "Positional argument not found"; }
-        };
-
-        /// Exception is thrown when a command with the same ID is already registered.
-        class CommandIdExists : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
-            const char * get_name() const noexcept override { return "CommandIdExists"; }
-            const char * get_description() const noexcept override {
-                return "Command with the same ID is already registered";
-            }
-        };
-
-        /// Exception is thrown when a named argument with the same ID is already registered.
-        class NamedArgIdExists : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
-            const char * get_name() const noexcept override { return "NamedArgIdExists"; }
-            const char * get_description() const noexcept override {
-                return "Named argument with the same ID is already registered";
-            }
-        };
-
-        /// Exception is thrown when a positional argument with the same ID is already registered.
-        class PositionalArgIdExists : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
-            const char * get_name() const noexcept override { return "PositionalArgIdExists"; }
-            const char * get_description() const noexcept override {
-                return "Positional argument with the same ID is already registered";
-            }
-        };
-
-        /// Exception is thrown when a group with the same ID is already registered.
-        class GroupIdExists : public Exception {
-        public:
-            using Exception::Exception;
-            const char * get_domain_name() const noexcept override { return "libdnf::cli::ArgumentParser::Command"; }
-            const char * get_name() const noexcept override { return "GroupIdExists"; }
-            const char * get_description() const noexcept override {
-                return "Group with the same ID is already registered";
-            }
-        };
-
         using ParseHookFunc = std::function<bool(Command * arg, const char * cmd, int argc, const char * const argv[])>;
 
         /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
@@ -516,7 +446,8 @@ public:
 
         Command(ArgumentParser & owner, const std::string & id) : Argument(owner, id) {}
 
-        void print_complete(const char * arg, std::vector<ArgumentParser::NamedArg *> named_args, size_t used_positional_arguments);
+        void print_complete(
+            const char * arg, std::vector<ArgumentParser::NamedArg *> named_args, size_t used_positional_arguments);
 
         Command * parent{nullptr};
         std::vector<Command *> cmds;

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -77,8 +77,8 @@ public:
     /// @since 5.0
     virtual void run() = 0;
 
-    /// Throw a MissingCommand exception with the command name in it
-    void throw_missing_command() const { throw ArgumentParser::MissingCommand(get_argument_parser_command()->get_id()); }
+    /// Throw a ArgumentParserMissingCommandError exception with the command name in it
+    void throw_missing_command() const { throw ArgumentParserMissingCommandError(get_argument_parser_command()->get_id()); }
 
     /// @return Pointer to the Session.
     ///         The returned pointer must **not** be freed manually.

--- a/include/libdnf/common/sack/query.hpp
+++ b/include/libdnf/common/sack/query.hpp
@@ -71,7 +71,7 @@ public:
         if (get_data().size() == 1) {
             return *get_data().begin();
         }
-        throw std::runtime_error("Query must contain exactly one object.");
+        throw RuntimeError("Query must contain exactly one object.");
     }
 
     /// List all objects matching the query.

--- a/include/libdnf/conf/option.hpp
+++ b/include/libdnf/conf/option.hpp
@@ -27,6 +27,36 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
+/// Option exception
+class OptionError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf"; }
+    const char * get_name() const noexcept override { return "OptionError"; }
+};
+
+/// Exception that is generated when an invalid input value is detected.
+class OptionInvalidValueError : public OptionError {
+public:
+    using OptionError::OptionError;
+    const char * get_name() const noexcept override { return "OptionInvalidValueError"; }
+};
+
+/// Exception that is generated when not allowed input value is detected.
+class OptionValueNotAllowedError : public OptionInvalidValueError {
+public:
+    using OptionInvalidValueError::OptionInvalidValueError;
+    const char * get_name() const noexcept override { return "OptionValueNotAllowedError"; }
+};
+
+/// Exception that is generated during read an empty Option.
+class OptionValueNotSetError : public OptionError {
+public:
+    using OptionError::OptionError;
+    const char * get_name() const noexcept override { return "OptionValueNotSetError"; }
+};
+
+
 /// Option class is an abstract class. Parent of all options. Options are used to store a configuration.
 /// @replaces libdnf:conf/Option.hpp:class:Option
 class Option {
@@ -44,23 +74,6 @@ public:
         DROPINCONFIG = 65,
         COMMANDLINE = 70,
         RUNTIME = 80
-    };
-
-    /// Option exception
-    class Exception : public RuntimeError {
-    public:
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::Option"; }
-        const char * get_name() const noexcept override { return "Exception"; }
-        const char * get_description() const noexcept override { return "Option exception"; }
-    };
-
-    /// Exception that is generated when an invalid input value is detected.
-    class InvalidValue : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "InvalidValue"; }
-        const char * get_description() const noexcept override { return "Invalid value"; }
     };
 
     explicit Option(Priority priority = Priority::EMPTY);

--- a/include/libdnf/conf/option_binds.hpp
+++ b/include/libdnf/conf/option_binds.hpp
@@ -28,31 +28,28 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
+struct OptionBindsError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf"; }
+    const char * get_name() const noexcept override { return "OptionBindsError"; }
+};
+
+class OptionBindsOptionNotFoundError : public OptionBindsError {
+public:
+    explicit OptionBindsOptionNotFoundError(const std::string & id);
+    const char * get_name() const noexcept override { return "OptionBindsOptionNotFoundError"; }
+};
+
+class OptionBindsOptionAlreadyExistsError : public OptionBindsError {
+public:
+    explicit OptionBindsOptionAlreadyExistsError(const std::string & id);
+    const char * get_name() const noexcept override { return "OptionBindsOptionAlreadyExistsError"; }
+};
+
 /// Maps the options names (text names readed from config file, command line, ...) to options objects.
 /// Supports user defined functions for processing new value and converting value to string.
 class OptionBinds {
 public:
-    struct Exception : public RuntimeError {
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionBinds"; }
-        const char * get_name() const noexcept override { return "Exception"; }
-        const char * get_description() const noexcept override { return "OptionBinds exception"; }
-    };
-
-    class OptionNotFound : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "OptionNotFound"; }
-        const char * get_description() const noexcept override { return "Option not found"; }
-    };
-
-    class OptionAlreadyExists : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "OptionAlreadyExists"; }
-        const char * get_description() const noexcept override { return "Option already exists"; }
-    };
-
     /// Extends the option with user-defined functions for processing a new value and converting value to a string.
     /// It is used as additional level of processing when the option is accesed by its text name.
     class Item final {

--- a/include/libdnf/conf/option_bool.hpp
+++ b/include/libdnf/conf/option_bool.hpp
@@ -38,13 +38,6 @@ class OptionBool : public Option {
 public:
     using ValueType = bool;
 
-    /// Exception that is generated when an invalid input value is detected.
-    class InvalidValue : public Option::InvalidValue {
-    public:
-        using Option::InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionBool"; }
-    };
-
     /// Constructor that sets default value.
     /// @replaces libdnf:conf/OptionBool.hpp:ctor:OptionBool.OptionBool(bool default_value)
     explicit OptionBool(bool default_value);

--- a/include/libdnf/conf/option_enum.hpp
+++ b/include/libdnf/conf/option_enum.hpp
@@ -37,21 +37,6 @@ public:
     using ValueType = T;
     using FromStringFunc = std::function<ValueType(const std::string &)>;
 
-    /// Exception that is generated when an invalid input value is detected.
-    class InvalidValue : public Option::InvalidValue {
-    public:
-        using Option::InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionEnum"; }
-    };
-
-    /// Exception that is generated when not allowed input value is detected.
-    class NotAllowedValue : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_name() const noexcept override { return "NotAllowedValue"; }
-        const char * get_description() const noexcept override { return "Not allowed value"; }
-    };
-
     OptionEnum(ValueType default_value, const std::vector<ValueType> & enum_vals);
     OptionEnum(ValueType default_value, std::vector<ValueType> && enum_vals);
     OptionEnum(ValueType default_value, const std::vector<ValueType> & enum_vals, FromStringFunc && from_string_func);
@@ -112,18 +97,6 @@ class OptionEnum<std::string> : public Option {
 public:
     using ValueType = std::string;
     using FromStringFunc = std::function<ValueType(const std::string &)>;
-
-    class InvalidValue : public Option::InvalidValue {
-    public:
-        using Option::InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionEnum"; }
-    };
-
-    class NotAllowedValue : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_name() const noexcept override { return "NotAllowedValue"; }
-    };
 
     OptionEnum(const std::string & default_value, std::vector<ValueType> enum_vals);
     OptionEnum(const std::string & default_value, std::vector<ValueType> enum_vals, FromStringFunc && from_string_func);

--- a/include/libdnf/conf/option_number.hpp
+++ b/include/libdnf/conf/option_number.hpp
@@ -36,21 +36,6 @@ public:
     using ValueType = T;
     using FromStringFunc = std::function<ValueType(const std::string &)>;
 
-    /// Exception that is generated when an invalid input value is detected.
-    class InvalidValue : public Option::InvalidValue {
-    public:
-        using Option::InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionNumber"; }
-    };
-
-    /// Exception that is generated when not allowed input value is detected.
-    class NotAllowedValue : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_name() const noexcept override { return "NotAllowedValue"; }
-        const char * get_description() const noexcept override { return "Not allowed value"; }
-    };
-
     /// Constructor that sets default value and limits for min and max values.
     /// @replaces libdnf:conf/OptionNumber.hpp:ctor:OptionNumber.OptionNumber<T>(T default_value, T min, T max)
     OptionNumber(T default_value, T min, T max);

--- a/include/libdnf/conf/option_path.hpp
+++ b/include/libdnf/conf/option_path.hpp
@@ -25,29 +25,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
+/// Exception that is generated when input path does not exist.
+class OptionPathNotFoundError : public OptionValueNotAllowedError {
+public:
+    using OptionValueNotAllowedError::OptionValueNotAllowedError;
+    const char * get_name() const noexcept override { return "OptionPathNotFoundError"; }
+};
+
+
 /// Option that stores file/directory path.
 /// Support default value, and path verification (absolute, existence).
 /// @replaces libdnf:conf/OptionPath.hpp:class:OptionPath
 class OptionPath : public OptionString {
 public:
-    /// Exception that is generated when not allowed input value is detected.
-    class NotAllowedValue : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionPath"; }
-        const char * get_name() const noexcept override { return "NotAllowedValue"; }
-        const char * get_description() const noexcept override { return "Not allowed value"; }
-    };
-
-    /// Exception that is generated when input path does not exist.
-    class PathNotExists : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionPath"; }
-        const char * get_name() const noexcept override { return "PathNotExists"; }
-        const char * get_description() const noexcept override { return "Path does not exist"; }
-    };
-
     /// Constructor sets default value and conditons.
     /// @replaces libdnf:conf/OptionPath.hpp:ctor:OptionPath.OptionPath(const std::string & defaultValue, bool exists = false, bool absPath = false)
     explicit OptionPath(const std::string & default_value, bool exists = false, bool abs_path = false);

--- a/include/libdnf/conf/option_seconds.hpp
+++ b/include/libdnf/conf/option_seconds.hpp
@@ -30,29 +30,6 @@ namespace libdnf {
 /// @replaces libdnf:conf/OptionSeconds.hpp:class:OptionSeconds
 class OptionSeconds : public OptionNumber<std::int32_t> {
 public:
-    /// Exception that is generated when an invalid input value is detected.
-    class InvalidValue : public Option::InvalidValue {
-    public:
-        using Option::InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionSeconds"; }
-    };
-
-    /// Exception that is generated when an negative input value is detected.
-    class NegativeValue : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_name() const noexcept override { return "NegativeValue"; }
-        const char * get_description() const noexcept override { return "Seconds value must not be negative"; };
-    };
-
-    /// Exception that is generated when an unknown input value is detected.
-    class UnknownUnit : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_name() const noexcept override { return "UnknownUnit"; }
-        const char * get_description() const noexcept override { return "Unknown unit"; };
-    };
-
     OptionSeconds(ValueType default_value, ValueType min, ValueType max);
     OptionSeconds(ValueType default_value, ValueType min);
     explicit OptionSeconds(ValueType default_value);

--- a/include/libdnf/conf/option_string.hpp
+++ b/include/libdnf/conf/option_string.hpp
@@ -32,30 +32,6 @@ class OptionString : public Option {
 public:
     using ValueType = std::string;
 
-    /// Exception that is generated when an invalid input value is detected.
-    class InvalidValue : public Option::InvalidValue {
-    public:
-        using Option::InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionString"; }
-    };
-
-    /// Exception that is generated when not allowed input value is detected.
-    class NotAllowedValue : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_name() const noexcept override { return "NotAllowedValue"; }
-        const char * get_description() const noexcept override { return "Not allowed value"; }
-    };
-
-    /// Exception that is generated during read an empty Option.
-    class ValueNotSet : public Exception {
-    public:
-        ValueNotSet() : Exception("") {}
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionString"; }
-        const char * get_name() const noexcept override { return "ValueNotSet"; }
-        const char * get_description() const noexcept override { return "Value is not set"; }
-    };
-
     explicit OptionString(const std::string & default_value);
     explicit OptionString(const char * default_value);
     OptionString(const std::string & default_value, std::string regex, bool icase);

--- a/include/libdnf/conf/option_string_list.hpp
+++ b/include/libdnf/conf/option_string_list.hpp
@@ -34,15 +34,6 @@ class OptionStringList : public Option {
 public:
     using ValueType = std::vector<std::string>;
 
-    /// Exception that is generated when not allowed input value is detected.
-    class NotAllowedValue : public InvalidValue {
-    public:
-        using InvalidValue::InvalidValue;
-        const char * get_domain_name() const noexcept override { return "libdnf::OptionStringList"; }
-        const char * get_name() const noexcept override { return "NotAllowedValue"; }
-        const char * get_description() const noexcept override { return "Not allowed value"; }
-    };
-
     explicit OptionStringList(const ValueType & default_value);
     OptionStringList(const ValueType & default_value, std::string regex, bool icase);
     explicit OptionStringList(const std::string & default_value);

--- a/include/libdnf/repo/repo_errors.hpp
+++ b/include/libdnf/repo/repo_errors.hpp
@@ -35,7 +35,6 @@ class RepoError : public Error {
 class RepoDownloadError : public RepoError {
 public:
     using RepoError::RepoError;
-    const char * get_domain_name() const noexcept override { return "libdnf::repo"; }
     const char * get_name() const noexcept override { return "RepoDownloadError"; }
 };
 
@@ -43,14 +42,12 @@ public:
 class RepoGpgError : public RepoError {
 public:
     using RepoError::RepoError;
-    const char * get_domain_name() const noexcept override { return "libdnf::repo"; }
     const char * get_name() const noexcept override { return "RepoGpgError"; }
 };
 
 
 class RepoRpmError : public RepoError {
     using RepoError::RepoError;
-    const char * get_domain_name() const noexcept override { return "libdnf::repo"; }
     const char * get_name() const noexcept override { return "RepoRpmError"; }
 };
 

--- a/include/libdnf/rpm/nevra.hpp
+++ b/include/libdnf/rpm/nevra.hpp
@@ -30,17 +30,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::rpm {
 
+struct NevraIncorrectInputError : public Error {
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf::rpm"; }
+    const char * get_name() const noexcept override { return "NevraIncorrectInputError"; }
+};
+
+
 /// @replaces hawkey:hawkey/__init__.py:class:Nevra
 struct Nevra {
 public:
     enum class Form { NEVRA = 1, NEVR = 2, NEV = 3, NA = 4, NAME = 5 };
-
-    struct IncorrectNevraString : public RuntimeError {
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::rpm::Nevra"; }
-        const char * get_name() const noexcept override { return "IncorrectNevraString"; }
-        const char * get_description() const noexcept override { return "Nevra exception"; }
-    };
 
     /// The default forms and their order determine pkg_spec matching
     static const std::vector<Form> & get_default_pkg_spec_forms();

--- a/include/libdnf/rpm/package_sack.hpp
+++ b/include/libdnf/rpm/package_sack.hpp
@@ -82,14 +82,6 @@ using PackageSackWeakPtr = WeakPtr<PackageSack, false>;
 
 class PackageSack {
 public:
-    class Exception : public RuntimeError {
-    public:
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::rpm::PackageSack"; }
-        const char * get_name() const noexcept override { return "Exception"; }
-        const char * get_description() const noexcept override { return "rpm::PackageSack exception"; }
-    };
-
     explicit PackageSack(const libdnf::BaseWeakPtr & base);
     explicit PackageSack(libdnf::Base & base);
     ~PackageSack();

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -218,15 +218,16 @@ private:
 };
 
 
+class TransactionError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf::rpm"; }
+    const char * get_name() const noexcept override { return "TransactionError"; }
+};
+
+
 class Transaction {
 public:
-    class Exception : public RuntimeError {
-    public:
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::rpm::Transaction"; }
-        const char * get_name() const noexcept override { return "Exception"; }
-        const char * get_description() const noexcept override { return "rpm::Transaction exception"; }
-    };
 
     // TODO(jrohel): Define enums or flag setters/getters
     using rpmVSFlags = uint32_t;

--- a/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -261,7 +261,7 @@ void PythonPluginLoader::load_plugins_from_dir(const fs::path & dir_path) {
         try {
             load_plugin_file(p);
         } catch (const std::exception & ex) {
-            std::string msg = fmt::format("Can't load plugin \"{}\": {}", p.string(), ex.what());
+            std::string msg = fmt::format("Cannot load plugin \"{}\": {}", p.string(), ex.what());
             logger.error(msg);
             error_msgs += msg + '\n';
         }

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -64,10 +64,12 @@ Base * Base::get_locked_base() noexcept {
     return locked_base;
 }
 
-void Base::load_config_from_file(const std::string & path) {
+void Base::load_config_from_file(const std::string & path) try {
     ConfigParser parser;
     parser.read(path);
     config.load_from_parser(parser, "main", vars, *get_logger());
+} catch (const Error & e) {
+    std::throw_with_nested(RuntimeError(M_("Unable to load configuration file \"{}\""), path));
 }
 
 void Base::load_config_from_file() {

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -23,6 +23,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/conf/const.hpp"
 #include "solv/pool.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <fmt/format.h>
 
 #include <algorithm>
@@ -52,12 +54,8 @@ void Base::lock() {
 }
 
 void Base::unlock() {
-    if (!locked_base) {
-        throw std::logic_error("Base::unlock() called on unlocked \"Base\" instance.");
-    }
-    if (locked_base != this) {
-        throw std::logic_error("Called Base::unlock(). But the lock is not owned by this \"Base\" instance.");
-    }
+    libdnf_assert(locked_base, "Base::unlock() called on unlocked \"Base\" instance");
+    libdnf_assert(locked_base == this, "Called Base::unlock(). But the lock is not owned by this \"Base\" instance.");
     locked_base = nullptr;
     locked_base_mutex.unlock();
 }

--- a/libdnf/common/exception.cpp
+++ b/libdnf/common/exception.cpp
@@ -60,15 +60,16 @@ std::string SystemError::get_error_message() const {
 
 
 static std::string format(const std::exception & e, std::size_t level, bool with_domain) {
-    std::string ret;
+    std::string ret(level, ' ');
     if (auto ex = dynamic_cast<const Error *>(&e)) {
         if (with_domain) {
-            ret = fmt::format("{}::{}: {}\n", ex->get_domain_name(), ex->get_name(), ex->what());
+            ret += fmt::format("{}::{}: {}\n", ex->get_domain_name(), ex->get_name(), ex->what());
         } else {
-            ret = fmt::format("{}: {}\n", ex->get_name(), ex->what());
+            ret += fmt::format("{}: {}\n", ex->get_name(), ex->what());
         }
     } else {
-        ret = std::string(level, ' ') + e.what() + '\n';
+        ret += e.what();
+        ret += '\n';
     }
     try {
         std::rethrow_if_nested(e);

--- a/libdnf/conf/config.cpp
+++ b/libdnf/conf/config.cpp
@@ -37,12 +37,11 @@ void Config<default_priority>::load_from_parser(
             if (opt_binds_iter != binds.end()) {
                 try {
                     opt_binds_iter->second.new_string(default_priority, vars.substitute(opt.second));
-                } catch (const Option::Exception & ex) {
+                } catch (const OptionError & ex) {
                     logger.warning(fmt::format(
-                        R"**(Config error in section "{}" key "{}": {}: {})**",
+                        "Config error in section \"{}\" key \"{}\": {}",
                         section,
                         opt.first,
-                        ex.get_description(),
                         ex.what()
                     ));
                 }

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -52,18 +52,18 @@ namespace libdnf {
 /// @return int Number of bytes
 static int str_to_bytes(const std::string & str) {
     if (str.empty()) {
-        throw Option::InvalidValue("no value specified");
+        throw OptionInvalidValueError("Input is empty. Must contain a value.");
     }
 
     std::size_t idx;
     auto res = std::stod(str, &idx);
     if (res < 0) {
-        throw Option::InvalidValue(fmt::format("seconds value '{}' must not be negative", str));
+        throw OptionInvalidValueError("Input value '{}' must not be negative", str);
     }
 
     if (idx < str.length()) {
         if (idx < str.length() - 1) {
-            throw Option::InvalidValue(fmt::format("could not convert '{}' to bytes", str));
+            throw OptionInvalidValueError("Could not convert '{}' to bytes", str);
         }
         switch (str.back()) {
             case 'k':
@@ -79,7 +79,7 @@ static int str_to_bytes(const std::string & str) {
                 res *= 1024 * 1024 * 1024;
                 break;
             default:
-                throw Option::InvalidValue(fmt::format("unknown unit '{}'", str.back()));
+                throw OptionInvalidValueError("Unknown unit '{}'", str.back());
         }
     }
 
@@ -89,7 +89,7 @@ static int str_to_bytes(const std::string & str) {
 static void add_from_file(std::ostream & out, const std::string & file_path) {
     std::ifstream ifs(file_path);
     if (!ifs) {
-        throw RuntimeError(M_("add_from_file(): Can't open file"));
+        throw RuntimeError(M_("add_from_file(): Cannot open file"));
     }
     ifs.exceptions(std::ifstream::badbit);
 
@@ -332,7 +332,7 @@ class ConfigMain::Impl {
                 if (res < 0 || res > 100) {
                     // TODO(jrohel): Better exception info?
                     // throw Option::InvalidValue(tfm::format(_("percentage '%s' is out of range"), value));
-                    throw Option::InvalidValue(value);
+                    throw OptionInvalidValueError(M_("The throttle value {} is outside the allowed range {} ... {}"), value, 0, 100);
                 }
                 return res / 100;
             }

--- a/libdnf/conf/option_binds.cpp
+++ b/libdnf/conf/option_binds.cpp
@@ -19,9 +19,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/option_binds.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <utility>
 
 namespace libdnf {
+
+OptionBindsOptionNotFoundError::OptionBindsOptionNotFoundError(const std::string & id)
+    : OptionBindsError(M_("Option \"{}\" not found"), id) {}
+
+OptionBindsOptionAlreadyExistsError::OptionBindsOptionAlreadyExistsError(const std::string & id)
+    : OptionBindsError(M_("Option \"{}\" already exists"), id) {}
 
 // ========== OptionBinds::Item class ===============
 
@@ -63,7 +71,7 @@ bool OptionBinds::Item::get_is_append_option() const {
 OptionBinds::Item & OptionBinds::at(const std::string & id) {
     auto item = items.find(id);
     if (item == items.end()) {
-        throw OptionNotFound(id);
+        throw OptionBindsOptionNotFoundError(id);
     }
     return item->second;
 }
@@ -71,7 +79,7 @@ OptionBinds::Item & OptionBinds::at(const std::string & id) {
 const OptionBinds::Item & OptionBinds::at(const std::string & id) const {
     auto item = items.find(id);
     if (item == items.end()) {
-        throw OptionNotFound(id);
+        throw OptionBindsOptionNotFoundError(id);
     }
     return item->second;
 }
@@ -84,7 +92,7 @@ OptionBinds::Item & OptionBinds::add(
     bool add_value) {
     auto item = items.find(id);
     if (item != items.end()) {
-        throw OptionAlreadyExists(id);
+        throw OptionBindsOptionAlreadyExistsError(id);
     }
     auto res = items.emplace(id, Item(option, std::move(new_string_func), std::move(get_value_string_func), add_value));
     return res.first->second;
@@ -93,7 +101,7 @@ OptionBinds::Item & OptionBinds::add(
 OptionBinds::Item & OptionBinds::add(const std::string & id, Option & option) {
     auto item = items.find(id);
     if (item != items.end()) {
-        throw OptionAlreadyExists(id);
+        throw OptionBindsOptionAlreadyExistsError(id);
     }
     auto res = items.emplace(id, Item(option));
     return res.first->second;

--- a/libdnf/conf/option_bool.cpp
+++ b/libdnf/conf/option_bool.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/option_bool.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <sstream>
 
 namespace libdnf {
@@ -79,7 +81,7 @@ bool OptionBool::from_string(const std::string & value) const {
             return true;
         }
     }
-    throw InvalidValue(value);
+    throw OptionInvalidValueError(M_("Invalid boolean value \"{}\""), value);
 }
 
 void OptionBool::set(Priority priority, bool value) {

--- a/libdnf/conf/option_enum.cpp
+++ b/libdnf/conf/option_enum.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/option_enum.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <algorithm>
 #include <sstream>
 
@@ -74,7 +76,7 @@ template <typename T>
 void OptionEnum<T>::test(ValueType value) const {
     auto it = std::find(enum_vals.begin(), enum_vals.end(), value);
     if (it == enum_vals.end()) {
-        throw NotAllowedValue(to_string(value));
+        throw OptionValueNotAllowedError(M_("Enum option value \"{}\" not allowed"), value);
     }
 }
 
@@ -87,7 +89,7 @@ T OptionEnum<T>::from_string(const std::string & value) const {
     if (libdnf::from_string<ValueType>(val, value, std::dec)) {
         return val;
     }
-    throw InvalidValue(value);
+    throw OptionInvalidValueError(M_("Invalid enum option value \"{}\""), value);
 }
 
 template <typename T>
@@ -149,7 +151,7 @@ OptionEnum<std::string>::OptionEnum(
 void OptionEnum<std::string>::test(const std::string & value) const {
     auto it = std::find(enum_vals.begin(), enum_vals.end(), value);
     if (it == enum_vals.end()) {
-        throw NotAllowedValue(value);
+        throw OptionValueNotAllowedError(M_("Enum option value \"{}\" not allowed"), value);
     }
 }
 

--- a/libdnf/conf/option_number.cpp
+++ b/libdnf/conf/option_number.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/option_number.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <limits>
 #include <sstream>
 
@@ -71,7 +73,7 @@ OptionNumber<T>::OptionNumber(T default_value, FromStringFunc && from_string_fun
 template <typename T>
 void OptionNumber<T>::test(ValueType value) const {
     if (value < min || value > max) {
-        throw NotAllowedValue(to_string(value));
+        throw OptionValueNotAllowedError(M_("Input value {} is outside the allowed range {} ... {}"), value, min, max);
     }
 }
 
@@ -84,7 +86,7 @@ T OptionNumber<T>::from_string(const std::string & value) const {
     if (libdnf::from_string<ValueType>(val, value, std::dec)) {
         return val;
     }
-    throw InvalidValue(value);
+    throw OptionInvalidValueError(M_("Invalid number option value \"{}\""), value);
 }
 
 template <typename T>

--- a/libdnf/conf/option_path.cpp
+++ b/libdnf/conf/option_path.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/option_path.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -76,12 +78,12 @@ OptionPath::OptionPath(const char * default_value, const std::string & regex, bo
 
 void OptionPath::test(const std::string & value) const {
     if (abs_path && value[0] != '/') {
-        throw NotAllowedValue(value);
+        throw OptionValueNotAllowedError(M_("Only absolute paths allowed, relative path \"{}\" detected"), value);
     }
 
     struct stat buffer;
     if (exists && stat(value.c_str(), &buffer) != 0) {
-        throw PathNotExists(value);
+        throw OptionPathNotFoundError(M_("Path \"{}\" does not exist"), value);
     }
 }
 

--- a/libdnf/conf/option_string.cpp
+++ b/libdnf/conf/option_string.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/option_string.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <regex>
 
 namespace libdnf {
@@ -64,7 +66,11 @@ void OptionString::test(const std::string & value) const {
         regex,
         std::regex::nosubs | std::regex::extended | (icase ? std::regex::icase : std::regex_constants::ECMAScript));
     if (!std::regex_match(value, re)) {
-        throw NotAllowedValue(value);
+        throw OptionValueNotAllowedError(
+            M_("Input value \"{}\" not allowed, allowed values for this option are defined by regular expression "
+               "\"{}\""),
+            value,
+            regex);
     }
 }
 
@@ -80,7 +86,9 @@ void OptionString::set(Priority priority, const std::string & value) {
 
 const std::string & OptionString::get_value() const {
     if (get_priority() == Priority::EMPTY) {
-        throw ValueNotSet();
+        //TODO(jrohel): We don't know the option name at this time. Add a text name to the options
+        //              or extend exception (add name) in upper layer.
+        throw OptionValueNotSetError(M_("Option value is not set"));
     }
     return value;
 }

--- a/libdnf/conf/option_string_list.cpp
+++ b/libdnf/conf/option_string_list.cpp
@@ -19,6 +19,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/option_string_list.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <regex>
 
 namespace libdnf {
@@ -60,7 +62,7 @@ void OptionStringList::test(const std::vector<std::string> & value) const {
         std::regex::nosubs | std::regex::extended | (icase ? std::regex::icase : std::regex_constants::ECMAScript));
     for (const auto & val : value) {
         if (!std::regex_match(val, re)) {
-            throw NotAllowedValue(val);
+            throw OptionValueNotAllowedError(M_("Input value \"{}\" not allowed, allowed values for this option are defined by regular expression \"{}\""), val, regex);
         }
     }
 }

--- a/libdnf/plugin/plugins.cpp
+++ b/libdnf/plugin/plugins.cpp
@@ -117,19 +117,19 @@ void Plugins::load_plugins(const std::string & dir_path) {
     }
     std::sort(lib_names.begin(), lib_names.end());
 
-    std::string error_msgs;
+    bool cant_load{false};
     for (auto & p : lib_names) {
         try {
             load_plugin(p);
         } catch (const std::exception & ex) {
-            std::string msg = fmt::format(_("Can't load plugin \"{}\": {}"), p.string(), ex.what());
+            std::string msg = fmt::format(_("Cannot load plugin \"{}\": {}"), p.string(), ex.what());
             logger.error(msg);
-            error_msgs += msg + '\n';
+            cant_load = true;
         }
     }
 
-    if (!error_msgs.empty()) {
-        throw RuntimeError(M_("Can't load plugins"));
+    if (cant_load) {
+        throw RuntimeError(M_("Cannot load plugins"));
     }
 }
 

--- a/libdnf/rpm/nevra.cpp
+++ b/libdnf/rpm/nevra.cpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/rpm/nevra.hpp"
 
+#include "utils/bgettext/bgettext-lib.h"
+
 #include <rpm/rpmver.h>
 
 
@@ -52,11 +54,11 @@ std::vector<Nevra> Nevra::parse(const std::string & nevra_str, const std::vector
         } else if (*end == ':') {
             // ':' can be only once in nevra
             if (epoch_delim != nullptr) {
-                throw IncorrectNevraString("String contains ':' multiple times");
+                throw NevraIncorrectInputError(M_("NEVRA string \"{}\" contains ':' multiple times"), nevra_str);
             }
             epoch_delim = end;
         } else if (*end == '(' || *end == '/' || *end == '=' || *end == '<' || *end == '>' || *end == ' ') {
-            throw IncorrectNevraString("String contains not allowed character from set: '(', '/', '=', '<', '>', ' '");
+            throw NevraIncorrectInputError(M_("Invalid character '{}' in NEVRA string \"{}\""), *end, nevra_str);
         }
     }
     for (auto form : forms) {

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -2296,7 +2296,7 @@ std::pair<bool, libdnf::rpm::Nevra> PackageQuery::resolve_pkg_spec(
                     return {true, libdnf::rpm::Nevra()};
                 }
             }
-        } catch (Nevra::IncorrectNevraString &) {
+        } catch (const NevraIncorrectInputError &) {
         }
     }
     if (settings.with_provides) {

--- a/libdnf/rpm/package_sack.cpp
+++ b/libdnf/rpm/package_sack.cpp
@@ -47,7 +47,6 @@ using LibsolvRepo = Repo;
 
 namespace libdnf::rpm {
 
-
 void PackageSack::Impl::make_provides_ready() {
     if (provides_ready) {
         return;

--- a/libdnf/transaction/transaction.cpp
+++ b/libdnf/transaction/transaction.cpp
@@ -76,7 +76,7 @@ bool Transaction::operator>(const Transaction & other) const {
 
 void Transaction::start() {
     if (id != 0) {
-        throw std::runtime_error(_("Transaction has already started!"));
+        throw RuntimeError(M_("Transaction has already started!"));
     }
 
     auto conn = transaction_db_connect(sack.base);
@@ -130,7 +130,7 @@ void Transaction::finish(TransactionState state) {
 
 void Transaction::add_console_output_line(int file_descriptor, const std::string & line) {
     if (!get_id()) {
-        throw std::runtime_error(_("Can't add console output to unsaved transaction"));
+        throw RuntimeError(M_("Cannot add console output to unsaved transaction"));
     }
 
     auto conn = transaction_db_connect(sack.base);

--- a/libdnf/utils/iniparser.hpp
+++ b/libdnf/utils/iniparser.hpp
@@ -29,6 +29,61 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf {
 
+class IniParserError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf"; }
+    const char * get_name() const noexcept override { return "IniParserError"; }
+};
+
+class IniParserOpenFileError : public IniParserError {
+public:
+    using IniParserError::IniParserError;
+    const char * get_name() const noexcept override { return "IniParserOpenFileError"; }
+};
+
+class IniParserMissingSectionHeaderError : public IniParserError {
+public:
+    using IniParserError::IniParserError;
+    const char * get_name() const noexcept override { return "IniParserMissingSectionHeaderError"; }
+};
+
+class IniParserMissingBracketError : public IniParserError {
+public:
+    using IniParserError::IniParserError;
+    const char * get_name() const noexcept override { return "IniParserMissingBracketError"; }
+};
+
+class IniParserEmptySectionNameError : public IniParserError {
+public:
+    using IniParserError::IniParserError;
+    const char * get_name() const noexcept override { return "IniParserEmptySectionNameError"; }
+};
+
+class IniParserTextAfterSectionError : public IniParserError {
+public:
+    using IniParserError::IniParserError;
+    const char * get_name() const noexcept override { return "IniParserTextAfterSectionError"; }
+};
+
+class IniParserIllegalContinuationLineError : public IniParserError {
+public:
+    using IniParserError::IniParserError;
+    const char * get_name() const noexcept override { return "IniParserIllegalContinuationLineError"; }
+};
+
+class IniParserMissingKeyError : public IniParserError {
+public:
+    using IniParserError::IniParserError;
+    const char * get_name() const noexcept override { return "IniParserMissingKeyError"; }
+};
+
+class IniParserMissingEqualError : public IniParserError {
+public:
+    using IniParserError::IniParserError;
+    const char * get_name() const noexcept override { return "IniParserMissingEqualError"; }
+};
+
 /// @class IniParser
 ///
 /// @brief Simple .INI file parser
@@ -37,70 +92,6 @@ namespace libdnf {
 /// It parses input text to tokens - SECTION, KEY_VAL, COMMENT_LINE, EMPTY_LINE, and END_OF_INPUT.
 class IniParser {
 public:
-    class Exception : public RuntimeError {
-    public:
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::IniParser"; }
-        const char * get_name() const noexcept override { return "Exception"; }
-        const char * get_description() const noexcept override { return "IniParser exception"; }
-    };
-
-    class CantOpenFile : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "CantOpenFile"; }
-        const char * get_description() const noexcept override { return "Can't open file"; }
-    };
-
-    class MissingSectionHeader : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "MissingSectionHeader"; }
-        const char * get_description() const noexcept override { return "Missing section header"; }
-    };
-
-    class MissingBracket : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "MissingBracket"; }
-        const char * get_description() const noexcept override { return "Missing ']'"; }
-    };
-
-    class EmptySectionName : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "EmptySectionName"; }
-        const char * get_description() const noexcept override { return "Empty section name"; }
-    };
-
-    class TextAfterSection : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "TextAfterSection"; }
-        const char * get_description() const noexcept override { return "Text after section"; }
-    };
-
-    class IllegalContinuationLine : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "IllegalContinuationLine"; }
-        const char * get_description() const noexcept override { return "Illegal continuation line"; }
-    };
-
-    class MissingKey : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "MissingKey"; }
-        const char * get_description() const noexcept override { return "Missing key"; }
-    };
-
-    class MissingEqual : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "MissingEqual"; }
-        const char * get_description() const noexcept override { return "Missing '='"; }
-    };
-
     enum class ItemType {
         SECTION,       // [section_name]
         KEY_VAL,       // key = value, (multiline value supported)

--- a/libdnf/utils/library.hpp
+++ b/libdnf/utils/library.hpp
@@ -27,31 +27,29 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::utils {
 
+/// Library exception
+class LibraryError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf::utils"; }
+    const char * get_name() const noexcept override { return "LibraryError"; }
+};
+
+class LibraryLoadingError : public LibraryError {
+public:
+    using LibraryError::LibraryError;
+    const char * get_name() const noexcept override { return "LibraryLoadingError"; }
+};
+
+class LibrarySymbolNotFoundError : public LibraryError {
+public:
+    using LibraryError::LibraryError;
+    const char * get_name() const noexcept override { return "LibrarySymbolNotFoundError"; }
+};
+
+
 class Library {
 public:
-    /// Library exception
-    class Exception : public RuntimeError {
-    public:
-        using RuntimeError::RuntimeError;
-        const char * get_domain_name() const noexcept override { return "libdnf::Library"; }
-        const char * get_name() const noexcept override { return "Exception"; }
-        const char * get_description() const noexcept override { return "Library exception"; }
-    };
-
-    class CantLoad : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "CantLoad"; }
-        const char * get_description() const noexcept override { return "Can't load shared library"; }
-    };
-
-    class NotFound : public Exception {
-    public:
-        using Exception::Exception;
-        const char * get_name() const noexcept override { return "NotFound"; }
-        const char * get_description() const noexcept override { return "Can't obtain address of symbol"; }
-    };
-
     explicit Library(const std::string & path);
     ~Library();
 

--- a/libdnf/utils/xdg.cpp
+++ b/libdnf/utils/xdg.cpp
@@ -41,7 +41,7 @@ std::filesystem::path get_user_home_dir() {
     if (struct passwd * pw = getpwuid(getuid())) {
         return std::filesystem::path(pw->pw_dir);
     }
-    throw RuntimeError(M_("get_user_home_dir(): Can't determine the user's home directory"));
+    throw RuntimeError(M_("get_user_home_dir(): Cannot determine the user's home directory"));
 }
 
 std::filesystem::path get_user_cache_dir() {
@@ -85,7 +85,7 @@ std::filesystem::path get_user_runtime_dir() {
             return ret;
         }
     }
-    throw RuntimeError(M_("get_user_runtime_dir(): Can't determine the user's runtime directory"));
+    throw RuntimeError(M_("get_user_runtime_dir(): Cannot determine the user's runtime directory"));
 }
 
 }  // namespace libdnf::utils::xdg

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -654,12 +654,12 @@ int main(int argc, char * argv[]) try {
     // Run selected command
     try {
         context.get_selected_command()->run();
-    } catch (libdnf::cli::ArgumentParser::MissingCommand & ex) {
+    } catch (libdnf::cli::ArgumentParserMissingCommandError & ex) {
         // print help if no command is provided
         std::cout << ex.what() << std::endl;
         context.get_argument_parser().get_selected_command()->help();
         return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
-    } catch (libdnf::cli::ArgumentParser::Exception & ex) {
+    } catch (libdnf::cli::ArgumentParserError & ex) {
         std::cout << ex.what() << std::endl;
         return static_cast<int>(libdnf::cli::ExitCode::ARGPARSER_ERROR);
     } catch (std::exception & ex) {
@@ -671,6 +671,6 @@ int main(int argc, char * argv[]) try {
     log_router.info("Microdnf end");
 
     return static_cast<int>(libdnf::cli::ExitCode::SUCCESS);
-} catch (const libdnf::RuntimeError & e) {
-    std::cerr << e.what() << std::endl;
+} catch (const libdnf::Error & e) {
+    std::cerr << libdnf::format(e, false);
 }

--- a/test/libdnf-cli/test_argument_parser.cpp
+++ b/test/libdnf-cli/test_argument_parser.cpp
@@ -139,62 +139,62 @@ void ArgumentParserTest::test_argument_parser() {
 
     test->register_command(repoquery);
 
-    CPPUNIT_ASSERT_THROW(arg_parser.add_new_command("bad.id"), ArgParser::Argument::InvalidId);
-    CPPUNIT_ASSERT_THROW(arg_parser.add_new_named_arg("bad.id"), ArgParser::Argument::InvalidId);
+    CPPUNIT_ASSERT_THROW(arg_parser.add_new_command("bad.id"), libdnf::cli::ArgumentParserArgumentInvalidIdError);
+    CPPUNIT_ASSERT_THROW(arg_parser.add_new_named_arg("bad.id"), libdnf::cli::ArgumentParserArgumentInvalidIdError);
     CPPUNIT_ASSERT_THROW(
         arg_parser.add_new_positional_arg("bad.id", ArgParser::PositionalArg::UNLIMITED, nullptr, nullptr),
-        ArgParser::Argument::InvalidId);
+        libdnf::cli::ArgumentParserArgumentInvalidIdError);
 
     CPPUNIT_ASSERT_EQUAL(test, arg_parser.get_root_command());
 
     CPPUNIT_ASSERT_EQUAL(repoquery, &arg_parser.get_command("repoquery"));
-    CPPUNIT_ASSERT_THROW(arg_parser.get_command("unknowncmd"), ArgParser::Command::CommandNotFound);
-    CPPUNIT_ASSERT_THROW(arg_parser.get_command("global_arg"), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_command("unknowncmd"), libdnf::cli::ArgumentParserNotFoundError);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_command("global_arg"), libdnf::cli::ArgumentParserNotFoundError);
 
     CPPUNIT_ASSERT_EQUAL(global_arg, &arg_parser.get_named_arg("global_arg", false));
     CPPUNIT_ASSERT_EQUAL(global_arg, &arg_parser.get_named_arg("global_arg", true));
     CPPUNIT_ASSERT_EQUAL(installed, &arg_parser.get_named_arg("repoquery.installed", false));
     CPPUNIT_ASSERT_EQUAL(installed, &arg_parser.get_named_arg("repoquery.installed", true));
-    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.global_arg", false), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.global_arg", false), libdnf::cli::ArgumentParserNotFoundError);
     CPPUNIT_ASSERT_EQUAL(global_arg, &arg_parser.get_named_arg("repoquery.global_arg", true));
-    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("unknowncmd.installed", false), ArgParser::Command::CommandNotFound);
-    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("unknowncmd.installed", true), ArgParser::Command::CommandNotFound);
-    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.unknown", false), ArgParser::Command::NamedArgNotFound);
-    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.unknown", true), ArgParser::Command::NamedArgNotFound);
-    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.keys", false), ArgParser::Command::NamedArgNotFound);
-    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.keys", true), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("unknowncmd.installed", false), libdnf::cli::ArgumentParserNotFoundError);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("unknowncmd.installed", true), libdnf::cli::ArgumentParserNotFoundError);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.unknown", false), libdnf::cli::ArgumentParserNotFoundError);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.unknown", true), libdnf::cli::ArgumentParserNotFoundError);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.keys", false), libdnf::cli::ArgumentParserNotFoundError);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_named_arg("repoquery.keys", true), libdnf::cli::ArgumentParserNotFoundError);
 
     CPPUNIT_ASSERT_EQUAL(keys, &arg_parser.get_positional_arg("repoquery.keys", false));
     CPPUNIT_ASSERT_EQUAL(keys, &arg_parser.get_positional_arg("repoquery.keys", true));
-    CPPUNIT_ASSERT_THROW(arg_parser.get_positional_arg("unknowncmd.keys", false), ArgParser::Command::CommandNotFound);
-    CPPUNIT_ASSERT_THROW(arg_parser.get_positional_arg("unknowncmd.keys", true), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_positional_arg("unknowncmd.keys", false), libdnf::cli::ArgumentParserNotFoundError);
+    CPPUNIT_ASSERT_THROW(arg_parser.get_positional_arg("unknowncmd.keys", true), libdnf::cli::ArgumentParserNotFoundError);
     CPPUNIT_ASSERT_THROW(
-        arg_parser.get_positional_arg("repoquery.unknown", false), ArgParser::Command::PositionalArgNotFound);
+        arg_parser.get_positional_arg("repoquery.unknown", false), libdnf::cli::ArgumentParserNotFoundError);
     CPPUNIT_ASSERT_THROW(
-        arg_parser.get_positional_arg("repoquery.unknown", true), ArgParser::Command::PositionalArgNotFound);
+        arg_parser.get_positional_arg("repoquery.unknown", true), libdnf::cli::ArgumentParserNotFoundError);
     CPPUNIT_ASSERT_THROW(
-        arg_parser.get_positional_arg("repoquery.installed", false), ArgParser::Command::PositionalArgNotFound);
+        arg_parser.get_positional_arg("repoquery.installed", false), libdnf::cli::ArgumentParserNotFoundError);
     CPPUNIT_ASSERT_THROW(
-        arg_parser.get_positional_arg("repoquery.installed", true), ArgParser::Command::PositionalArgNotFound);
+        arg_parser.get_positional_arg("repoquery.installed", true), libdnf::cli::ArgumentParserNotFoundError);
 
     CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::Command *>{repoquery}), test->get_commands());
     CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::NamedArg *>{help, global_arg}), test->get_named_args());
     CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::PositionalArg *>{}), test->get_positional_args());
     CPPUNIT_ASSERT_EQUAL(repoquery, &test->get_command("repoquery"));
-    CPPUNIT_ASSERT_THROW(test->get_command("unknowncmd"), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(test->get_command("unknowncmd"), libdnf::cli::ArgumentParserNotFoundError);
     CPPUNIT_ASSERT_EQUAL(global_arg, &test->get_named_arg("global_arg"));
-    CPPUNIT_ASSERT_THROW(test->get_named_arg("unknown"), ArgParser::Command::NamedArgNotFound);
-    CPPUNIT_ASSERT_THROW(test->get_positional_arg("keys"), ArgParser::Command::PositionalArgNotFound);
+    CPPUNIT_ASSERT_THROW(test->get_named_arg("unknown"), libdnf::cli::ArgumentParserNotFoundError);
+    CPPUNIT_ASSERT_THROW(test->get_positional_arg("keys"), libdnf::cli::ArgumentParserNotFoundError);
 
     CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::Command *>{}), repoquery->get_commands());
     CPPUNIT_ASSERT_EQUAL(
         (std::vector<ArgParser::NamedArg *>{available, installed, info, nevra}), repoquery->get_named_args());
     CPPUNIT_ASSERT_EQUAL((std::vector<ArgParser::PositionalArg *>{keys}), repoquery->get_positional_args());
-    CPPUNIT_ASSERT_THROW(repoquery->get_command("repoquery"), ArgParser::Command::CommandNotFound);
+    CPPUNIT_ASSERT_THROW(repoquery->get_command("repoquery"), libdnf::cli::ArgumentParserNotFoundError);
     CPPUNIT_ASSERT_EQUAL(info, &repoquery->get_named_arg("info"));
-    CPPUNIT_ASSERT_THROW(repoquery->get_named_arg("unknown"), ArgParser::Command::NamedArgNotFound);
+    CPPUNIT_ASSERT_THROW(repoquery->get_named_arg("unknown"), libdnf::cli::ArgumentParserNotFoundError);
     CPPUNIT_ASSERT_EQUAL(keys, &repoquery->get_positional_arg("keys"));
-    CPPUNIT_ASSERT_THROW(repoquery->get_positional_arg("unknown"), ArgParser::Command::PositionalArgNotFound);
+    CPPUNIT_ASSERT_THROW(repoquery->get_positional_arg("unknown"), libdnf::cli::ArgumentParserNotFoundError);
 
     CPPUNIT_ASSERT_EQUAL(std::string("info"), info->get_id());
     CPPUNIT_ASSERT_EQUAL(info_option, dynamic_cast<libdnf::OptionBool *>(info->get_linked_value()));
@@ -218,6 +218,6 @@ void ArgumentParserTest::test_argument_parser() {
     {
         // "--info" and "--nevra" cannot be used together
         constexpr const char * argv[]{"test", "repoquery", "--nevra", "--info"};
-        CPPUNIT_ASSERT_THROW(arg_parser.parse(std::size(argv), argv), ArgParser::Conflict);
+        CPPUNIT_ASSERT_THROW(arg_parser.parse(std::size(argv), argv), libdnf::cli::ArgumentParserConflictingArgumentsError);
     }
 }

--- a/test/libdnf/conf/test_option.cpp
+++ b/test/libdnf/conf/test_option.cpp
@@ -88,7 +88,7 @@ void OptionTest::test_options_bool() {
     CPPUNIT_ASSERT_EQUAL(false, option.get_value());
     CPPUNIT_ASSERT_EQUAL(Option::Priority::RUNTIME, option.get_priority());
 
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, std::string("invalid")), Option::InvalidValue);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, std::string("invalid")), OptionInvalidValueError);
 
 
     const std::vector<std::string> MY_TRUE_VALUES{"1", "ano", "true", "zap"};
@@ -109,7 +109,7 @@ void OptionTest::test_options_bool() {
     CPPUNIT_ASSERT_EQUAL(false, option2.get_value());
     CPPUNIT_ASSERT_EQUAL(Option::Priority::RUNTIME, option2.get_priority());
 
-    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, std::string("invalid")), Option::InvalidValue);
+    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, std::string("invalid")), OptionInvalidValueError);
 
     option.lock("option locked by test_options_bool");
     CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, true), AssertionError);
@@ -143,7 +143,7 @@ void OptionTest::test_options_child() {
     CPPUNIT_ASSERT_EQUAL(true, ochild.get_value());
     CPPUNIT_ASSERT_EQUAL(Option::Priority::COMMANDLINE, ochild.get_priority());
 
-    CPPUNIT_ASSERT_THROW(ochild.set(Option::Priority::COMMANDLINE, std::string("invalid")), Option::InvalidValue);
+    CPPUNIT_ASSERT_THROW(ochild.set(Option::Priority::COMMANDLINE, std::string("invalid")), OptionInvalidValueError);
 
     ochild.set(Option::Priority::RUNTIME, true);
     ochild.lock("ochild_bool locked by test_option_child");
@@ -165,7 +165,7 @@ void OptionTest::test_options_enum() {
         CPPUNIT_ASSERT_EQUAL(val, option.get_value());
     }
 
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "not_allowed"), OptionEnum<std::string>::NotAllowedValue);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "not_allowed"), OptionValueNotAllowedError);
 
     option.set(Option::Priority::RUNTIME, "aa");
     option.lock("option locked by test_option_enum");
@@ -189,8 +189,8 @@ void OptionTest::test_options_number() {
         CPPUNIT_ASSERT_EQUAL(val, option.get_value());
     }
 
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, MIN - 1), OptionNumber<NumberType>::NotAllowedValue);
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, MAX + 1), OptionNumber<NumberType>::NotAllowedValue);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, MIN - 1), OptionValueNotAllowedError);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, MAX + 1), OptionValueNotAllowedError);
 
     option.set(Option::Priority::RUNTIME, 1);
     option.lock("option locked by test_option_number");
@@ -212,7 +212,7 @@ void OptionTest::test_options_path() {
     CPPUNIT_ASSERT_EQUAL(std::string("/path2"), option.get_value());
     CPPUNIT_ASSERT_EQUAL(Option::Priority::RUNTIME, option.get_priority());
 
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "not_absolute"), OptionPath::NotAllowedValue);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "not_absolute"), OptionValueNotAllowedError);
 
     option.lock("option locked by test_option_path");
     CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "/path2"), AssertionError);
@@ -236,8 +236,8 @@ void OptionTest::test_options_seconds() {
         CPPUNIT_ASSERT_EQUAL(val, option.get_value());
     }
 
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, MIN - 1), OptionSeconds::NotAllowedValue);
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, MAX + 1), OptionSeconds::NotAllowedValue);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, MIN - 1), OptionValueNotAllowedError);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, MAX + 1), OptionValueNotAllowedError);
 
     option.set(Option::Priority::RUNTIME, 12);
     option.lock("option locked by test_option_seconds");
@@ -267,10 +267,10 @@ void OptionTest::test_options_seconds() {
     option2.set(Option::Priority::RUNTIME, NEVER);
     CPPUNIT_ASSERT_EQUAL(NEVER, option2.get_value());
 
-    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, -2), OptionSeconds::NotAllowedValue);
-    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, "-2"), OptionSeconds::InvalidValue);
-    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, ""), OptionSeconds::InvalidValue);
-    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, "5g"), OptionSeconds::UnknownUnit);
+    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, -2), OptionValueNotAllowedError);
+    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, "-2"), OptionInvalidValueError);
+    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, ""), OptionInvalidValueError);
+    CPPUNIT_ASSERT_THROW(option2.set(Option::Priority::RUNTIME, "5g"), OptionInvalidValueError);
 }
 
 void OptionTest::test_options_string() {
@@ -291,7 +291,7 @@ void OptionTest::test_options_string() {
     CPPUNIT_ASSERT_EQUAL(std::string("do iT"), option.get_value());
     CPPUNIT_ASSERT_EQUAL(Option::Priority::RUNTIME, option.get_priority());
 
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "drain"), OptionString::NotAllowedValue);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "drain"), OptionValueNotAllowedError);
 
     option.lock("option locked by test_option_string");
     CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "do iT"), AssertionError);
@@ -317,8 +317,8 @@ void OptionTest::test_options_string_list() {
     CPPUNIT_ASSERT_EQUAL(DEFAULT, option.get_default_value());
     CPPUNIT_ASSERT_EQUAL((std::vector<std::string>{"Dfirstx", "DsecondX"}), option.get_value());
 
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, std::vector<std::string>{"donutX", "drain"}), OptionStringList::NotAllowedValue);
-    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "donutX, drain"), OptionStringList::NotAllowedValue);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, std::vector<std::string>{"donutX", "drain"}), OptionValueNotAllowedError);
+    CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "donutX, drain"), OptionValueNotAllowedError);
 
     option.lock("option locked by test_option_string_list");
     CPPUNIT_ASSERT_THROW(option.set(Option::Priority::RUNTIME, "do iT"), AssertionError);

--- a/test/libdnf/rpm/test_nevra.cpp
+++ b/test/libdnf/rpm/test_nevra.cpp
@@ -59,7 +59,7 @@ void NevraTest::test_nevra() {
     {
         CPPUNIT_ASSERT_THROW(
             libdnf::rpm::Nevra::parse("four-of-fish-8:9:3.6.9-11.fc100.x86_64", {libdnf::rpm::Nevra::Form::NEVRA}),
-            libdnf::rpm::Nevra::IncorrectNevraString);
+            libdnf::rpm::NevraIncorrectInputError);
     }
 
 
@@ -162,7 +162,7 @@ void NevraTest::test_nevra() {
     {
         CPPUNIT_ASSERT_THROW(
             libdnf::rpm::Nevra::parse("four-of(fish.i686)", {libdnf::rpm::Nevra::Form::NA}),
-            libdnf::rpm::Nevra::IncorrectNevraString);
+            libdnf::rpm::NevraIncorrectInputError);
     }
 
     // Test parsing NEVRA with glob in epoch

--- a/test/libdnf/rpm/test_reldep.cpp
+++ b/test/libdnf/rpm/test_reldep.cpp
@@ -71,6 +71,6 @@ void ReldepTest::test_rich_reldep() {
 
 
 void ReldepTest::test_invalid_reldep() {
-    CPPUNIT_ASSERT_THROW(libdnf::rpm::Reldep a(base, "(lab-list if labirinto.txt"), std::runtime_error);
-    CPPUNIT_ASSERT_THROW(libdnf::rpm::Reldep a(base, "labirinto = "), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(libdnf::rpm::Reldep a(base, "(lab-list if labirinto.txt"), libdnf::RuntimeError);
+    CPPUNIT_ASSERT_THROW(libdnf::rpm::Reldep a(base, "labirinto = "), libdnf::RuntimeError);
 }

--- a/test/libdnf/transaction/test_transaction.cpp
+++ b/test/libdnf/transaction/test_transaction.cpp
@@ -83,7 +83,7 @@ void TransactionTest::test_second_start_raises() {
     auto trans = base->get_transaction_sack()->new_transaction();
     trans->start();
     // 2nd begin must throw an exception
-    CPPUNIT_ASSERT_THROW(trans->start(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(trans->start(), libdnf::RuntimeError);
 }
 
 
@@ -92,7 +92,7 @@ void TransactionTest::test_save_with_specified_id_raises() {
     auto trans = base->get_transaction_sack()->new_transaction();
     trans->set_id(1);
     // it is not allowed to save a transaction with arbitrary ID
-    CPPUNIT_ASSERT_THROW(trans->start(), std::runtime_error);
+    CPPUNIT_ASSERT_THROW(trans->start(), libdnf::RuntimeError);
 }
 
 


### PR DESCRIPTION
* Exception classes are moved out of related classes.
* More detailed reports.
* Messages are marked for translation.
* Reduced number of exception types for Options and `ArgumentParser`
* `std::logic_error` replaced by `libdnf_assert`