### PR TITLE
[dnf5] Improve solv::SolvMap, advisory::AdvisorySet, rpm::PackageSet, and their iterators

### DIFF
--- a/include/libdnf/advisory/advisory_set.hpp
+++ b/include/libdnf/advisory/advisory_set.hpp
@@ -46,6 +46,8 @@ namespace libdnf::advisory {
 
 class AdvisorySet {
 public:
+    using iterator = AdvisorySetIterator;
+
     explicit AdvisorySet(const libdnf::BaseWeakPtr & base);
     explicit AdvisorySet(libdnf::Base & base);
 
@@ -58,9 +60,8 @@ public:
     AdvisorySet & operator=(const AdvisorySet & src);
     AdvisorySet & operator=(AdvisorySet && src);
 
-    using iterator = AdvisorySetIterator;
-    iterator begin() const;
-    iterator end() const;
+    iterator begin() const { return AdvisorySetIterator::begin(*this); }
+    iterator end() const { return AdvisorySetIterator::end(*this); }
 
     AdvisorySet & operator|=(const AdvisorySet & other);
 

--- a/include/libdnf/advisory/advisory_set_iterator.hpp
+++ b/include/libdnf/advisory/advisory_set_iterator.hpp
@@ -35,15 +35,17 @@ class AdvisorySet;
 
 class AdvisorySetIterator {
 public:
-    explicit AdvisorySetIterator(const AdvisorySet & advisory_set);
-    AdvisorySetIterator(const AdvisorySetIterator & other);
-    ~AdvisorySetIterator();
-
     using iterator_category = std::forward_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = Advisory;
     using pointer = void;
     using reference = Advisory;
+
+    AdvisorySetIterator(const AdvisorySetIterator & other);
+    ~AdvisorySetIterator();
+
+    static AdvisorySetIterator begin(const AdvisorySet & advisory_set);
+    static AdvisorySetIterator end(const AdvisorySet & advisory_set);
 
     Advisory operator*();
 
@@ -57,6 +59,8 @@ public:
     void end();
 
 private:
+    explicit AdvisorySetIterator(const AdvisorySet & advisory_set);
+
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/include/libdnf/advisory/advisory_set_iterator.hpp
+++ b/include/libdnf/advisory/advisory_set_iterator.hpp
@@ -44,6 +44,8 @@ public:
     AdvisorySetIterator(const AdvisorySetIterator & other);
     ~AdvisorySetIterator();
 
+    AdvisorySetIterator & operator=(const AdvisorySetIterator & other);
+
     static AdvisorySetIterator begin(const AdvisorySet & advisory_set);
     static AdvisorySetIterator end(const AdvisorySet & advisory_set);
 

--- a/include/libdnf/rpm/package_set.hpp
+++ b/include/libdnf/rpm/package_set.hpp
@@ -42,6 +42,8 @@ namespace libdnf::rpm {
 /// @replaces libdnf:sack/packageset.hpp:struct:PackageSet
 class PackageSet {
 public:
+    using iterator = PackageSetIterator;
+
     /// @replaces libdnf:hy-packageset.h:function:dnf_packageset_new(DnfSack * sack)
     explicit PackageSet(const libdnf::BaseWeakPtr & base);
     explicit PackageSet(libdnf::Base & base);
@@ -57,9 +59,8 @@ public:
     PackageSet & operator=(const PackageSet & src);
     PackageSet & operator=(PackageSet && src);
 
-    using iterator = PackageSetIterator;
-    iterator begin() const;
-    iterator end() const;
+    iterator begin() const { return iterator::begin(*this); }
+    iterator end() const { return iterator::end(*this); }
 
     // @replaces libdnf:sack/packageset.hpp:method:PackageSet.operator+=(const libdnf::PackageSet & other)
     PackageSet & operator|=(const PackageSet & other);

--- a/include/libdnf/rpm/package_set_iterator.hpp
+++ b/include/libdnf/rpm/package_set_iterator.hpp
@@ -35,15 +35,17 @@ class PackageSet;
 
 class PackageSetIterator {
 public:
-    explicit PackageSetIterator(const PackageSet & package_set);
-    PackageSetIterator(const PackageSetIterator & other);
-    ~PackageSetIterator();
-
     using iterator_category = std::forward_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = Package;
     using pointer = void;
     using reference = Package;
+
+    PackageSetIterator(const PackageSetIterator & other);
+    ~PackageSetIterator();
+
+    static PackageSetIterator begin(const PackageSet & package_set);
+    static PackageSetIterator end(const PackageSet & package_set);
 
     Package operator*();
 
@@ -57,6 +59,8 @@ public:
     void end();
 
 private:
+    explicit PackageSetIterator(const PackageSet & package_set);
+
     class Impl;
     std::unique_ptr<Impl> p_impl;
 };

--- a/include/libdnf/rpm/package_set_iterator.hpp
+++ b/include/libdnf/rpm/package_set_iterator.hpp
@@ -44,6 +44,8 @@ public:
     PackageSetIterator(const PackageSetIterator & other);
     ~PackageSetIterator();
 
+    PackageSetIterator & operator=(const PackageSetIterator & other);
+
     static PackageSetIterator begin(const PackageSet & package_set);
     static PackageSetIterator end(const PackageSet & package_set);
 

--- a/libdnf/advisory/advisory_set.cpp
+++ b/libdnf/advisory/advisory_set.cpp
@@ -57,19 +57,6 @@ AdvisorySet & AdvisorySet::operator=(AdvisorySet && other) {
     return *this;
 }
 
-AdvisorySet::iterator AdvisorySet::begin() const {
-    AdvisorySet::iterator it(*this);
-    it.begin();
-    return it;
-}
-
-
-AdvisorySet::iterator AdvisorySet::end() const {
-    AdvisorySet::iterator it(*this);
-    it.end();
-    return it;
-}
-
 
 AdvisorySet & AdvisorySet::operator|=(const AdvisorySet & other) {
     libdnf_assert_same_base(p_impl->base, other.p_impl->base);

--- a/libdnf/advisory/advisory_set_impl.hpp
+++ b/libdnf/advisory/advisory_set_impl.hpp
@@ -70,12 +70,10 @@ inline AdvisorySet::Impl::Impl(const BaseWeakPtr & base, libdnf::solv::SolvMap &
     : libdnf::solv::SolvMap::SolvMap(solv_map),
       base(base) {}
 
-inline AdvisorySet::Impl::Impl(const Impl & other)
-    : libdnf::solv::SolvMap::SolvMap(other.get_map()),
-      base(other.base) {}
+inline AdvisorySet::Impl::Impl(const Impl & other) : libdnf::solv::SolvMap::SolvMap(other), base(other.base) {}
 
 inline AdvisorySet::Impl::Impl(Impl && other)
-    : libdnf::solv::SolvMap::SolvMap(std::move(other.get_map())),
+    : libdnf::solv::SolvMap::SolvMap(std::move(other)),
       base(std::move(other.base)) {}
 
 inline AdvisorySet::Impl & AdvisorySet::Impl::operator=(const Impl & other) {

--- a/libdnf/advisory/advisory_set_iterator.cpp
+++ b/libdnf/advisory/advisory_set_iterator.cpp
@@ -30,16 +30,14 @@ class AdvisorySetIterator::Impl : private libdnf::solv::SolvMap::iterator {
 private:
     Impl(const AdvisorySet & advisory_set)
         : libdnf::solv::SolvMap::iterator(advisory_set.p_impl->get_map()),
-          advisory_set{advisory_set} {}
-
-    Impl(const AdvisorySetIterator::Impl & advisory_set_iterator_impl) = default;
+          advisory_set{&advisory_set} {}
 
     AdvisorySetIterator::Impl & operator++() {
         libdnf::solv::SolvMap::iterator::operator++();
         return *this;
     }
 
-    const AdvisorySet & advisory_set;
+    const AdvisorySet * advisory_set;
 
     friend AdvisorySetIterator;
 };
@@ -50,6 +48,12 @@ AdvisorySetIterator::AdvisorySetIterator(const AdvisorySet & advisory_set) : p_i
 AdvisorySetIterator::AdvisorySetIterator(const AdvisorySetIterator & other) : p_impl{new Impl(*other.p_impl)} {}
 
 AdvisorySetIterator::~AdvisorySetIterator() = default;
+
+
+AdvisorySetIterator & AdvisorySetIterator::operator=(const AdvisorySetIterator & other) {
+    *p_impl = *other.p_impl;
+    return *this;
+}
 
 
 AdvisorySetIterator AdvisorySetIterator::begin(const AdvisorySet & advisory_set) {
@@ -76,7 +80,7 @@ void AdvisorySetIterator::end() {
 
 
 Advisory AdvisorySetIterator::operator*() {
-    return {p_impl->advisory_set.get_base(), libdnf::advisory::AdvisoryId(**p_impl)};
+    return {p_impl->advisory_set->get_base(), libdnf::advisory::AdvisoryId(**p_impl)};
 }
 
 

--- a/libdnf/advisory/advisory_set_iterator.cpp
+++ b/libdnf/advisory/advisory_set_iterator.cpp
@@ -26,8 +26,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::advisory {
 
-class AdvisorySetIterator::Impl : public libdnf::solv::SolvMap::iterator {
-public:
+class AdvisorySetIterator::Impl : private libdnf::solv::SolvMap::iterator {
+private:
     Impl(const AdvisorySet & advisory_set)
         : libdnf::solv::SolvMap::iterator(advisory_set.p_impl->get_map()),
           advisory_set{advisory_set} {}
@@ -39,9 +39,9 @@ public:
         return *this;
     }
 
-private:
-    friend AdvisorySetIterator;
     const AdvisorySet & advisory_set;
+
+    friend AdvisorySetIterator;
 };
 
 
@@ -49,7 +49,21 @@ AdvisorySetIterator::AdvisorySetIterator(const AdvisorySet & advisory_set) : p_i
 
 AdvisorySetIterator::AdvisorySetIterator(const AdvisorySetIterator & other) : p_impl{new Impl(*other.p_impl)} {}
 
-AdvisorySetIterator::~AdvisorySetIterator() {}
+AdvisorySetIterator::~AdvisorySetIterator() = default;
+
+
+AdvisorySetIterator AdvisorySetIterator::begin(const AdvisorySet & advisory_set) {
+    AdvisorySetIterator it(advisory_set);
+    it.begin();
+    return it;
+}
+
+
+AdvisorySetIterator AdvisorySetIterator::end(const AdvisorySet & advisory_set) {
+    AdvisorySetIterator it(advisory_set);
+    it.end();
+    return it;
+}
 
 void AdvisorySetIterator::begin() {
     p_impl->begin();

--- a/libdnf/rpm/package_set.cpp
+++ b/libdnf/rpm/package_set.cpp
@@ -56,19 +56,6 @@ PackageSet & PackageSet::operator=(PackageSet && other) {
     return *this;
 }
 
-PackageSet::iterator PackageSet::begin() const {
-    PackageSet::iterator it(*this);
-    it.begin();
-    return it;
-}
-
-
-PackageSet::iterator PackageSet::end() const {
-    PackageSet::iterator it(*this);
-    it.end();
-    return it;
-}
-
 
 PackageSet & PackageSet::operator|=(const PackageSet & other) {
     libdnf_assert_same_base(p_impl->base, other.p_impl->base);

--- a/libdnf/rpm/package_set_impl.hpp
+++ b/libdnf/rpm/package_set_impl.hpp
@@ -70,10 +70,10 @@ inline PackageSet::Impl::Impl(const BaseWeakPtr & base, libdnf::solv::SolvMap & 
     : libdnf::solv::SolvMap::SolvMap(solv_map),
       base(base) {}
 
-inline PackageSet::Impl::Impl(const Impl & other) : libdnf::solv::SolvMap::SolvMap(other.get_map()), base(other.base) {}
+inline PackageSet::Impl::Impl(const Impl & other) : libdnf::solv::SolvMap::SolvMap(other), base(other.base) {}
 
 inline PackageSet::Impl::Impl(Impl && other)
-    : libdnf::solv::SolvMap::SolvMap(std::move(other.get_map())),
+    : libdnf::solv::SolvMap::SolvMap(std::move(other)),
       base(std::move(other.base)) {}
 
 inline PackageSet::Impl & PackageSet::Impl::operator=(const Impl & other) {

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -30,16 +30,14 @@ class PackageSetIterator::Impl : private libdnf::solv::SolvMap::iterator {
 private:
     Impl(const PackageSet & package_set)
         : libdnf::solv::SolvMap::iterator(package_set.p_impl->get_map()),
-          package_set{package_set} {}
-
-    Impl(const PackageSetIterator::Impl & package_set_iterator_impl) = default;
+          package_set{&package_set} {}
 
     PackageSetIterator::Impl & operator++() {
         libdnf::solv::SolvMap::iterator::operator++();
         return *this;
     }
 
-    const PackageSet & package_set;
+    const PackageSet * package_set;
 
     friend PackageSetIterator;
 };
@@ -50,6 +48,12 @@ PackageSetIterator::PackageSetIterator(const PackageSet & package_set) : p_impl{
 PackageSetIterator::PackageSetIterator(const PackageSetIterator & other) : p_impl{new Impl(*other.p_impl)} {}
 
 PackageSetIterator::~PackageSetIterator() = default;
+
+
+PackageSetIterator & PackageSetIterator::operator=(const PackageSetIterator & other) {
+    *p_impl = *other.p_impl;
+    return *this;
+}
 
 
 PackageSetIterator PackageSetIterator::begin(const PackageSet & package_set) {
@@ -76,7 +80,7 @@ void PackageSetIterator::end() {
 
 
 Package PackageSetIterator::operator*() {
-    return {p_impl->package_set.get_base(), libdnf::rpm::PackageId(**p_impl)};
+    return {p_impl->package_set->get_base(), libdnf::rpm::PackageId(**p_impl)};
 }
 
 

--- a/libdnf/rpm/package_set_iterator.cpp
+++ b/libdnf/rpm/package_set_iterator.cpp
@@ -26,8 +26,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::rpm {
 
-class PackageSetIterator::Impl : public libdnf::solv::SolvMap::iterator {
-public:
+class PackageSetIterator::Impl : private libdnf::solv::SolvMap::iterator {
+private:
     Impl(const PackageSet & package_set)
         : libdnf::solv::SolvMap::iterator(package_set.p_impl->get_map()),
           package_set{package_set} {}
@@ -39,9 +39,9 @@ public:
         return *this;
     }
 
-private:
-    friend PackageSetIterator;
     const PackageSet & package_set;
+
+    friend PackageSetIterator;
 };
 
 
@@ -49,7 +49,21 @@ PackageSetIterator::PackageSetIterator(const PackageSet & package_set) : p_impl{
 
 PackageSetIterator::PackageSetIterator(const PackageSetIterator & other) : p_impl{new Impl(*other.p_impl)} {}
 
-PackageSetIterator::~PackageSetIterator() {}
+PackageSetIterator::~PackageSetIterator() = default;
+
+
+PackageSetIterator PackageSetIterator::begin(const PackageSet & package_set) {
+    PackageSetIterator it(package_set);
+    it.begin();
+    return it;
+}
+
+
+PackageSetIterator PackageSetIterator::end(const PackageSet & package_set) {
+    PackageSetIterator it(package_set);
+    it.end();
+    return it;
+}
 
 void PackageSetIterator::begin() {
     p_impl->begin();

--- a/libdnf/rpm/solv/goal_private.cpp
+++ b/libdnf/rpm/solv/goal_private.cpp
@@ -45,7 +45,7 @@ void allow_uninstall_all_but_protected(
         not_protected_pkgs.remove_unsafe(protected_kernel.id);
     }
     if (pool->considered) {
-        not_protected_pkgs &= pool->considered;
+        not_protected_pkgs &= *pool->considered;
     }
 
     for (Id id = 1; id < pool->nsolvables; ++id) {

--- a/libdnf/solv/solv_map.hpp
+++ b/libdnf/solv/solv_map.hpp
@@ -49,7 +49,7 @@ public:
     using pointer = void;
     using reference = Id;
 
-    explicit SolvMapIterator(const Map * map) noexcept : map{map}, map_end{map->map + map->size} { begin(); }
+    explicit SolvMapIterator(const Map & map) noexcept : map{&map}, map_end{map.map + map.size} { begin(); }
 
     SolvMapIterator(const SolvMapIterator & other) noexcept = default;
 
@@ -111,7 +111,7 @@ public:
     SolvMap(const SolvMap & other) : SolvMap(other.get_map()) {}
 
     /// Clones from an existing libsolv Map.
-    explicit SolvMap(const Map * map) { map_init_clone(&this->map, map); }
+    explicit SolvMap(const Map & map) { map_init_clone(&this->map, &map); }
 
     SolvMap(SolvMap && other) noexcept {
         map = other.map;
@@ -124,10 +124,10 @@ public:
     SolvMap & operator=(const SolvMap & other) noexcept;
     SolvMap & operator=(SolvMap && other) noexcept;
 
-    iterator begin() const { return iterator(&map); }
+    iterator begin() const { return iterator(map); }
 
     iterator end() const {
-        iterator it(&map);
+        iterator it(map);
         it.end();
         return it;
     }
@@ -145,7 +145,7 @@ public:
     /// Sets all bits in the map to 0.
     void clear() noexcept { map_empty(&map); }
 
-    const Map * get_map() const noexcept { return &map; }
+    const Map & get_map() const noexcept { return map; }
 
     /// @return the number of solvables in the SolvMap (number of 1s in the bitmap).
     std::size_t size() const noexcept;
@@ -179,20 +179,20 @@ public:
     // SET OPERATIONS - Map
 
     /// Union operator
-    SolvMap & operator|=(const Map * other) noexcept {
-        map_or(&map, const_cast<Map *>(other));
+    SolvMap & operator|=(const Map & other) noexcept {
+        map_or(&map, const_cast<Map *>(&other));
         return *this;
     }
 
     /// Difference operator
-    SolvMap & operator-=(const Map * other) noexcept {
-        map_subtract(&map, const_cast<Map *>(other));
+    SolvMap & operator-=(const Map & other) noexcept {
+        map_subtract(&map, const_cast<Map *>(&other));
         return *this;
     }
 
     /// Intersection operator
-    SolvMap & operator&=(const Map * other) noexcept {
-        map_and(&map, other);
+    SolvMap & operator&=(const Map & other) noexcept {
+        map_and(&map, &other);
         return *this;
     }
 

--- a/libdnf/solv/solv_map.hpp
+++ b/libdnf/solv/solv_map.hpp
@@ -49,40 +49,54 @@ public:
     using pointer = void;
     using reference = Id;
 
-    explicit SolvMapIterator(const Map & map) noexcept : map{&map}, map_end{map.map + map.size} { begin(); }
+    [[nodiscard]] static SolvMapIterator begin(const Map & map) noexcept {
+        SolvMapIterator it(map);
+        it.begin();
+        return it;
+    }
 
-    SolvMapIterator(const SolvMapIterator & other) noexcept = default;
+    [[nodiscard]] static SolvMapIterator end(const Map & map) noexcept {
+        SolvMapIterator it(map);
+        it.end();
+        return it;
+    }
 
-    Id operator*() const noexcept { return current_value; }
+    [[nodiscard]] Id operator*() const noexcept { return current_value; }
 
     SolvMapIterator & operator++() noexcept;
 
-    SolvMapIterator operator++(int) noexcept {
+    [[nodiscard]] SolvMapIterator operator++(int) noexcept {
         SolvMapIterator it(*this);
         ++*this;
         return it;
     }
 
-    bool operator==(const SolvMapIterator & other) const noexcept { return current_value == other.current_value; }
+    [[nodiscard]] bool operator==(const SolvMapIterator & other) const noexcept {
+        return current_value == other.current_value;
+    }
 
-    bool operator!=(const SolvMapIterator & other) const noexcept { return current_value != other.current_value; }
+    [[nodiscard]] bool operator!=(const SolvMapIterator & other) const noexcept {
+        return current_value != other.current_value;
+    }
 
+    /// Sets the iterator to the first contained item or to the end if there are no items.
     void begin() noexcept {
         current_value = BEGIN;
         map_current = map->map;
         ++*this;
     }
 
+    /// Sets the iterator to the end.
     void end() noexcept {
         current_value = END;
         map_current = map_end;
     }
 
-    /// Sets iterator to the first contained package in the range <id, end>.
+    /// Sets the iterator to the first contained item in the range <id, end>.
     void jump(Id id) noexcept;
 
 protected:
-    const Map * get_map() const noexcept { return map; }
+    explicit SolvMapIterator(const Map & map) noexcept : map{&map}, map_end{map.map + map.size} {}
 
 private:
     constexpr static int BEGIN = -1;
@@ -124,13 +138,8 @@ public:
     SolvMap & operator=(const SolvMap & other) noexcept;
     SolvMap & operator=(SolvMap && other) noexcept;
 
-    iterator begin() const { return iterator(map); }
-
-    iterator end() const {
-        iterator it(map);
-        it.end();
-        return it;
-    }
+    [[nodiscard]] iterator begin() const { return iterator::begin(map); }
+    [[nodiscard]] iterator end() const { return iterator::end(map); }
 
     // GENERIC OPERATIONS
 
@@ -145,16 +154,16 @@ public:
     /// Sets all bits in the map to 0.
     void clear() noexcept { map_empty(&map); }
 
-    const Map & get_map() const noexcept { return map; }
+    [[nodiscard]] const Map & get_map() const noexcept { return map; }
 
     /// @return the number of solvables in the SolvMap (number of 1s in the bitmap).
-    std::size_t size() const noexcept;
+    [[nodiscard]] std::size_t size() const noexcept;
 
     /// @return the size allocated for the map in memory (in number of items, not bytes).
-    int allocated_size() const noexcept { return map.size << 3; }
+    [[nodiscard]] int allocated_size() const noexcept { return map.size << 3; }
 
     /// @return whether the map is empty.
-    bool empty() const noexcept;
+    [[nodiscard]] bool empty() const noexcept;
 
     // ITEM OPERATIONS
 
@@ -163,18 +172,18 @@ public:
         add_unsafe(id);
     }
 
-    void add_unsafe(Id id) noexcept;
+    void add_unsafe(Id id) noexcept { map_set(&map, id); }
 
-    bool contains(Id id) const noexcept;
+    [[nodiscard]] bool contains(Id id) const noexcept;
 
-    bool contains_unsafe(Id id) const noexcept { return MAPTST(&map, id); }
+    [[nodiscard]] bool contains_unsafe(Id id) const noexcept { return MAPTST(&map, id); }
 
     void remove(Id id) {
         check_id_in_bitmap_range(id);
         remove_unsafe(id);
     }
 
-    void remove_unsafe(Id id) noexcept;
+    void remove_unsafe(Id id) noexcept { map_clr(&map, id); }
 
     // SET OPERATIONS - Map
 
@@ -329,22 +338,6 @@ inline bool SolvMap::contains(Id id) const noexcept {
         return false;
     }
     return contains_unsafe(id);
-}
-
-
-inline void SolvMap::add_unsafe(Id id) noexcept {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-    MAPSET(&map, id);
-#pragma GCC diagnostic pop
-}
-
-
-inline void SolvMap::remove_unsafe(Id id) noexcept {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-    MAPCLR(&map, id);
-#pragma GCC diagnostic pop
 }
 
 

--- a/libdnf/solv/solv_map.hpp
+++ b/libdnf/solv/solv_map.hpp
@@ -180,13 +180,13 @@ public:
 
     /// Union operator
     SolvMap & operator|=(const Map & other) noexcept {
-        map_or(&map, const_cast<Map *>(&other));
+        map_or(&map, &other);
         return *this;
     }
 
     /// Difference operator
     SolvMap & operator-=(const Map & other) noexcept {
-        map_subtract(&map, const_cast<Map *>(&other));
+        map_subtract(&map, &other);
         return *this;
     }
 

--- a/libdnf/solv/solv_map.hpp
+++ b/libdnf/solv/solv_map.hpp
@@ -41,7 +41,7 @@ static const unsigned char BIT_COUNT_LOOKUP[256] = {
 // clang-format on
 
 
-class SolvMapIterator {
+class ConstMapIterator {
 public:
     using iterator_category = std::forward_iterator_tag;
     using difference_type = std::ptrdiff_t;
@@ -49,33 +49,33 @@ public:
     using pointer = void;
     using reference = Id;
 
-    [[nodiscard]] static SolvMapIterator begin(const Map & map) noexcept {
-        SolvMapIterator it(map);
+    [[nodiscard]] static ConstMapIterator begin(const Map & map) noexcept {
+        ConstMapIterator it(map);
         it.begin();
         return it;
     }
 
-    [[nodiscard]] static SolvMapIterator end(const Map & map) noexcept {
-        SolvMapIterator it(map);
+    [[nodiscard]] static ConstMapIterator end(const Map & map) noexcept {
+        ConstMapIterator it(map);
         it.end();
         return it;
     }
 
     [[nodiscard]] Id operator*() const noexcept { return current_value; }
 
-    SolvMapIterator & operator++() noexcept;
+    ConstMapIterator & operator++() noexcept;
 
-    [[nodiscard]] SolvMapIterator operator++(int) noexcept {
-        SolvMapIterator it(*this);
+    [[nodiscard]] ConstMapIterator operator++(int) noexcept {
+        ConstMapIterator it(*this);
         ++*this;
         return it;
     }
 
-    [[nodiscard]] bool operator==(const SolvMapIterator & other) const noexcept {
+    [[nodiscard]] bool operator==(const ConstMapIterator & other) const noexcept {
         return current_value == other.current_value;
     }
 
-    [[nodiscard]] bool operator!=(const SolvMapIterator & other) const noexcept {
+    [[nodiscard]] bool operator!=(const ConstMapIterator & other) const noexcept {
         return current_value != other.current_value;
     }
 
@@ -96,7 +96,7 @@ public:
     void jump(Id id) noexcept;
 
 protected:
-    explicit SolvMapIterator(const Map & map) noexcept : map{&map}, map_end{map.map + map.size} {}
+    explicit ConstMapIterator(const Map & map) noexcept : map{&map}, map_end{map.map + map.size} {}
 
 private:
     constexpr static int BEGIN = -1;
@@ -118,7 +118,8 @@ private:
 
 class SolvMap {
 public:
-    using iterator = SolvMapIterator;
+    using iterator = ConstMapIterator;
+    using const_iterator = ConstMapIterator;
 
     explicit SolvMap(int size) { map_init(&map, size); }
 
@@ -138,8 +139,8 @@ public:
     SolvMap & operator=(const SolvMap & other) noexcept;
     SolvMap & operator=(SolvMap && other) noexcept;
 
-    [[nodiscard]] iterator begin() const { return iterator::begin(map); }
-    [[nodiscard]] iterator end() const { return iterator::end(map); }
+    [[nodiscard]] const_iterator begin() const { return const_iterator::begin(map); }
+    [[nodiscard]] const_iterator end() const { return const_iterator::end(map); }
 
     // GENERIC OPERATIONS
 
@@ -239,7 +240,7 @@ private:
 };
 
 
-inline SolvMapIterator & SolvMapIterator::operator++() noexcept {
+inline ConstMapIterator & ConstMapIterator::operator++() noexcept {
     if (current_value >= 0) {
         // make a copy of byte with the previous match to avoid changing the map
         unsigned char byte = *map_current;
@@ -279,7 +280,7 @@ inline SolvMapIterator & SolvMapIterator::operator++() noexcept {
 }
 
 
-inline void SolvMapIterator::jump(Id id) noexcept {
+inline void ConstMapIterator::jump(Id id) noexcept {
     if (id < 0) {
         begin();
         return;

--- a/test/libdnf/advisory/test_advisory_set.cpp
+++ b/test/libdnf/advisory/test_advisory_set.cpp
@@ -176,6 +176,10 @@ void AdvisoryAdvisorySetTest::test_iterator() {
     CPPUNIT_ASSERT_EQUAL((*it2).get_id().id, 2);
     CPPUNIT_ASSERT_EQUAL((*it3).get_id().id, 1);
 
+    // test copy assignment
+    it1 = it2;
+    CPPUNIT_ASSERT_EQUAL((*it1).get_id().id, 2);
+
     // test begin()
     it1.begin();
     CPPUNIT_ASSERT_EQUAL((*it1).get_id().id, 0);

--- a/test/libdnf/rpm/test_package_set.cpp
+++ b/test/libdnf/rpm/test_package_set.cpp
@@ -182,6 +182,10 @@ void RpmPackageSetTest::test_iterator() {
     CPPUNIT_ASSERT_EQUAL((*it2).get_id().id, 2);
     CPPUNIT_ASSERT_EQUAL((*it3).get_id().id, 1);
 
+    // test copy assignment
+    it1 = it2;
+    CPPUNIT_ASSERT_EQUAL((*it1).get_id().id, 2);
+
     // test begin()
     it1.begin();
     CPPUNIT_ASSERT_EQUAL((*it1).get_id().id, 0);

--- a/test/libdnf/solv/test_solv_map.cpp
+++ b/test/libdnf/solv/test_solv_map.cpp
@@ -260,7 +260,7 @@ void SolvMapTest::test_iterator_performance_full() {
     // initialize a map filed with ones
     constexpr int max = 1000000;
     libdnf::solv::SolvMap map(max);
-    memset(map.get_map()->map, 255, static_cast<std::size_t>(map.get_map()->size));
+    memset(map.get_map().map, 255, static_cast<std::size_t>(map.get_map().size));
 
     for (int i = 0; i < 500; i++) {
         std::vector<Id> result;
@@ -275,7 +275,7 @@ void SolvMapTest::test_iterator_performance_4bits() {
     // initialize a map filed with 00001111 bytes
     constexpr int max = 1000000;
     libdnf::solv::SolvMap map(max);
-    memset(map.get_map()->map, 15, static_cast<std::size_t>(map.get_map()->size));
+    memset(map.get_map().map, 15, static_cast<std::size_t>(map.get_map().size));
 
     for (int i = 0; i < 500; i++) {
         std::vector<Id> result;

--- a/test/libdnf/solv/test_solv_map.cpp
+++ b/test/libdnf/solv/test_solv_map.cpp
@@ -139,7 +139,7 @@ void SolvMapTest::test_iterator_empty() {
     std::vector<Id> expected = {};
     std::vector<Id> result;
     libdnf::solv::SolvMap map(16);
-    for (auto it = map.begin(); it != map.end(); it++) {
+    for (auto it = map.begin(); it != map.end(); ++it) {
         result.push_back(*it);
     }
     CPPUNIT_ASSERT(result == expected);
@@ -182,6 +182,10 @@ void SolvMapTest::test_iterator_sparse() {
     CPPUNIT_ASSERT_EQUAL(*it2, 10);
     CPPUNIT_ASSERT_EQUAL(*it3, 6);
 
+    // test copy assignment
+    it1 = it2;
+    CPPUNIT_ASSERT_EQUAL(*it1, 10);
+
     // test move back to begin
     it2.begin();
     CPPUNIT_ASSERT_EQUAL(*it2, 4);
@@ -206,10 +210,13 @@ void SolvMapTest::test_iterator_sparse() {
     // test loop with post-increment operator
     {
         std::vector<Id> result;
-        for (auto it = map.begin(), end = map.end(); it != end; it++) {
+        std::vector<Id> result2;
+        for (auto it = map.begin(), end = map.end(), prev = it; it != end; prev = it++) {
             result.push_back(*it);
+            result2.push_back(*prev);
         }
         CPPUNIT_ASSERT(result == expected);
+        CPPUNIT_ASSERT(result2 == (std::vector<Id>{4, 4, 6, 10, 11}));
     }
 
     // test jump to existing package
@@ -249,7 +256,7 @@ void SolvMapTest::test_iterator_performance_empty() {
 
     for (int i = 0; i < 500; i++) {
         std::vector<Id> result;
-        for (auto it = map.begin(); it != map.end(); it++) {
+        for (auto it = map.begin(); it != map.end(); ++it) {
             result.push_back(*it);
         }
     }
@@ -262,9 +269,9 @@ void SolvMapTest::test_iterator_performance_full() {
     libdnf::solv::SolvMap map(max);
     memset(map.get_map().map, 255, static_cast<std::size_t>(map.get_map().size));
 
-    for (int i = 0; i < 500; i++) {
+    for (int i = 0; i < 500; ++i) {
         std::vector<Id> result;
-        for (auto it = map.begin(); it != map.end(); it++) {
+        for (auto it = map.begin(); it != map.end(); ++it) {
             result.push_back(*it);
         }
     }
@@ -277,9 +284,9 @@ void SolvMapTest::test_iterator_performance_4bits() {
     libdnf::solv::SolvMap map(max);
     memset(map.get_map().map, 15, static_cast<std::size_t>(map.get_map().size));
 
-    for (int i = 0; i < 500; i++) {
+    for (int i = 0; i < 500; ++i) {
         std::vector<Id> result;
-        for (auto it = map.begin(); it != map.end(); it++) {
+        for (auto it = map.begin(); it != map.end(); ++it) {
             result.push_back(*it);
         }
     }


### PR DESCRIPTION
* use references where the null pointer must not appear
* removes `const_cast` for calling Libsolv `map_*` functions
* fixes/optimizes `rpm::PackageSet` and `advisory::AdvisorySet` move constructors to move internal `Map` instead of copying
* `solv::SolvMapIterator` - Optimization of `SolvMapIterator` construction. The class now provides the factory methods `begin` and `end`. This is better than the previous solution, where the constructor always sets the iterator to "begin", which is expensive - it looks for  the first item on the map. And then it calls `end` if we want an iterator at the end.
* implements copy assignment operator for iterators, including unit tests
* remove `solv::SolvMapIterator::get_map` method - not needed
* Added `[[nodiscard]]` attribute for `SolvMap` and `SolvMapIterator` methods - forces the user to write the correct and optimal code. For example, use `++it` instead of the slower `it++` when the iterator return value is not used. Cannot be used in headers processed by swig (e.g. in `PackageSet`). Swig does not support attributes.
* Cleans `SolvMap` the code so we don't have to turn off "conversion" GCC diagnostics.
* Rename `solv::SolvMapIterator` to `solv::ConstMapIterator` - works with Map and it is not possible to mutate elements in Map via this iterator.
* `advisory::AdvisorySet` and `rpm::PackageSet` - iterators now provide the factory methods `begin` and `end`, similar to `solv::MapIterator`.