### PR TITLE
Write and check version for solvfiles cache (RhBug:2027445)

### DIFF
--- a/libdnf/hy-iutil-private.hpp
+++ b/libdnf/hy-iutil-private.hpp
@@ -25,6 +25,11 @@
 #include "hy-types.h"
 #include "sack/packageset.hpp"
 
+// Use 5 bytes to be future proof even though the version currently is only "1.2"
+#define SOLVFILE_VERSION_BYTES 5
+int solvfile_version_write(const char *solvfile_version, FILE *fp);
+int solvfile_version_read(char *solvfile_version_out, FILE *fp);
+
 /* crypto utils */
 int checksum_cmp(const unsigned char *cs1, const unsigned char *cs2);
 int checksum_fp(unsigned char *out, FILE *fp);

--- a/libdnf/hy-iutil.cpp
+++ b/libdnf/hy-iutil.cpp
@@ -145,7 +145,7 @@ checksum_fp(unsigned char *out, FILE *fp)
 int
 checksum_read(unsigned char *csout, FILE *fp)
 {
-    if (fseek(fp, -32, SEEK_END) ||
+    if (fseek(fp, -1 * (CHKSUM_BYTES + SOLVFILE_VERSION_BYTES), SEEK_END) ||
         fread(csout, CHKSUM_BYTES, 1, fp) != 1)
         return 1;
     rewind(fp);
@@ -179,6 +179,33 @@ int checksum_write(const unsigned char *cs, FILE *fp)
     if (fseek(fp, 0, SEEK_END) ||
         fwrite(cs, CHKSUM_BYTES, 1, fp) != 1)
         return 1;
+    return 0;
+}
+
+int solvfile_version_write(const char *solvfile_version, FILE *fp)
+{
+    if (strlen(solvfile_version) > SOLVFILE_VERSION_BYTES) {
+        return 1;
+    }
+
+    // Since solvfile_version is shorter than SOLVFILE_VERSION_BYTES g_strndup padds it with 0.
+    char *padded_solvfile_ver = g_strndup(solvfile_version, SOLVFILE_VERSION_BYTES);
+    int ret = 0;
+    if (fseek(fp, 0, SEEK_END) || fwrite(padded_solvfile_ver, SOLVFILE_VERSION_BYTES, 1, fp) != 1) {
+        ret = 1;
+    }
+    g_free(padded_solvfile_ver);
+    return ret;
+}
+
+int
+solvfile_version_read(char *solvfile_version_out, FILE *fp)
+{
+    if (fseek(fp, -1 * SOLVFILE_VERSION_BYTES, SEEK_END) ||
+        fread(solvfile_version_out, SOLVFILE_VERSION_BYTES, 1, fp) != 1) {
+        return 1;
+    }
+    rewind(fp);
     return 0;
 }
 

--- a/tests/hawkey/test_iutil.cpp
+++ b/tests/hawkey/test_iutil.cpp
@@ -99,14 +99,15 @@ START_TEST(test_checksum)
 }
 END_TEST
 
-START_TEST(test_checksum_write_read)
+START_TEST(test_checksum_solvversion_write_read)
 {
     char *new_file = solv_dupjoin(test_globals.tmpdir,
-                                  "/test_checksum_write_read", NULL);
+                                  "/test_checksum_solvversion_write_read", NULL);
     build_test_file(new_file);
 
     unsigned char cs_computed[CHKSUM_BYTES];
     unsigned char cs_read[CHKSUM_BYTES];
+    char sv_read[SOLVFILE_VERSION_BYTES];
     FILE *fp = fopen(new_file, "r");
     checksum_fp(cs_computed, fp);
     // fails, file opened read-only:
@@ -114,10 +115,13 @@ START_TEST(test_checksum_write_read)
     fclose(fp);
     fp = fopen(new_file, "r+");
     fail_if(checksum_write(cs_computed, fp));
+    fail_if(solvfile_version_write(solv_toolversion, fp));
     fclose(fp);
     fp = fopen(new_file, "r");
     fail_if(checksum_read(cs_read, fp));
+    fail_if(solvfile_version_read(sv_read, fp));
     fail_if(checksum_cmp(cs_computed, cs_read));
+    fail_if(g_strcmp0(solv_toolversion, sv_read));
     fclose(fp);
 
     g_free(new_file);
@@ -183,7 +187,7 @@ iutil_suite(void)
     TCase *tc = tcase_create("Main");
     tcase_add_test(tc, test_abspath);
     tcase_add_test(tc, test_checksum);
-    tcase_add_test(tc, test_checksum_write_read);
+    tcase_add_test(tc, test_checksum_solvversion_write_read);
     tcase_add_test(tc, test_mkcachedir);
     tcase_add_test(tc, test_version_split);
     suite_add_tcase(s, tc);


### PR DESCRIPTION
Version is written at the end of solvfiles together with checksum.
This requires recent change in libsolv: https://github.com/openSUSE/libsolv/pull/486

= changelog =
msg: Write and check version for solvfiles cache (RhBug:2027445)
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2027445