### PR TITLE
[dnf5] ImplPtr: smart pointer, specialized in class implementation ownership - version2

### DIFF
--- a/include/libdnf/advisory/advisory_module.hpp
+++ b/include/libdnf/advisory/advisory_module.hpp
@@ -31,8 +31,8 @@ public:
     AdvisoryModule(const AdvisoryModule & src);
     AdvisoryModule & operator=(const AdvisoryModule & src);
 
-    AdvisoryModule(AdvisoryModule && src) = default;
-    AdvisoryModule & operator=(AdvisoryModule && src) = default;
+    AdvisoryModule(AdvisoryModule && src) noexcept;
+    AdvisoryModule & operator=(AdvisoryModule && src) noexcept;
 
     ~AdvisoryModule();
 

--- a/include/libdnf/advisory/advisory_module.hpp
+++ b/include/libdnf/advisory/advisory_module.hpp
@@ -22,20 +22,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "advisory.hpp"
 
-#include <memory>
+#include "libdnf/common/impl_ptr.hpp"
 
 namespace libdnf::advisory {
 
 class AdvisoryModule {
 public:
-    AdvisoryModule(const AdvisoryModule & src);
-    AdvisoryModule & operator=(const AdvisoryModule & src);
-
-    AdvisoryModule(AdvisoryModule && src) noexcept;
-    AdvisoryModule & operator=(AdvisoryModule && src) noexcept;
-
-    ~AdvisoryModule();
-
     /// Get name of this AdvisoryModule.
     ///
     /// @return Name of this AdvisoryModule as std::string.
@@ -91,7 +83,7 @@ private:
     class Impl;
 
     AdvisoryModule(Impl * private_module);
-    std::unique_ptr<Impl> p_impl;
+    ImplPtr<Impl> p_impl;
 };
 
 }  // namespace libdnf::advisory

--- a/include/libdnf/advisory/advisory_package.hpp
+++ b/include/libdnf/advisory/advisory_package.hpp
@@ -39,8 +39,8 @@ public:
     AdvisoryPackage(const AdvisoryPackage & src);
     AdvisoryPackage & operator=(const AdvisoryPackage & src);
 
-    AdvisoryPackage(AdvisoryPackage && src) = default;
-    AdvisoryPackage & operator=(AdvisoryPackage && src) = default;
+    AdvisoryPackage(AdvisoryPackage && src) noexcept;
+    AdvisoryPackage & operator=(AdvisoryPackage && src) noexcept;
 
     ~AdvisoryPackage();
 

--- a/include/libdnf/base/solver_problems.hpp
+++ b/include/libdnf/base/solver_problems.hpp
@@ -33,8 +33,8 @@ public:
     SolverProblems(const SolverProblems & src);
     SolverProblems & operator=(const SolverProblems & src);
 
-    SolverProblems(SolverProblems && src) noexcept = default;
-    SolverProblems & operator=(SolverProblems && src) noexcept = default;
+    SolverProblems(SolverProblems && src) noexcept;
+    SolverProblems & operator=(SolverProblems && src) noexcept;
 
     ~SolverProblems();
 

--- a/include/libdnf/common/impl_ptr.hpp
+++ b/include/libdnf/common/impl_ptr.hpp
@@ -1,0 +1,62 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_COMMON_IMPL_PTR_HPP
+#define LIBDNF_COMMON_IMPL_PTR_HPP
+
+
+namespace libdnf {
+
+template <class T>
+class ImplPtr {
+public:
+    /// Constructs a ImplPtr that owns nothing.
+    constexpr ImplPtr() noexcept = default;
+
+    /// Constructs a ImplPtr that takes ownership of `ptr`.
+    explicit constexpr ImplPtr(T * ptr) noexcept { this->ptr = ptr; }
+
+    /// Constructs a ImplPtr that owns newly created instance value initialized from `src` or
+    /// owns nothing if `src` owns nothing.
+    ImplPtr(const ImplPtr & src);
+
+    /// Constructs a ImplPtr by transferring ownership from `src` to *this and stores the null pointer in `src`.
+    constexpr ImplPtr(ImplPtr && src) noexcept : ptr(src.ptr) { src.ptr = nullptr; }
+
+    /// Copy assignment operator. Copies the value pointed to by `src`. Not a pointer itself.
+    /// If the destination owns nothing and `src` points to a value, a new instance of the value initialized from
+    /// `src` is created. It does not do anything if both of them own nothing.
+    ImplPtr & operator=(const ImplPtr & src);
+
+    /// Move assignment operator. Transfers ownership from `src` to *this and stores the null pointer in `src`.
+    ImplPtr & operator=(ImplPtr && src) noexcept;
+
+    ~ImplPtr();
+
+    constexpr T * operator->() noexcept { return ptr; }
+
+    constexpr const T * operator->() const noexcept { return ptr; }
+
+private:
+    T * ptr{nullptr};  // object is owner of the pointer
+};
+
+}  // namespace libdnf
+
+#endif

--- a/libdnf/advisory/advisory_module.cpp
+++ b/libdnf/advisory/advisory_module.cpp
@@ -30,13 +30,22 @@ AdvisoryModule::AdvisoryModule(AdvisoryModule::Impl * private_module) : p_impl(p
 
 AdvisoryModule::AdvisoryModule(const AdvisoryModule & src) : p_impl(new Impl(*src.p_impl)) {}
 
+AdvisoryModule::AdvisoryModule(AdvisoryModule && src) noexcept = default;
+
 AdvisoryModule & AdvisoryModule::operator=(const AdvisoryModule & src) {
-    *p_impl = *src.p_impl;
+    if (p_impl != src.p_impl) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl.reset(new Impl(*src.p_impl));
+        }
+    }
     return *this;
 }
 
-AdvisoryModule::~AdvisoryModule() = default;
+AdvisoryModule & AdvisoryModule::operator=(AdvisoryModule && src) noexcept = default;
 
+AdvisoryModule::~AdvisoryModule() = default;
 
 std::string AdvisoryModule::get_name() const {
     return get_pool(p_impl->base).id2str(p_impl->name);

--- a/libdnf/advisory/advisory_module.cpp
+++ b/libdnf/advisory/advisory_module.cpp
@@ -20,32 +20,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/advisory/advisory_module.hpp"
 
 #include "advisory_module_private.hpp"
+#include "common/impl_ptr_impl.hpp"
 #include "solv/pool.hpp"
 
+namespace libdnf {
+template class ImplPtr<advisory::AdvisoryModule::Impl>;
+}
 
 namespace libdnf::advisory {
 
 // AdvisoryModule
 AdvisoryModule::AdvisoryModule(AdvisoryModule::Impl * private_module) : p_impl(private_module) {}
-
-AdvisoryModule::AdvisoryModule(const AdvisoryModule & src) : p_impl(new Impl(*src.p_impl)) {}
-
-AdvisoryModule::AdvisoryModule(AdvisoryModule && src) noexcept = default;
-
-AdvisoryModule & AdvisoryModule::operator=(const AdvisoryModule & src) {
-    if (p_impl != src.p_impl) {
-        if (p_impl) {
-            *p_impl = *src.p_impl;
-        } else {
-            p_impl.reset(new Impl(*src.p_impl));
-        }
-    }
-    return *this;
-}
-
-AdvisoryModule & AdvisoryModule::operator=(AdvisoryModule && src) noexcept = default;
-
-AdvisoryModule::~AdvisoryModule() = default;
 
 std::string AdvisoryModule::get_name() const {
     return get_pool(p_impl->base).id2str(p_impl->name);

--- a/libdnf/advisory/advisory_package.cpp
+++ b/libdnf/advisory/advisory_package.cpp
@@ -35,10 +35,20 @@ AdvisoryPackage::AdvisoryPackage(AdvisoryPackage::Impl * private_pkg) : p_impl(p
 
 AdvisoryPackage::AdvisoryPackage(const AdvisoryPackage & src) : p_impl(new Impl(*src.p_impl)) {}
 
+AdvisoryPackage::AdvisoryPackage(AdvisoryPackage && src) noexcept = default;
+
 AdvisoryPackage & AdvisoryPackage::operator=(const AdvisoryPackage & src) {
-    *p_impl = *src.p_impl;
+    if (p_impl != src.p_impl) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl.reset(new Impl(*src.p_impl));
+        }
+    }
     return *this;
 }
+
+AdvisoryPackage & AdvisoryPackage::operator=(AdvisoryPackage && src) noexcept = default;
 
 AdvisoryPackage::~AdvisoryPackage() = default;
 

--- a/libdnf/base/solver_problems.cpp
+++ b/libdnf/base/solver_problems.cpp
@@ -177,12 +177,20 @@ SolverProblems::SolverProblems() : p_impl(new Impl()) {}
 
 SolverProblems::SolverProblems(const SolverProblems & src) : p_impl(new Impl(*src.p_impl)) {}
 
+SolverProblems::SolverProblems(SolverProblems && src) noexcept = default;
+
 SolverProblems & SolverProblems::operator=(const SolverProblems & src) {
-    if (this != &src) {
-        *p_impl = *src.p_impl;
+    if (p_impl != src.p_impl) {
+        if (p_impl) {
+            *p_impl = *src.p_impl;
+        } else {
+            p_impl.reset(new Impl(*src.p_impl));
+        }
     }
     return *this;
 }
+
+SolverProblems & SolverProblems::operator=(SolverProblems && src) noexcept = default;
 
 SolverProblems::~SolverProblems() = default;
 

--- a/libdnf/common/impl_ptr_impl.hpp
+++ b/libdnf/common/impl_ptr_impl.hpp
@@ -1,0 +1,60 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_COMMON_IMPL_PTR_IMPL_HPP
+#define LIBDNF_COMMON_IMPL_PTR_IMPL_HPP
+
+#include "libdnf/common/impl_ptr.hpp"
+
+
+namespace libdnf {
+
+template <class T>
+ImplPtr<T>::ImplPtr(const ImplPtr & src) : ptr(src.ptr ? new T(*src.ptr) : nullptr) {}
+
+template <class T>
+ImplPtr<T> & ImplPtr<T>::operator=(const ImplPtr & src) {
+    if (ptr != src.ptr) {
+        if (ptr) {
+            *ptr = *src.ptr;
+        } else {
+            ptr = new T(*src.ptr);
+        }
+    }
+    return *this;
+}
+
+template <class T>
+ImplPtr<T> & ImplPtr<T>::operator=(ImplPtr && src) noexcept {
+    if (ptr != src.ptr) {
+        delete ptr;
+        ptr = src.ptr;
+        src.ptr = nullptr;
+    }
+    return *this;
+}
+
+template <class T>
+ImplPtr<T>::~ImplPtr() {
+    delete ptr;
+}
+
+}  // namespace libdnf
+
+#endif

--- a/test/libdnf/advisory/test_advisory_module.cpp
+++ b/test/libdnf/advisory/test_advisory_module.cpp
@@ -82,3 +82,37 @@ void AdvisoryAdvisoryModuleTest::test_get_advisory_collection() {
     size_t target_size = 2;
     CPPUNIT_ASSERT_EQUAL(target_size, out_mods.size());
 }
+
+void AdvisoryAdvisoryModuleTest::test_copy_move() {
+    // Tests copy constructor
+    auto advisory_module_copy(modules[0]);
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), advisory_module_copy.get_name());
+
+    // Tests copy assignment operator
+    advisory_module_copy = modules[1];
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), advisory_module_copy.get_name());
+
+    // Tests copy assignment operator - self-assignment
+    advisory_module_copy = advisory_module_copy;
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), advisory_module_copy.get_name());
+
+    // Tests move constructor
+    auto advisory_module_move(std::move(modules[1]));
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), advisory_module_move.get_name());
+
+    // Tests move assignment operator
+    advisory_module_move = std::move(modules[0]);
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), advisory_module_move.get_name());
+
+    // Tests move assignment operator - self-assignment
+    advisory_module_move = std::move(advisory_module_move);
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), advisory_module_move.get_name());
+
+    // Test copy assignment to moved from object
+    modules[0] = advisory_module_copy;
+    CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), modules[0].get_name());
+
+    // Test move assignment to moved from object
+    modules[1] = std::move(advisory_module_move);
+    CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), modules[1].get_name());
+}

--- a/test/libdnf/advisory/test_advisory_module.hpp
+++ b/test/libdnf/advisory/test_advisory_module.hpp
@@ -42,6 +42,8 @@ class AdvisoryAdvisoryModuleTest : public LibdnfTestCase {
     CPPUNIT_TEST(test_get_advisory);
     CPPUNIT_TEST(test_get_advisory_collection);
 
+    CPPUNIT_TEST(test_copy_move);
+
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -56,6 +58,8 @@ public:
     void test_get_advisory_id();
     void test_get_advisory();
     void test_get_advisory_collection();
+
+    void test_copy_move();
 
 private:
     std::vector<libdnf::advisory::AdvisoryModule> modules;

--- a/test/libdnf/advisory/test_advisory_package.cpp
+++ b/test/libdnf/advisory/test_advisory_package.cpp
@@ -77,3 +77,37 @@ void AdvisoryAdvisoryPackageTest::test_get_advisory_collection() {
     size_t target_size = 2;
     CPPUNIT_ASSERT_EQUAL(target_size, out_pkgs.size());
 }
+
+void AdvisoryAdvisoryPackageTest::test_copy_move() {
+    // Tests copy constructor
+    auto advisory_package_copy(packages[0]);
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), advisory_package_copy.get_name());
+
+    // Tests copy assignment operator
+    advisory_package_copy = packages[1];
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), advisory_package_copy.get_name());
+
+    // Tests copy assignment operator - self-assignment
+    advisory_package_copy = advisory_package_copy;
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), advisory_package_copy.get_name());
+
+    // Tests move constructor
+    auto advisory_package_move(std::move(packages[1]));
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), advisory_package_move.get_name());
+
+    // Tests move assignment operator
+    advisory_package_move = std::move(packages[0]);
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), advisory_package_move.get_name());
+
+    // Tests move assignment operator - self-assignment
+    advisory_package_move = std::move(advisory_package_move);
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), advisory_package_move.get_name());
+
+    // Test copy assignment to moved from object
+    packages[0] = advisory_package_copy;
+    CPPUNIT_ASSERT_EQUAL(std::string("filesystem"), packages[0].get_name());
+
+    // Test move assignment to moved from object
+    packages[1] = std::move(advisory_package_move);
+    CPPUNIT_ASSERT_EQUAL(std::string("pkg"), packages[1].get_name());
+}

--- a/test/libdnf/advisory/test_advisory_package.hpp
+++ b/test/libdnf/advisory/test_advisory_package.hpp
@@ -39,6 +39,7 @@ class AdvisoryAdvisoryPackageTest : public LibdnfTestCase {
     CPPUNIT_TEST(test_get_advisory_id);
     CPPUNIT_TEST(test_get_advisory);
     CPPUNIT_TEST(test_get_advisory_collection);
+    CPPUNIT_TEST(test_copy_move);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -52,6 +53,7 @@ public:
     void test_get_advisory_id();
     void test_get_advisory();
     void test_get_advisory_collection();
+    void test_copy_move();
 
 private:
     std::vector<libdnf::advisory::AdvisoryPackage> packages;


### PR DESCRIPTION
`ImplPtr` owns the value it points to.
Implemented using two header files. Allows the use of explicit instantion in a .cpp file: `template class ImplPtr<Impl>;`

Differences from `std::unique_ptr`:
* implements copy constructor - Constructs a `ImplPtr` that owns newly created instance value initialized from `src` or owns nothing if `src` owns nothing.

* implements copy assignment operator - Copies the value pointed to by `src`. Not a pointer itself. If the destination owns nothing and `src` points to a value, a new instance of the value initialized from `src` is created. It does not do anything if both of them own nothing.

* implements `T * operator->() noexcept` - `std::unique_ptr` implements only const version that returns pointer to non-constant value

* implements `const T * operator->() const noexcept` - `std::unique_ptr` returns pointer to non-constant value

* implements only the methods needed for the given purpose