### PR TITLE
[dnf5] Create centralized point for final setup of Base class

### DIFF
--- a/dnfdaemon-server/services/repoconf/configuration.cpp
+++ b/dnfdaemon-server/services/repoconf/configuration.cpp
@@ -47,7 +47,7 @@ void Configuration::read_main_config() {
         main_parser->read(main_config_path);
         cfg_main.load_from_parser(*main_parser, "main", *base->get_vars(), *base->get_logger());
 
-        base->get_vars()->load(cfg_main.installroot().get_value(), cfg_main.varsdir().get_value());
+        base->setup();
 
         // read repos possibly configured in the main config file
         read_repos(main_parser.get(), main_config_path);

--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -89,7 +89,7 @@ Session::Session(
     base->load_config_from_file();
 
     // set variables
-    base->get_vars()->load(config.installroot().get_value(), config.varsdir().get_value());
+    base->setup();
     if (session_configuration.find("releasever") != session_configuration.end()) {
         auto releasever = session_configuration_value<std::string>("releasever");
         base->get_vars()->set("releasever", releasever);

--- a/include/libdnf/base/base.hpp
+++ b/include/libdnf/base/base.hpp
@@ -75,6 +75,12 @@ public:
     repo::RepoSackWeakPtr get_repo_sack() { return repo_sack.get_weak_ptr(); }
     rpm::PackageSackWeakPtr get_rpm_package_sack() { return rpm_package_sack.get_weak_ptr(); }
 
+    /// Load vars from environment, varsdirs and installroot (releasever, arch). To prevent differences between
+    /// configuration and internal Base settings, following configurations will be locked: installroot, varsdir.
+    /// The method is supposed to be called after configuration is updated, plugins applied their pre configuration
+    /// modification in configuration, but before repositories are loaded or any Package or Advisory query created.
+    void setup();
+
     transaction::TransactionSackWeakPtr get_transaction_sack() { return transaction_sack.get_weak_ptr(); }
     libdnf::comps::CompsWeakPtr get_comps() { return comps.get_weak_ptr(); }
     libdnf::advisory::AdvisorySackWeakPtr get_rpm_advisory_sack() { return rpm_advisory_sack.get_weak_ptr(); }

--- a/include/libdnf/conf/vars.hpp
+++ b/include/libdnf/conf/vars.hpp
@@ -81,6 +81,9 @@ public:
     /// @param name Name of the variable
     const Variable & get(const std::string & name) const { return variables.at(name); }
 
+private:
+    friend class Base;
+
     /// @brief Loads DNF vars from the environment and the passed directories.
     ///
     /// Environment variables are loaded first, then the directories are loaded
@@ -91,7 +94,6 @@ public:
     /// @param directories The directories to load vars from
     void load(const std::string & installroot, const std::vector<std::string> & directories);
 
-private:
     /// @brief Detects the system's arch, basearch and relesever.
     ///
     /// @param installroot The installroot directory

--- a/libdnf/solv/pool.hpp
+++ b/libdnf/solv/pool.hpp
@@ -240,6 +240,7 @@ private:
 namespace libdnf {
 
 inline solv::Pool & get_pool(const libdnf::BaseWeakPtr & base) {
+    libdnf_assert(base->pool, "Base instance was not fully initialized by Base::setup()");
     return *base->pool;
 }
 

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -794,7 +794,7 @@ std::vector<std::string> match_available_pkgs(Context & ctx, const std::string &
 
     auto & base = ctx.base;
     base.load_config_from_file();
-    base.get_vars()->load(base.get_config().installroot().get_value(), base.get_config().varsdir().get_value());
+    base.setup();
 
     // create rpm repositories according configuration files
     auto repo_sack = base.get_repo_sack();

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -628,7 +628,7 @@ int main(int argc, char * argv[]) try {
     log_router.swap_logger(logger, 0);
     dynamic_cast<libdnf::MemoryBufferLogger &>(*logger).write_to_logger(log_router);
 
-    base.get_vars()->load(base.get_config().installroot().get_value(), base.get_config().varsdir().get_value());
+    base.setup();
 
     // create rpm repositories according configuration files
     auto repo_sack = base.get_repo_sack();

--- a/test/libdnf/base/test_base.cpp
+++ b/test/libdnf/base/test_base.cpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "test_base.hpp"
 
 #include "libdnf/base/base.hpp"
+#include "libdnf/rpm/package_query.hpp"
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(BaseTest);
@@ -47,4 +48,15 @@ void BaseTest::test_weak_ptr() {
     // Base object is invalid. -> Both WeakPtr are invalid. The code must throw an exception.
     CPPUNIT_ASSERT_THROW(vars->get_value("test_variable"), libdnf::InvalidPointerError);
     CPPUNIT_ASSERT_THROW(vars2->get_value("test_variable"), libdnf::InvalidPointerError);
+}
+
+void BaseTest::test_incorrect_workflow() {
+    // Creates a new Base object
+    auto base = std::make_unique<libdnf::Base>();
+
+    // Base object is not fully initialized - not initialized by Base::setup()
+    CPPUNIT_ASSERT_THROW(libdnf::rpm::PackageQuery(*base.get()), libdnf::AssertionError);
+
+    base->setup();
+    libdnf::rpm::PackageQuery(*base.get());
 }

--- a/test/libdnf/base/test_base.hpp
+++ b/test/libdnf/base/test_base.hpp
@@ -29,10 +29,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 class BaseTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE(BaseTest);
     CPPUNIT_TEST(test_weak_ptr);
+    CPPUNIT_TEST(test_incorrect_workflow);
     CPPUNIT_TEST_SUITE_END();
 
 public:
     void test_weak_ptr();
+    void test_incorrect_workflow();
 };
 
 

--- a/test/libdnf/conf/test_conf.cpp
+++ b/test/libdnf/conf/test_conf.cpp
@@ -33,7 +33,7 @@ void ConfTest::setUp() {
     TestCaseFixture::setUp();
     ConfigParser parser;
     parser.read(PROJECT_SOURCE_DIR "/test/libdnf/conf/data/main.conf");
-    config.load_from_parser(parser, "main", vars, logger);
+    config.load_from_parser(parser, "main", *base.get_vars(), logger);
 }
 
 void ConfTest::test_config_main() {
@@ -48,8 +48,10 @@ void ConfTest::test_config_repo() {
     repo::ConfigRepo config_repo(config, "test-repo");
     ConfigParser parser;
     parser.read(PROJECT_SOURCE_DIR "/test/libdnf/conf/data/main.conf");
-    vars.load("/", {PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
-    config_repo.load_from_parser(parser, "repo-1", vars, logger);
+    base.get_config().varsdir().set(
+        libdnf::Option::Priority::RUNTIME, std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
+    base.setup();
+    config_repo.load_from_parser(parser, "repo-1", *base.get_vars(), logger);
 
     std::vector<std::string> baseurl = {"http://example.com/value123", "http://example.com/456"};
     CPPUNIT_ASSERT_EQUAL(baseurl, config_repo.baseurl().get_value());

--- a/test/libdnf/conf/test_conf.hpp
+++ b/test/libdnf/conf/test_conf.hpp
@@ -23,8 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "testcase_fixture.hpp"
 
-#include "libdnf/conf/config_main.hpp"
-#include "libdnf/conf/vars.hpp"
+#include "libdnf/base/base.hpp"
 #include "libdnf/logger/log_router.hpp"
 
 #include <cppunit/extensions/HelperMacros.h>
@@ -42,7 +41,7 @@ public:
     void test_config_main();
     void test_config_repo();
 
-    libdnf::Vars vars;
+    libdnf::Base base;
     libdnf::LogRouter logger;
     libdnf::ConfigMain config;
 };

--- a/test/libdnf/conf/test_vars.cpp
+++ b/test/libdnf/conf/test_vars.cpp
@@ -26,24 +26,32 @@ CPPUNIT_TEST_SUITE_REGISTRATION(VarsTest);
 // TODO possibly test the automatically detected vars (they depend on the host)
 
 void VarsTest::test_vars() {
-    vars.load("/", {PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
+    base.get_config().varsdir().set(
+        libdnf::Option::Priority::RUNTIME, std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
+    // Load all variables.
+    base.setup();
 
-    CPPUNIT_ASSERT_EQUAL(std::string("foovalue123-bar"), vars.substitute("foo$var1-bar"));
-    CPPUNIT_ASSERT_EQUAL(std::string("$$$value123456-$nn-${nnn}"), vars.substitute("$$$${var1}$var2-$nn-${nnn}"));
+    CPPUNIT_ASSERT_EQUAL(std::string("foovalue123-bar"), base.get_vars()->substitute("foo$var1-bar"));
+    CPPUNIT_ASSERT_EQUAL(
+        std::string("$$$value123456-$nn-${nnn}"), base.get_vars()->substitute("$$$${var1}$var2-$nn-${nnn}"));
 }
 
 void VarsTest::test_vars_multiple_dirs() {
-    vars.load(
-        "/",
-        {
+    base.get_config().varsdir().set(
+        libdnf::Option::Priority::RUNTIME,
+        std::vector<std::string>{
             PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars",
             PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars2",
         });
+    // Load all variables.
+    base.setup();
 
-    CPPUNIT_ASSERT_EQUAL(std::string("av333bthe answer is here"), vars.substitute("a${var1}b${var42}"));
+    CPPUNIT_ASSERT_EQUAL(std::string("av333bthe answer is here"), base.get_vars()->substitute("a${var1}b${var42}"));
 }
 
 void VarsTest::test_vars_env() {
+    base.get_config().varsdir().set(
+        libdnf::Option::Priority::RUNTIME, std::vector<std::string>{PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
     // Setting environment variables.
     // Environment variables have higher priority than variables from files.
     setenv("DNF0", "foo0", 1);
@@ -53,11 +61,11 @@ void VarsTest::test_vars_env() {
     setenv("DNF_VAR_var41", "testvar2", 1);
 
     // Load all variables.
-    vars.load("/", {PROJECT_SOURCE_DIR "/test/libdnf/conf/data/vars"});
+    base.setup();
 
     // The variables var1 and var2 are defined in the files.
     // However, var1 was also an environment variable. The environment has a higher priority.
     CPPUNIT_ASSERT_EQUAL(
         std::string("foo0-foo1-foo9-testvar1-testvar2-456"),
-        vars.substitute("${DNF0}-${DNF1}-${DNF9}-${var1}-${var41}-${var2}"));
+        base.get_vars()->substitute("${DNF0}-${DNF1}-${DNF9}-${var1}-${var41}-${var2}"));
 }

--- a/test/libdnf/conf/test_vars.hpp
+++ b/test/libdnf/conf/test_vars.hpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "testcase_fixture.hpp"
 
-#include "libdnf/conf/vars.hpp"
+#include "libdnf/base/base.hpp"
 
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -40,7 +40,7 @@ public:
     void test_vars_multiple_dirs();
     void test_vars_env();
 
-    libdnf::Vars vars;
+    libdnf::Base base;
 };
 
 

--- a/test/libdnf/repo/test_repo.cpp
+++ b/test/libdnf/repo/test_repo.cpp
@@ -57,6 +57,9 @@ void RepoTest::test_repo_basics() {
     // set cachedir to a temp directory
     base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, temp->get_path() / "cache");
 
+    // Setup base internals according to config
+    base.setup();
+
     libdnf::repo::RepoSack repo_sack(base);
 
     // Creates system repository and loads it

--- a/test/libdnf/repo/test_repo_query.cpp
+++ b/test/libdnf/repo/test_repo_query.cpp
@@ -33,6 +33,7 @@ void RepoQueryTest::tearDown() {}
 
 void RepoQueryTest::test_query_basics() {
     libdnf::Base base;
+    base.setup();
     auto repo_sack = base.get_repo_sack();
     //libdnf::repo::RepoSack repo_sack(base);
     //auto repo_sack_weak_ptr = repo_sack.get_weak_ptr();

--- a/test/libdnf/rpm/test_reldep.cpp
+++ b/test/libdnf/rpm/test_reldep.cpp
@@ -24,6 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 CPPUNIT_TEST_SUITE_REGISTRATION(ReldepTest);
 
 
+void ReldepTest::setUp() {
+    base.setup();
+}
+
+
 void ReldepTest::test_short_reldep() {
     libdnf::rpm::Reldep a(base, "labirinto.txt");
     CPPUNIT_ASSERT(std::string(a.get_name()) == "labirinto.txt");

--- a/test/libdnf/rpm/test_reldep.hpp
+++ b/test/libdnf/rpm/test_reldep.hpp
@@ -35,6 +35,8 @@ class ReldepTest : public CppUnit::TestCase {
     CPPUNIT_TEST_SUITE_END();
 
 public:
+    void setUp() override;
+
     void test_short_reldep();
     void test_full_reldep();
     void test_rich_reldep();

--- a/test/libdnf/support.cpp
+++ b/test/libdnf/support.cpp
@@ -136,6 +136,7 @@ void LibdnfTestCase::setUp() {
         cache_dirs.insert({class_name, std::make_unique<libdnf::utils::TempDir>("libdnf_unittest")});
     }
     base.get_config().cachedir().set(libdnf::Option::Priority::RUNTIME, cache_dirs.at(class_name)->get_path());
+    base.setup();
 
     repo_sack = base.get_repo_sack();
     sack = base.get_rpm_package_sack();

--- a/test/perl5/libdnf/rpm/test_package_query.t
+++ b/test/perl5/libdnf/rpm/test_package_query.t
@@ -33,6 +33,9 @@ my $base = new libdnf::base::Base();
 my $tmpdir = tempdir("libdnf-perl5-XXXX", TMPDIR => 1, CLEANUP => 1);
 $base->get_config()->cachedir()->set($libdnf::conf::Option::Priority_RUNTIME, $tmpdir);
 
+# Sets base internals according to configuration
+$base->setup();
+
 my $repo_sack = new libdnf::repo::RepoSack($base);
 
 # Creates new repositories in the repo_sack

--- a/test/python3/libdnf/comps/test_group.py
+++ b/test/python3/libdnf/comps/test_group.py
@@ -31,6 +31,9 @@ class TestGroup(unittest.TestCase):
         tmpdir = tempfile.mkdtemp(prefix="libdnf-python3-test-comps-")
         base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, tmpdir)
 
+        # Sets Base internals according to configuration
+        base.setup()
+
         repo = base.get_repo_sack().new_repo("repo")
         comps = libdnf.comps.Comps(base)
         data_path = os.path.join(os.getcwd(), "../../../test/libdnf/comps/data/core.xml")

--- a/test/python3/libdnf/repo/test_repo.py
+++ b/test/python3/libdnf/repo/test_repo.py
@@ -32,6 +32,9 @@ class TestRepo(unittest.TestCase):
         tmpdir = tempfile.mkdtemp(prefix="libdnf-python3-")
         base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, tmpdir)
 
+        # Sets Base internals according to configuration
+        base.setup()
+
         repo_sack = libdnf.repo.RepoSack(base)
 
         # Creates system repository and loads it

--- a/test/python3/libdnf/repo/test_repo_query.py
+++ b/test/python3/libdnf/repo/test_repo_query.py
@@ -23,6 +23,9 @@ class TestRepQueryo(unittest.TestCase):
     def test_repo_query(self):
         base = libdnf.base.Base()
 
+        # Sets Base internals according to configuration
+        base.setup()
+
         repo_sack = base.get_repo_sack()
 
         # Creates new repositories in the repo_sack

--- a/test/python3/libdnf/support/support.py
+++ b/test/python3/libdnf/support/support.py
@@ -35,6 +35,9 @@ class LibdnfTestCase(unittest.TestCase):
         self.cachedir = tempfile.mkdtemp(prefix="libdnf-test-python3-")
         self.base.get_config().cachedir().set(libdnf.conf.Option.Priority_RUNTIME, self.cachedir)
 
+        # Sets Base internals according to configuration
+        self.base.setup()
+
         self.repo_sack = self.base.get_repo_sack()
         self.sack = self.base.get_rpm_package_sack()
 

--- a/test/ruby/libdnf/repo/test_repo.rb
+++ b/test/ruby/libdnf/repo/test_repo.rb
@@ -29,6 +29,9 @@ class TestRepo < Test::Unit::TestCase
         tmpdir = Dir.mktmpdir("libdnf-ruby-")
         base.get_config().cachedir().set(Conf::Option::Priority_RUNTIME, tmpdir)
 
+        # Sets Base internals according to configuration
+        base.setup()
+
         repo_sack = Repo::RepoSack.new(base)
 
         # Creates system repository and loads it into rpm::PackageSack.

--- a/test/ruby/libdnf/support/support.rb
+++ b/test/ruby/libdnf/support/support.rb
@@ -36,6 +36,9 @@ class LibdnfTestCase < Test::Unit::TestCase
         @cachedir = Dir.mktmpdir("libdnf-test-ruby-")
         @base.get_config().cachedir().set(Conf::Option::Priority_RUNTIME, @cachedir)
 
+        # Sets Base internals according to configuration
+        @base.setup()
+
         @repo_sack = @base.get_repo_sack()
         @package_sack = @base.get_rpm_package_sack()
     end

--- a/test/tutorial/session/create_base.cpp
+++ b/test/tutorial/session/create_base.cpp
@@ -13,3 +13,6 @@ conf.installroot().set(libdnf::Option::Priority::RUNTIME, installroot);
 
 // TODO(dmach): we shouldn't be forcing API users to always set the cache dir
 conf.cachedir().set(libdnf::Option::Priority::RUNTIME, installroot + "/var/cache/dnf");
+
+// set Base internals according to configuration
+base.setup();


### PR DESCRIPTION
At the time of initialization of Base class Pool cannot be correctly
setup because we do not know the correct values for installroot and
arch. Bot values are related additional values.

The PR changes work flow to prevents incorrect usage of Base and it
creates a new method that will set correctly internals and locks related
variables to prevent inconsistency between configuration and internal
settings.