### PR TITLE
[dnfdaemon] Fix warning: failed to load external entity

### DIFF
--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.Goal.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+"file:///usr/share/xml/dbus-1/introspect.dtd">
 
 <!--
 Copyright Contributors to the libdnf project.

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.SessionManager.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+"file:///usr/share/xml/dbus-1/introspect.dtd">
 
 <!--
 Copyright Contributors to the libdnf project.

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Repo.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+"file:///usr/share/xml/dbus-1/introspect.dtd">
 
 <!--
 Copyright Contributors to the libdnf project.

--- a/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
+++ b/dnfdaemon-server/dbus/interfaces/org.rpm.dnf.v0.rpm.Rpm.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+"file:///usr/share/xml/dbus-1/introspect.dtd">
 
 <!--
 Copyright Contributors to the libdnf project.


### PR DESCRIPTION
The specification https://specifications.freedesktop.org/dbus/1.0/introspect.dtd
gives a 404

https://gitlab.gnome.org/GNOME/gnome-session/-/issues/63