### PR TITLE
Make build_cache global option defaulting to true

### DIFF
--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -197,6 +197,8 @@ public:
     const OptionBool & countme() const;
     OptionBool & protect_running_kernel();
     const OptionBool & protect_running_kernel() const;
+    OptionBool & build_cache();
+    const OptionBool & build_cache() const;
 
     // Repo main config
     OptionNumber<std::uint32_t> & retries();

--- a/include/libdnf/repo/config_repo.hpp
+++ b/include/libdnf/repo/config_repo.hpp
@@ -129,8 +129,8 @@ public:
     OptionChild<OptionBool> & skip_if_unavailable();
     const OptionChild<OptionBool> & skip_if_unavailable() const;
     /// If true it will create libsolv cache that will speed up the next loading process
-    OptionBool & build_cache();
-    const OptionBool & build_cache() const;
+    OptionChild<OptionBool> & build_cache();
+    const OptionChild<OptionBool> & build_cache() const;
 
     // option recognized by other tools, e.g. gnome-software, but unused in dnf
     OptionString & enabled_metadata();

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -278,6 +278,7 @@ class ConfigMain::Impl {
     OptionString user_agent{"libdnf"};  // TODO(jrohel): getUserAgent()
     OptionBool countme{false};
     OptionBool protect_running_kernel{true};
+    OptionBool build_cache{true};
 
     // Repo main config
 
@@ -445,6 +446,7 @@ ConfigMain::Impl::Impl(Config & owner) : owner(owner) {
     owner.opt_binds().add("user_agent", user_agent);
     owner.opt_binds().add("countme", countme);
     owner.opt_binds().add("protect_running_kernel", protect_running_kernel);
+    owner.opt_binds().add("build_cache", build_cache);
 
     // Repo main config
 
@@ -1044,6 +1046,13 @@ OptionBool & ConfigMain::protect_running_kernel() {
 
 const OptionBool & ConfigMain::protect_running_kernel() const {
     return p_impl->protect_running_kernel;
+}
+
+OptionBool & ConfigMain::build_cache() {
+    return p_impl->build_cache;
+}
+const OptionBool & ConfigMain::build_cache() const {
+    return p_impl->build_cache;
 }
 
 // Repo main config

--- a/libdnf/repo/config_repo.cpp
+++ b/libdnf/repo/config_repo.cpp
@@ -87,7 +87,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionString> user_agent{main_config.user_agent()};
     OptionChild<OptionBool> countme{main_config.countme()};
     OptionEnum<std::string> failovermethod{"priority", {"priority", "roundrobin"}};
-    OptionBool build_cache{false};
+    OptionChild<OptionBool> build_cache{main_config.build_cache()};
 };
 
 ConfigRepo::Impl::Impl(Config & owner, ConfigMain & main_config, const std::string & id)
@@ -540,10 +540,10 @@ const OptionEnum<std::string> & ConfigRepo::failovermethod() const {
     return p_impl->failovermethod;
 }
 
-OptionBool & ConfigRepo::build_cache() {
+OptionChild<OptionBool> & ConfigRepo::build_cache() {
     return p_impl->build_cache;
 }
-const OptionBool & ConfigRepo::build_cache() const {
+const OptionChild<OptionBool> & ConfigRepo::build_cache() const {
     return p_impl->build_cache;
 }
 

--- a/libdnf/repo/repo_sack.cpp
+++ b/libdnf/repo/repo_sack.cpp
@@ -79,6 +79,7 @@ RepoWeakPtr RepoSack::new_repo_from_libsolv_testcase(const std::string & repoid,
 RepoWeakPtr RepoSack::get_cmdline_repo() {
     if (!cmdline_repo) {
         std::unique_ptr<Repo> repo(new Repo(base, CMDLINE_REPO_NAME, Repo::Type::COMMANDLINE));
+        repo->get_config().build_cache().set(libdnf::Option::Priority::RUNTIME, false);
         cmdline_repo = repo.get();
         add_item(std::move(repo));
     }
@@ -90,6 +91,8 @@ RepoWeakPtr RepoSack::get_cmdline_repo() {
 RepoWeakPtr RepoSack::get_system_repo() {
     if (!system_repo) {
         std::unique_ptr<Repo> repo(new Repo(base, SYSTEM_REPO_NAME, Repo::Type::SYSTEM));
+        // TODO(mblaha): re-enable caching once we can reliably detect whether system repo is up-to-date
+        repo->get_config().build_cache().set(libdnf::Option::Priority::RUNTIME, false);
         system_repo = repo.get();
         add_item(std::move(repo));
         pool_set_installed(*get_pool(base), system_repo->p_impl->solv_repo.repo);


### PR DESCRIPTION
The impact of build_cache on repository metadata loading is significant.
Let's change the hard-coded default to `true`. Commit also adds global
`build_cache` option which makes changing the value for all repositories
in one place possible.