### PR TITLE
[dnf5] .github/workflows/clang-format: Do a rebase before clang-format run

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,6 +10,15 @@ jobs:
     steps:
       - name: Check out sources
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Rebase the pull request on target branch
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          echo "Rebasing \"`git log --oneline -1`\" on ${{github.event.pull_request.base.ref}}: \"`git log --oneline -1 origin/${{github.event.pull_request.base.ref}}`\""
+          git rebase origin/${{github.event.pull_request.base.ref}}
 
       - name: Run Clang Format
         run: |


### PR DESCRIPTION
The target branch may contain clang-format issues which can later be
fixed. Do a rebase so that we are checking the latest state of the
target branch.