### PR TITLE
[dnf5] unittests: Asserting objects directly instead of converting to strings

### DIFF
--- a/include/libdnf/comps/group/package.hpp
+++ b/include/libdnf/comps/group/package.hpp
@@ -40,6 +40,12 @@ public:
           type(type),
           condition(condition) {}
 
+    bool operator==(const Package & other) const noexcept {
+        return name == other.name && type == other.type && condition == other.condition;
+    }
+
+    bool operator!=(const Package & other) const noexcept { return !(*this == other); }
+
     /// @replaces dnf:dnf/comps.py:attribute:Package.name
     std::string get_name() const { return name; }
     void set_name(const std::string & value) { name = value; }

--- a/include/libdnf/rpm/reldep.hpp
+++ b/include/libdnf/rpm/reldep.hpp
@@ -81,7 +81,7 @@ public:
 
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:toString()
     /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_to_string(DnfReldep *reldep)
-    std::string to_string();
+    std::string to_string() const;
 
     /// @replaces libdnf/repo/solvable/Dependency.hpp:method:getId()
     /// @replaces libdnf/dnf-reldep.h:function:dnf_reldep_to_string(DnfReldep *reldep)

--- a/libdnf/rpm/reldep.cpp
+++ b/libdnf/rpm/reldep.cpp
@@ -57,7 +57,7 @@ const char * Reldep::get_relation() const {
 const char * Reldep::get_version() const {
     return get_pool(base).id2evr(id.id);
 }
-std::string Reldep::to_string() {
+std::string Reldep::to_string() const {
     auto * cstring = get_pool(base).dep2str(id.id);
     return cstring ? std::string(cstring) : std::string();
 }

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -32,160 +32,158 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 CPPUNIT_TEST_SUITE_REGISTRATION(AdvisoryAdvisoryQueryTest);
 
+using namespace libdnf::advisory;
+
 void AdvisoryAdvisoryQueryTest::setUp() {
     BaseTestCase::setUp();
     BaseTestCase::add_repo_repomd("repomd-repo1");
 }
 
 void AdvisoryAdvisoryQueryTest::test_size() {
-    auto adv_query = libdnf::advisory::AdvisoryQuery(base);
-    std::vector<std::string> expected = {"DNF-2019-1", "DNF-2020-1", "PKG-NEWER", "PKG-OLDER"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    auto adv_query = AdvisoryQuery(base);
+    std::vector<Advisory> expected = {
+        get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1"), get_advisory("PKG-NEWER"), get_advisory("PKG-OLDER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_name() {
     // Tests filter_name method
-    libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
-    std::vector<std::string> expected = {"DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
+    std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
-    expected = {"DNF-2019-1", "DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
+    expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name(
+    adv_query = AdvisoryQuery(base).filter_name(
         std::vector<std::string>{"DNF-2019-1", "DNF-2020-1"}, libdnf::sack::QueryCmp::EQ);
-    expected = {"DNF-2019-1", "DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_type() {
     // Tests filter_type method
-    libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_type("bugfix");
-    std::vector<std::string> expected = {"DNF-2020-1", "PKG-OLDER"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_type("bugfix");
+    std::vector<Advisory> expected = {get_advisory("DNF-2020-1"), get_advisory("PKG-OLDER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_type("enhancement");
-    expected = {"PKG-NEWER"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_type("enhancement");
+    expected = {get_advisory("PKG-NEWER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_type(
-        std::vector<std::string>{"bugfix", "security"}, libdnf::sack::QueryCmp::EQ);
-    expected = {"DNF-2019-1", "DNF-2020-1", "PKG-OLDER"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query =
+        AdvisoryQuery(base).filter_type(std::vector<std::string>{"bugfix", "security"}, libdnf::sack::QueryCmp::EQ);
+    expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1"), get_advisory("PKG-OLDER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_packages() {
     // Tests filter_packages method
     libdnf::rpm::PackageQuery pkg_query(base);
 
-    libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
-    std::vector<std::string> expected = {"PKG-NEWER"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
+    std::vector<Advisory> expected = {get_advisory("PKG-NEWER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
-    expected = {"DNF-2019-1", "PKG-NEWER"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
+    expected = {get_advisory("DNF-2019-1"), get_advisory("PKG-NEWER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
-    expected = {"DNF-2019-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
+    expected = {get_advisory("DNF-2019-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
-    expected = {"DNF-2019-1", "PKG-OLDER"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
+    expected = {get_advisory("DNF-2019-1"), get_advisory("PKG-OLDER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
-    expected = {"PKG-OLDER"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
+    expected = {get_advisory("PKG-OLDER")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_cve() {
     // Tests filter_reference method with cve
-    libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_reference("3333", libdnf::sack::QueryCmp::EQ, "cve");
-    std::vector<std::string> expected = {"DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_reference("3333", libdnf::sack::QueryCmp::EQ, "cve");
+    std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference(
+    adv_query = AdvisoryQuery(base).filter_reference(
         std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "cve");
-    expected = {"DNF-2019-1", "DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference(
+    adv_query = AdvisoryQuery(base).filter_reference(
         std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ, "cve");
-    expected = {"DNF-2019-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    expected = {get_advisory("DNF-2019-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB, "cve");
-    expected = {"DNF-2019-1", "DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB, "cve");
+    expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_bugzilla() {
     // Tests filter_reference method with bugzilla
-    libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_reference("2222", libdnf::sack::QueryCmp::EQ, "bugzilla");
-    std::vector<std::string> expected = {"DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_reference("2222", libdnf::sack::QueryCmp::EQ, "bugzilla");
+    std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference(
+    adv_query = AdvisoryQuery(base).filter_reference(
         std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "bugzilla");
     expected = {};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB, "bugzilla");
-    expected = {"DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB, "bugzilla");
+    expected = {get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_reference() {
     // Tests filter_reference method without type specified
-    libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("2222");
-    std::vector<std::string> expected = {"DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_reference("2222");
+    std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference(std::vector<std::string>{"1111", "3333"});
-    expected = {"DNF-2019-1", "DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_reference(std::vector<std::string>{"1111", "3333"});
+    expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB);
-    expected = {"DNF-2019-1", "DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    adv_query = AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB);
+    expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_reference("none*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = AdvisoryQuery(base).filter_reference("none*", libdnf::sack::QueryCmp::GLOB);
     expected = {};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_severity() {
     // Tests filter_severity method
-    libdnf::advisory::AdvisoryQuery adv_query =
-        libdnf::advisory::AdvisoryQuery(base).filter_severity("moderate", libdnf::sack::QueryCmp::EQ);
-    std::vector<std::string> expected = {"DNF-2019-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_severity("moderate", libdnf::sack::QueryCmp::EQ);
+    std::vector<Advisory> expected = {get_advisory("DNF-2019-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = libdnf::advisory::AdvisoryQuery(base).filter_severity(
+    adv_query = AdvisoryQuery(base).filter_severity(
         std::vector<std::string>{"moderate", "critical"}, libdnf::sack::QueryCmp::EQ);
-    expected = {"DNF-2019-1", "DNF-2020-1"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_name_string(adv_query));
+    expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_get_advisory_packages() {
     // Tests get_advisory_packages method
     libdnf::rpm::PackageQuery pkg_query(base);
     // pkg_query contains: pkg-1.2-3.x86_64, pkg-libs-1:1.3-4.x86_64, unresolvable-1:2-3.noarch
-    std::vector<libdnf::advisory::AdvisoryPackage> adv_pkgs =
-        libdnf::advisory::AdvisoryQuery(base).get_advisory_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
+    std::vector<AdvisoryPackage> adv_pkgs =
+        AdvisoryQuery(base).get_advisory_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
     CPPUNIT_ASSERT_EQUAL(2lu, adv_pkgs.size());
     CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("1.2-3"), adv_pkgs[0].get_evr());
     CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[1].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("4.0-1"), adv_pkgs[1].get_evr());
 
-    adv_pkgs = libdnf::advisory::AdvisoryQuery(base).get_advisory_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
+    adv_pkgs = AdvisoryQuery(base).get_advisory_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
     CPPUNIT_ASSERT_EQUAL(2lu, adv_pkgs.size());
     CPPUNIT_ASSERT_EQUAL(std::string("pkg"), adv_pkgs[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("1.2-3"), adv_pkgs[0].get_evr());

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -220,8 +220,8 @@ void BaseGoalTest::test_install_installed_pkg() {
     libdnf::rpm::PackageQuery query(base);
     query.filter_available().filter_nevra({"one-0:1-1.noarch"});
 
-    std::vector<std::string> expected = {"one-0:1-1.noarch"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+    std::vector<libdnf::rpm::Package> expected = {get_pkg("one-0:1-1.noarch")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
 
     libdnf::Goal goal(base);
     goal.add_rpm_install(query);

--- a/test/libdnf/base_test_case.cpp
+++ b/test/libdnf/base_test_case.cpp
@@ -68,6 +68,27 @@ libdnf::repo::RepoWeakPtr BaseTestCase::add_repo_solv(const std::string & repoid
 }
 
 
+libdnf::advisory::Advisory BaseTestCase::get_advisory(const std::string & name) {
+    // This is used for testing queries as well, hence we don't use the AdvisoryQuery facility for filtering
+    libdnf::advisory::AdvisorySet advisories = libdnf::advisory::AdvisoryQuery(base);
+
+    libdnf::advisory::AdvisorySet found(base);
+    for (auto advisory : advisories) {
+        if (advisory.get_name() == name) {
+            found.add(advisory);
+        }
+    }
+
+    if (found.empty()) {
+        CPPUNIT_FAIL(sformat("No advisory \"{}\" found. All pool advisories:{}", name, to_string(advisories)));
+    } else if (found.size() > 1) {
+        CPPUNIT_FAIL(sformat("More than one advisory matching \"{}\" found:{}", name, to_string(advisories)));
+    }
+
+    return *found.begin();
+}
+
+
 libdnf::rpm::Package BaseTestCase::get_pkg(const std::string & nevra, bool installed) {
     libdnf::rpm::PackageQuery query(base);
     query.filter_nevra({nevra});

--- a/test/libdnf/base_test_case.cpp
+++ b/test/libdnf/base_test_case.cpp
@@ -30,6 +30,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <map>
 
 
+using libdnf::utils::sformat;
+
+
 libdnf::repo::RepoWeakPtr BaseTestCase::add_repo(const std::string & repoid, const std::string & repo_path, bool load) {
     auto repo = repo_sack->create_repo(repoid);
 
@@ -110,9 +113,9 @@ libdnf::rpm::Package BaseTestCase::add_cmdline_pkg(const std::string & relative_
 libdnf::rpm::Package BaseTestCase::first_query_pkg(libdnf::rpm::PackageQuery & query, const std::string & what) {
     if (query.empty()) {
         CPPUNIT_FAIL(
-            "No package \"" + what + "\" found. All sack packages:" + list_pkg_infos(libdnf::rpm::PackageQuery(base)));
+            sformat("No package \"{}\" found. All sack packages:{}", what, to_string(libdnf::rpm::PackageQuery(base))));
     } else if (query.size() > 1) {
-        CPPUNIT_FAIL("More than one package matching \"" + what + "\" found:" + list_pkg_infos(query));
+        CPPUNIT_FAIL(sformat("More than one package matching \"{}\" found:{}", what, to_string(query)));
     }
 
     return *query.begin();

--- a/test/libdnf/base_test_case.cpp
+++ b/test/libdnf/base_test_case.cpp
@@ -88,6 +88,24 @@ libdnf::rpm::Package BaseTestCase::get_pkg(const std::string & nevra, const char
 }
 
 
+libdnf::rpm::Package BaseTestCase::get_pkg_i(const std::string & nevra, size_t index) {
+    libdnf::rpm::PackageQuery query(base);
+    query.filter_nevra({nevra});
+
+    if (query.size() <= index) {
+        CPPUNIT_FAIL(
+            sformat("Package index {} out of bounds for \"{}\", query packages:{}", index, nevra, to_string(query)));
+    }
+
+    auto it = query.begin();
+    while (index-- > 0) {
+        ++it;
+    }
+
+    return *it;
+}
+
+
 libdnf::rpm::Package BaseTestCase::add_system_pkg(
     const std::string & relative_path, libdnf::transaction::TransactionItemReason reason) {
     if (reason != libdnf::transaction::TransactionItemReason::UNKNOWN) {

--- a/test/libdnf/base_test_case.hpp
+++ b/test/libdnf/base_test_case.hpp
@@ -51,6 +51,8 @@ public:
     // Add (load) a repo from PROJECT_SOURCE_DIR/test/data/repos-solv/<repoid>.repo
     libdnf::repo::RepoWeakPtr add_repo_solv(const std::string & repoid);
 
+    libdnf::advisory::Advisory get_advisory(const std::string & name);
+
     libdnf::rpm::Package get_pkg(const std::string & nevra, bool installed = false);
     libdnf::rpm::Package get_pkg(const std::string & nevra, const char * repo);
     libdnf::rpm::Package get_pkg(const std::string & nevra, const std::string & repo) {

--- a/test/libdnf/base_test_case.hpp
+++ b/test/libdnf/base_test_case.hpp
@@ -56,6 +56,7 @@ public:
     libdnf::rpm::Package get_pkg(const std::string & nevra, const std::string & repo) {
         return get_pkg(nevra, repo.c_str());
     }
+    libdnf::rpm::Package get_pkg_i(const std::string & nevra, size_t index);
 
     libdnf::rpm::Package add_system_pkg(
         const std::string & relative_path,

--- a/test/libdnf/comps/test_group.cpp
+++ b/test/libdnf/comps/test_group.cpp
@@ -31,10 +31,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 CPPUNIT_TEST_SUITE_REGISTRATION(CompsGroupTest);
 
 
+using namespace libdnf::comps;
+
+
 void CompsGroupTest::test_load() {
     add_repo_repomd("repomd-comps-core");
 
-    libdnf::comps::GroupQuery q_core(base.get_comps()->get_group_sack());
+    GroupQuery q_core(base.get_comps()->get_group_sack());
     q_core.filter_installed(false);
     q_core.filter_groupid("core");
     auto core = q_core.get();
@@ -48,14 +51,14 @@ void CompsGroupTest::test_load() {
     CPPUNIT_ASSERT_EQUAL(false, core.get_uservisible());
     CPPUNIT_ASSERT_EQUAL(false, core.get_default());
     CPPUNIT_ASSERT_EQUAL(false, core.get_installed());
+
     CPPUNIT_ASSERT_EQUAL(5lu, core.get_packages().size());
-    std::vector<libdnf::comps::Package> exp_pkgs_core;
-    exp_pkgs_core.push_back(libdnf::comps::Package("bash", libdnf::comps::PackageType::MANDATORY, ""));
-    exp_pkgs_core.push_back(libdnf::comps::Package("glibc", libdnf::comps::PackageType::MANDATORY, ""));
-    exp_pkgs_core.push_back(libdnf::comps::Package("dnf", libdnf::comps::PackageType::DEFAULT, ""));
-    exp_pkgs_core.push_back(
-        libdnf::comps::Package("conditional", libdnf::comps::PackageType::CONDITIONAL, "nonexistent"));
-    exp_pkgs_core.push_back(libdnf::comps::Package("dnf-plugins-core", libdnf::comps::PackageType::OPTIONAL, ""));
+    std::vector<Package> exp_pkgs_core = {
+        Package("bash", PackageType::MANDATORY, ""),
+        Package("glibc", PackageType::MANDATORY, ""),
+        Package("dnf", PackageType::DEFAULT, ""),
+        Package("conditional", PackageType::CONDITIONAL, "nonexistent"),
+        Package("dnf-plugins-core", PackageType::OPTIONAL, "")};
     for (unsigned i = 0; i < exp_pkgs_core.size(); i++) {
         CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_name(), core.get_packages()[i].get_name());
         CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_type(), core.get_packages()[i].get_type());
@@ -64,7 +67,7 @@ void CompsGroupTest::test_load() {
 
     add_repo_repomd("repomd-comps-standard");
 
-    libdnf::comps::GroupQuery q_standard(base.get_comps()->get_group_sack());
+    GroupQuery q_standard(base.get_comps()->get_group_sack());
     q_standard.filter_installed(false);
     q_standard.filter_groupid("standard");
     auto standard = q_standard.get();
@@ -81,13 +84,12 @@ void CompsGroupTest::test_load() {
     CPPUNIT_ASSERT_EQUAL(false, standard.get_uservisible());
     CPPUNIT_ASSERT_EQUAL(false, standard.get_default());
     CPPUNIT_ASSERT_EQUAL(false, standard.get_installed());
+
     CPPUNIT_ASSERT_EQUAL(3lu, standard.get_packages().size());
-    std::vector<libdnf::comps::Package> exp_pkgs_standard;
-    exp_pkgs_standard.push_back(libdnf::comps::Package("cryptsetup", libdnf::comps::PackageType::MANDATORY, ""));
-    exp_pkgs_standard.push_back(
-        libdnf::comps::Package("chrony", libdnf::comps::PackageType::CONDITIONAL, "gnome-control-center"));
-    exp_pkgs_standard.push_back(
-        libdnf::comps::Package("conditional", libdnf::comps::PackageType::CONDITIONAL, "nonexistent"));
+    std::vector<Package> exp_pkgs_standard = {
+        Package("cryptsetup", PackageType::MANDATORY, ""),
+        Package("chrony", PackageType::CONDITIONAL, "gnome-control-center"),
+        Package("conditional", PackageType::CONDITIONAL, "nonexistent")};
     for (unsigned i = 0; i < exp_pkgs_standard.size(); i++) {
         CPPUNIT_ASSERT_EQUAL(exp_pkgs_standard[i].get_name(), standard.get_packages()[i].get_name());
         CPPUNIT_ASSERT_EQUAL(exp_pkgs_standard[i].get_type(), standard.get_packages()[i].get_type());
@@ -99,7 +101,7 @@ void CompsGroupTest::test_load() {
 void CompsGroupTest::test_load_defaults() {
     add_repo_repomd("repomd-comps-core-empty");
 
-    libdnf::comps::GroupQuery q_core_empty(base.get_comps()->get_group_sack());
+    GroupQuery q_core_empty(base.get_comps()->get_group_sack());
     q_core_empty.filter_groupid("core");
     auto core_empty = q_core_empty.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core_empty.get_groupid());
@@ -122,7 +124,7 @@ void CompsGroupTest::test_merge() {
     // load another definiton of the core group that changes all attributes
     add_repo_repomd("repomd-comps-core-v2");
 
-    libdnf::comps::GroupQuery q_core2(base.get_comps()->get_group_sack());
+    GroupQuery q_core2(base.get_comps()->get_group_sack());
     q_core2.filter_groupid("core");
     auto core2 = q_core2.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core2.get_groupid());
@@ -137,12 +139,13 @@ void CompsGroupTest::test_merge() {
     CPPUNIT_ASSERT_EQUAL(true, core2.get_uservisible());
     CPPUNIT_ASSERT_EQUAL(true, core2.get_default());
     CPPUNIT_ASSERT_EQUAL(false, core2.get_installed());
+
     CPPUNIT_ASSERT_EQUAL(4lu, core2.get_packages().size());
-    std::vector<libdnf::comps::Package> exp_pkgs_core2;
-    exp_pkgs_core2.push_back(libdnf::comps::Package("bash", libdnf::comps::PackageType::MANDATORY, ""));
-    exp_pkgs_core2.push_back(libdnf::comps::Package("glibc", libdnf::comps::PackageType::MANDATORY, ""));
-    exp_pkgs_core2.push_back(libdnf::comps::Package("dnf", libdnf::comps::PackageType::DEFAULT, ""));
-    exp_pkgs_core2.push_back(libdnf::comps::Package("dnf-plugins-core", libdnf::comps::PackageType::OPTIONAL, ""));
+    std::vector<Package> exp_pkgs_core2 = {
+        Package("bash", PackageType::MANDATORY, ""),
+        Package("glibc", PackageType::MANDATORY, ""),
+        Package("dnf", PackageType::DEFAULT, ""),
+        Package("dnf-plugins-core", PackageType::OPTIONAL, "")};
     for (unsigned i = 0; i < exp_pkgs_core2.size(); i++) {
         CPPUNIT_ASSERT_EQUAL(exp_pkgs_core2[i].get_name(), core2.get_packages()[i].get_name());
         CPPUNIT_ASSERT_EQUAL(exp_pkgs_core2[i].get_type(), core2.get_packages()[i].get_type());
@@ -157,7 +160,7 @@ void CompsGroupTest::test_merge_with_empty() {
     // load another definiton of the core group that has all attributes empty
     add_repo_repomd("repomd-comps-core-empty");
 
-    libdnf::comps::GroupQuery q_core_empty(base.get_comps()->get_group_sack());
+    GroupQuery q_core_empty(base.get_comps()->get_group_sack());
     q_core_empty.filter_groupid("core");
     auto core_empty = q_core_empty.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core_empty.get_groupid());
@@ -183,7 +186,7 @@ void CompsGroupTest::test_merge_empty_with_nonempty() {
     // load another definiton of the core group that has all attributes filled
     add_repo_repomd("repomd-comps-core");
 
-    libdnf::comps::GroupQuery q_core(base.get_comps()->get_group_sack());
+    GroupQuery q_core(base.get_comps()->get_group_sack());
     q_core.filter_groupid("core");
     auto core = q_core.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core.get_groupid());
@@ -196,14 +199,14 @@ void CompsGroupTest::test_merge_empty_with_nonempty() {
     CPPUNIT_ASSERT_EQUAL(false, core.get_uservisible());
     CPPUNIT_ASSERT_EQUAL(false, core.get_default());
     CPPUNIT_ASSERT_EQUAL(false, core.get_installed());
+
     CPPUNIT_ASSERT_EQUAL(5lu, core.get_packages().size());
-    std::vector<libdnf::comps::Package> exp_pkgs_core;
-    exp_pkgs_core.push_back(libdnf::comps::Package("bash", libdnf::comps::PackageType::MANDATORY, ""));
-    exp_pkgs_core.push_back(libdnf::comps::Package("glibc", libdnf::comps::PackageType::MANDATORY, ""));
-    exp_pkgs_core.push_back(libdnf::comps::Package("dnf", libdnf::comps::PackageType::DEFAULT, ""));
-    exp_pkgs_core.push_back(
-        libdnf::comps::Package("conditional", libdnf::comps::PackageType::CONDITIONAL, "nonexistent"));
-    exp_pkgs_core.push_back(libdnf::comps::Package("dnf-plugins-core", libdnf::comps::PackageType::OPTIONAL, ""));
+    std::vector<Package> exp_pkgs_core = {
+        Package("bash", PackageType::MANDATORY, ""),
+        Package("glibc", PackageType::MANDATORY, ""),
+        Package("dnf", PackageType::DEFAULT, ""),
+        Package("conditional", PackageType::CONDITIONAL, "nonexistent"),
+        Package("dnf-plugins-core", PackageType::OPTIONAL, "")};
     for (unsigned i = 0; i < exp_pkgs_core.size(); i++) {
         CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_name(), core.get_packages()[i].get_name());
         CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_type(), core.get_packages()[i].get_type());
@@ -217,7 +220,7 @@ void CompsGroupTest::test_merge_different_translations() {
     // load another definiton of the core group with different set of translations
     add_repo_repomd("repomd-comps-core-different-translations");
 
-    libdnf::comps::GroupQuery q_core(base.get_comps()->get_group_sack());
+    GroupQuery q_core(base.get_comps()->get_group_sack());
     q_core.filter_groupid("core");
     auto core = q_core.get();
     CPPUNIT_ASSERT_EQUAL(std::string("core"), core.get_groupid());
@@ -235,7 +238,7 @@ void CompsGroupTest::test_merge_different_translations() {
 void CompsGroupTest::test_dump() {
     add_repo_repomd("repomd-comps-standard");
 
-    libdnf::comps::GroupQuery q_standard(base.get_comps()->get_group_sack());
+    GroupQuery q_standard(base.get_comps()->get_group_sack());
     q_standard.filter_groupid("standard");
     auto standard = q_standard.get();
 

--- a/test/libdnf/comps/test_group.cpp
+++ b/test/libdnf/comps/test_group.cpp
@@ -20,15 +20,38 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "test_group.hpp"
 
+#include "utils.hpp"
+
 #include "libdnf/comps/comps.hpp"
 #include "libdnf/comps/group/package.hpp"
 #include "libdnf/comps/group/query.hpp"
+#include "libdnf/utils/format.hpp"
 
 #include <filesystem>
 #include <fstream>
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(CompsGroupTest);
+
+
+namespace CPPUNIT_NS {
+
+template <>
+struct assertion_traits<libdnf::comps::Package> {
+    inline static bool equal(const libdnf::comps::Package & left, const libdnf::comps::Package & right) {
+        return left == right;
+    }
+
+    inline static std::string toString(const libdnf::comps::Package & package) {
+        return libdnf::utils::sformat(
+            "{} (type: {}, condition: {})",
+            package.get_name(),
+            static_cast<int>(package.get_type()),
+            package.get_condition());
+    }
+};
+
+}  // namespace CPPUNIT_NS
 
 
 using namespace libdnf::comps;
@@ -52,18 +75,13 @@ void CompsGroupTest::test_load() {
     CPPUNIT_ASSERT_EQUAL(false, core.get_default());
     CPPUNIT_ASSERT_EQUAL(false, core.get_installed());
 
-    CPPUNIT_ASSERT_EQUAL(5lu, core.get_packages().size());
     std::vector<Package> exp_pkgs_core = {
         Package("bash", PackageType::MANDATORY, ""),
         Package("glibc", PackageType::MANDATORY, ""),
         Package("dnf", PackageType::DEFAULT, ""),
         Package("conditional", PackageType::CONDITIONAL, "nonexistent"),
         Package("dnf-plugins-core", PackageType::OPTIONAL, "")};
-    for (unsigned i = 0; i < exp_pkgs_core.size(); i++) {
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_name(), core.get_packages()[i].get_name());
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_type(), core.get_packages()[i].get_type());
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_condition(), core.get_packages()[i].get_condition());
-    }
+    CPPUNIT_ASSERT_EQUAL(exp_pkgs_core, core.get_packages());
 
     add_repo_repomd("repomd-comps-standard");
 
@@ -85,16 +103,11 @@ void CompsGroupTest::test_load() {
     CPPUNIT_ASSERT_EQUAL(false, standard.get_default());
     CPPUNIT_ASSERT_EQUAL(false, standard.get_installed());
 
-    CPPUNIT_ASSERT_EQUAL(3lu, standard.get_packages().size());
     std::vector<Package> exp_pkgs_standard = {
         Package("cryptsetup", PackageType::MANDATORY, ""),
         Package("chrony", PackageType::CONDITIONAL, "gnome-control-center"),
         Package("conditional", PackageType::CONDITIONAL, "nonexistent")};
-    for (unsigned i = 0; i < exp_pkgs_standard.size(); i++) {
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_standard[i].get_name(), standard.get_packages()[i].get_name());
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_standard[i].get_type(), standard.get_packages()[i].get_type());
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_standard[i].get_condition(), standard.get_packages()[i].get_condition());
-    }
+    CPPUNIT_ASSERT_EQUAL(exp_pkgs_standard, standard.get_packages());
 }
 
 
@@ -140,17 +153,12 @@ void CompsGroupTest::test_merge() {
     CPPUNIT_ASSERT_EQUAL(true, core2.get_default());
     CPPUNIT_ASSERT_EQUAL(false, core2.get_installed());
 
-    CPPUNIT_ASSERT_EQUAL(4lu, core2.get_packages().size());
     std::vector<Package> exp_pkgs_core2 = {
         Package("bash", PackageType::MANDATORY, ""),
         Package("glibc", PackageType::MANDATORY, ""),
         Package("dnf", PackageType::DEFAULT, ""),
         Package("dnf-plugins-core", PackageType::OPTIONAL, "")};
-    for (unsigned i = 0; i < exp_pkgs_core2.size(); i++) {
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core2[i].get_name(), core2.get_packages()[i].get_name());
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core2[i].get_type(), core2.get_packages()[i].get_type());
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core2[i].get_condition(), core2.get_packages()[i].get_condition());
-    }
+    CPPUNIT_ASSERT_EQUAL(exp_pkgs_core2, core2.get_packages());
 }
 
 
@@ -200,18 +208,13 @@ void CompsGroupTest::test_merge_empty_with_nonempty() {
     CPPUNIT_ASSERT_EQUAL(false, core.get_default());
     CPPUNIT_ASSERT_EQUAL(false, core.get_installed());
 
-    CPPUNIT_ASSERT_EQUAL(5lu, core.get_packages().size());
     std::vector<Package> exp_pkgs_core = {
         Package("bash", PackageType::MANDATORY, ""),
         Package("glibc", PackageType::MANDATORY, ""),
         Package("dnf", PackageType::DEFAULT, ""),
         Package("conditional", PackageType::CONDITIONAL, "nonexistent"),
         Package("dnf-plugins-core", PackageType::OPTIONAL, "")};
-    for (unsigned i = 0; i < exp_pkgs_core.size(); i++) {
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_name(), core.get_packages()[i].get_name());
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_type(), core.get_packages()[i].get_type());
-        CPPUNIT_ASSERT_EQUAL(exp_pkgs_core[i].get_condition(), core.get_packages()[i].get_condition());
-    }
+    CPPUNIT_ASSERT_EQUAL(exp_pkgs_core, core.get_packages());
 }
 
 

--- a/test/libdnf/rpm/test_package.cpp
+++ b/test/libdnf/rpm/test_package.cpp
@@ -27,6 +27,9 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 
+using libdnf::rpm::Reldep;
+
+
 CPPUNIT_TEST_SUITE_REGISTRATION(RpmPackageTest);
 
 
@@ -168,83 +171,83 @@ void RpmPackageTest::test_get_files() {
 
 
 void RpmPackageTest::test_get_provides() {
-    const auto actual = get_pkg("pkg-1.2-3.x86_64").get_provides();
-    const std::vector<std::string> expected = {"pkg = 1.2-3"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(actual));
+    auto actual = get_pkg("pkg-1.2-3.x86_64").get_provides();
+    const std::vector<Reldep> expected = {Reldep(base, "pkg = 1.2-3")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(actual));
 }
 
 
 void RpmPackageTest::test_get_requires() {
-    const auto actual = get_pkg("unresolvable-1:2-3.noarch").get_requires();
-    const std::vector<std::string> expected = {"req = 1:2-3", "prereq"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(actual));
+    auto actual = get_pkg("unresolvable-1:2-3.noarch").get_requires();
+    const std::vector<Reldep> expected = {Reldep(base, "req = 1:2-3"), Reldep(base, "prereq")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(actual));
 }
 
 
 void RpmPackageTest::test_get_requires_pre() {
-    const auto actual = get_pkg("unresolvable-1:2-3.noarch").get_requires_pre();
-    const std::vector<std::string> expected = {"prereq"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(actual));
+    auto actual = get_pkg("unresolvable-1:2-3.noarch").get_requires_pre();
+    const std::vector<Reldep> expected = {Reldep(base, "prereq")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(actual));
 }
 
 
 void RpmPackageTest::test_get_conflicts() {
-    const auto actual = get_pkg("unresolvable-1:2-3.noarch").get_conflicts();
-    const std::vector<std::string> expected = {"con < 1:2"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(actual));
+    auto actual = get_pkg("unresolvable-1:2-3.noarch").get_conflicts();
+    const std::vector<Reldep> expected = {Reldep(base, "con < 1:2")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(actual));
 }
 
 
 void RpmPackageTest::test_get_obsoletes() {
-    const auto actual = get_pkg("unresolvable-1:2-3.noarch").get_obsoletes();
-    const std::vector<std::string> expected = {"obs < 1:2"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(actual));
+    auto actual = get_pkg("unresolvable-1:2-3.noarch").get_obsoletes();
+    const std::vector<Reldep> expected = {Reldep(base, "obs < 1:2")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(actual));
 }
 
 
 void RpmPackageTest::test_get_prereq_ignoreinst() {
-    const auto actual = get_pkg("unresolvable-1:2-3.noarch").get_prereq_ignoreinst();
+    auto actual = get_pkg("unresolvable-1:2-3.noarch").get_prereq_ignoreinst();
     // TODO requires the package to be installed
     //const std::vector<std::string> expected = {"test-requires-pre"};
-    const std::vector<std::string> expected = {};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(actual));
+    const std::vector<Reldep> expected = {};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(actual));
 }
 
 
 void RpmPackageTest::test_get_regular_requires() {
-    const auto actual = get_pkg("unresolvable-1:2-3.noarch").get_regular_requires();
-    const std::vector<std::string> expected = {"req = 1:2-3"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(actual));
+    auto actual = get_pkg("unresolvable-1:2-3.noarch").get_regular_requires();
+    const std::vector<Reldep> expected = {Reldep(base, "req = 1:2-3")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(actual));
 }
 
 
 void RpmPackageTest::test_get_recommends() {
-    const auto actual = get_pkg("unresolvable-1:2-3.noarch").get_recommends();
-    const std::vector<std::string> expected = {"rec"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(actual));
+    auto actual = get_pkg("unresolvable-1:2-3.noarch").get_recommends();
+    const std::vector<Reldep> expected = {Reldep(base, "rec")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(actual));
 }
 
 
 void RpmPackageTest::test_get_suggests() {
-    const auto suggests = get_pkg("unresolvable-1:2-3.noarch").get_suggests();
-    const std::vector<std::string> expected = {"sug"};
+    auto suggests = get_pkg("unresolvable-1:2-3.noarch").get_suggests();
+    const std::vector<Reldep> expected = {Reldep(base, "sug")};
 
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(suggests));
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(suggests));
 }
 
 
 void RpmPackageTest::test_get_enhances() {
-    const auto enhances = get_pkg("unresolvable-1:2-3.noarch").get_enhances();
-    const std::vector<std::string> expected = {"enh"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(enhances));
+    auto enhances = get_pkg("unresolvable-1:2-3.noarch").get_enhances();
+    const std::vector<Reldep> expected = {Reldep(base, "enh")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(enhances));
 }
 
 
 void RpmPackageTest::test_get_supplements() {
-    const auto supplements = get_pkg("unresolvable-1:2-3.noarch").get_supplements();
-    const std::vector<std::string> expected = {"sup"};
+    auto supplements = get_pkg("unresolvable-1:2-3.noarch").get_supplements();
+    const std::vector<Reldep> expected = {Reldep(base, "sup")};
 
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(supplements));
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(supplements));
 }
 
 

--- a/test/libdnf/rpm/test_package_query.cpp
+++ b/test/libdnf/rpm/test_package_query.cpp
@@ -32,13 +32,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 CPPUNIT_TEST_SUITE_REGISTRATION(RpmPackageQueryTest);
 
+using namespace libdnf::rpm;
 
 namespace {
 
 // make constructor public so we can create Package instances in the tests
-class TestPackage : public libdnf::rpm::Package {
+class TestPackage : public Package {
 public:
-    TestPackage(const libdnf::BaseWeakPtr & base, libdnf::rpm::PackageId id) : libdnf::rpm::Package(base, id) {}
+    TestPackage(const libdnf::BaseWeakPtr & base, PackageId id) : libdnf::rpm::Package(base, id) {}
 };
 
 }  // namespace
@@ -52,7 +53,7 @@ void RpmPackageQueryTest::setUp() {
 void RpmPackageQueryTest::test_size() {
     add_repo_solv("solv-repo1");
 
-    libdnf::rpm::PackageQuery query(base);
+    PackageQuery query(base);
     CPPUNIT_ASSERT_EQUAL(5LU, query.size());
 }
 
@@ -66,49 +67,51 @@ void RpmPackageQueryTest::test_filter_latest_evr() {
     sack->add_cmdline_package(rpm_path, false);
 
     {
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_latest_evr(1);
-        std::vector<std::string> expected = {
-            "pkg-0:1.2-3.src",
-            "pkg-0:1.2-3.x86_64",
-            "pkg-libs-1:1.3-4.x86_64",
-            "pkg-0:1-24.noarch",
-            "cmdline-0:1.2-3.noarch",
-            "cmdline-0:1.2-3.noarch"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {
+            get_pkg("pkg-0:1.2-3.src"),
+            get_pkg("pkg-0:1.2-3.x86_64"),
+            get_pkg("pkg-libs-1:1.3-4.x86_64"),
+            get_pkg("pkg-0:1-24.noarch"),
+            get_pkg_i("cmdline-0:1.2-3.noarch", 0),
+            get_pkg_i("cmdline-0:1.2-3.noarch", 1)};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
     {
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_latest_evr(2);
-        std::vector<std::string> expected = {
-            "pkg-0:1.2-3.src",
-            "pkg-0:1.2-3.x86_64",
-            "pkg-libs-1:1.2-4.x86_64",
-            "pkg-libs-1:1.3-4.x86_64",
-            "pkg-0:1-23.noarch",
-            "pkg-0:1-24.noarch",
-            "cmdline-0:1.2-3.noarch",
-            "cmdline-0:1.2-3.noarch"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {
+            get_pkg("pkg-0:1.2-3.src"),
+            get_pkg("pkg-0:1.2-3.x86_64"),
+            get_pkg("pkg-libs-1:1.2-4.x86_64"),
+            get_pkg("pkg-libs-1:1.3-4.x86_64"),
+            get_pkg("pkg-0:1-23.noarch"),
+            get_pkg("pkg-0:1-24.noarch"),
+            get_pkg_i("cmdline-0:1.2-3.noarch", 0),
+            get_pkg_i("cmdline-0:1.2-3.noarch", 1)};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
     {
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_latest_evr(-1);
-        std::vector<std::string> expected = {
-            "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-0:1-1.noarch",  "pkg-0:1-2.noarch",
-            "pkg-0:1-3.noarch",        "pkg-0:1-4.noarch",        "pkg-0:1-5.noarch",  "pkg-0:1-6.noarch",
-            "pkg-0:1-7.noarch",        "pkg-0:1-8.noarch",        "pkg-0:1-9.noarch",  "pkg-0:1-10.noarch",
-            "pkg-0:1-11.noarch",       "pkg-0:1-12.noarch",       "pkg-0:1-13.noarch", "pkg-0:1-14.noarch",
-            "pkg-0:1-15.noarch",       "pkg-0:1-16.noarch",       "pkg-0:1-17.noarch", "pkg-0:1-18.noarch",
-            "pkg-0:1-19.noarch",       "pkg-0:1-20.noarch",       "pkg-0:1-21.noarch", "pkg-0:1-22.noarch",
-            "pkg-0:1-23.noarch"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {
+            get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-0:1-1.noarch"),
+            get_pkg("pkg-0:1-2.noarch"),        get_pkg("pkg-0:1-3.noarch"),        get_pkg("pkg-0:1-4.noarch"),
+            get_pkg("pkg-0:1-5.noarch"),        get_pkg("pkg-0:1-6.noarch"),        get_pkg("pkg-0:1-7.noarch"),
+            get_pkg("pkg-0:1-8.noarch"),        get_pkg("pkg-0:1-9.noarch"),        get_pkg("pkg-0:1-10.noarch"),
+            get_pkg("pkg-0:1-11.noarch"),       get_pkg("pkg-0:1-12.noarch"),       get_pkg("pkg-0:1-13.noarch"),
+            get_pkg("pkg-0:1-14.noarch"),       get_pkg("pkg-0:1-15.noarch"),       get_pkg("pkg-0:1-16.noarch"),
+            get_pkg("pkg-0:1-17.noarch"),       get_pkg("pkg-0:1-18.noarch"),       get_pkg("pkg-0:1-19.noarch"),
+            get_pkg("pkg-0:1-20.noarch"),       get_pkg("pkg-0:1-21.noarch"),       get_pkg("pkg-0:1-22.noarch"),
+            get_pkg("pkg-0:1-23.noarch")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
     {
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_latest_evr(-23);
-        std::vector<std::string> expected = {"pkg-0:1-1.noarch"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1-1.noarch")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 }
 
@@ -116,80 +119,83 @@ void RpmPackageQueryTest::test_filter_name() {
     add_repo_solv("solv-repo1");
 
     // packages with Name == "pkg"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_name({"pkg"});
 
-    std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 
     // ---
 
     // packages with Name matching "pkg*" glob
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_name({"pkg*"}, libdnf::sack::QueryCmp::GLOB);
 
     expected = {
-        "pkg-0:1.2-3.src",
-        "pkg-0:1.2-3.x86_64",
-        "pkg-libs-0:1.2-3.x86_64",
-        "pkg-libs-1:1.2-4.x86_64",
-        "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.2-4.x86_64"),
+        get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
 
     // ---
 
     // packages with Name matching "p?g" glob
-    libdnf::rpm::PackageQuery query3(base);
+    PackageQuery query3(base);
     query3.filter_name({"p?g"}, libdnf::sack::QueryCmp::GLOB);
 
-    expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query3));
+    expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query3));
 
     // ---
 
     // packages with Name != "pkg"
-    libdnf::rpm::PackageQuery query4(base);
+    PackageQuery query4(base);
     query4.filter_name({"pkg"}, libdnf::sack::QueryCmp::NEQ);
 
-    expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query4));
+    expected = {
+        get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query4));
 
     // ---
 
     // packages with Name == "Pkg" - case insensitive match
-    libdnf::rpm::PackageQuery query5(base);
+    PackageQuery query5(base);
     query5.filter_name({"Pkg"}, libdnf::sack::QueryCmp::IEXACT);
 
-    expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query5));
+    expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query5));
 
     // ---
 
     // packages with Name matching "P?g" glob - case insensitive match
-    libdnf::rpm::PackageQuery query6(base);
+    PackageQuery query6(base);
     std::vector<std::string> names_glob_icase{"cq?lib"};
     query6.filter_name({"P?g"}, libdnf::sack::QueryCmp::IGLOB);
 
-    expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query6));
+    expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query6));
 
     // ---
 
     // packages with Name that contain "kg-l"
-    libdnf::rpm::PackageQuery query7(base);
+    PackageQuery query7(base);
     query7.filter_name({"kg-l"}, libdnf::sack::QueryCmp::CONTAINS);
 
-    expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query7));
+    expected = {
+        get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query7));
 
     // ---
 
     // packages with Name that contain "kG-l" - case insensitive match
-    libdnf::rpm::PackageQuery query8(base);
+    PackageQuery query8(base);
     query8.filter_name({"kG-l"}, libdnf::sack::QueryCmp::ICONTAINS);
 
-    expected = {"pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query8));
+    expected = {
+        get_pkg("pkg-libs-0:1.2-3.x86_64"), get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query8));
 
     // ---
 
@@ -199,34 +205,34 @@ void RpmPackageQueryTest::test_filter_name() {
     // ---
 
     // packages with Name "pkg" or "pkg-libs" - two patterns matched in one expression
-    libdnf::rpm::PackageQuery query9(base);
+    PackageQuery query9(base);
     query9.filter_name({"pkg", "pkg-libs"});
 
     expected = {
-        "pkg-0:1.2-3.src",
-        "pkg-0:1.2-3.x86_64",
-        "pkg-libs-0:1.2-3.x86_64",
-        "pkg-libs-1:1.2-4.x86_64",
-        "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query9));
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.2-4.x86_64"),
+        get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query9));
 }
 
 void RpmPackageQueryTest::test_filter_name_packgset() {
     add_repo_solv("solv-repo1");
 
     // packages with Name == "pkg"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_name({"pkg"});
     query1.filter_arch({"src"});
 
-    std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_name(query1);
 
-    std::vector<std::string> expected2 = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected2, to_vector_string(query2));
+    std::vector<Package> expected2 = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected2, to_vector(query2));
 }
 
 void RpmPackageQueryTest::test_filter_nevra_packgset() {
@@ -236,38 +242,38 @@ void RpmPackageQueryTest::test_filter_nevra_packgset() {
     sack->add_system_package(rpm_path, false);
     sack->add_cmdline_package(rpm_path, false);
 
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_name({"cmdline"});
-    std::vector<std::string> expected1 = {"cmdline-0:1.2-3.noarch", "cmdline-0:1.2-3.noarch"};
-    CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query1));
+    std::vector<Package> expected1 = {get_pkg("cmdline-0:1.2-3.noarch", true), get_pkg("cmdline-0:1.2-3.noarch")};
+    CPPUNIT_ASSERT_EQUAL(expected1, to_vector(query1));
     query1.filter_installed();
 
-    std::vector<std::string> expected = {"cmdline-0:1.2-3.noarch"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {get_pkg("cmdline-0:1.2-3.noarch", true)};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
     CPPUNIT_ASSERT_EQUAL(1lu, query1.size());
 
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_nevra(query1);
 
     CPPUNIT_ASSERT_EQUAL(2lu, query2.size());
-    CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query2));
+    CPPUNIT_ASSERT_EQUAL(expected1, to_vector(query2));
 }
 
 void RpmPackageQueryTest::test_filter_name_arch() {
     add_repo_solv("solv-repo1");
 
     // packages with Name == "pkg"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_name({"pkg"});
     query1.filter_arch({"src"});
 
-    std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_name_arch(query1);
 
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
 }
 
 void RpmPackageQueryTest::test_filter_name_arch2() {
@@ -277,21 +283,21 @@ void RpmPackageQueryTest::test_filter_name_arch2() {
     sack->add_system_package(rpm_path, false);
     sack->add_cmdline_package(rpm_path, false);
 
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_name({"cmdline"});
-    std::vector<std::string> expected1 = {"cmdline-0:1.2-3.noarch", "cmdline-0:1.2-3.noarch"};
-    CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query1));
-    query1.filter_installed();
+    std::vector<Package> expected1 = {get_pkg("cmdline-0:1.2-3.noarch", true), get_pkg("cmdline-0:1.2-3.noarch")};
+    CPPUNIT_ASSERT_EQUAL(expected1, to_vector(query1));
 
-    std::vector<std::string> expected = {"cmdline-0:1.2-3.noarch"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    query1.filter_installed();
+    std::vector<Package> expected = {get_pkg("cmdline-0:1.2-3.noarch", true)};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
     CPPUNIT_ASSERT_EQUAL(1lu, query1.size());
 
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_name_arch(query1);
 
     CPPUNIT_ASSERT_EQUAL(2lu, query2.size());
-    CPPUNIT_ASSERT_EQUAL(expected1, to_vector_string(query2));
+    CPPUNIT_ASSERT_EQUAL(expected1, to_vector(query2));
 }
 
 void RpmPackageQueryTest::test_filter_nevra() {
@@ -299,59 +305,59 @@ void RpmPackageQueryTest::test_filter_nevra() {
 
     {
         // Test QueryCmp::EQ - argument without 0 epoch - two elements
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_nevra({"pkg-1.2-3.src", "pkg-1.2-3.x86_64"});
-        std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::EQ - argument without 0 epoch - two elements
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_nevra({"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"});
-        std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::EQ - argument without 0 epoch - single argument
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_nevra({"pkg-1.2-3.src"});
-        std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::EQ - argument with 0 epoch - single argument
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_nevra({"pkg-0:1.2-3.src"});
-        std::vector<std::string> expected = {"pkg-0:1.2-3.src"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::EQ - argument with unknown release - two elements
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_nevra({"pkg-0:1.2-unknown.src", "pkg-0:1.2-unknown1.x86_64"});
-        std::vector<std::string> expected = {};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::EQ - argument with unknown version - single argument
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_nevra({"pkg-0:1.2-unknown2.x86_64"});
         CPPUNIT_ASSERT_EQUAL(0LU, query.size());
-        std::vector<std::string> expected = {};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::EQ - argument without epoch, but package with epoch - single argument
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_nevra({"pkg-libs-1.2-4.x86_64"});
-        std::vector<std::string> expected = {};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 }
 
@@ -360,21 +366,24 @@ void RpmPackageQueryTest::test_filter_version() {
     add_repo_solv("solv-repo1");
 
     // packages with version == "1.2"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_version({"1.2"});
 
-    std::vector<std::string> expected = {
-        "pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64", "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.2-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 
     // ---
 
     // packages with version != "1.2"
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_version({"1.2"}, libdnf::sack::QueryCmp::NEQ);
 
-    expected = {"pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
+    expected = {get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
 }
 
 
@@ -382,27 +391,28 @@ void RpmPackageQueryTest::test_filter_release() {
     add_repo_solv("solv-repo1");
 
     // packages with release == "3"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_release({"3"});
 
-    std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64", "pkg-libs-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {
+        get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64"), get_pkg("pkg-libs-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 
     // ---
 
     // packages with Release != "3"
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_release({"3"}, libdnf::sack::QueryCmp::NEQ);
 
-    expected = {"pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
+    expected = {get_pkg("pkg-libs-1:1.2-4.x86_64"), get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
 }
 
 void RpmPackageQueryTest::test_filter_priority() {
     add_repo_solv("solv-repo1");
     add_repo_solv("solv-24pkgs");
 
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_priority();
     /// TODO(jmracek) Run test with repository with a different priority and check result
 }
@@ -411,20 +421,24 @@ void RpmPackageQueryTest::test_filter_provides() {
     add_repo_solv("solv-repo1");
 
     // packages with Provides == "libpkg.so.0()(64bit)"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_provides({"libpkg.so.0()(64bit)"});
 
-    std::vector<std::string> expected = {"pkg-libs-1:1.2-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {get_pkg("pkg-libs-1:1.2-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 
     // ---
 
     // packages without Provides == "libpkg.so.0()(64bit)"
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_provides({"libpkg.so.0()(64bit)"}, libdnf::sack::QueryCmp::NEQ);
 
-    expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64", "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
+    expected = {
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
 }
 
 
@@ -432,20 +446,24 @@ void RpmPackageQueryTest::test_filter_requires() {
     add_repo_solv("solv-repo1");
 
     // packages with Requires == "pkg-libs"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_requires({"pkg-libs"});
 
-    std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 
     // ---
 
     // packages without Requires == "pkg-libs"
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_requires({"pkg-libs"}, libdnf::sack::QueryCmp::NEQ);
 
-    expected = {"pkg-0:1.2-3.src", "pkg-libs-0:1.2-3.x86_64", "pkg-libs-1:1.2-4.x86_64", "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query2));
+    expected = {
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.2-4.x86_64"),
+        get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query2));
 }
 
 void RpmPackageQueryTest::test_filter_advisories() {
@@ -454,46 +472,46 @@ void RpmPackageQueryTest::test_filter_advisories() {
     {
         // Test QueryCmp::EQ with equal advisory pkg
         libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("DNF-2019-1");
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::GT with older advisory pkg
         libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-OLDER");
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::GT);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::LTE with older advisory pkg
         libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-OLDER");
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::LTE);
-        std::vector<std::string> expected = {};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::LT with newer advisory pkg
         libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-NEWER");
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::LT);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test QueryCmp::GTE with newer advisory pkg
         libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-NEWER");
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::GTE);
-        std::vector<std::string> expected = {};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
@@ -501,17 +519,17 @@ void RpmPackageQueryTest::test_filter_advisories() {
         libdnf::advisory::AdvisoryQuery adv_query =
             libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
         ;
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
-        std::vector<std::string> expected = {};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 }
 
 void RpmPackageQueryTest::test_filter_chain() {
     add_repo_solv("solv-repo1");
 
-    libdnf::rpm::PackageQuery query(base);
+    PackageQuery query(base);
     query.filter_name({"pkg"})
         .filter_epoch({"0"})
         .filter_version({"1.2"})
@@ -520,8 +538,8 @@ void RpmPackageQueryTest::test_filter_chain() {
         .filter_provides({"foo"}, libdnf::sack::QueryCmp::NEQ)
         .filter_requires({"foo"}, libdnf::sack::QueryCmp::NEQ);
 
-    std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+    std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
 }
 
 
@@ -530,71 +548,71 @@ void RpmPackageQueryTest::test_resolve_pkg_spec() {
 
     {
         // test Name.Arch
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         libdnf::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("pkg.x86_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test NA icase
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         libdnf::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("Pkg.x86_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test a provide
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         libdnf::ResolveSpecSettings settings{.with_filenames = false};
         auto return_value = query.resolve_pkg_spec("pkg >= 1", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test NEVRA glob
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         libdnf::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test NEVRA glob - icase == false, nothing found
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         libdnf::ResolveSpecSettings settings{.with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("Pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, false);
-        std::vector<std::string> expected = {};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test NEVRA glob - icase == true
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         libdnf::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("Pk?-?:1.?-?.x8?_64", settings, true);
         CPPUNIT_ASSERT_EQUAL(return_value.first, true);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 
     {
         // Test NEVRA icase
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         libdnf::ResolveSpecSettings settings{.ignore_case = true, .with_provides = false, .with_filenames = false};
         auto return_value = query.resolve_pkg_spec("Pkg-0:1.2-3.X86_64", settings, true);
-        std::vector<std::string> expected = {"pkg-0:1.2-3.x86_64"};
-        CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query));
+        std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
+        CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
     }
 }
 
@@ -603,10 +621,10 @@ void RpmPackageQueryTest::test_update() {
     add_repo_solv("solv-repo1");
 
     // packages with Release == "3"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_release({"3"});
 
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(3LU, query2.size());
 
@@ -614,13 +632,13 @@ void RpmPackageQueryTest::test_update() {
     CPPUNIT_ASSERT_EQUAL(5LU, query1.size());
 
     // check the resulting NEVRAs
-    std::vector<std::string> expected = {
-        "pkg-0:1.2-3.src",
-        "pkg-0:1.2-3.x86_64",
-        "pkg-libs-0:1.2-3.x86_64",
-        "pkg-libs-1:1.2-4.x86_64",
-        "pkg-libs-1:1.3-4.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {
+        get_pkg("pkg-0:1.2-3.src"),
+        get_pkg("pkg-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-0:1.2-3.x86_64"),
+        get_pkg("pkg-libs-1:1.2-4.x86_64"),
+        get_pkg("pkg-libs-1:1.3-4.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 }
 
 
@@ -628,12 +646,12 @@ void RpmPackageQueryTest::test_intersection() {
     add_repo_solv("solv-repo1");
 
     // packages with Release == "3"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_release({"3"});
     CPPUNIT_ASSERT_EQUAL(3LU, query1.size());
 
     // packages with Name == "pkg-libs"
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(3LU, query2.size());
 
@@ -641,8 +659,8 @@ void RpmPackageQueryTest::test_intersection() {
     CPPUNIT_ASSERT_EQUAL(1LU, query1.size());
 
     // check the resulting NEVRAs
-    std::vector<std::string> expected = {"pkg-libs-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {get_pkg("pkg-libs-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 }
 
 
@@ -650,12 +668,12 @@ void RpmPackageQueryTest::test_difference() {
     add_repo_solv("solv-repo1");
 
     // packages with Release == "3"
-    libdnf::rpm::PackageQuery query1(base);
+    PackageQuery query1(base);
     query1.filter_release({"3"});
     CPPUNIT_ASSERT_EQUAL(3LU, query1.size());
 
     // packages with Release == "3" and name == "pkg-libs"
-    libdnf::rpm::PackageQuery query2(base);
+    PackageQuery query2(base);
     query2.filter_release({"3"});
     query2.filter_name({"pkg-libs"});
     CPPUNIT_ASSERT_EQUAL(1LU, query2.size());
@@ -664,8 +682,8 @@ void RpmPackageQueryTest::test_difference() {
     CPPUNIT_ASSERT_EQUAL(2LU, query1.size());
 
     // check the resulting NEVRAs
-    std::vector<std::string> expected = {"pkg-0:1.2-3.src", "pkg-0:1.2-3.x86_64"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(query1));
+    std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.src"), get_pkg("pkg-0:1.2-3.x86_64")};
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(query1));
 }
 
 
@@ -673,7 +691,7 @@ void RpmPackageQueryTest::test_filter_latest_evr_performance() {
     add_repo_solv("solv-humongous");
 
     for (int i = 0; i < 10000; ++i) {
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_latest_evr();
     }
 }
@@ -683,7 +701,7 @@ void RpmPackageQueryTest::test_filter_provides_performance() {
     add_repo_solv("solv-humongous");
 
     for (int i = 0; i < 100000; ++i) {
-        libdnf::rpm::PackageQuery query(base);
+        PackageQuery query(base);
         query.filter_provides({"prv-all"});
     }
 }

--- a/test/libdnf/rpm/test_reldep_list.cpp
+++ b/test/libdnf/rpm/test_reldep_list.cpp
@@ -24,6 +24,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/rpm/reldep_list.hpp"
 
+
+using libdnf::rpm::Reldep;
+
+
 CPPUNIT_TEST_SUITE_REGISTRATION(ReldepListTest);
 
 
@@ -176,6 +180,12 @@ void ReldepListTest::test_add_reldep_with_glob() {
     libdnf::rpm::ReldepList list(base);
     list.add_reldep_with_glob("pkg*");
 
-    const std::vector<std::string> expected = {"pkg", "pkg-libs", "pkg.conf", "pkg.conf.d", "pkg-libs"};
-    CPPUNIT_ASSERT_EQUAL(expected, to_vector_string(list));
+    const std::vector<Reldep> expected = {
+        Reldep(base, "pkg"),
+        Reldep(base, "pkg-libs"),
+        Reldep(base, "pkg.conf"),
+        Reldep(base, "pkg.conf.d"),
+        Reldep(base, "pkg-libs"),
+    };
+    CPPUNIT_ASSERT_EQUAL(expected, to_vector(list));
 }

--- a/test/libdnf/utils.cpp
+++ b/test/libdnf/utils.cpp
@@ -39,15 +39,6 @@ std::vector<std::string> to_vector_string(const libdnf::rpm::PackageSet & pset) 
 }
 
 
-std::vector<std::string> to_vector_string(const std::vector<libdnf::rpm::Package> & pkg_list) {
-    std::vector<std::string> result;
-    for (auto & pkg : pkg_list) {
-        result.emplace_back(pkg.get_full_nevra());
-    }
-    return result;
-}
-
-
 std::vector<std::string> to_vector_name_string(const libdnf::advisory::AdvisorySet & aset) {
     std::vector<std::string> result;
     for (auto adv : aset) {

--- a/test/libdnf/utils.cpp
+++ b/test/libdnf/utils.cpp
@@ -21,10 +21,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "utils.hpp"
 
 
-std::vector<std::string> to_vector_string(const libdnf::rpm::ReldepList & rdl) {
-    std::vector<std::string> res;
-    for (int i = 0; i < rdl.size(); ++i) {
-        res.emplace_back(rdl.get(i).to_string());
+std::vector<libdnf::rpm::Reldep> to_vector(const libdnf::rpm::ReldepList & reldep_list) {
+    std::vector<libdnf::rpm::Reldep> res;
+    for (const auto & reldep : reldep_list) {
+        res.push_back(reldep);
     }
     return res;
 }

--- a/test/libdnf/utils.cpp
+++ b/test/libdnf/utils.cpp
@@ -30,10 +30,10 @@ std::vector<libdnf::rpm::Reldep> to_vector(const libdnf::rpm::ReldepList & relde
 }
 
 
-std::vector<std::string> to_vector_string(const libdnf::rpm::PackageSet & pset) {
-    std::vector<std::string> res;
-    for (auto pkg : pset) {
-        res.emplace_back(pkg.get_full_nevra());
+std::vector<libdnf::rpm::Package> to_vector(const libdnf::rpm::PackageSet & package_set) {
+    std::vector<libdnf::rpm::Package> res;
+    for (const auto & pkg : package_set) {
+        res.push_back(pkg);
     }
     return res;
 }

--- a/test/libdnf/utils.cpp
+++ b/test/libdnf/utils.cpp
@@ -39,10 +39,10 @@ std::vector<libdnf::rpm::Package> to_vector(const libdnf::rpm::PackageSet & pack
 }
 
 
-std::vector<std::string> to_vector_name_string(const libdnf::advisory::AdvisorySet & aset) {
-    std::vector<std::string> result;
-    for (auto adv : aset) {
-        result.emplace_back(adv.get_name());
+std::vector<libdnf::advisory::Advisory> to_vector(const libdnf::advisory::AdvisorySet & advisory_set) {
+    std::vector<libdnf::advisory::Advisory> res;
+    for (const auto & advisory : advisory_set) {
+        res.push_back(advisory);
     }
-    return result;
+    return res;
 }

--- a/test/libdnf/utils.hpp
+++ b/test/libdnf/utils.hpp
@@ -70,6 +70,30 @@ struct assertion_traits<C<T>> {
 };
 
 template <>
+struct assertion_traits<libdnf::advisory::Advisory> {
+    inline static bool equal(const libdnf::advisory::Advisory & left, const libdnf::advisory::Advisory & right) {
+        return left == right;
+    }
+
+    inline static std::string toString(const libdnf::advisory::Advisory & advisory) {
+        return libdnf::utils::sformat("{} (id: {})", advisory.get_name(), advisory.get_id().id);
+    }
+};
+
+template <>
+struct assertion_traits<libdnf::advisory::AdvisorySet> {
+    inline static std::string toString(const libdnf::advisory::AdvisorySet & advisories) {
+        std::string result;
+
+        for (const auto & advisory : advisories) {
+            result += "\n    " + assertion_traits<libdnf::advisory::Advisory>::toString(advisory);
+        }
+
+        return result;
+    }
+};
+
+template <>
 struct assertion_traits<libdnf::rpm::Package> {
     inline static bool equal(const libdnf::rpm::Package & left, const libdnf::rpm::Package & right) {
         return left == right;
@@ -130,10 +154,8 @@ struct assertion_traits<libdnf::base::TransactionPackage> {
 }  // namespace CPPUNIT_NS
 
 
+std::vector<libdnf::advisory::Advisory> to_vector(const libdnf::advisory::AdvisorySet & advisory_set);
 std::vector<libdnf::rpm::Reldep> to_vector(const libdnf::rpm::ReldepList & reldep_list);
 std::vector<libdnf::rpm::Package> to_vector(const libdnf::rpm::PackageSet & package_set);
-
-/// Convert AdvisoryQuery to a vector of strings of their names for easy assertions.
-std::vector<std::string> to_vector_name_string(const libdnf::advisory::AdvisorySet & aset);
 
 #endif  // TEST_LIBDNF_UTILS_HPP

--- a/test/libdnf/utils.hpp
+++ b/test/libdnf/utils.hpp
@@ -99,6 +99,17 @@ struct assertion_traits<libdnf::rpm::PackageQuery> {
 };
 
 template <>
+struct assertion_traits<libdnf::rpm::Reldep> {
+    inline static bool equal(const libdnf::rpm::Reldep & left, const libdnf::rpm::Reldep & right) {
+        return left == right;
+    }
+
+    inline static std::string toString(const libdnf::rpm::Reldep & reldep) {
+        return libdnf::utils::sformat("{} (id: {})", reldep.to_string(), reldep.get_id().id);
+    }
+};
+
+template <>
 struct assertion_traits<libdnf::base::TransactionPackage> {
     inline static bool equal(
         const libdnf::base::TransactionPackage & left, const libdnf::base::TransactionPackage & right) {
@@ -119,8 +130,7 @@ struct assertion_traits<libdnf::base::TransactionPackage> {
 }  // namespace CPPUNIT_NS
 
 
-/// Convert ReldepList to a vector of strings for easy assertions.
-std::vector<std::string> to_vector_string(const libdnf::rpm::ReldepList & rdl);
+std::vector<libdnf::rpm::Reldep> to_vector(const libdnf::rpm::ReldepList & reldep_list);
 
 /// Convert PackageSet to a vector of strings for easy assertions.
 std::vector<std::string> to_vector_string(const libdnf::rpm::PackageSet & pset);

--- a/test/libdnf/utils.hpp
+++ b/test/libdnf/utils.hpp
@@ -131,9 +131,7 @@ struct assertion_traits<libdnf::base::TransactionPackage> {
 
 
 std::vector<libdnf::rpm::Reldep> to_vector(const libdnf::rpm::ReldepList & reldep_list);
-
-/// Convert PackageSet to a vector of strings for easy assertions.
-std::vector<std::string> to_vector_string(const libdnf::rpm::PackageSet & pset);
+std::vector<libdnf::rpm::Package> to_vector(const libdnf::rpm::PackageSet & package_set);
 
 /// Convert AdvisoryQuery to a vector of strings of their names for easy assertions.
 std::vector<std::string> to_vector_name_string(const libdnf::advisory::AdvisorySet & aset);


### PR DESCRIPTION
Converting our containers into vectors of strings for assertions was never a great idea. This replaces it with converting to vectors of the objects themselves (on that note, we could compare our pool-based containers directly, but they aren't initializer-list-constructible due to needing a reference to base, which across the test suite would amount to a large amount of verbosity).

Also improves assertion failure output by nicely printing the items being compared.