### PR TITLE
[dnf5] ImplPtr: smart pointer, specialized in class implementation ownership

### DIFF
--- a/include/libdnf/advisory/advisory_module.hpp
+++ b/include/libdnf/advisory/advisory_module.hpp
@@ -22,18 +22,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "advisory.hpp"
 
-#include <memory>
+#include "libdnf/common/impl_ptr.hpp"
+
 
 namespace libdnf::advisory {
 
 class AdvisoryModule {
 public:
     AdvisoryModule(const AdvisoryModule & src);
+    AdvisoryModule(AdvisoryModule && src) noexcept;
     AdvisoryModule & operator=(const AdvisoryModule & src);
-
-    AdvisoryModule(AdvisoryModule && src) = default;
-    AdvisoryModule & operator=(AdvisoryModule && src) = default;
-
+    AdvisoryModule & operator=(AdvisoryModule && src) noexcept;
     ~AdvisoryModule();
 
     /// Get name of this AdvisoryModule.
@@ -89,9 +88,8 @@ private:
     friend class AdvisoryCollection;
 
     class Impl;
-
     AdvisoryModule(Impl * private_module);
-    std::unique_ptr<Impl> p_impl;
+    ImplPtr<Impl> p_impl;
 };
 
 }  // namespace libdnf::advisory

--- a/include/libdnf/advisory/advisory_package.hpp
+++ b/include/libdnf/advisory/advisory_package.hpp
@@ -21,8 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_ADVISORY_ADVISORY_PACKAGE_HPP
 
 #include "libdnf/advisory/advisory.hpp"
+#include "libdnf/common/impl_ptr.hpp"
 
-#include <memory>
 #include <vector>
 
 
@@ -37,11 +37,9 @@ namespace libdnf::advisory {
 class AdvisoryPackage {
 public:
     AdvisoryPackage(const AdvisoryPackage & src);
+    AdvisoryPackage(AdvisoryPackage && src) noexcept;
     AdvisoryPackage & operator=(const AdvisoryPackage & src);
-
-    AdvisoryPackage(AdvisoryPackage && src) = default;
-    AdvisoryPackage & operator=(AdvisoryPackage && src) = default;
-
+    AdvisoryPackage & operator=(AdvisoryPackage && src) noexcept;
     ~AdvisoryPackage();
 
     /// Get name of this AdvisoryPackage.
@@ -113,7 +111,7 @@ private:
 
     class Impl;
     AdvisoryPackage(Impl * private_pkg);
-    std::unique_ptr<Impl> p_impl;
+    ImplPtr<Impl> p_impl;
 };
 
 }  // namespace libdnf::advisory

--- a/include/libdnf/base/solver_problems.hpp
+++ b/include/libdnf/base/solver_problems.hpp
@@ -24,6 +24,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "goal_elements.hpp"
 
+#include "libdnf/common/impl_ptr.hpp"
+
 
 namespace libdnf::base {
 
@@ -31,11 +33,9 @@ namespace libdnf::base {
 class SolverProblems {
 public:
     SolverProblems(const SolverProblems & src);
+    SolverProblems(SolverProblems && src) noexcept;
     SolverProblems & operator=(const SolverProblems & src);
-
-    SolverProblems(SolverProblems && src) noexcept = default;
-    SolverProblems & operator=(SolverProblems && src) noexcept = default;
-
+    SolverProblems & operator=(SolverProblems && src) noexcept;
     ~SolverProblems();
 
     /// Provide information about package solver problems in a vector. Each problem can be transformed to string by
@@ -59,10 +59,10 @@ public:
 private:
     friend class Transaction;
 
-    class Impl;
-    std::unique_ptr<Impl> p_impl;
-
     SolverProblems();
+
+    class Impl;
+    ImplPtr<Impl> p_impl;
 };
 
 }  // namespace libdnf::base

--- a/include/libdnf/common/impl_ptr.hpp
+++ b/include/libdnf/common/impl_ptr.hpp
@@ -1,0 +1,86 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_COMMON_IMPL_PTR_HPP
+#define LIBDNF_COMMON_IMPL_PTR_HPP
+
+
+namespace libdnf {
+
+template <class T>
+class ImplPtr {
+public:
+    /// Constructs an ImplPtr that owns nothing.
+    constexpr ImplPtr() noexcept = default;
+
+    /// Constructs an ImplPtr that takes ownership of `ptr`.
+    explicit constexpr ImplPtr(T * ptr) noexcept { this->ptr = ptr; }
+
+    /// Constructs an ImplPtr that owns newly created instance value initialized from `src` or
+    /// owns nothing if `src` owns nothing.
+    ImplPtr(const ImplPtr & src) : ptr(src.ptr ? new T(*src.ptr) : nullptr) {}
+
+    /// Constructs an ImplPtr by transferring ownership from `src` to *this and stores the null pointer in `src`.
+    constexpr ImplPtr(ImplPtr && src) noexcept : ptr(src.ptr) { src.ptr = nullptr; }
+
+    /// Copies the value pointed to by `src`, not the pointer itself.
+    /// If the destination owns nothing and `src` points to a value, a new instance of the value initialized from
+    /// `src` is created. Does not do anything if both of them own nothing.
+    ImplPtr & operator=(const ImplPtr & src) {
+        if (ptr != src.ptr) {
+            if (ptr) {
+                *ptr = *src.ptr;
+            } else {
+                ptr = new T(*src.ptr);
+            }
+        }
+        return *this;
+    }
+
+    /// Transfers ownership from `src` to *this and stores the null pointer in `src`.
+    ImplPtr & operator=(ImplPtr && src) noexcept {
+        if (ptr != src.ptr) {
+            delete ptr;
+            ptr = src.ptr;
+            src.ptr = nullptr;
+        }
+        return *this;
+    }
+
+    ~ImplPtr() { delete ptr; }
+
+    constexpr T * operator->() noexcept { return ptr; }
+
+    constexpr const T * operator->() const noexcept { return ptr; }
+
+    constexpr T & operator*() noexcept { return *ptr; }
+
+    constexpr const T & operator*() const noexcept { return *ptr; }
+
+    constexpr T * get() noexcept { return ptr; }
+
+    constexpr const T * get() const noexcept { return ptr; }
+
+private:
+    T * ptr{nullptr};  // object is owner of the pointer
+};
+
+}  // namespace libdnf
+
+#endif

--- a/libdnf/advisory/advisory_module.cpp
+++ b/libdnf/advisory/advisory_module.cpp
@@ -28,15 +28,11 @@ namespace libdnf::advisory {
 // AdvisoryModule
 AdvisoryModule::AdvisoryModule(AdvisoryModule::Impl * private_module) : p_impl(private_module) {}
 
-AdvisoryModule::AdvisoryModule(const AdvisoryModule & src) : p_impl(new Impl(*src.p_impl)) {}
-
-AdvisoryModule & AdvisoryModule::operator=(const AdvisoryModule & src) {
-    *p_impl = *src.p_impl;
-    return *this;
-}
-
+AdvisoryModule::AdvisoryModule(const AdvisoryModule & src) = default;
+AdvisoryModule::AdvisoryModule(AdvisoryModule && src) noexcept = default;
+AdvisoryModule & AdvisoryModule::operator=(const AdvisoryModule & src) = default;
+AdvisoryModule & AdvisoryModule::operator=(AdvisoryModule && src) noexcept = default;
 AdvisoryModule::~AdvisoryModule() = default;
-
 
 std::string AdvisoryModule::get_name() const {
     return get_pool(p_impl->base).id2str(p_impl->name);

--- a/libdnf/advisory/advisory_package.cpp
+++ b/libdnf/advisory/advisory_package.cpp
@@ -33,13 +33,10 @@ namespace libdnf::advisory {
 // AdvisoryPackage
 AdvisoryPackage::AdvisoryPackage(AdvisoryPackage::Impl * private_pkg) : p_impl(private_pkg) {}
 
-AdvisoryPackage::AdvisoryPackage(const AdvisoryPackage & src) : p_impl(new Impl(*src.p_impl)) {}
-
-AdvisoryPackage & AdvisoryPackage::operator=(const AdvisoryPackage & src) {
-    *p_impl = *src.p_impl;
-    return *this;
-}
-
+AdvisoryPackage::AdvisoryPackage(const AdvisoryPackage & src) = default;
+AdvisoryPackage::AdvisoryPackage(AdvisoryPackage && src) noexcept = default;
+AdvisoryPackage & AdvisoryPackage::operator=(const AdvisoryPackage & src) = default;
+AdvisoryPackage & AdvisoryPackage::operator=(AdvisoryPackage && src) noexcept = default;
 AdvisoryPackage::~AdvisoryPackage() = default;
 
 

--- a/libdnf/base/solver_problems.cpp
+++ b/libdnf/base/solver_problems.cpp
@@ -175,15 +175,10 @@ std::vector<std::pair<ProblemRules, std::vector<std::string>>> get_removal_of_pr
 
 SolverProblems::SolverProblems() : p_impl(new Impl()) {}
 
-SolverProblems::SolverProblems(const SolverProblems & src) : p_impl(new Impl(*src.p_impl)) {}
-
-SolverProblems & SolverProblems::operator=(const SolverProblems & src) {
-    if (this != &src) {
-        *p_impl = *src.p_impl;
-    }
-    return *this;
-}
-
+SolverProblems::SolverProblems(const SolverProblems & src) = default;
+SolverProblems::SolverProblems(SolverProblems && src) noexcept = default;
+SolverProblems & SolverProblems::operator=(const SolverProblems & src) = default;
+SolverProblems & SolverProblems::operator=(SolverProblems && src) noexcept = default;
 SolverProblems::~SolverProblems() = default;
 
 std::vector<std::vector<std::pair<libdnf::ProblemRules, std::vector<std::string>>>> SolverProblems::get_problems() {

--- a/test/libdnf/impl_ptr/test_impl_ptr.cpp
+++ b/test/libdnf/impl_ptr/test_impl_ptr.cpp
@@ -1,0 +1,252 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "test_impl_ptr.hpp"
+
+#include "libdnf/common/impl_ptr.hpp"
+
+#include <type_traits>
+#include <utility>
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ImplPtrTest);
+
+namespace {
+
+// Test class with instance counter. It is non move constructible, non move assignable, and non swappable.
+class CTest {
+public:
+    CTest() noexcept { ++instance_counter; }
+    CTest(int a) : a(a) { ++instance_counter; }
+    CTest(const CTest & src) noexcept : a(src.a) { ++instance_counter; }
+    CTest(CTest && src) = delete;
+
+    CTest & operator=(const CTest & src) noexcept {
+        a = src.a;
+        return *this;
+    }
+
+    CTest & operator=(CTest && src) = delete;
+
+    ~CTest() { --instance_counter; }
+
+    // Returns the nuber of existing class instances.
+    static int get_instance_counter() noexcept { return instance_counter; }
+
+    int get_a() const noexcept { return a; }
+    void set_a(int value) noexcept { a = value; }
+
+private:
+    int a{0};
+    static int instance_counter;
+};
+
+int CTest::instance_counter = 0;
+
+}  // namespace
+
+
+static_assert(std::is_nothrow_default_constructible_v<libdnf::ImplPtr<CTest>>);
+static_assert(std::is_nothrow_default_constructible_v<libdnf::ImplPtr<CTest>>);
+static_assert(std::is_copy_constructible_v<libdnf::ImplPtr<CTest>>);
+static_assert(std::is_copy_assignable_v<libdnf::ImplPtr<CTest>>);
+
+// `ImplPtr` is_nothrow_move_constructible, is_nothrow_move_assignable, and nothrow_swappable, even if CTest is not.
+static_assert(!std::is_move_constructible_v<CTest>);
+static_assert(!std::is_move_assignable_v<CTest>);
+static_assert(!std::is_swappable_v<CTest>);
+static_assert(std::is_nothrow_move_constructible_v<libdnf::ImplPtr<CTest>>);
+static_assert(std::is_nothrow_move_assignable_v<libdnf::ImplPtr<CTest>>);
+static_assert(std::is_nothrow_swappable_v<libdnf::ImplPtr<CTest>>);
+
+
+void ImplPtrTest::test_default_constructor() {
+    // Tests an empty constructor. `p_impl` is` nullptr`. No new CTest instance is created.
+    libdnf::ImplPtr<CTest> empty_object;
+    CPPUNIT_ASSERT(nullptr == empty_object.get());
+    CPPUNIT_ASSERT_EQUAL(0, CTest::get_instance_counter());
+}
+
+void ImplPtrTest::test_constructor_from_pointer() {
+    {
+        // Tests constructor that takes ownership of existing `CTtest` instance.
+        libdnf::ImplPtr<CTest> object(new CTest);
+        CPPUNIT_ASSERT(nullptr != object.get());
+        CPPUNIT_ASSERT_EQUAL(1, CTest::get_instance_counter());
+    }
+
+    // `ImplPtr` was the owner of the` CTest` instance and destroyed it.
+    CPPUNIT_ASSERT_EQUAL(0, CTest::get_instance_counter());
+}
+
+void ImplPtrTest::test_access_to_managed_object() {
+    {
+        // Constructs mutable (non-constant) object.
+        libdnf::ImplPtr<CTest> object(new CTest(10));
+
+        // Tests the `T * operator->()`.
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(object.operator->())>>);
+        CPPUNIT_ASSERT_EQUAL(10, object->get_a());
+        object->set_a(0);
+        CPPUNIT_ASSERT_EQUAL(0, object->get_a());
+
+        // Tests the `T & operator*()`.
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(object.operator*())>>);
+        CPPUNIT_ASSERT_EQUAL(0, (*object).get_a());
+        (*object).set_a(10);
+        CPPUNIT_ASSERT_EQUAL(10, (*object).get_a());
+
+        // Tests the `T * get()`.
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(object.get())>>);
+        CPPUNIT_ASSERT_EQUAL(10, object.get()->get_a());
+        object.get()->set_a(0);
+        CPPUNIT_ASSERT_EQUAL(0, object.get()->get_a());
+    }
+
+    // Tests that all instances of the `CTest` class are destroyed. No leaks.
+    CPPUNIT_ASSERT_EQUAL(0, CTest::get_instance_counter());
+}
+
+void ImplPtrTest::test_const_access_to_managed_object() {
+    {
+        // Constructs constant object.
+        const libdnf::ImplPtr<CTest> const_object(new CTest(10));
+
+        // Tests the `const T * operator->() const`
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(const_object.operator->())>>);
+        CPPUNIT_ASSERT_EQUAL(10, const_object->get_a());
+
+        // Tests the `const T & operator*() const`.
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(const_object.operator*())>>);
+        CPPUNIT_ASSERT_EQUAL(10, (*const_object).get_a());
+
+        // Tests the `const T * get() const`.
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(const_object.get())>>);
+        CPPUNIT_ASSERT_EQUAL(10, const_object.get()->get_a());
+    }
+
+    // Tests that all instances of the `CTest` class are destroyed. No leaks.
+    CPPUNIT_ASSERT_EQUAL(0, CTest::get_instance_counter());
+}
+
+void ImplPtrTest::test_copy_constructor() {
+    {
+        libdnf::ImplPtr<CTest> src_object(new CTest(10));
+        CPPUNIT_ASSERT_EQUAL(1, CTest::get_instance_counter());
+
+        // Tests the copy constructor. The source object remains unchanged.
+        // A new `CTest` instance is created.
+        libdnf::ImplPtr<CTest> new_object(src_object);
+        CPPUNIT_ASSERT_EQUAL(2, CTest::get_instance_counter());
+        CPPUNIT_ASSERT_EQUAL(10, new_object->get_a());
+        CPPUNIT_ASSERT(nullptr != src_object.get());
+        CPPUNIT_ASSERT_EQUAL(10, src_object->get_a());
+    }
+
+    // Tests that all instances of the `CTest` class are destroyed. No leaks.
+    CPPUNIT_ASSERT_EQUAL(0, CTest::get_instance_counter());
+}
+
+void ImplPtrTest::test_move_constructor() {
+    {
+        libdnf::ImplPtr<CTest> src_object(new CTest(10));
+        CPPUNIT_ASSERT_EQUAL(1, CTest::get_instance_counter());
+
+        // Tests the move constructor. Ownership is transferred from the source object to `*this`.
+        // `p_impl` in the source object becomes `nullptr`.
+        // No new `CTest` instances are created.
+        libdnf::ImplPtr<CTest> new_object(std::move(src_object));
+        CPPUNIT_ASSERT_EQUAL(1, CTest::get_instance_counter());
+        CPPUNIT_ASSERT_EQUAL(10, new_object->get_a());
+        CPPUNIT_ASSERT(nullptr == src_object.get());
+    }
+
+    // Tests that all instances of the `CTest` class are destroyed. No leaks.
+    CPPUNIT_ASSERT_EQUAL(0, CTest::get_instance_counter());
+}
+
+void ImplPtrTest::test_copy_assignment() {
+    {
+        libdnf::ImplPtr<CTest> src_object(new CTest(10));
+        libdnf::ImplPtr<CTest> dst_object(new CTest(5));
+        CPPUNIT_ASSERT_EQUAL(2, CTest::get_instance_counter());
+
+        // Tests the copy assignment operator. The source object remains unchanged.
+        // The value of the `CTest` instance in the source is copied to the CTest instance in the destination.
+        dst_object = src_object;
+        CPPUNIT_ASSERT_EQUAL(2, CTest::get_instance_counter());
+        CPPUNIT_ASSERT_EQUAL(10, dst_object->get_a());
+        CPPUNIT_ASSERT(nullptr != src_object.get());
+        CPPUNIT_ASSERT_EQUAL(10, src_object->get_a());
+
+        // Tests the copy assignment operator - self-assignment.
+        // The object must remain unchanged.
+        dst_object = dst_object;
+        CPPUNIT_ASSERT_EQUAL(2, CTest::get_instance_counter());
+        CPPUNIT_ASSERT_EQUAL(10, dst_object->get_a());
+
+        // Tests the copy assignment to empty (moved from) object. The source object remains unchanged.
+        // A new `CTest` instance is created.
+        libdnf::ImplPtr<CTest> empty_object;
+        CPPUNIT_ASSERT(nullptr == empty_object.get());
+        empty_object = dst_object;
+        CPPUNIT_ASSERT_EQUAL(3, CTest::get_instance_counter());
+        CPPUNIT_ASSERT_EQUAL(10, empty_object->get_a());
+        CPPUNIT_ASSERT_EQUAL(10, dst_object->get_a());
+    }
+
+    // Tests that all instances of the `CTest` class are destroyed. No leaks.
+    CPPUNIT_ASSERT_EQUAL(0, CTest::get_instance_counter());
+}
+
+void ImplPtrTest::test_move_assignment() {
+    {
+        libdnf::ImplPtr<CTest> src_object(new CTest(10));
+        libdnf::ImplPtr<CTest> dst_object(new CTest(5));
+        CPPUNIT_ASSERT_EQUAL(2, CTest::get_instance_counter());
+
+        // Tests the move assignment operator.
+        // `CTest` instance ownership is transferred from the source object to the destination.
+        // The old `CTest` instance in the destination is destroyed.
+        // `p_impl` in the original object becomes nullptr.
+        dst_object = std::move(src_object);
+        CPPUNIT_ASSERT_EQUAL(1, CTest::get_instance_counter());
+        CPPUNIT_ASSERT_EQUAL(10, dst_object->get_a());
+        CPPUNIT_ASSERT(nullptr == src_object.get());
+
+        // Tests the move assignment operator - self-assignment.
+        // The object must remain unchanged.
+        dst_object = std::move(dst_object);
+        CPPUNIT_ASSERT_EQUAL(1, CTest::get_instance_counter());
+        CPPUNIT_ASSERT_EQUAL(10, dst_object->get_a());
+
+        // Tests the move assignment to empty (moved from) object.
+        // `CTest` instance ownership is transferred from the source object to the destination.
+        // `p_impl` in the original object becomes nullptr.
+        libdnf::ImplPtr<CTest> empty_object;
+        CPPUNIT_ASSERT(nullptr == empty_object.get());
+        empty_object = std::move(dst_object);
+        CPPUNIT_ASSERT_EQUAL(1, CTest::get_instance_counter());
+        CPPUNIT_ASSERT_EQUAL(10, empty_object->get_a());
+        CPPUNIT_ASSERT(nullptr == dst_object.get());
+    }
+
+    // Tests that all instances of the `CTest` class are destroyed. No leaks.
+    CPPUNIT_ASSERT_EQUAL(0, CTest::get_instance_counter());
+}

--- a/test/libdnf/impl_ptr/test_impl_ptr.hpp
+++ b/test/libdnf/impl_ptr/test_impl_ptr.hpp
@@ -1,0 +1,51 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_TEST_IMPL_PTR_HPP
+#define LIBDNF_TEST_IMPL_PTR_HPP
+
+
+#include <cppunit/TestCase.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class ImplPtrTest : public CppUnit::TestCase {
+    CPPUNIT_TEST_SUITE(ImplPtrTest);
+    CPPUNIT_TEST(test_default_constructor);
+    CPPUNIT_TEST(test_constructor_from_pointer);
+    CPPUNIT_TEST(test_access_to_managed_object);
+    CPPUNIT_TEST(test_const_access_to_managed_object);
+    CPPUNIT_TEST(test_copy_constructor);
+    CPPUNIT_TEST(test_move_constructor);
+    CPPUNIT_TEST(test_copy_assignment);
+    CPPUNIT_TEST(test_move_assignment);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void test_default_constructor();
+    void test_constructor_from_pointer();
+    void test_access_to_managed_object();
+    void test_const_access_to_managed_object();
+    void test_copy_constructor();
+    void test_move_constructor();
+    void test_copy_assignment();
+    void test_move_assignment();
+};
+
+#endif


### PR DESCRIPTION
`ImplPtr` owns the value it points to.
This is an inline version implemented using only one header file.

Differences from `std::unique_ptr`:
- implements copy constructor - Constructs a `ImplPtr` that owns newly created instance value initialized from `src` or owns nothing if `src` owns nothing.

- implements copy assignment operator - Copies the value pointed to by `src`. Not a pointer itself. If the destination owns nothing and `src` points to a value, a new instance of the value initialized from `src` is created. It does not do anything if both of them own nothing.

- implements `T * operator->() noexcept` - `std::unique_ptr` implements only `const` version that returns pointer to non-constant value

- implements `const T * operator->() const noexcept` - `std::unique_ptr` returns pointer to non-constant value

- implements `T & operator*() noexcept` - `std::unique_ptr` implements only `const` version that returns reference to non-constant value

- implements `const T & operator*() const noexcept` - `std::unique_ptr` returns reference to non-constant value

- implements `T * get() noexcept` - `std::unique_ptr` implements only `const` version that returns pointer to non-constant value

- implements `const T * get() const noexcept` - `std::unique_ptr` returns  pointer to non-constant value

- implements only the methods needed for the given purpose