### PR TITLE
[dnf5] Fix moving and copying AdvisoryModule, AdvisoryPackage, SolverProblems, unit tests

### DIFF
--- a/include/libdnf/advisory/advisory_module.hpp
+++ b/include/libdnf/advisory/advisory_module.hpp
@@ -31,8 +31,8 @@ public:
     AdvisoryModule(const AdvisoryModule & src);
     AdvisoryModule & operator=(const AdvisoryModule & src);
 
-    AdvisoryModule(AdvisoryModule && src) = default;
-    AdvisoryModule & operator=(AdvisoryModule && src) = default;
+    AdvisoryModule(AdvisoryModule && src) noexcept;
+    AdvisoryModule & operator=(AdvisoryModule && src) noexcept;
 
     ~AdvisoryModule();
 

--- a/include/libdnf/advisory/advisory_package.hpp
+++ b/include/libdnf/advisory/advisory_package.hpp
@@ -39,8 +39,8 @@ public:
     AdvisoryPackage(const AdvisoryPackage & src);
     AdvisoryPackage & operator=(const AdvisoryPackage & src);
 
-    AdvisoryPackage(AdvisoryPackage && src) = default;
-    AdvisoryPackage & operator=(AdvisoryPackage && src) = default;
+    AdvisoryPackage(AdvisoryPackage && src) noexcept;
+    AdvisoryPackage & operator=(AdvisoryPackage && src) noexcept;
 
     ~AdvisoryPackage();
 

--- a/include/libdnf/base/solver_problems.hpp
+++ b/include/libdnf/base/solver_problems.hpp
@@ -33,8 +33,8 @@ public:
     SolverProblems(const SolverProblems & src);
     SolverProblems & operator=(const SolverProblems & src);
 
-    SolverProblems(SolverProblems && src) noexcept = default;
-    SolverProblems & operator=(SolverProblems && src) noexcept = default;
+    SolverProblems(SolverProblems && src) noexcept;
+    SolverProblems & operator=(SolverProblems && src) noexcept;
 
     ~SolverProblems();
 

--- a/libdnf/advisory/advisory_module.cpp
+++ b/libdnf/advisory/advisory_module.cpp
@@ -30,13 +30,22 @@ AdvisoryModule::AdvisoryModule(AdvisoryModule::Impl * private_module) : p_impl(p
 
 AdvisoryModule::AdvisoryModule(const AdvisoryModule & src) : p_impl(new Impl(*src.p_impl)) {}
 
+AdvisoryModule::AdvisoryModule(AdvisoryModule && src) noexcept = default;
+
 AdvisoryModule & AdvisoryModule::operator=(const AdvisoryModule & src) {
-    *p_impl = *src.p_impl;
+    if (p_impl != src.p_impl) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl.reset(new Impl(*src.p_impl));
+        }
+    }
     return *this;
 }
 
-AdvisoryModule::~AdvisoryModule() = default;
+AdvisoryModule & AdvisoryModule::operator=(AdvisoryModule && src) noexcept = default;
 
+AdvisoryModule::~AdvisoryModule() = default;
 
 std::string AdvisoryModule::get_name() const {
     return get_pool(p_impl->base).id2str(p_impl->name);

--- a/libdnf/advisory/advisory_package.cpp
+++ b/libdnf/advisory/advisory_package.cpp
@@ -35,10 +35,20 @@ AdvisoryPackage::AdvisoryPackage(AdvisoryPackage::Impl * private_pkg) : p_impl(p
 
 AdvisoryPackage::AdvisoryPackage(const AdvisoryPackage & src) : p_impl(new Impl(*src.p_impl)) {}
 
+AdvisoryPackage::AdvisoryPackage(AdvisoryPackage && src) noexcept = default;
+
 AdvisoryPackage & AdvisoryPackage::operator=(const AdvisoryPackage & src) {
-    *p_impl = *src.p_impl;
+    if (p_impl != src.p_impl) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl.reset(new Impl(*src.p_impl));
+        }
+    }
     return *this;
 }
+
+AdvisoryPackage & AdvisoryPackage::operator=(AdvisoryPackage && src) noexcept = default;
 
 AdvisoryPackage::~AdvisoryPackage() = default;
 

--- a/libdnf/base/solver_problems.cpp
+++ b/libdnf/base/solver_problems.cpp
@@ -177,12 +177,20 @@ SolverProblems::SolverProblems() : p_impl(new Impl()) {}
 
 SolverProblems::SolverProblems(const SolverProblems & src) : p_impl(new Impl(*src.p_impl)) {}
 
+SolverProblems::SolverProblems(SolverProblems && src) noexcept = default;
+
 SolverProblems & SolverProblems::operator=(const SolverProblems & src) {
-    if (this != &src) {
-        *p_impl = *src.p_impl;
+    if (p_impl != src.p_impl) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl.reset(new Impl(*src.p_impl));
+        }
     }
     return *this;
 }
+
+SolverProblems & SolverProblems::operator=(SolverProblems && src) noexcept = default;
 
 SolverProblems::~SolverProblems() = default;
 

--- a/test/libdnf/advisory/test_advisory_module.cpp
+++ b/test/libdnf/advisory/test_advisory_module.cpp
@@ -82,3 +82,37 @@ void AdvisoryAdvisoryModuleTest::test_get_advisory_collection() {
     size_t target_size = 2;
     CPPUNIT_ASSERT_EQUAL(target_size, out_mods.size());
 }
+
+void AdvisoryAdvisoryModuleTest::test_copy_move() {
+    // Tests copy constructor
+    auto advisory_module_copy(modules[0]);
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), advisory_module_copy.get_name());
+
+    // Tests copy assignment operator
+    advisory_module_copy = modules[1];
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), advisory_module_copy.get_name());
+
+    // Tests copy assignment operator - self-assignment
+    advisory_module_copy = advisory_module_copy;
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), advisory_module_copy.get_name());
+
+    // Tests move constructor
+    auto advisory_module_move(std::move(modules[1]));
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), advisory_module_move.get_name());
+
+    // Tests move assignment operator
+    advisory_module_move = std::move(modules[0]);
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), advisory_module_move.get_name());
+
+    // Tests move assignment operator - self-assignment
+    advisory_module_move = std::move(advisory_module_move);
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), advisory_module_move.get_name());
+
+    // Test copy assignment to moved from object
+    modules[0] = advisory_module_copy;
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), modules[0].get_name());
+
+    // Test move assignment to moved from object
+    modules[1] = std::move(advisory_module_move);
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), modules[1].get_name());
+}

--- a/test/libdnf/advisory/test_advisory_module.hpp
+++ b/test/libdnf/advisory/test_advisory_module.hpp
@@ -42,6 +42,8 @@ class AdvisoryAdvisoryModuleTest : public LibdnfTestCase {
     CPPUNIT_TEST(test_get_advisory);
     CPPUNIT_TEST(test_get_advisory_collection);
 
+    CPPUNIT_TEST(test_copy_move);
+
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -56,6 +58,8 @@ public:
     void test_get_advisory_id();
     void test_get_advisory();
     void test_get_advisory_collection();
+
+    void test_copy_move();
 
 private:
     std::vector<libdnf::advisory::AdvisoryModule> modules;

--- a/test/libdnf/advisory/test_advisory_package.cpp
+++ b/test/libdnf/advisory/test_advisory_package.cpp
@@ -77,3 +77,37 @@ void AdvisoryAdvisoryPackageTest::test_get_advisory_collection() {
     size_t target_size = 2;
     CPPUNIT_ASSERT_EQUAL(target_size, out_pkgs.size());
 }
+
+void AdvisoryAdvisoryPackageTest::test_copy_move() {
+    // Tests copy constructor
+    auto advisory_package_copy(packages[0]);
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), advisory_package_copy.get_name());
+
+    // Tests copy assignment operator
+    advisory_package_copy = packages[1];
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), advisory_package_copy.get_name());
+
+    // Tests copy assignment operator - self-assignment
+    advisory_package_copy = advisory_package_copy;
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), advisory_package_copy.get_name());
+
+    // Tests move constructor
+    auto advisory_package_move(std::move(packages[1]));
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), advisory_package_move.get_name());
+
+    // Tests move assignment operator
+    advisory_package_move = std::move(packages[0]);
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), advisory_package_move.get_name());
+
+    // Tests move assignment operator - self-assignment
+    advisory_package_move = std::move(advisory_package_move);
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), advisory_package_move.get_name());
+
+    // Test copy assignment to moved from object
+    packages[0] = advisory_package_copy;
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), packages[0].get_name());
+
+    // Test move assignment to moved from object
+    packages[1] = std::move(advisory_package_move);
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), packages[1].get_name());
+}

--- a/test/libdnf/advisory/test_advisory_package.hpp
+++ b/test/libdnf/advisory/test_advisory_package.hpp
@@ -39,6 +39,7 @@ class AdvisoryAdvisoryPackageTest : public LibdnfTestCase {
     CPPUNIT_TEST(test_get_advisory_id);
     CPPUNIT_TEST(test_get_advisory);
     CPPUNIT_TEST(test_get_advisory_collection);
+    CPPUNIT_TEST(test_copy_move);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -52,6 +53,7 @@ public:
     void test_get_advisory_id();
     void test_get_advisory();
     void test_get_advisory_collection();
+    void test_copy_move();
 
 private:
     std::vector<libdnf::advisory::AdvisoryPackage> packages;


### PR DESCRIPTION
* default move constructors and move assignment operatorst must be defined in .cpp (not in the header file) - incomplete type `Impl` in the header file

* copy assignment operators must work with "moved from" destination objects - objects to which "move" has been applied.
  Allows reuse of "moved from" objects.