### PR TITLE
Error handling in Locker class

### DIFF
--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -329,7 +329,7 @@ Transaction::TransactionRunResult Transaction::Impl::run(
     std::filesystem::path lock_file_path = system_cache_dir;
     lock_file_path /= "rpmtransaction.lock";
     libdnf::utils::Locker locker(lock_file_path);
-    if (locker.lock() != libdnf::utils::Locker::LockResult::SUCCESS) {
+    if (!locker.lock()) {
         return TransactionRunResult::ERROR_LOCK;
     }
     // fill and check the rpm transaction

--- a/libdnf/utils/locker.hpp
+++ b/libdnf/utils/locker.hpp
@@ -26,10 +26,9 @@ namespace libdnf::utils {
 
 class Locker {
 public:
-    enum class LockResult { SUCCESS, ERROR_FD, ERROR_LOCK };
     explicit Locker(const std::string & path) : path(path){};
     ~Locker();
-    LockResult lock();
+    bool lock();
     void unlock();
 
 private:


### PR DESCRIPTION
Throw SystemError in case the syscalls failed. lock() method now returns
either SUCCESS or ALREADY_LOCKED status.