### PR TITLE
Generate DBus documentation from xml annotations

### DIFF
--- a/dnfdaemon-server/dbus/interfaces/dnfdaemon_dbus_api.xsl
+++ b/dnfdaemon-server/dbus/interfaces/dnfdaemon_dbus_api.xsl
@@ -1,0 +1,79 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<xsl:stylesheet version = "1.0" xmlns:xsl = "http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="text" omit-xml-declaration="yes" indent="no"/>
+
+<xsl:variable name="newline"><xsl:text>
+</xsl:text></xsl:variable>
+
+<xsl:template match="/">
+..
+    Copyright Contributors to the libdnf project.
+
+    This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+    Libdnf is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    Libdnf is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libdnf.  If not, see &lt;https://www.gnu.org/licenses/&gt;.
+
+
+########################
+ DBus API documentation
+########################
+
+
+Synopsis
+========
+
+Dbus API doc
+
+Generated automatically using xslt
+
+
+Description
+===========
+
+
+Interfaces
+==========
+<xsl:for-each select="/interface_list/file">
+<xsl:apply-templates select="document(@name)/node" />
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template match="node">
+<xsl:apply-templates />
+</xsl:template>
+
+<xsl:template match="interface">
+<xsl:value-of select="@name"/>
+`````
+<xsl:for-each select="method">
+.. <xsl:value-of select="@name"/>
+<xsl:for-each select="arg">
+<xsl:value-of select="$newline" />
+<xsl:value-of select="@name" />
+<xsl:value-of select="$newline" />
+<xsl:for-each select="annotation">
+<xsl:value-of select="@value" />
+</xsl:for-each>
+type:  <xsl:value-of select="@type" />
+direction:  <xsl:value-of select="@direction" />
+<xsl:value-of select="$newline" />
+
+</xsl:for-each>
+<!--xsl:for-each select="annotation">
+<xsl:value-of select="$newline" />
+<xsl:value-of select="@value"/>
+</xsl:for-each-->
+</xsl:for-each>
+</xsl:template>
+</xsl:stylesheet>

--- a/dnfdaemon-server/dbus/interfaces/dnfdaemon_dbus_api.xsl
+++ b/dnfdaemon-server/dbus/interfaces/dnfdaemon_dbus_api.xsl
@@ -70,10 +70,10 @@ direction:  <xsl:value-of select="@direction" />
 <xsl:value-of select="$newline" />
 
 </xsl:for-each>
-<!--xsl:for-each select="annotation">
+<xsl:for-each select="annotation">
 <xsl:value-of select="$newline" />
 <xsl:value-of select="@value"/>
-</xsl:for-each-->
+</xsl:for-each>
 </xsl:for-each>
 </xsl:template>
 </xsl:stylesheet>

--- a/dnfdaemon-server/dbus/interfaces/dnfdaemon_dbus_interfaces.xml
+++ b/dnfdaemon-server/dbus/interfaces/dnfdaemon_dbus_interfaces.xml
@@ -1,0 +1,6 @@
+<interface_list>
+    <file name="org.rpm.dnf.v0.Goal.xml" />
+    <file name="org.rpm.dnf.v0.rpm.Repo.xml" />
+    <file name="org.rpm.dnf.v0.rpm.Rpm.xml" />
+    <file name="org.rpm.dnf.v0.SessionManager.xml" />
+</interface_list>

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
@@ -21,78 +21,81 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>
-<!-- org.rpm.dnf.v0.Goal:
-   @short_description: Interface to Goal
--->
 <interface name="org.rpm.dnf.v0.Goal">
+    <annotation name="org.gtk.GDBus.DocString.Short"
+        value="Interface to Goal"/>
     <!--
         resolve:
-        @options: an array of key/value pairs to modify dependency resolving
-        @transaction: array of (action, n, e, v, r, a, repoid) tuples where action is one of libdnf::transaction::TransactionItemAction enum
         @resolve_results: problems detected during transaction resolving
-
-        Resolve the transaction.
-
-        Following @options are supported:
-        <variablelist>
-          <varlistentry>
-            <term>allow_erasing: boolean, default false</term>
-            <listitem><para>
-            Whether removal of installed package is allowed to resolve the
-            transaction.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-        Unknown options are ignored.
-
-        Following @resolve_results are returned:
-        <variablelist>
-          <varlistentry>
-            <term>transaction_problems: libdnf::GoalProblem</term>
-            <listitem><para>
-                Overall result of the resolving.
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>transaction_solver_problems: string</term>
-            <listitem><para>
-                Problems found by the solver.
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>goal_problems: string</term>
-            <listitem><para>
-                Problems of goal resolution other then those from the solver.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-
     -->
     <method name="resolve">
-        <arg name="options" type="a{sv}" direction="in" />
-        <arg name="transaction" type="a(ussssss)" direction="out" />
-        <arg name="problems" type="a{sv}" direction="out" />
+        <annotation name="org.gtk.GDBus.Docstring"
+            value="Resolve the transaction.
+
+            Following @options are supported:
+            &lt;variablelist&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;allow_erasing: boolean, default false&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                Whether removal of installed package is allowed to resolve the
+                transaction.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+            &lt;/variablelist&gt;
+            Unknown options are ignored.
+
+            Following @resolve_results are returned:
+            &lt;variablelist&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;transaction_problems: libdnf::GoalProblem&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                    Overall result of the resolving.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;transaction_solver_problems: string&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                    Problems found by the solver.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;goal_problems: string&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                    Problems of goal resolution other then those from the solver.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+            &lt;/variablelist&gt;"/>
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs to modify dependency resolving"/>
+        </arg>
+        <arg name="transaction" type="a(ussssss)" direction="out">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="array of (action, n, e, v, r, a, repoid) tuples where action is one of libdnf::transaction::TransactionItemAction enum"/>
+        </arg>
+        <arg name="problems" type="a{sv}" direction="out">
+            <annotation name="org.gtk.GDBusDocstring"
+                value=""/>
+        </arg>
     </method>
 
-    <!--
-        do_transaction:
-        @options: an array of key/value pairs to modify transaction running
-
-        Perform the resolved transaction.
-
-        Following @options are supported:
-        <variablelist>
-          <varlistentry>
-            <term>comment: string</term>
-            <listitem><para>
-            Adds a comment to a transaction.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-        Unknown options are ignored.
-    -->
     <method name="do_transaction">
-        <arg name="options" type="a{sv}" direction="in" />
+        <annotation name="org.gtk.GDBus.Docstring"
+            value="Perform the resolved transaction.
+        Following @options are supported:
+        &lt;variablelist&gt;
+          &lt;varlistentry&gt;
+            &lt;term>comment: string&lt;/term&gt;
+            &lt;listitem&gt;&lt;para&gt;
+            Adds a comment to a transaction.
+            &lt;/para&gt;&lt;/listitem&gt;
+          &lt;/varlistentry&gt;
+        &lt;/variablelist&gt;
+        Unknown options are ignored." />
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs to modify transaction running"/>
+        </arg>
     </method>
 
 </interface>

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
@@ -1,6 +1,4 @@
-<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-
+<!DOCTYPE node [<!ATTLIST poem xml:space (preserve) #FIXED 'preserve'>]>
 <!--
 Copyright Contributors to the libdnf project.
 
@@ -31,40 +29,40 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
     <method name="resolve">
         <annotation name="org.gtk.GDBus.Docstring"
             value="Resolve the transaction.
-
-            Following @options are supported:
-            &lt;variablelist&gt;
-              &lt;varlistentry&gt;
-                &lt;term&gt;allow_erasing: boolean, default false&lt;/term&gt;
-                &lt;listitem&gt;&lt;para&gt;
-                Whether removal of installed package is allowed to resolve the
-                transaction.
-                &lt;/para&gt;&lt;/listitem&gt;
-              &lt;/varlistentry&gt;
-            &lt;/variablelist&gt;
-            Unknown options are ignored.
-
-            Following @resolve_results are returned:
-            &lt;variablelist&gt;
-              &lt;varlistentry&gt;
-                &lt;term&gt;transaction_problems: libdnf::GoalProblem&lt;/term&gt;
-                &lt;listitem&gt;&lt;para&gt;
-                    Overall result of the resolving.
-                &lt;/para&gt;&lt;/listitem&gt;
-              &lt;/varlistentry&gt;
-              &lt;varlistentry&gt;
-                &lt;term&gt;transaction_solver_problems: string&lt;/term&gt;
-                &lt;listitem&gt;&lt;para&gt;
-                    Problems found by the solver.
-                &lt;/para&gt;&lt;/listitem&gt;
-              &lt;/varlistentry&gt;
-              &lt;varlistentry&gt;
-                &lt;term&gt;goal_problems: string&lt;/term&gt;
-                &lt;listitem&gt;&lt;para&gt;
-                    Problems of goal resolution other then those from the solver.
-                &lt;/para&gt;&lt;/listitem&gt;
-              &lt;/varlistentry&gt;
-            &lt;/variablelist&gt;"/>
+&#10;
+Following @options are supported:&#10;
+&lt;variablelist&gt;&#10;
+  &lt;varlistentry&gt;&#10;
+    &lt;term&gt;allow_erasing: boolean, default false&lt;/term&gt;&#10;
+    &lt;listitem&gt;&lt;para&gt;&#10;
+    Whether removal of installed package is allowed to resolve the&#10;
+    transaction.&#10;
+    &lt;/para&gt;&lt;/listitem&gt;&#10;
+  &lt;/varlistentry&gt;&#10;
+&lt;/variablelist&gt;&#10;
+Unknown options are ignored.&#10;
+&#10;
+Following @resolve_results are returned:&#10;
+&lt;variablelist&gt;&#10;
+  &lt;varlistentry&gt;&#10;
+    &lt;term&gt;transaction_problems: libdnf::GoalProblem&lt;/term&gt;&#10;
+    &lt;listitem&gt;&lt;para&gt;&#10;
+        Overall result of the resolving.&#10;
+    &lt;/para&gt;&lt;/listitem&gt;&#10;
+  &lt;/varlistentry&gt;&#10;
+  &lt;varlistentry&gt;&#10;
+    &lt;term&gt;transaction_solver_problems: string&lt;/term&gt;&#10;
+    &lt;listitem&gt;&lt;para&gt;&#10;
+        Problems found by the solver.&#10;
+    &lt;/para&gt;&lt;/listitem&gt;&#10;
+  &lt;/varlistentry&gt;&#10;
+  &lt;varlistentry&gt;&#10;
+    &lt;term&gt;goal_problems: string&lt;/term&gt;&#10;
+    &lt;listitem&gt;&lt;para&gt;&#10;
+        Problems of goal resolution other then those from the solver.&#10;
+    &lt;/para&gt;&lt;/listitem&gt;&#10;
+  &lt;/varlistentry&gt;&#10;
+&lt;/variablelist&gt;"/>
         <arg name="options" type="a{sv}" direction="in">
             <annotation name="org.gtk.GDBusDocstring"
                 value="an array of key/value pairs to modify dependency resolving"/>

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
@@ -21,63 +21,68 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>
-<!-- org.rpm.dnf.v0.SessionManager:
-   @short_description: Interface to dnfdaemon sessions management
--->
 <interface name="org.rpm.dnf.v0.SessionManager">
+    <annotation name="org.gtk.GDBus.DocString.Short"
+        value="Interface to dnfdaemon sessions management"/>
     <!--
-        open_session:
         @configuration: session configuration - an array of key/value pairs
-        @path: object path to created Session object
-
-        Opens a new session.
-
-        Following configuration options are supported:
-
-        <variablelist>
-          <varlistentry>
-            <term>load_system_repo: bool, default true</term>
-            <listitem><para>
-                If true information about currently installed packages is loaded.
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>load_available_repos: bool, default true</term>
-                If true information about packages available in enabled repositories is loaded.
-            <listitem><para>
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>config: map {string: string}</term>
-            <listitem><para>
-                Override configuration options.
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>releasever: string</term>
-            <listitem><para>
-                Override releasever variable used for substitutions in repository configurations.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-
-        Unknown options are ignored.
     -->
     <method name="open_session">
-        <arg name="options" type="a{sv}" direction="in"/>
-        <arg name="path" type="o" direction="out"/>
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Opens a new session.
+
+            Following configuration options are supported:
+
+            &lt;variablelist&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;load_system_repo: bool, default true&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                    If true information about currently installed packages is loaded.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;load_available_repos: bool, default true&lt;/term&gt;
+                    If true information about packages available in enabled repositories is loaded.
+                &lt;listitem&gt;&lt;para&gt;
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;config: map {string: string}&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                    Override configuration options.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;releasever: string&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                    Override releasever variable used for substitutions in repository configurations.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+            &lt;/variablelist&gt;
+
+            Unknown options are ignored."/>
+
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value=""/>
+        </arg>
+        <arg name="path" type="o" direction="out">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="object path to created Session object"/>
+        </arg>
     </method>
 
-    <!--
-        close_session:
-        @path: object path of session to close
-        @result: bool whether the requested session was successfully closed
-
-        Close session on given object path.
-    -->
     <method name="close_session">
-        <arg name="path" type="o" direction="in" />
-        <arg name="result" type="b" direction="out" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Close session on given object path." />
+        <arg name="path" type="o" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="object path of session to close"/>
+        </arg>
+        <arg name="result" type="b" direction="out">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="bool whether the requested session was successfully closed"/>
+        </arg>
     </method>
 
 </interface>

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
@@ -21,45 +21,45 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>
-<!-- org.rpm.dnf.v0.rpm.Repo:
-   @short_description: Interface to repositories
--->
 <interface name="org.rpm.dnf.v0.rpm.Repo">
-    <!--
-        list:
-        @options: an array of key/value pairs
-        @data: array of returned repositories with requested attributes
-
-        Get list of repositories that match to given filters.
-
-        Following options are supported:
-
-        <variablelist>
-          <varlistentry>
-            <term>patterns: list of strings</term>
-            <listitem><para>
-              any repository with id matching to any of patterns is returned
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>repo_attrs: list of strings</term>
-            <listitem><para>
-              list of repository attributes that are returned
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>enable_disable: string (default "enabled")</term>
-            <listitem><para>
-              When set to "enabled" or "disabled", only enabled / disabled repositories are listed. Any other value means all repositories are returned.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-
-        Unknown options are ignored.
-    -->
+    <annotation name="org.gtk.GDBus.DocString.Short"
+        value="Interface to repositories" />
     <method name="list">
-        <arg name="options" type="a{sv}" direction="in"/>
-        <arg name="data" type="aa{sv}" direction="out"/>
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Get list of repositories that match to given filters.
+
+            Following options are supported:
+
+            &lt;variablelist&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;patterns: list of strings&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  any repository with id matching to any of patterns is returned
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;repo_attrs: list of strings&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  list of repository attributes that are returned
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;enable_disable: string (default &quot;enabled&quot;)&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  When set to &quot;enabled&quot; or &quot;disabled&quot;, only enabled / disabled repositories are listed. Any other value means all repositories are returned.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+            &lt;/variablelist&gt;
+
+            Unknown options are ignored."/>
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs"/>
+        </arg>
+        <arg name="data" type="aa{sv}" direction="out">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="array of returned repositories with requested attributes"/>
+        </arg>
     </method>
 
 </interface>

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -21,289 +21,311 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>
-<!-- org.rpm.dnf.v0.rpm.Rpm:
-   @short_description: Interface to RPM packages
--->
 <interface name="org.rpm.dnf.v0.rpm.Rpm">
-    <!--
-        list:
-        @options: an array of key/value pairs
-        @data: array of returned packages with requested attributes
-
-        Get list of packages that match to given filters.
-
-        Following options are supported:
-
-        <variablelist>
-          <varlistentry>
-            <term>patterns: list of strings</term>
-            <listitem><para>
-              any package matching to any of patterns is returned
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>package_attrs: list of strings</term>
-            <listitem><para>
-              list of package attributes that are returned
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>with_nevra: bool (default true)</term>
-            <listitem><para>
-              match patterns against available packages NEVRAs
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>with_provides: bool (default true)</term>
-            <listitem><para>
-              match patterns against available packages provides
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>with_filenames: bool (default true)</term>
-            <listitem><para>
-              match patterns against names of the files in available packages
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>with_src: bool (default true)</term>
-            <listitem><para>
-              include source rpms into the results
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>icase: bool (default true)</term>
-            <listitem><para>
-              ignore case while matching patterns
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-
-        Unknown options are ignored.
-    -->
+    <annotation name="org.gtk.GDBus.DocString.Short"
+        value="Interface to RPM packages" />
     <method name="list">
-        <arg name="options" type="a{sv}" direction="in"/>
-        <arg name="data" type="aa{sv}" direction="out"/>
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Get list of packages that match to given filters.
+
+            Following options are supported:
+
+            &lt;variablelist&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;patterns: list of strings&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  any package matching to any of patterns is returned
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;package_attrs: list of strings&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  list of package attributes that are returned
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;with_nevra: bool (default true)&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  match patterns against available packages NEVRAs
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;with_provides: bool (default true)&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  match patterns against available packages provides
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;with_filenames: bool (default true)&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  match patterns against names of the files in available packages
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;with_src: bool (default true)&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  include source rpms into the results
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;icase: bool (default true)&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                  ignore case while matching patterns
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+            &lt;/variablelist&gt;
+
+            Unknown options are ignored."/>
+
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs"/>
+        </arg>
+        <arg name="data" type="aa{sv}" direction="out">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="array of returned packages with requested attributes"/>
+        </arg>
     </method>
 
-    <!--
-        install:
-        @specs: an array of package specifications to be installed on the system
-        @options: an array of key/value pairs to modify install behavior
-
-        Mark packages specified by @specs for installation.
-
-        Following @options are supported:
-
-        <variablelist>
-          <varlistentry>
-            <term>repo_ids: list of strings</term>
-            <listitem><para>
-            Identifiers of the repos from which the packages could be installed.
-            </para></listitem>
-          </varlistentry>
-          <varlistentry>
-            <term>strict: boolean, default true</term>
-            <listitem><para>
-            Indicates whether existing but non-installable packages should
-            be skipped (false) or cause transaction resolving fail (true).
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-
-        Unknown options are ignored.
-    -->
     <method name="install">
-        <arg name="specs" type="as" direction="in" />
-        <arg name="options" type="a{sv}" direction="in" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value=" Mark packages specified by @specs for installation.
+
+            Following @options are supported:
+
+            &lt;variablelist&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;repo_ids: list of strings&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                Identifiers of the repos from which the packages could be installed.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;strict: boolean, default true&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                Indicates whether existing but non-installable packages should
+                be skipped (false) or cause transaction resolving fail (true).
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+            &lt;/variablelist&gt;
+
+            Unknown options are ignored."/>
+
+        <arg name="specs" type="as" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of package specifications to be installed on the system"/>
+        </arg>
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs to modify install behavior"/>
+        </arg>
     </method>
 
-    <!--
-        upgrade:
-        @specs: an array of package specifications to be upgraded on the system
-        @options: an array of key/value pairs to modify upgrade behavior
-
-        Mark packages specified by @specs for upgrade.
-
-        Following @options are supported:
-
-        <variablelist>
-          <varlistentry>
-            <term>repo_ids: list of strings</term>
-            <listitem><para>
-            Identifiers of the repos from which the packages could be upgraded.
-            </para></listitem>
-          </varlistentry>
-        </variablelist>
-
-        Unknown options are ignored.
-    -->
     <method name="upgrade">
-        <arg name="specs" type="as" direction="in" />
-        <arg name="options" type="a{sv}" direction="in" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Mark packages specified by @specs for upgrade.
+
+            Following @options are supported:
+
+            &lt;variablelist&gt;
+              &lt;varlistentry&gt;
+                &lt;term&gt;repo_ids: list of strings&lt;/term&gt;
+                &lt;listitem&gt;&lt;para&gt;
+                Identifiers of the repos from which the packages could be upgraded.
+                &lt;/para&gt;&lt;/listitem&gt;
+              &lt;/varlistentry&gt;
+            &lt;/variablelist&gt;
+
+            Unknown options are ignored."/>
+
+        <arg name="specs" type="as" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of package specifications to be upgraded on the system"/>
+        </arg>
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs to modify upgrade behavior"/>
+        </arg>
     </method>
 
-    <!--
-        remove:
-        @specs: an array of package specifications to be removed on the system
-        @options: an array of key/value pairs to modify remove behavior
-
-        Mark packages specified by @specs for removal.
-
-        Unknown options are ignored.
-    -->
     <method name="remove">
-        <arg name="specs" type="as" direction="in" />
-        <arg name="options" type="a{sv}" direction="in" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value=" Mark packages specified by @specs for removal.
+
+            Unknown options are ignored."/>
+
+        <arg name="specs" type="as" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of package specifications to be removed on the system"/>
+        </arg>
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs to modify remove behavior"/>
+        </arg>
     </method>
 
-    <!--
-        downgrade:
-        @specs: an array of package specifications to be downgraded on the system
-        @options: an array of key/value pairs to modify downgrade behavior
-
-        Mark packages specified by @specs for downgrade.
-
-        Following @options are supported:
-
-        Unknown options are ignored.
-    -->
     <method name="downgrade">
-        <arg name="specs" type="as" direction="in" />
-        <arg name="options" type="a{sv}" direction="in" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value=" Mark packages specified by @specs for downgrade.
+
+            Following @options are supported:
+
+            Unknown options are ignored."/>
+        <arg name="specs" type="as" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of package specifications to be downgraded on the system"/>
+        </arg>
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs to modify downgrade behavior"/>
+        </arg>
     </method>
 
-    <!--
-        reinstall:
-        @specs: an array of package specifications to be reinstalled on the system
-        @options: an array of key/value pairs to modify reinstall behavior
-
-        Mark packages specified by @specs for reinstall.
-
-        Following @options are supported:
-
-        Unknown options are ignored.
-    -->
     <method name="reinstall">
-        <arg name="specs" type="as" direction="in" />
-        <arg name="options" type="a{sv}" direction="in" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Mark packages specified by @specs for reinstall.
+
+            Following @options are supported:
+
+            Unknown options are ignored."/>
+        <arg name="specs" type="as" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of package specifications to be reinstalled on the system"/>
+        </arg>
+        <arg name="options" type="a{sv}" direction="in">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="an array of key/value pairs to modify reinstall behavior"/>
+        </arg>
     </method>
 
-    <!--
-        transaction_action_start:
-        @nevra: full NEVRA of the package
-        @action: one of the dnfdaemon::RpmTransactionItem::Actions enum
-        @total: total to process
-
-        Processing of the item has started.
-    -->
     <signal name="transaction_action_start">
-        <arg name="nevra" type="s" />
-        <arg name="action" type="u" />
-        <arg name="total" type="t" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Processing of the item has started."/>
+        <arg name="nevra" type="s">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="full NEVRA of the package"/>
+        </arg>
+        <arg name="action" type="u">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="one of the dnfdaemon::RpmTransactionItem::Actions enum"/>
+        </arg>
+        <arg name="total" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="total to process"/>
+        </arg>
     </signal>
 
-    <!--
-        transaction_action_progress:
-        @nevra: full NEVRA of the package
-        @amount: amount already processed
-        @total: total to process
-
-        Progress in processing of the package.
-    -->
     <signal name="transaction_action_progress">
-        <arg name="nevra" type="s" />
-        <arg name="amount" type="t" />
-        <arg name="total" type="t" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Progress in processing of the package."/>
+        <arg name="nevra" type="s">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="full NEVRA of the package"/>
+        </arg>
+        <arg name="amount" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="amount already processed"/>
+        </arg>
+        <arg name="total" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="total to process"/>
+        </arg>
     </signal>
 
-    <!--
-        transaction_action_stop:
-        @nevra: full NEVRA of the package
-        @total: total processed
-
-        Processing of the item has finished.
-    -->
     <signal name="transaction_action_stop">
-        <arg name="nevra" type="s" />
-        <arg name="total" type="t" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Processing of the item has finished."/>
+        <arg name="nevra" type="s">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="full NEVRA of the package"/>
+        </arg>
+        <arg name="total" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="total processed"/>
+        </arg>
     </signal>
 
-    <!--
-        transaction_script_start:
-        @nevra: full NEVRA of the package script belongs to
-
-        The scriptlet has started.
-    -->
     <signal name="transaction_script_start">
-        <arg name="nevra" type="s" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="The scriptlet has started."/>
+        <arg name="nevra" type="s">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="full NEVRA of the package script belongs to"/>
+        </arg>
     </signal>
 
-    <!--
-        transaction_script_stop:
-        @nevra: full NEVRA of the package script belongs to
-        @return_code: return value of the script
-
-        The scriptlet has successfully finished.
-    -->
     <signal name="transaction_script_stop">
-        <arg name="nevra" type="s" />
-        <arg name="return_code" type="t" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="The scriptlet has successfully finished."/>
+        <arg name="nevra" type="s">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="full NEVRA of the package script belongs to"/>
+        </arg>
+        <arg name="return_code" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="return value of the script"/>
+        </arg>
     </signal>
 
-    <!--
-        transaction_script_error:
-        @nevra: full NEVRA of the package script belongs to
-        @return_code: return value of the script
-
-        The scriptlet has finished with an error.
-    -->
     <signal name="transaction_script_error">
-        <arg name="nevra" type="s" />
-        <arg name="return_code" type="t" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="The scriptlet has finished with an error."/>
+        <arg name="nevra" type="s">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="full NEVRA of the package script belongs to"/>
+        </arg>
+        <arg name="return_code" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="return value of the script"/>
+        </arg>
     </signal>
 
-    <!--
-        transaction_verify_start:
-        @total: total to process
-
-        Package files verification has started.
-    -->
     <signal name="transaction_verify_start">
-        <arg name="total" type="t" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Package files verification has started."/>
+        <arg name="total" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="total to process"/>
+        </arg>
     </signal>
 
     <!--
         transaction_verify_progress:
         @nevra: full NEVRA of the package
-        @amount: amount already processed
-        @total: total to process
-
-        Progress in processing of the package.
     -->
     <signal name="transaction_verify_progress">
-        <arg name="amount" type="t" />
-        <arg name="total" type="t" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Progress in processing of the package."/>
+        <arg name="amount" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="amount already processed"/>
+        </arg>
+        <arg name="total" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="total to process"/>
+        </arg>
     </signal>
 
     <!--
         transaction_verify_stop:
         @nevra: full NEVRA of the package
-
-        Package files verification has finished.
     -->
     <signal name="transaction_verify_stop">
-        <arg name="total" type="t" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Package files verification has finished."/>
+        <arg name="total" type="t">
+            <annotation name="org.gtk.GDBusDocstring"
+                value=""/>
+        </arg>
     </signal>
 
-    <!--
-        transaction_unpack_error:
-        @nevra: full NEVRA of the package
-
-        Error while unpacking the package.
-    -->
     <signal name="transaction_unpack_error">
-        <arg name="nevra" type="s" />
+        <annotation name="org.gtk.GDBusDocstring"
+            value="Error while unpacking the package."/>
+        <arg name="nevra" type="s">
+            <annotation name="org.gtk.GDBusDocstring"
+                value="full NEVRA of the package"/>
+        </arg>
     </signal>
 </interface>
 


### PR DESCRIPTION
Comments in xml files were replaced by xml annotations following
the documentation.
https://dbus.freedesktop.org/doc/dbus-api-design.html#documentation

rst files can be generated using
xsltproc dnfdaemon_dbus_api.xsl dnfdaemon_dbus_interfaces.xml > out.rst