### PR TITLE
libdnf/advisory/advisory: Fix operator!=

### DIFF
--- a/include/libdnf/advisory/advisory.hpp
+++ b/include/libdnf/advisory/advisory.hpp
@@ -51,8 +51,13 @@ public:
     Advisory(const libdnf::BaseWeakPtr & base, AdvisoryId id);
     Advisory(libdnf::Base & base, AdvisoryId id);
 
-    bool operator==(const Advisory & other) const noexcept;
-    bool operator!=(const Advisory & other) const noexcept;
+    bool operator==(const Advisory & other) const noexcept {
+        return id == other.id && base == other.base;
+    }
+
+    bool operator!=(const Advisory & other) const noexcept {
+        return !(*this == other);
+    }
 
     /// Destroy the Advisory object
     ~Advisory();
@@ -136,14 +141,6 @@ private:
 
     AdvisoryId id;
 };
-
-inline bool Advisory::operator==(const Advisory & other) const noexcept {
-    return id == other.id && base == other.base;
-}
-
-inline bool Advisory::operator!=(const Advisory & other) const noexcept {
-    return id != other.id && base != other.base;
-}
 
 }  // namespace libdnf::advisory
 


### PR DESCRIPTION
Moves the operator== and operator!= definitions inline with the class
declaration.

Fixes the implementation of operator!=, there should have been ||
instead of &&, but in case of a compound condition it's better to just
call !operator==(), so that the condition isn't duplicated in its
negated form.