### PR TITLE
[dnf5] swig: Python: Support methods that return reference to *this

### DIFF
--- a/bindings/libdnf/common.i
+++ b/bindings/libdnf/common.i
@@ -47,6 +47,21 @@
     }
 }
 
+// Support for methods that return object to which them are attached - return reference to `*this`.
+// Allows use method chaining on an object - fluent interface.
+#if defined(SWIGPYTHON)
+%typemap(out) FLUENT& %{
+  if ($1 == arg1) {
+    // The returned pointer points to `this`. No new return object is created.
+    // Instead, the reference count for object `self` is incremented. And the `self` object is returned.
+    Py_INCREF(swig_obj[0]);
+    $result = swig_obj[0];
+  } else {
+    $result = SWIG_NewPointerObj($1, $descriptor, $owner);
+  }
+%}
+#endif
+
 %template(VectorString) std::vector<std::string>;
 #if defined(SWIGPYTHON) || defined(SWIGRUBY)
 %template(SetString) std::set<std::string>;

--- a/bindings/libdnf/comps.i
+++ b/bindings/libdnf/comps.i
@@ -30,7 +30,11 @@
 
 %include "libdnf/comps/group/package.hpp"
 %include "libdnf/comps/group/group.hpp"
+
+%apply FLUENT& { libdnf::comps::GroupQuery& };
 %include "libdnf/comps/group/query.hpp"
+%clear libdnf::comps::GroupQuery&;
+
 %include "libdnf/comps/group/sack.hpp"
 %include "libdnf/comps/comps.hpp"
 

--- a/bindings/libdnf/repo.i
+++ b/bindings/libdnf/repo.i
@@ -54,8 +54,11 @@ wrap_unique_ptr(PackageDownloadCallbacksUniquePtr, libdnf::repo::PackageDownload
 %include "libdnf/repo/repo_callbacks.hpp"
 wrap_unique_ptr(RepoCallbacksUniquePtr, libdnf::repo::RepoCallbacks);
 
+%apply FLUENT& { libdnf::repo::RepoQuery& };
 %include "libdnf/repo/repo_query.hpp"
+%clear libdnf::repo::RepoQuery&;
 %template(SackRepoRepoQuery) libdnf::sack::Sack<libdnf::repo::Repo>;
+
 %include "libdnf/repo/repo_sack.hpp"
 %template(RepoSackWeakPtr) libdnf::WeakPtr<libdnf::repo::RepoSack, false>;
 

--- a/bindings/libdnf/rpm.i
+++ b/bindings/libdnf/rpm.i
@@ -72,8 +72,10 @@
 %include "libdnf/rpm/package_set_iterator.hpp"
 %include "libdnf/rpm/package_set.hpp"
 
+%apply FLUENT& { libdnf::rpm::PackageQuery& };
 %ignore libdnf::rpm::PackageQuery::PackageQuery(PackageQuery && src);
 %include "libdnf/rpm/package_query.hpp"
+%clear libdnf::rpm::PackageQuery&;
 
 add_iterator(PackageSet)
 add_iterator(ReldepList)

--- a/bindings/libdnf/transaction.i
+++ b/bindings/libdnf/transaction.i
@@ -48,7 +48,9 @@
 %include "libdnf/transaction/rpm_package.hpp"
 
 // sack and query
+%apply FLUENT& { libdnf::transaction::TransactionQuery& };
 %include "libdnf/transaction/query.hpp"
+%clear libdnf::transaction::TransactionQuery&;
 %include "libdnf/transaction/sack.hpp"
 %template(TransactionSackWeakPtr) libdnf::WeakPtr<libdnf::transaction::TransactionSack, false>;
 


### PR DESCRIPTION
Support for methods that returns object to which them are attached - returns reference to `*this`.
Allows use method chaining on an object - fluent interface.