### PR TITLE
Revert upstream configuration exclude_from_weak_autodetect to false

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -299,7 +299,7 @@ class ConfigMain::Impl {
     OptionStringList excludepkgs{std::vector<std::string>{}};
     OptionStringList includepkgs{std::vector<std::string>{}};
     OptionStringList exclude_from_weak{std::vector<std::string>{}};
-    OptionBool exclude_from_weak_autodetect{true};
+    OptionBool exclude_from_weak_autodetect{false};
     OptionString proxy{""};
     OptionString proxy_username{nullptr};
     OptionString proxy_password{nullptr};


### PR DESCRIPTION
The patch is required for Fedora < 35 and RHEL8 if
exclude_from_weak_autodetect will be backported.