### PR TITLE
[dnf5] Fix: Explicitly cast enum arguments to underlaying type in messages

### DIFF
--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -144,7 +144,10 @@ sdbus::MethodReply Goal::do_transaction(sdbus::MethodCall & call) {
 
     if (rpm_result != libdnf::base::Transaction::TransactionRunResult::SUCCESS) {
         throw sdbus::Error(
-            dnfdaemon::ERROR_TRANSACTION, fmt::format("rpm transaction failed with code {}.", rpm_result));
+            dnfdaemon::ERROR_TRANSACTION,
+            fmt::format(
+                "rpm transaction failed with code {}.",
+                static_cast<std::underlying_type_t<libdnf::base::Transaction::TransactionRunResult>>(rpm_result)));
     }
 
     // TODO(mblaha): clean up downloaded packages after successfull transaction

--- a/dnfdaemon-server/transaction.cpp
+++ b/dnfdaemon-server/transaction.cpp
@@ -21,6 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf/common/exception.hpp>
 
+#include <type_traits>
+
 
 namespace dnfdaemon {
 
@@ -44,9 +46,13 @@ RpmTransactionItemActions transaction_package_to_action(const libdnf::base::Tran
         case libdnf::base::TransactionPackage::Action::REASON_CHANGE:
         case libdnf::transaction::TransactionItemAction::OBSOLETED:
             // TODO(lukash) handle cases
-            libdnf_throw_assertion("Unexpected action in RpmTransactionItem: {}", tspkg.get_action());
+            libdnf_throw_assertion(
+                "Unexpected action in RpmTransactionItem: {}",
+                static_cast<std::underlying_type_t<libdnf::base::TransactionPackage::Action>>(tspkg.get_action()));
     }
-    libdnf_throw_assertion("Unknown action in RpmTransactionItem: {}", tspkg.get_action());
+    libdnf_throw_assertion(
+        "Unknown action in RpmTransactionItem: {}",
+        static_cast<std::underlying_type_t<libdnf::base::TransactionPackage::Action>>(tspkg.get_action()));
 }
 
 }  // namespace dnfdaemon

--- a/include/libdnf-cli/output/transaction_table.hpp
+++ b/include/libdnf-cli/output/transaction_table.hpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf-cli/utils/units.hpp"
 
 #include "libdnf/common/exception.hpp"
+#include "libdnf/utils/to_underlying.hpp"
 
 #include <fmt/format.h>
 #include <libdnf/rpm/nevra.hpp>
@@ -64,7 +65,7 @@ static const char * action_color(libdnf::transaction::TransactionItemAction acti
             break;
     }
 
-    libdnf_throw_assertion("Unexpected action in print_transaction_table: {}", action);
+    libdnf_throw_assertion("Unexpected action in print_transaction_table: {}", libdnf::utils::to_underlying(action));
 }
 
 
@@ -118,7 +119,9 @@ public:
                 case libdnf::transaction::TransactionItemAction::OBSOLETED:
                 case libdnf::transaction::TransactionItemAction::REASON_CHANGE:
                 case libdnf::transaction::TransactionItemAction::REPLACED:
-                    libdnf_throw_assertion("Unexpected action in print_transaction_table: {}", tspkg.get_action());
+                    libdnf_throw_assertion(
+                        "Unexpected action in print_transaction_table: {}",
+                        libdnf::utils::to_underlying(tspkg.get_action()));
             }
 
             text += ":";
@@ -171,7 +174,8 @@ public:
             case libdnf::transaction::TransactionItemAction::OBSOLETE:
             case libdnf::transaction::TransactionItemAction::OBSOLETED:
             case libdnf::transaction::TransactionItemAction::REASON_CHANGE:
-                libdnf_throw_assertion("Unexpected action in print_transaction_table: {}", action);
+                libdnf_throw_assertion(
+                    "Unexpected action in print_transaction_table: {}", libdnf::utils::to_underlying(action));
         }
     }
 

--- a/include/libdnf/utils/to_underlying.hpp
+++ b/include/libdnf/utils/to_underlying.hpp
@@ -1,11 +1,11 @@
 /*
-Copyright Contributors to the libdnf project.
+Copyright (C) 2022 Red Hat, Inc.
 
 This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
 
 Libdnf is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 2.1 of the License, or
+the Free Software Foundation, either version 2 of the License, or
 (at your option) any later version.
 
 Libdnf is distributed in the hope that it will be useful,
@@ -17,15 +17,22 @@ You should have received a copy of the GNU Lesser General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#ifndef LIBDNF_UTILS_TO_UNDERLYING_HPP
+#define LIBDNF_UTILS_TO_UNDERLYING_HPP
 
-#ifndef LIBDNF_COMMON_SACK_QUERY_CMP_PRIVATE_HPP
-#define LIBDNF_COMMON_SACK_QUERY_CMP_PRIVATE_HPP
+#include <fmt/format.h>
 
-#include "libdnf/common/exception.hpp"
-#include "libdnf/common/sack/query_cmp.hpp"
-#include "libdnf/utils/to_underlying.hpp"
+#include <type_traits>
 
-#define libdnf_throw_assert_unsupported_query_cmp_type(cmp_type) \
-    libdnf_throw_assertion("Unsupported sack::QueryCmp value {}", utils::to_underlying(cmp_type))
+namespace libdnf::utils {
 
-#endif  // LIBDNF_COMMON_SACK_QUERY_CMP_PRIVATE_HPP
+/// Converts an enumeration to its underlying type.
+/// `std::to_underlying` is planed for C++23.
+template <class Enum>
+constexpr std::underlying_type_t<Enum> to_underlying(Enum e) noexcept {
+    return static_cast<std::underlying_type_t<Enum>>(e);
+}
+
+}  // namespace libdnf::utils
+
+#endif  // LIBDNF_UTILS_TO_UNDERLYING_HPP

--- a/libdnf/common/sack/match_int64.cpp
+++ b/libdnf/common/sack/match_int64.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/common/sack/match_int64.hpp"
 
+#include "common/sack/query_cmp_private.hpp"
 #include "utils/bgettext/bgettext-lib.h"
 
 #include "libdnf/common/exception.hpp"
@@ -52,7 +53,7 @@ bool match_int64(int64_t value, QueryCmp cmp, int64_t pattern) {
             break;
         default:
             libdnf_assert(cmp - QueryCmp::NOT - QueryCmp::ICASE, "NOT and ICASE modifiers cannot be used standalone");
-            libdnf_throw_assertion("Unsupported operator: operator code {}", cmp);
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp);
     }
     return result;
 }

--- a/libdnf/common/sack/match_string.cpp
+++ b/libdnf/common/sack/match_string.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/common/sack/match_string.hpp"
 
+#include "common/sack/query_cmp_private.hpp"
 #include "utils/bgettext/bgettext-lib.h"
 #include "utils/string.hpp"
 
@@ -82,7 +83,7 @@ bool match_string(const std::string & value, QueryCmp cmp, const std::string & p
             break;
         default:
             libdnf_assert(cmp - QueryCmp::NOT - QueryCmp::ICASE, "NOT and ICASE modifiers cannot be used standalone");
-            libdnf_throw_assertion("Unsupported operator: operator code {}", cmp);
+            libdnf_throw_assert_unsupported_query_cmp_type(cmp);
     }
 
     return static_cast<bool>(cmp & QueryCmp::NOT) ? !result : result;

--- a/libdnf/repo/solv_repo.cpp
+++ b/libdnf/repo/solv_repo.cpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils/temp.hpp"
 
 #include "libdnf/base/base.hpp"
+#include "libdnf/utils/to_underlying.hpp"
 
 extern "C" {
 #include <solv/chksum.h>
@@ -103,7 +104,7 @@ static const char * repodata_type_to_suffix(RepodataType type) {
             return "-other";
     }
 
-    libdnf_throw_assertion("Unknown RepodataType: {}", type);
+    libdnf_throw_assertion("Unknown RepodataType: {}", utils::to_underlying(type));
 }
 
 static int repodata_type_to_flags(RepodataType type) {
@@ -118,7 +119,7 @@ static int repodata_type_to_flags(RepodataType type) {
             return REPO_EXTEND_SOLVABLES | REPO_LOCALPOOL;
     }
 
-    libdnf_throw_assertion("Unknown RepodataType: {}", type);
+    libdnf_throw_assertion("Unknown RepodataType: {}", utils::to_underlying(type));
 }
 
 SolvRepo::SolvRepo(const libdnf::BaseWeakPtr & base, const ConfigRepo & config)

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -27,6 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/exception.hpp"
 #include "libdnf/rpm/transaction.hpp"
 #include "libdnf/transaction/transaction_item_action.hpp"
+#include "libdnf/utils/to_underlying.hpp"
 
 #include <fcntl.h>
 #include <fmt/format.h>
@@ -841,7 +842,7 @@ void Transaction::Impl::install_up_down(TransactionItem & item, libdnf::transact
         upgrade = false;
         msg_action = "install";
     } else {
-        libdnf_throw_assertion("Unsupported action: {}", action);
+        libdnf_throw_assertion("Unsupported action: {}", utils::to_underlying(action));
     }
     auto file_path = item.get_package().get_package_path();
     auto * header = read_pkg_header(file_path);

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -551,7 +551,10 @@ public:
             case libdnf::transaction::TransactionItemAction::OBSOLETE:
             case libdnf::transaction::TransactionItemAction::OBSOLETED:
             case libdnf::transaction::TransactionItemAction::REASON_CHANGE:
-                throw std::logic_error(fmt::format("Unexpected action in TransactionPackage: {}", item.get_action()));
+                throw std::logic_error(fmt::format(
+                    "Unexpected action in TransactionPackage: {}",
+                    static_cast<std::underlying_type_t<libdnf::base::Transaction::TransactionRunResult>>(
+                        item.get_action())));
         }
         if (!msg) {
             msg = "Installing ";


### PR DESCRIPTION
Implicit conversion for the enum class was disabled in the "fmt" library.