### PR TITLE
[dnf5] C++20 compatibility changes and switch compiler to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ find_package(PkgConfig REQUIRED)
 
 
 # C++ standard
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # remove PROJECT_SOURCE_DIR prefix from __FILE__ macro used in asserts (available since GCC 8 and Clang 10)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -34,10 +34,15 @@ set(SWIG_COMPILE_OPTIONS
     -Wno-unused-parameter
 )
 
-if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
+        -Wno-deprecated-volatile
+    )
+else()
     set(SWIG_COMPILE_OPTIONS ${SWIG_COMPILE_OPTIONS}
         -Wno-catch-value
         -Wno-maybe-uninitialized
+        -Wno-volatile
     )
 endif()
 

--- a/include/libdnf/common/exception.hpp
+++ b/include/libdnf/common/exception.hpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_COMMON_EXCEPTION_HPP
 #define LIBDNF_COMMON_EXCEPTION_HPP
 
+#include "libdnf/utils/format.hpp"
+
 #include <fmt/format.h>
 
 #include <stdexcept>
@@ -102,7 +104,7 @@ public:
         : std::runtime_error(format),
         // stores the format args in the lambda's closure
         formatter([args...](const char * format) {
-            return fmt::format(format, args...);
+            return libdnf::utils::sformat(format, args...);
         }) {}
 
     Error(const Error & e) noexcept;

--- a/include/libdnf/utils/format.hpp
+++ b/include/libdnf/utils/format.hpp
@@ -1,0 +1,38 @@
+/*
+Copyright (C) 2021 Red Hat, Inc.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_UTILS_FORMAT_HPP
+#define LIBDNF_UTILS_FORMAT_HPP
+
+#include <fmt/format.h>
+
+
+namespace libdnf::utils {
+
+/// Format `args` according to the `runtime_format_string`, and return the result as a string.
+/// Unlike C++20 `std::format`, the format string of the `libdnf::sformat` function template
+/// does not have to be a constant expression.
+template <typename... Args>
+inline std::string sformat(std::string_view runtime_format_string, Args&&... args) {
+    return fmt::vformat(runtime_format_string, fmt::make_format_args(args...));
+}
+
+}
+
+#endif  // LIBDNF_UTILS_FORMAT_HPP

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -9,6 +9,11 @@ list(APPEND LIBDNF_PC_REQUIRES_PRIVATE)
 # set gettext domain for translations
 add_definitions(-DGETTEXT_DOMAIN=\"libdnf\")
 
+# If defined, libsolv adds the prefix "dep_" to solvable dependencies.
+# As a result, `requires` is renamed to `dep_requires`.
+# Needed for C++20. `requires` is a keyword in C++20.
+add_definitions(-DLIBSOLV_SOLVABLE_PREPEND_DEP)
+
 include_directories(.)
 
 # build libdnf.so

--- a/libdnf/base/log_event.cpp
+++ b/libdnf/base/log_event.cpp
@@ -19,11 +19,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 #include "libdnf/base/log_event.hpp"
+#include "libdnf/utils/format.hpp"
 
 #include "utils/bgettext/bgettext-lib.h"
 #include "utils/string.hpp"
-
-#include <fmt/format.h>
 
 namespace libdnf::base {
 
@@ -51,48 +50,48 @@ std::string LogEvent::to_string(
         // TODO(jmracek) Improve messages => Each message can contain also an action
         case GoalProblem::NOT_FOUND:
             if (action == GoalAction::REMOVE) {
-                return ret.append(fmt::format(_("No packages to remove for argument: {}"), *spec));
+                return ret.append(utils::sformat(_("No packages to remove for argument: {}"), *spec));
             }
-            return ret.append(fmt::format(_("No match for argument: {}"), *spec));
+            return ret.append(utils::sformat(_("No match for argument: {}"), *spec));
         case GoalProblem::NOT_FOUND_IN_REPOSITORIES:
-            return ret.append(fmt::format(
+            return ret.append(utils::sformat(
                 _("No match for argument '{0}' in repositories '{1}'"),
                 *spec,
                 utils::string::join(settings->to_repo_ids, ", ")));
         case GoalProblem::NOT_INSTALLED:
-            return ret.append(fmt::format(_("Packages for argument '{}' available, but not installed."), *spec));
+            return ret.append(utils::sformat(_("Packages for argument '{}' available, but not installed."), *spec));
         case GoalProblem::NOT_INSTALLED_FOR_ARCHITECTURE:
-            return ret.append(fmt::format(
+            return ret.append(utils::sformat(
                 _("Packages for argument '{}' available, but installed for a different architecture."), *spec));
         case GoalProblem::ONLY_SRC:
-            return ret.append(fmt::format(_("Argument '{}' matches only source packages."), *spec));
+            return ret.append(utils::sformat(_("Argument '{}' matches only source packages."), *spec));
         case GoalProblem::EXCLUDED:
-            return ret.append(fmt::format(_("Argument '{}' matches only excluded packages."), *spec));
+            return ret.append(utils::sformat(_("Argument '{}' matches only excluded packages."), *spec));
         case GoalProblem::HINT_ICASE:
-            return ret.append(fmt::format(_("  * Maybe you meant: {}"), *spec));
+            return ret.append(utils::sformat(_("  * Maybe you meant: {}"), *spec));
         case GoalProblem::HINT_ALTERNATIVES: {
             auto elements = utils::string::join(*additional_data, ", ");
-            return ret.append(fmt::format(_("There are following alternatives for '{0}': {1}"), *spec, elements));
+            return ret.append(utils::sformat(_("There are following alternatives for '{0}': {1}"), *spec, elements));
         }
         case GoalProblem::INSTALLED_LOWEST_VERSION: {
             if (additional_data->size() != 1) {
                 throw std::invalid_argument("Incorrect number of elements for INSTALLED_LOWEST_VERSION");
             }
-            return ret.append(fmt::format(
+            return ret.append(utils::sformat(
                 _("Package \"{}\" of lowest version already installed, cannot downgrade it."),
                 *additional_data->begin()));
         }
         case GoalProblem::INSTALLED_IN_DIFFERENT_VERSION:
             if (action == GoalAction::REINSTALL) {
-                return ret.append(fmt::format(
+                return ret.append(utils::sformat(
                     _("Packages for argument '{}' installed and available, but in a different version => cannot "
                       "reinstall"),
                     *spec));
             }
-            return ret.append(fmt::format(
+            return ret.append(utils::sformat(
                 _("Packages for argument '{}' installed and available, but in a different version."), *spec));
         case GoalProblem::NOT_AVAILABLE:
-            return ret.append(fmt::format(_("Packages for argument '{}' installed, but not available."), *spec));
+            return ret.append(utils::sformat(_("Packages for argument '{}' installed, but not available."), *spec));
         case GoalProblem::NO_PROBLEM:
         case GoalProblem::SOLVER_ERROR:
             throw std::invalid_argument("Unsupported elements for a goal problem");
@@ -100,7 +99,7 @@ std::string LogEvent::to_string(
             if (additional_data->size() != 1) {
                 throw std::invalid_argument("Incorrect number of elements for ALREADY_INSTALLED");
             }
-            return ret.append(fmt::format(_("Package \"{}\" is already installed."), *additional_data->begin()));
+            return ret.append(utils::sformat(_("Package \"{}\" is already installed."), *additional_data->begin()));
     }
     return ret;
 }

--- a/libdnf/base/solver_problems.cpp
+++ b/libdnf/base/solver_problems.cpp
@@ -20,6 +20,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "solver_problems_impl.hpp"
 
+#include "libdnf/utils/format.hpp"
+
 #include "utils/bgettext/bgettext-lib.h"
 #include "utils/string.hpp"
 
@@ -206,7 +208,7 @@ std::string SolverProblems::problem_to_string(
             if (raw.second.size() != 1) {
                 throw std::invalid_argument("Incorrect number of elements for a problem rule");
             }
-            return fmt::format(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0]);
+            return utils::sformat(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0]);
         case ProblemRules::RULE_JOB:
         case ProblemRules::RULE_JOB_UNSUPPORTED:
         case ProblemRules::RULE_PKG:
@@ -222,7 +224,7 @@ std::string SolverProblems::problem_to_string(
             if (raw.second.size() != 2) {
                 throw std::invalid_argument("Incorrect number of elements for a problem rule");
             }
-            return fmt::format(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0], raw.second[1]);
+            return utils::sformat(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0], raw.second[1]);
         case ProblemRules::RULE_PKG_CONFLICTS:
         case ProblemRules::RULE_PKG_OBSOLETES:
         case ProblemRules::RULE_PKG_INSTALLED_OBSOLETES:
@@ -231,7 +233,7 @@ std::string SolverProblems::problem_to_string(
             if (raw.second.size() != 3) {
                 throw std::invalid_argument("Incorrect number of elements for a problem rule");
             }
-            return fmt::format(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0], raw.second[1], raw.second[2]);
+            return utils::sformat(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), raw.second[0], raw.second[1], raw.second[2]);
         case ProblemRules::RULE_UNKNOWN:
             if (raw.second.size() != 0) {
                 throw std::invalid_argument("Incorrect number of elements for a problem rule");
@@ -240,7 +242,7 @@ std::string SolverProblems::problem_to_string(
         case ProblemRules::RULE_PKG_REMOVAL_OF_PROTECTED:
         case ProblemRules::RULE_PKG_REMOVAL_OF_RUNNING_KERNEL:
             auto elements = utils::string::join(raw.second, ", ");
-            return fmt::format(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), elements);
+            return utils::sformat(TM_(PKG_PROBLEMS_DICT.at(raw.first), 1), elements);
     }
     return {};
 }
@@ -258,13 +260,13 @@ std::string SolverProblems::to_string() const {
     }
     const char * problem_prefix = _("Problem {}: ");
 
-    output.append(fmt::format(problem_prefix, 1));
+    output.append(utils::sformat(problem_prefix, 1));
     output.append(string_join(*p_impl->problems.begin(), "\n  - "));
 
     int index = 2;
     for (auto iter = std::next(p_impl->problems.begin()); iter != p_impl->problems.end(); ++iter) {
         output.append("\n ");
-        output.append(fmt::format(problem_prefix, index));
+        output.append(utils::sformat(problem_prefix, index));
         output.append(string_join(*iter, "\n  - "));
         ++index;
     }

--- a/libdnf/comps/group/group.cpp
+++ b/libdnf/comps/group/group.cpp
@@ -213,14 +213,14 @@ std::vector<Package> Group::get_packages() {
     Solvable * solvable = pool.id2solvable(group_ids[0].id);
 
     // Load MANDATORY pacakges from solvable->requires
-    if (solvable->requires) {
-        for (Id * r_id = solvable->repo->idarraydata + solvable->requires; *r_id; ++r_id) {
+    if (solvable->dep_requires) {
+        for (Id * r_id = solvable->repo->idarraydata + solvable->dep_requires; *r_id; ++r_id) {
             packages.push_back(Package(pool.id2str(*r_id), PackageType::MANDATORY, ""));
         }
     }
     // Load DEFAULT and CONDITIONAL pacakges from solvable->recommends
-    if (solvable->recommends) {
-        for (Id * r_id = solvable->repo->idarraydata + solvable->recommends; *r_id; ++r_id) {
+    if (solvable->dep_recommends) {
+        for (Id * r_id = solvable->repo->idarraydata + solvable->dep_recommends; *r_id; ++r_id) {
             if (strcmp(pool.id2rel(*r_id), "") == 0) {
                 packages.push_back(Package(pool.id2str(*r_id), PackageType::DEFAULT, ""));
             }
@@ -230,8 +230,8 @@ std::vector<Package> Group::get_packages() {
         }
     }
     // Load OPTIONAL pacakges from solvable->suggests
-    if (solvable->suggests) {
-        for (Id * r_id = solvable->repo->idarraydata + solvable->suggests; *r_id; ++r_id) {
+    if (solvable->dep_suggests) {
+        for (Id * r_id = solvable->repo->idarraydata + solvable->dep_suggests; *r_id; ++r_id) {
             if (strcmp(pool.id2rel(*r_id), "") == 0) {
                 packages.push_back(Package(pool.id2str(*r_id), PackageType::OPTIONAL, ""));
             }

--- a/libdnf/plugin/plugins.cpp
+++ b/libdnf/plugin/plugins.cpp
@@ -81,27 +81,27 @@ void Plugins::register_plugin(std::unique_ptr<Plugin> && plugin) {
     auto name = iplugin->get_name();
     auto version = iplugin->get_version();
     logger.debug(fmt::format(
-        _("Added plugin name=\"{}\", version=\"{}.{}.{}\""), name, version.major, version.minor, version.micro));
+        "Added plugin name=\"{}\", version=\"{}.{}.{}\"", name, version.major, version.minor, version.micro));
 
-    logger.debug(fmt::format(_("Trying to load more plugins using the \"{}\" plugin."), name));
+    logger.debug(fmt::format("Trying to load more plugins using the \"{}\" plugin.", name));
     iplugin->load_plugins(base);
-    logger.debug(fmt::format(_("End of loading plugins using the \"{}\" plugin."), name));
+    logger.debug(fmt::format("End of loading plugins using the \"{}\" plugin.", name));
 }
 
 void Plugins::load_plugin(const std::string & file_path) {
     auto & logger = *base->get_logger();
-    logger.debug(fmt::format(_("Loading plugin file=\"{}\""), file_path));
+    logger.debug(fmt::format("Loading plugin file=\"{}\"", file_path));
     auto plugin = std::make_unique<PluginLibrary>(file_path);
     auto * iplugin = plugin->get_iplugin();
     plugins.emplace_back(std::move(plugin));
     auto name = iplugin->get_name();
     auto version = iplugin->get_version();
     logger.debug(fmt::format(
-        _("Loaded plugin name=\"{}\", version=\"{}.{}.{}\""), name, version.major, version.minor, version.micro));
+        "Loaded plugin name=\"{}\", version=\"{}.{}.{}\"", name, version.major, version.minor, version.micro));
 
-    logger.debug(fmt::format(_("Trying to load more plugins using the \"{}\" plugin."), name));
+    logger.debug(fmt::format("Trying to load more plugins using the \"{}\" plugin.", name));
     iplugin->load_plugins(base);
-    logger.debug(fmt::format(_("End of loading plugins using the \"{}\" plugin."), name));
+    logger.debug(fmt::format("End of loading plugins using the \"{}\" plugin.", name));
 }
 
 void Plugins::load_plugins(const std::string & dir_path) {
@@ -122,7 +122,7 @@ void Plugins::load_plugins(const std::string & dir_path) {
         try {
             load_plugin(p);
         } catch (const std::exception & ex) {
-            std::string msg = fmt::format(_("Cannot load plugin \"{}\": {}"), p.string(), ex.what());
+            std::string msg = fmt::format("Cannot load plugin \"{}\": {}", p.string(), ex.what());
             logger.error(msg);
             cant_load = true;
         }

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -408,7 +408,7 @@ bool Repo::Impl::fetch_metadata() {
     if (!get_metadata_path(RepoDownloader::MD_FILENAME_PRIMARY).empty() || try_load_cache()) {
         reset_metadata_expired();
         if (!expired || sync_strategy == SyncStrategy::ONLY_CACHE || sync_strategy == SyncStrategy::LAZY) {
-            logger.debug(fmt::format(_("repo: using cache for: {}"), config.get_id()));
+            logger.debug(fmt::format("repo: using cache for: {}", config.get_id()));
             return false;
         }
 
@@ -423,7 +423,7 @@ bool Repo::Impl::fetch_metadata() {
         throw RepoError(M_("Cache-only enabled but no cache for repository \"{}\""), config.get_id());
     }
 
-    logger.debug(fmt::format(_("repo: downloading from remote: {}"), config.get_id()));
+    logger.debug(fmt::format("repo: downloading from remote: {}", config.get_id()));
     downloader.download_metadata(config.get_cachedir());
     timestamp = -1;
     read_metadata_cache();

--- a/libdnf/repo/repo_downloader.cpp
+++ b/libdnf/repo/repo_downloader.cpp
@@ -374,7 +374,7 @@ bool RepoDownloader::is_metalink_in_sync() try {
     LrMetalink * metalink;
     handle_get_info(h.get(), LRI_METALINK, &metalink);
     if (!metalink) {
-        logger.debug(fmt::format(_("reviving: repo '{}' skipped, no metalink."), config.get_id()));
+        logger.debug(fmt::format("reviving: repo '{}' skipped, no metalink.", config.get_id()));
         return false;
     }
 
@@ -393,7 +393,7 @@ bool RepoDownloader::is_metalink_in_sync() try {
         }
     }
     if (hashes.empty()) {
-        logger.debug(fmt::format(_("reviving: repo '{}' skipped, no usable hash."), config.get_id()));
+        logger.debug(fmt::format("reviving: repo '{}' skipped, no usable hash.", config.get_id()));
         return false;
     }
 
@@ -417,12 +417,12 @@ bool RepoDownloader::is_metalink_in_sync() try {
         solv_bin2hex(chksum, chksumLen, chksumHex);
         if (strcmp(chksumHex, hash.lr_metalink_hash->value) != 0) {
             logger.debug(
-                fmt::format(_("reviving: failed for '{}', mismatched {} sum."), config.get_id(), hash.lr_metalink_hash->type));
+                fmt::format("reviving: failed for '{}', mismatched {} sum.", config.get_id(), hash.lr_metalink_hash->type));
             return false;
         }
     }
 
-    logger.debug(fmt::format(_("reviving: '{}' can be revived - metalink checksums match."), config.get_id()));
+    logger.debug(fmt::format("reviving: '{}' can be revived - metalink checksums match.", config.get_id()));
     return true;
 } catch (const std::runtime_error & e) {
     throw_with_nested(RepoDownloadError(
@@ -449,9 +449,9 @@ bool RepoDownloader::is_repomd_in_sync() try {
 
     auto same = utils::fs::have_files_same_content_noexcept(repomd_filename.c_str(), yum_repo->repomd);
     if (same)
-        logger.debug(fmt::format(_("reviving: '{}' can be revived - repomd matches."), config.get_id()));
+        logger.debug(fmt::format("reviving: '{}' can be revived - repomd matches.", config.get_id()));
     else
-        logger.debug(fmt::format(_("reviving: failed for '{}', mismatched repomd."), config.get_id()));
+        logger.debug(fmt::format("reviving: failed for '{}', mismatched repomd.", config.get_id()));
     return same;
 } catch (const std::runtime_error & e) {
     auto src = get_source_info();

--- a/libdnf/repo/repo_gpgme.cpp
+++ b/libdnf/repo/repo_gpgme.cpp
@@ -94,7 +94,7 @@ static void ensure_socket_dir_exists(Logger & logger) {
     std::string dirname = "/run/user/" + std::to_string(getuid());
     int res = mkdir(dirname.c_str(), 0700);
     if (res != 0 && errno != EEXIST) {
-        logger.debug(fmt::format(_("Failed to create directory \"{}\": {} - {}"), dirname, errno, strerror(errno)));
+        logger.debug(fmt::format("Failed to create directory \"{}\": {} - {}", dirname, errno, strerror(errno)));
     }
 }
 
@@ -248,7 +248,7 @@ void RepoGpgme::import_key(int fd, const std::string & url) {
 
     for (auto & key_info : key_infos) {
         if (std::find(known_keys.begin(), known_keys.end(), key_info.get_id()) != known_keys.end()) {
-            logger.debug(fmt::format(_("Gpg key 0x{} for repository {} already imported."), key_info.get_id(), config.get_id()));
+            logger.debug(fmt::format("Gpg key 0x{} for repository {} already imported.", key_info.get_id(), config.get_id()));
             continue;
         }
 
@@ -270,7 +270,7 @@ void RepoGpgme::import_key(int fd, const std::string & url) {
 
         gpg_import_key(context.get(), key_info.raw_key);
 
-        logger.debug(fmt::format(_("Imported gpg key 0x{} for repository {}."), key_info.get_id(), config.get_id()));
+        logger.debug(fmt::format("Imported gpg key 0x{} for repository {}.", key_info.get_id(), config.get_id()));
     }
 }
 

--- a/libdnf/repo/solv_repo.cpp
+++ b/libdnf/repo/solv_repo.cpp
@@ -319,7 +319,7 @@ bool SolvRepo::load_system_repo(const std::string & rootdir) {
     int flagsrpm = REPO_REUSE_REPODATA | RPM_ADD_WITH_HDRID | REPO_USE_ROOTDIR;
     int rc = repo_add_rpmdb(repo, nullptr, flagsrpm);
     if (rc != 0) {
-        logger.warning(fmt::format(_("load_system_repo(): failed loading RPMDB: {}"), pool_errstr(*pool)));
+        logger.warning(fmt::format("load_system_repo(): failed loading RPMDB: {}", pool_errstr(*pool)));
         return false;
     }
 

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -1789,7 +1789,7 @@ PackageQuery & PackageQuery::filter_obsoletes(const PackageSet & package_set, li
         Solvable * solvable = spool.id2solvable(package_id);
         if (!solvable->repo)
             continue;
-        for (Id * r_id = solvable->repo->idarraydata + solvable->obsoletes; *r_id; ++r_id) {
+        for (Id * r_id = solvable->repo->idarraydata + solvable->dep_obsoletes; *r_id; ++r_id) {
             Id r;
             Id rr;
 

--- a/libdnf/rpm/solv/goal_private.cpp
+++ b/libdnf/rpm/solv/goal_private.cpp
@@ -99,11 +99,11 @@ void init_solver(Pool * pool, Solver ** solver) {
 
 /// @brief return false when does not depend on anything from b
 bool can_depend_on(Pool * pool, Solvable * sa, Id b) {
-    libdnf::solv::IdQueue requires;
+    libdnf::solv::IdQueue dep_requires;
 
-    solvable_lookup_idarray(sa, SOLVABLE_REQUIRES, &requires.get_queue());
-    for (int i = 0; i < requires.size(); ++i) {
-        Id req_dep = requires[i];
+    solvable_lookup_idarray(sa, SOLVABLE_REQUIRES, &dep_requires.get_queue());
+    for (int i = 0; i < dep_requires.size(); ++i) {
+        Id req_dep = dep_requires[i];
         Id p, pp;
 
         FOR_PROVIDES(p, pp, req_dep)

--- a/test/libdnf/comps/test_group.cpp
+++ b/test/libdnf/comps/test_group.cpp
@@ -23,10 +23,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/comps/group/query.hpp"
 #include "libdnf/comps/group/package.hpp"
 
-extern "C" {
-#include <solv/repo.h>
-}
-
 #include <filesystem>
 #include <fstream>
 

--- a/test/libdnf/solv/test_solv_map.hpp
+++ b/test/libdnf/solv/test_solv_map.hpp
@@ -24,8 +24,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "solv/solv_map.hpp"
 
-#include <solv/pool.h>
-
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
 


### PR DESCRIPTION
First, merge https://github.com/rpm-software-management/libdnf/pull/1391 first. Then I rebase this PR.

The code could only be compiled with C++17. PR modifies the code to be compatible with C++20 and switches the compiler to C++20 mode.

* Remove libsolv includes from unit tests

* Logs untranslated messages
The code was inconsistent. Some of the logged messages were translated. Untranslated messages are now written to the log.

* Introduces `sformat`: replacing `fmt::format` in cases when the formatting message is a non-constant expression
In C++20, the `format` function template requires that the format argument be convertible to `std::string_view` or `std::wstring_view`, and the conversion results in a **constant expression** and a valid format string for the arguments.
Sometimes we do not know the format string at compile time because we use text translation at runtime. The commit adds `sformat` function template, which accepts the runtime computed format string.

* Rename local variable `requires` to `dep_requires`
Compatibility with C++20. `requires` is a keyword in C++20.

* Uses the new libsolv, witch renames `Solvable` dependencies - adding the prefix "dep_" to them - https://github.com/openSUSE/libsolv/pull/477
Compatibility with C++20. One of the `Solvable` dependencies is called `requires`. This will rename it to `dep_requires`. `requires` is a keyword in C++20.

* Swithes the compiler to C++20 mode

Requires https://github.com/openSUSE/libsolv/pull/477 .