### PR TITLE
[dnf5] Dump dnf log on a unittest failure

### DIFF
--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -29,27 +29,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "services/rpm/rpm.hpp"
 #include "utils.hpp"
 
-#include <libdnf/logger/logger.hpp>
+#include <libdnf/logger/stream_logger.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
 #include <chrono>
 #include <iostream>
 #include <string>
 
-namespace {
-
-class StderrLogger : public libdnf::StringLogger {
-public:
-    explicit StderrLogger() {}
-    void write(const char * line) noexcept override {
-        try {
-            std::cerr << line;
-        } catch (...) {
-        }
-    }
-};
-
-}  // namespace
 
 Session::Session(
     sdbus::IConnection & connection,
@@ -64,7 +50,7 @@ Session::Session(
       sender(sender) {
     // set-up log router for base
     auto & logger = *base->get_logger();
-    logger.add_logger(std::make_unique<StderrLogger>());
+    logger.add_logger(std::make_unique<libdnf::StdCStreamLogger>(std::cerr));
 
     auto & config = base->get_config();
 

--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -38,18 +38,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace {
 
-class StderrLogger : public libdnf::Logger {
+class StderrLogger : public libdnf::StringLogger {
 public:
     explicit StderrLogger() {}
-    void write(time_t, pid_t, Level, const std::string & message) noexcept override;
-};
-
-void StderrLogger::write(time_t, pid_t, Level, const std::string & message) noexcept {
-    try {
-        std::cerr << message << std::endl;
-    } catch (...) {
+    void write(const char * line) noexcept override {
+        try {
+            std::cerr << line;
+        } catch (...) {
+        }
     }
-}
+};
 
 }  // namespace
 

--- a/include/libdnf/logger/log_router.hpp
+++ b/include/libdnf/logger/log_router.hpp
@@ -49,7 +49,12 @@ public:
     size_t get_loggers_count() const noexcept { return loggers.size(); }
 
     void log(Level level, const std::string & message) noexcept override;
-    void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept override;
+
+    void write(
+        const std::chrono::time_point<std::chrono::system_clock> & time,
+        pid_t pid,
+        Level level,
+        const std::string & message) noexcept override;
 
 private:
     std::vector<std::unique_ptr<Logger>> loggers;

--- a/include/libdnf/logger/logger.hpp
+++ b/include/libdnf/logger/logger.hpp
@@ -83,6 +83,13 @@ private:
 #endif
 };
 
+class StringLogger : public Logger {
+public:
+    void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept override;
+
+    virtual void write(const char * line) noexcept = 0;
+};
+
 }  // namespace libdnf
 
 #endif

--- a/include/libdnf/logger/logger.hpp
+++ b/include/libdnf/logger/logger.hpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <unistd.h>
 
 #include <array>
-#include <ctime>
+#include <chrono>
 #include <string>
 
 
@@ -74,7 +74,11 @@ public:
     virtual void log(Level level, const std::string & message) noexcept;
 
     /// @replaces libdnf:utils/logger.hpp:method:Logger.write(time_t time, pid_t pid, libdnf::Logger::Level level, const std::string & message)
-    virtual void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept = 0;
+    virtual void write(
+        const std::chrono::time_point<std::chrono::system_clock> & time,
+        pid_t pid,
+        Level level,
+        const std::string & message) noexcept = 0;
 
 private:
 #ifndef SWIG
@@ -85,7 +89,11 @@ private:
 
 class StringLogger : public Logger {
 public:
-    void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept override;
+    void write(
+        const std::chrono::time_point<std::chrono::system_clock> & time,
+        pid_t pid,
+        Level level,
+        const std::string & message) noexcept override;
 
     virtual void write(const char * line) noexcept = 0;
 };

--- a/include/libdnf/logger/memory_buffer_logger.hpp
+++ b/include/libdnf/logger/memory_buffer_logger.hpp
@@ -33,14 +33,20 @@ namespace libdnf {
 class MemoryBufferLogger : public Logger {
 public:
     struct Item {
-        time_t time;
+        std::chrono::time_point<std::chrono::system_clock> time;
         pid_t pid;
         Level level;
         std::string message;
     };
 
     explicit MemoryBufferLogger(std::size_t max_items_to_keep, std::size_t reserve = 0);
-    void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept override;
+
+    void write(
+        const std::chrono::time_point<std::chrono::system_clock> & time,
+        pid_t pid,
+        Level level,
+        const std::string & message) noexcept override;
+
     std::size_t get_items_count() const { return items.size(); }
     const Item & get_item(std::size_t item_idx) const;
     void clear() noexcept;

--- a/include/libdnf/logger/stream_logger.hpp
+++ b/include/libdnf/logger/stream_logger.hpp
@@ -30,10 +30,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf {
 
 /// StreamLogger is an implementation of logging class that writes messages into a stream.
-class StreamLogger : public Logger {
+class StreamLogger : public StringLogger {
 public:
     explicit StreamLogger(std::unique_ptr<std::ostream> && log_stream) : log_stream(std::move(log_stream)) {}
-    void write(time_t time, pid_t pid, Level level, const std::string & message) noexcept override;
+    void write(const char * line) noexcept override;
 
 private:
     mutable std::mutex stream_mutex;

--- a/include/libdnf/logger/stream_logger.hpp
+++ b/include/libdnf/logger/stream_logger.hpp
@@ -40,6 +40,17 @@ private:
     std::unique_ptr<std::ostream> log_stream;
 };
 
+/// Logger that logs to a stream stored as a reference, meant to be used with std::cerr and std::cout.
+class StdCStreamLogger : public StringLogger {
+public:
+    explicit StdCStreamLogger(std::ostream & stream) : log_stream(stream) {}
+    void write(const char * line) noexcept override;
+
+private:
+    mutable std::mutex stream_mutex;
+    std::ostream & log_stream;
+};
+
 }  // namespace libdnf
 
 #endif

--- a/libdnf/logger/log_router.cpp
+++ b/libdnf/logger/log_router.cpp
@@ -28,14 +28,19 @@ std::unique_ptr<Logger> LogRouter::release_logger(size_t index) {
 }
 
 void LogRouter::log(Level level, const std::string & message) noexcept {
-    auto now = time(nullptr);
+    auto now = std::chrono::system_clock::now();
     auto pid = getpid();
     for (auto & logger : loggers) {
         logger->write(now, pid, level, message);
     }
 }
 
-void LogRouter::write(time_t time, pid_t pid, Level level, const std::string & message) noexcept {
+
+void LogRouter::write(
+    const std::chrono::time_point<std::chrono::system_clock> & time,
+    pid_t pid,
+    Level level,
+    const std::string & message) noexcept {
     for (auto & logger : loggers) {
         logger->write(time, pid, level, message);
     }

--- a/libdnf/logger/logger.cpp
+++ b/libdnf/logger/logger.cpp
@@ -19,10 +19,36 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/logger/logger.hpp"
 
+#include <iomanip>
+#include <sstream>
+
+
 namespace libdnf {
 
 void Logger::log(Level level, const std::string & message) noexcept {
     write(time(nullptr), getpid(), level, message);
+}
+
+
+void StringLogger::write(time_t time, pid_t pid, Level level, const std::string & message) noexcept {
+    try {
+        struct tm now;
+
+        // gmtime_r() is used because it is thread-safe (std::gmtime() is not).
+        gmtime_r(&time, &now);
+
+        std::ostringstream ss;
+        ss << std::put_time(&now, "%FT%TZ [");  // "YYYY-MM-DDTHH:MM:SSZ ["
+        ss << pid << "] ";
+        ss << level_to_cstr(level) << " " << message << "\n";
+        write(ss.str().c_str());
+    } catch (const std::exception & e) {
+        write("Failed to format: ");
+        write(message.c_str());
+        write(" (");
+        write(e.what());
+        write(")\n");
+    }
 }
 
 }  // namespace libdnf

--- a/libdnf/logger/memory_buffer_logger.cpp
+++ b/libdnf/logger/memory_buffer_logger.cpp
@@ -29,7 +29,12 @@ MemoryBufferLogger::MemoryBufferLogger(std::size_t max_items_to_keep, std::size_
     }
 }
 
-void MemoryBufferLogger::write(time_t time, pid_t pid, Level level, const std::string & message) noexcept {
+
+void MemoryBufferLogger::write(
+    const std::chrono::time_point<std::chrono::system_clock> & time,
+    pid_t pid,
+    Level level,
+    const std::string & message) noexcept {
     try {
         std::lock_guard<std::mutex> guard(items_mutex);
         if (max_items == 0 || items.size() < max_items) {

--- a/libdnf/logger/stream_logger.cpp
+++ b/libdnf/logger/stream_logger.cpp
@@ -19,24 +19,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/logger/stream_logger.hpp"
 
-#include <iomanip>
-#include <sstream>
 
 namespace libdnf {
 
-void StreamLogger::write(time_t time, pid_t pid, Level level, const std::string & message) noexcept {
+void StreamLogger::write(const char * line) noexcept {
     try {
-        struct tm now;
-
-        // gmtime_r() is used because it is thread-safe (std::gmtime() is not).
-        gmtime_r(&time, &now);
-
-        std::ostringstream ss;
-        ss << std::put_time(&now, "%FT%TZ [");  // "YYYY-MM-DDTHH:MM:SSZ ["
-        ss << pid << "] ";
-        ss << level_to_cstr(level) << " " << message << "\n";
         std::lock_guard<std::mutex> guard(stream_mutex);
-        *log_stream << ss.str() << std::flush;
+        *log_stream << line << std::flush;
     } catch (...) {
     }
 }

--- a/libdnf/logger/stream_logger.cpp
+++ b/libdnf/logger/stream_logger.cpp
@@ -30,4 +30,13 @@ void StreamLogger::write(const char * line) noexcept {
     }
 }
 
+
+void StdCStreamLogger::write(const char * line) noexcept {
+    try {
+        std::lock_guard<std::mutex> guard(stream_mutex);
+        log_stream << line << std::flush;
+    } catch (...) {
+    }
+}
+
 }  // namespace libdnf

--- a/test/libdnf-cli/CMakeLists.txt
+++ b/test/libdnf-cli/CMakeLists.txt
@@ -9,9 +9,6 @@ pkg_check_modules(CPPUNIT REQUIRED cppunit)
 # use any sources found under the current directory
 file(GLOB_RECURSE TEST_LIBDNF_CLI_SOURCES *.cpp)
 
-# share the test runner code with libdnf
-list(APPEND TEST_LIBDNF_CLI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../libdnf/run_tests.cpp)
-
 include_directories(.)
 include_directories(${PROJECT_SOURCE_DIR}/libdnf-cli)
 

--- a/test/libdnf-cli/run_tests.cpp
+++ b/test/libdnf-cli/run_tests.cpp
@@ -1,0 +1,75 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include <cppunit/BriefTestProgressListener.h>
+#include <cppunit/CompilerOutputter.h>
+#include <cppunit/TestResult.h>
+#include <cppunit/TestResultCollector.h>
+#include <cppunit/TestRunner.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+
+#include <chrono>
+#include <iostream>
+
+
+class TimingListener : public CppUnit::TestListener {
+public:
+    void startTest(CppUnit::Test *) override { start = std::chrono::high_resolution_clock::now(); }
+
+    void endTest(CppUnit::Test *) override {
+        auto end = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+        std::cout << " (duration: " << duration << "ms)";
+    }
+
+private:
+    std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::from_time_t(0);
+};
+
+
+int main() {
+    // Create the event manager and test controller
+    CPPUNIT_NS::TestResult controller;
+
+    // Uncomment to stop cppunit from catching exceptions (for e.g. gdb debugging)
+    //controller.popProtector();
+
+    // Add a listener that colllects test result
+    CPPUNIT_NS::TestResultCollector result;
+    controller.addListener(&result);
+
+    TimingListener timer;
+    controller.addListener(&timer);
+
+    // Add a listener that print dots as test run.
+    CPPUNIT_NS::BriefTestProgressListener progress;
+    controller.addListener(&progress);
+
+    // Add the top suite to the test runner
+    CPPUNIT_NS::TestRunner runner;
+    runner.addTest(CPPUNIT_NS::TestFactoryRegistry::getRegistry().makeTest());
+    runner.run(controller);
+
+    // Print test in a compiler compatible format.
+    CPPUNIT_NS::CompilerOutputter outputter(&result, CPPUNIT_NS::stdCOut());
+    outputter.write();
+
+    return result.wasSuccessful() ? 0 : 1;
+}

--- a/test/libdnf/logger/test_loggers.cpp
+++ b/test/libdnf/logger/test_loggers.cpp
@@ -26,6 +26,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <sstream>
 
+
+using namespace std::chrono_literals;
+
+
 CPPUNIT_TEST_SUITE_REGISTRATION(LoggersTest);
 
 
@@ -43,24 +47,26 @@ void LoggersTest::tearDown() {}
 // 5. Write aditional message into LogRouter instance.
 // 6. Check content of streams of both StreamLogger instances.
 void LoggersTest::test_loggers() {
-    const time_t first_msg_time = 1582604702;  // Timestamp of the first message. "2020-02-25T04:25:02Z"
-    const pid_t pid = 25;                      // Process identifier.
+    const char * tz = "TZ=UTC";
+    putenv(const_cast<char *>(tz));
+    tzset();
 
-    time_t msg_time = first_msg_time;
+    auto msg_time = std::chrono::system_clock::from_time_t(1582604701);  // "2020-02-25T04:25:01Z"
+    const pid_t pid = 25;
 
     // Text that is expected in the logs.
     const std::string expected_loggers_content =
-        "2020-02-25T04:25:06Z [25] INFO Info message\n"
-        "2020-02-25T04:25:07Z [25] DEBUG Debug message\n"
-        "2020-02-25T04:25:08Z [25] TRACE Trace message\n"
-        "2020-02-25T04:25:09Z [25] CRITICAL Critical message\n"
-        "2020-02-25T04:25:10Z [25] ERROR Error message\n"
-        "2020-02-25T04:25:11Z [25] WARNING Warning message\n"
-        "2020-02-25T04:25:12Z [25] NOTICE Notice message\n"
-        "2020-02-25T04:25:13Z [25] INFO Info message\n"
-        "2020-02-25T04:25:14Z [25] DEBUG Debug message\n"
-        "2020-02-25T04:25:15Z [25] TRACE Trace message\n"
-        "2020-02-25T04:25:16Z [25] INFO Info additional message\n";
+        "2020-02-25T04:25:06+0000 [25] INFO Info message\n"
+        "2020-02-25T04:25:07+0000 [25] DEBUG Debug message\n"
+        "2020-02-25T04:25:08+0000 [25] TRACE Trace message\n"
+        "2020-02-25T04:25:09+0000 [25] CRITICAL Critical message\n"
+        "2020-02-25T04:25:10+0000 [25] ERROR Error message\n"
+        "2020-02-25T04:25:11+0000 [25] WARNING Warning message\n"
+        "2020-02-25T04:25:12+0000 [25] NOTICE Notice message\n"
+        "2020-02-25T04:25:13+0000 [25] INFO Info message\n"
+        "2020-02-25T04:25:14+0000 [25] DEBUG Debug message\n"
+        "2020-02-25T04:25:15+0000 [25] TRACE Trace message\n"
+        "2020-02-25T04:25:16+0000 [25] INFO Info additional message\n";
 
     // ====================
     // 1. Create a LogRouter instance with one MemoryBufferLogger instances attached.
@@ -79,13 +85,13 @@ void LoggersTest::test_loggers() {
     // 2. Write messages into log_router. They will be routed into memory_buffer_logger.
     // ====================
     for (int i = 0; i < 2; ++i) {
-        log_router->write(msg_time++, pid, libdnf::Logger::Level::CRITICAL, "Critical message");
-        log_router->write(msg_time++, pid, libdnf::Logger::Level::ERROR, "Error message");
-        log_router->write(msg_time++, pid, libdnf::Logger::Level::WARNING, "Warning message");
-        log_router->write(msg_time++, pid, libdnf::Logger::Level::NOTICE, "Notice message");
-        log_router->write(msg_time++, pid, libdnf::Logger::Level::INFO, "Info message");
-        log_router->write(msg_time++, pid, libdnf::Logger::Level::DEBUG, "Debug message");
-        log_router->write(msg_time++, pid, libdnf::Logger::Level::TRACE, "Trace message");
+        log_router->write(msg_time += 1s, pid, libdnf::Logger::Level::CRITICAL, "Critical message");
+        log_router->write(msg_time += 1s, pid, libdnf::Logger::Level::ERROR, "Error message");
+        log_router->write(msg_time += 1s, pid, libdnf::Logger::Level::WARNING, "Warning message");
+        log_router->write(msg_time += 1s, pid, libdnf::Logger::Level::NOTICE, "Notice message");
+        log_router->write(msg_time += 1s, pid, libdnf::Logger::Level::INFO, "Info message");
+        log_router->write(msg_time += 1s, pid, libdnf::Logger::Level::DEBUG, "Debug message");
+        log_router->write(msg_time += 1s, pid, libdnf::Logger::Level::TRACE, "Trace message");
     }
 
     // ====================
@@ -120,7 +126,7 @@ void LoggersTest::test_loggers() {
     // ====================
     // 5. Write aditional message into LogRouter instance.
     // ====================
-    log_router->write(msg_time++, pid, libdnf::Logger::Level::INFO, "Info additional message");
+    log_router->write(msg_time += 1s, pid, libdnf::Logger::Level::INFO, "Info additional message");
 
     // ====================
     // 6. Check content of streams of both StreamLogger instances.

--- a/test/libdnf/run_tests.cpp
+++ b/test/libdnf/run_tests.cpp
@@ -18,8 +18,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
+#include "support.hpp"
+
+#include "libdnf/logger/memory_buffer_logger.hpp"
+#include "libdnf/logger/stream_logger.hpp"
+
 #include <cppunit/BriefTestProgressListener.h>
 #include <cppunit/CompilerOutputter.h>
+#include <cppunit/TestFailure.h>
 #include <cppunit/TestResult.h>
 #include <cppunit/TestResultCollector.h>
 #include <cppunit/TestRunner.h>
@@ -27,6 +33,20 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <chrono>
 #include <iostream>
+#include <memory>
+
+
+// HACK: CppUnit doesn't give access to the actual test case it is running. The
+// given pointer is an instance of CppUnit::TestCaller, which has the test case
+// itself as a private member with no getter.
+//
+// Here we mimic the structure of CppUnit::TestCaller and make the pointer
+// accessible.
+class HackTestCaller : CppUnit::TestCase {
+public:
+    bool m_ownFixture;              // unused
+    CppUnit::TestCase * m_fixture;  // our test case class
+};
 
 
 class TimingListener : public CppUnit::TestListener {
@@ -43,6 +63,31 @@ private:
     std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::from_time_t(0);
 };
 
+class LogCaptureListener : public CppUnit::TestListener {
+public:
+    void startTest(CppUnit::Test * t) override {
+        auto * f = reinterpret_cast<HackTestCaller *>(t);
+        auto * tc = dynamic_cast<LibdnfTestCase *>(f->m_fixture);
+
+        if (tc) {
+            tc->base.get_logger()->add_logger(std::make_unique<libdnf::MemoryBufferLogger>(10000, 256));
+        }
+    }
+
+    void addFailure(const CppUnit::TestFailure & failure) override {
+        auto * f = reinterpret_cast<HackTestCaller *>(failure.failedTest());
+        auto * tc = dynamic_cast<LibdnfTestCase *>(f->m_fixture);
+
+        if (tc) {
+            std::cout << std::endl << "Dnf log:" << std::endl;
+            libdnf::StdCStreamLogger cout_logger(std::cout);
+            dynamic_cast<libdnf::MemoryBufferLogger *>(tc->base.get_logger()->get_logger(0))
+                ->write_to_logger(cout_logger);
+            std::cout << std::endl << std::flush;
+        }
+    }
+};
+
 
 int main() {
     // Create the event manager and test controller
@@ -57,6 +102,9 @@ int main() {
 
     TimingListener timer;
     controller.addListener(&timer);
+
+    LogCaptureListener log_capture;
+    controller.addListener(&log_capture);
 
     // Add a listener that print dots as test run.
     CPPUNIT_NS::BriefTestProgressListener progress;

--- a/test/libdnf/support.hpp
+++ b/test/libdnf/support.hpp
@@ -38,7 +38,6 @@ public:
 
     void dump_debugdata();
 
-protected:
     // Add (load) a repo from `repo_path`.
     // It's also a shared code for add_repo_repomd() and add_repo_rpm().
     void add_repo(const std::string & repoid, const std::string & repo_path);

--- a/test/tutorial/CMakeLists.txt
+++ b/test/tutorial/CMakeLists.txt
@@ -4,9 +4,6 @@ pkg_check_modules(CPPUNIT REQUIRED cppunit)
 # use any sources found under the current directory
 file(GLOB TEST_TUTORIAL_SOURCES *.cpp)
 
-# share the test runner code with libdnf
-list(APPEND TEST_TUTORIAL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../libdnf/run_tests.cpp)
-
 include_directories(${PROJECT_SOURCE_DIR}/libdnf)
 
 

--- a/test/tutorial/run_tests.cpp
+++ b/test/tutorial/run_tests.cpp
@@ -1,0 +1,54 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include <cppunit/BriefTestProgressListener.h>
+#include <cppunit/CompilerOutputter.h>
+#include <cppunit/TestResult.h>
+#include <cppunit/TestResultCollector.h>
+#include <cppunit/TestRunner.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+
+
+int main() {
+    // Create the event manager and test controller
+    CPPUNIT_NS::TestResult controller;
+
+    // Uncomment to stop cppunit from catching exceptions (for e.g. gdb debugging)
+    //controller.popProtector();
+
+    // Add a listener that colllects test result
+    CPPUNIT_NS::TestResultCollector result;
+    controller.addListener(&result);
+
+    // Add a listener that print dots as test run.
+    CPPUNIT_NS::BriefTestProgressListener progress;
+    controller.addListener(&progress);
+
+    // Add the top suite to the test runner
+    CPPUNIT_NS::TestRunner runner;
+    runner.addTest(CPPUNIT_NS::TestFactoryRegistry::getRegistry().makeTest());
+    runner.run(controller);
+
+    // Print test in a compiler compatible format.
+    CPPUNIT_NS::CompilerOutputter outputter(&result, CPPUNIT_NS::stdCOut());
+    outputter.write();
+
+    return result.wasSuccessful() ? 0 : 1;
+}


### PR DESCRIPTION
This makes it easier to debug unittest failures and also gives a helpful insight of how helpful the log is in various situations.

A hack was needed because CppUnit doesn't give access to the actual test case object in the `startTest`, `endTest`, etc. hooks.

I've also wanted to share the code for formatting the log line (previously, every descendant of `Logger` had to duplicate it in its `write()` method), which ultimately required a bigger incision.