### PR TITLE
[dnf5] Modify query filters to return `void`

### DIFF
--- a/dnfdaemon-server/services/comps/group.cpp
+++ b/dnfdaemon-server/services/comps/group.cpp
@@ -137,9 +137,10 @@ sdbus::MethodReply Group::list(sdbus::MethodCall & call) {
 
     libdnf::comps::GroupQuery query(base->get_comps()->get_group_sack());
     if (patterns.size() > 0) {
-        auto query_names = libdnf::comps::GroupQuery(query);
+        libdnf::comps::GroupQuery query_names(query);
+        query_names.filter_name(patterns, libdnf::sack::QueryCmp::IGLOB);
         query.filter_groupid(patterns, libdnf::sack::QueryCmp::IGLOB);
-        query |= query_names.filter_name(patterns, libdnf::sack::QueryCmp::IGLOB);
+        query |= query_names;
     }
 
     // create reply from the query

--- a/dnfdaemon-server/services/repo/repo.cpp
+++ b/dnfdaemon-server/services/repo/repo.cpp
@@ -252,8 +252,9 @@ sdbus::MethodReply Repo::list(sdbus::MethodCall & call) {
 
     if (patterns.size() > 0) {
         auto query_names = repos_query;
+        query_names.filter_name(patterns, libdnf::sack::QueryCmp::IGLOB);
         repos_query.filter_id(patterns, libdnf::sack::QueryCmp::IGLOB);
-        repos_query |= query_names.filter_name(patterns, libdnf::sack::QueryCmp::IGLOB);
+        repos_query |= query_names;
     }
 
     // create reply from the query

--- a/dnfdaemon-server/session.cpp
+++ b/dnfdaemon-server/session.cpp
@@ -128,7 +128,8 @@ bool Session::read_all_repos() {
     // TODO(mblaha): get flags from session configuration
     //auto & logger = base->get_logger();
     libdnf::repo::RepoQuery enabled_repos(*base);
-    enabled_repos.filter_enabled(true).filter_type(libdnf::repo::Repo::Type::AVAILABLE);
+    enabled_repos.filter_enabled(true);
+    enabled_repos.filter_type(libdnf::repo::Repo::Type::AVAILABLE);
     bool retval = true;
     for (auto & repo : enabled_repos) {
         repo->set_callbacks(std::make_unique<DbusRepoCB>(*this));

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -53,34 +53,32 @@ public:
     ///
     /// @param pattern      Pattern used when matching agains advisory names.
     /// @param cmp_type     What comparator to use with pattern, allows: EQ, GLOB, IGLOB.
-    AdvisoryQuery & filter_name(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & filter_name(
-        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_name(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter Advisories by type
     ///
     /// @param type         Possible types are: "security", "bugfix", "enhancement", "newpackage".
     /// @param cmp_type     What comparator to use with type, allows: EQ.
-    AdvisoryQuery & filter_type(const std::string & type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & filter_type(
-        const std::vector<std::string> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_type(const std::string & type, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_type(const std::vector<std::string> & types, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter Advisories by reference
     ///
     /// @param pattern      Pattern to match with reference id.
     /// @param cmp_type     What comparator to use with pattern, allows: EQ, IEXACT, GLOB, IGLOB, CONTAINS, ICONTAINS.
     /// @param type         Possible reference types are: "bugzilla", "cve", "vendor". If none is specified it matches all.
-    AdvisoryQuery & filter_reference(
+    void filter_reference(
         const std::string & pattern,
         sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ,
         const std::optional<std::string> type = {});
-    AdvisoryQuery & filter_reference(
+    void filter_reference(
         const std::vector<std::string> & pattern,
         sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ,
         const std::optional<std::string> type = {});
 
-    AdvisoryQuery & filter_severity(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
-    AdvisoryQuery & filter_severity(
+    void filter_severity(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_severity(
         const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     //TODO(amatej): this might not be needed and could be possibly removed
@@ -89,7 +87,7 @@ public:
     /// @param package_set  libdnf::rpm::PackageSet used when filtering.
     /// @param cmp_type     Condition to fulfill with packages.
     /// @return This AdvisoryQuery with applied filter.
-    AdvisoryQuery & filter_packages(
+    void filter_packages(
         const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     std::vector<AdvisoryPackage> get_advisory_packages(

--- a/include/libdnf/comps/group/query.hpp
+++ b/include/libdnf/comps/group/query.hpp
@@ -40,15 +40,25 @@ public:
     explicit GroupQuery(const libdnf::BaseWeakPtr & base);
     explicit GroupQuery(libdnf::Base & base);
 
-    GroupQuery & filter_groupid(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
-    GroupQuery & filter_groupid(
-        const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
-    GroupQuery & filter_name(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
-    GroupQuery & filter_name(
-        const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
-    GroupQuery & filter_uservisible(bool value);
-    GroupQuery & filter_default(bool value);
-    GroupQuery & filter_installed(bool value);
+    void filter_groupid(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ) {
+        filter(F::groupid, pattern, cmp);
+    }
+
+    void filter_groupid(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ) {
+        filter(F::groupid, patterns, cmp);
+    }
+
+    void filter_name(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ) {
+        filter(F::name, pattern, cmp);
+    }
+
+    void filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ) {
+        filter(F::name, patterns, cmp);
+    }
+
+    void filter_uservisible(bool value) { filter(F::is_uservisible, value, sack::QueryCmp::EQ); }
+    void filter_default(bool value) { filter(F::is_default, value, sack::QueryCmp::EQ); }
+    void filter_installed(bool value) { filter(F::is_installed, value, sack::QueryCmp::EQ); }
 
 private:
     struct F {
@@ -64,48 +74,6 @@ private:
     friend Group;
     friend GroupSack;
 };
-
-
-inline GroupQuery & GroupQuery::filter_groupid(const std::string & pattern, sack::QueryCmp cmp) {
-    filter(F::groupid, pattern, cmp);
-    return *this;
-}
-
-
-inline GroupQuery & GroupQuery::filter_groupid(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
-    filter(F::groupid, patterns, cmp);
-    return *this;
-}
-
-
-inline GroupQuery & GroupQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp) {
-    filter(F::name, pattern, cmp);
-    return *this;
-}
-
-
-inline GroupQuery & GroupQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
-    filter(F::name, patterns, cmp);
-    return *this;
-}
-
-
-inline GroupQuery & GroupQuery::filter_default(bool value) {
-    filter(F::is_default, value, sack::QueryCmp::EQ);
-    return *this;
-}
-
-
-inline GroupQuery & GroupQuery::filter_uservisible(bool value) {
-    filter(F::is_uservisible, value, sack::QueryCmp::EQ);
-    return *this;
-}
-
-
-inline GroupQuery & GroupQuery::filter_installed(bool value) {
-    filter(F::is_installed, value, sack::QueryCmp::EQ);
-    return *this;
-}
 
 
 }  // namespace libdnf::comps

--- a/include/libdnf/repo/repo_query.hpp
+++ b/include/libdnf/repo/repo_query.hpp
@@ -69,54 +69,54 @@ public:
     ///
     /// @param enabled  A boolean value the filter is matched against.
     /// @since 5.0
-    RepoQuery & filter_enabled(bool enabled);
+    void filter_enabled(bool enabled);
 
     /// Filter repos by their `expired` state.
     ///
     /// @param expired  A boolean value the filter is matched against.
     /// @since 5.0
-    RepoQuery & filter_expired(bool expired);
+    void filter_expired(bool expired);
 
     /// Filter repos by their `id`.
     ///
     /// @param pattern  A string the filter is matched against.
     /// @param cmp      A comparison (match) operator, defaults to `QueryCmp::EQ`.
     /// @since 5.0
-    RepoQuery & filter_id(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    void filter_id(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
     /// Filter repos by their `id`.
     ///
     /// @param pattern  A vector of strings the filter is matched against.
     /// @param cmp      A comparison (match) operator, defaults to `QueryCmp::EQ`.
     /// @since 5.0
-    RepoQuery & filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    void filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
     /// Filter repos by their `name`.
     ///
     /// @param pattern  A string the filter is matched against.
     /// @since 5.0
-    RepoQuery & filter_local(bool local);
+    void filter_local(bool local);
 
     /// Filter repos by their `name`.
     ///
     /// @param pattern  A string the filter is matched against.
     /// @param cmp      A comparison (match) operator, defaults to `QueryCmp::EQ`.
     /// @since 5.0
-    RepoQuery & filter_name(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    void filter_name(const std::string & pattern, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
     /// Filter repos by their `name`.
     ///
     /// @param pattern  A vector of strings the filter is matched against.
     /// @param cmp      A comparison (match) operator, defaults to `QueryCmp::EQ`.
     /// @since 5.0
-    RepoQuery & filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    void filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
     /// Filter repos by their `type`.
     ///
     /// @param pattern  A type the filter is matched against.
     /// @param cmp      A comparison (match) operator, defaults to `QueryCmp::EQ`.
     /// @since 5.0
-    RepoQuery & filter_type(Repo::Type type, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
+    void filter_type(Repo::Type type, sack::QueryCmp cmp = libdnf::sack::QueryCmp::EQ);
 
 private:
     BaseWeakPtr base;

--- a/include/libdnf/rpm/package_query.hpp
+++ b/include/libdnf/rpm/package_query.hpp
@@ -74,7 +74,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NAME
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NAME
-    PackageQuery & filter_name(
+    void filter_name(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `name` based on names of the packages in the `package_set`.
@@ -83,8 +83,7 @@ public:
     /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
-    PackageQuery & filter_name(
-        const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_name(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `epoch`.
     ///
@@ -95,7 +94,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_EPOCH
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_EPOCH
-    PackageQuery & filter_epoch(
+    void filter_epoch(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `epoch`.
@@ -104,7 +103,7 @@ public:
     /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
     /// @since 5.0
-    PackageQuery & filter_epoch(
+    void filter_epoch(
         const std::vector<unsigned long> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `version`.
@@ -116,7 +115,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_VERSION
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_VERSION
-    PackageQuery & filter_version(
+    void filter_version(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `release`.
@@ -128,7 +127,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_RELEASE
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_RELEASE
-    PackageQuery & filter_release(
+    void filter_release(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `arch`.
@@ -137,7 +136,7 @@ public:
     /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`.
     /// @since 5.0
-    PackageQuery & filter_arch(
+    void filter_arch(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `name` and `arch` based on names and arches of the packages in the `package_set`.
@@ -146,8 +145,7 @@ public:
     /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
-    PackageQuery & filter_name_arch(
-        const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_name_arch(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `epoch:version-release`.
     ///
@@ -158,7 +156,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_EVR
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_EVR
-    PackageQuery & filter_evr(
+    void filter_evr(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `name-[epoch:]version-release.arch`. The following matches are tolerant to omitted 0 epoch: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`.
@@ -172,7 +170,7 @@ public:
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NEVRA
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_NEVRA_STRICT
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_NEVRA_STRICT
-    PackageQuery & filter_nevra(
+    void filter_nevra(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by the `name`, `epoch`, `version`, `release` and `arch` attributes from the `nevra` object.
@@ -182,8 +180,7 @@ public:
     /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`, `GLOB`, `NOT_GLOB`, `IEXACT`, `NOT_IEXACT`, `IGLOB`, `NOT_IGLOB`.
     /// @since 5.0
-    PackageQuery & filter_nevra(
-        const libdnf::rpm::Nevra & nevra, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_nevra(const libdnf::rpm::Nevra & nevra, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `name-[epoch:]version-release.arch` attributes of the packages in the `package_set`.
     ///
@@ -191,8 +188,7 @@ public:
     /// @param cmp              A comparison (match) operator, defaults to `QueryCmp::EQ`.
     ///                         Supported values: `EQ`, `NEQ`.
     /// @since 5.0
-    PackageQuery & filter_nevra(
-        const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_nevra(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `sourcerpm`.
     ///
@@ -202,7 +198,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SOURCERPM
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SOURCERPM
-    PackageQuery & filter_sourcerpm(
+    void filter_sourcerpm(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `url`.
@@ -214,7 +210,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_URL
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_URL
-    PackageQuery & filter_url(
+    void filter_url(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `summary`.
@@ -226,7 +222,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUMMARY
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SUMMARY
-    PackageQuery & filter_summary(
+    void filter_summary(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `summary`.
@@ -238,7 +234,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_DESCRIPTION
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_DESCRIPTION
-    PackageQuery & filter_description(
+    void filter_description(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `provides`.
@@ -250,8 +246,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_PROVIDES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_PROVIDES
-    PackageQuery & filter_provides(
-        const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_provides(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `provides`.
     ///
@@ -262,7 +257,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_PROVIDES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_PROVIDES
-    PackageQuery & filter_provides(
+    void filter_provides(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `requires`.
@@ -274,8 +269,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_REQUIRES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_REQUIRES
-    PackageQuery & filter_requires(
-        const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_requires(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `requires`.
     ///
@@ -286,7 +280,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_REQUIRES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_REQUIRES
-    PackageQuery & filter_requires(
+    void filter_requires(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `requires`.
@@ -297,8 +291,7 @@ public:
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_REQUIRES
-    PackageQuery & filter_requires(
-        const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_requires(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `conflicts`.
     ///
@@ -309,8 +302,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_CONFLICTS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_CONFLICTS
-    PackageQuery & filter_conflicts(
-        const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_conflicts(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `conflicts`.
     ///
@@ -321,7 +313,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_CONFLICTS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_CONFLICTS
-    PackageQuery & filter_conflicts(
+    void filter_conflicts(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `conflicts`.
@@ -332,8 +324,7 @@ public:
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_CONFLICTS
-    PackageQuery & filter_conflicts(
-        const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_conflicts(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `obsoletes`.
     ///
@@ -344,8 +335,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_OBSOLETES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_OBSOLETES
-    PackageQuery & filter_obsoletes(
-        const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_obsoletes(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `obsoletes`.
     ///
@@ -356,7 +346,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_OBSOLETES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_OBSOLETES
-    PackageQuery & filter_obsoletes(
+    void filter_obsoletes(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `obsoletes`.
@@ -367,8 +357,7 @@ public:
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_OBSOLETES
-    PackageQuery & filter_obsoletes(
-        const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_obsoletes(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `recommends`.
     ///
@@ -379,7 +368,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_RECOMMENDS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_RECOMMENDS
-    PackageQuery & filter_recommends(
+    void filter_recommends(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `recommends`.
@@ -391,7 +380,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_RECOMMENDS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_RECOMMENDS
-    PackageQuery & filter_recommends(
+    void filter_recommends(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `recommends`.
@@ -402,7 +391,7 @@ public:
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_RECOMMENDS
-    PackageQuery & filter_recommends(
+    void filter_recommends(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `suggests`.
@@ -414,8 +403,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_SUGGESTS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_SUGGESTS
-    PackageQuery & filter_suggests(
-        const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_suggests(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `suggests`.
     ///
@@ -426,7 +414,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUGGESTS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SUGGESTS
-    PackageQuery & filter_suggests(
+    void filter_suggests(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `suggests`.
@@ -437,8 +425,7 @@ public:
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_SUGGESTS
-    PackageQuery & filter_suggests(
-        const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_suggests(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `enhances`.
     ///
@@ -449,8 +436,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_ENHANCES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_ENHANCES
-    PackageQuery & filter_enhances(
-        const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_enhances(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `enhances`.
     ///
@@ -461,7 +447,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_ENHANCES
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_ENHANCES
-    PackageQuery & filter_enhances(
+    void filter_enhances(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `enhances`.
@@ -472,8 +458,7 @@ public:
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_ENHANCES
-    PackageQuery & filter_enhances(
-        const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    void filter_enhances(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `supplements`.
     ///
@@ -484,7 +469,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const Dependency * reldep) - cmp_type = HY_PKG_SUPPLEMENTS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DependencyContainer * reldeplist) - cmp_type = HY_PKG_SUPPLEMENTS
-    PackageQuery & filter_supplements(
+    void filter_supplements(
         const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `supplements`.
@@ -496,7 +481,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_SUPPLEMENTS
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_SUPPLEMENTS
-    PackageQuery & filter_supplements(
+    void filter_supplements(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `supplements`.
@@ -507,7 +492,7 @@ public:
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_SUPPLEMENTS
-    PackageQuery & filter_supplements(
+    void filter_supplements(
         const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by `files` they contain.
@@ -519,7 +504,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_FILE
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_FILE
-    PackageQuery & filter_file(
+    void filter_file(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by their `location`.
@@ -531,7 +516,7 @@ public:
     // TODO(dmach): enable glob match to enable filename matching: {nevra.rpm, */nevra.rpm}
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_LOCATION
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_LOCATION
-    PackageQuery & filter_location(
+    void filter_location(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by `id` of the Repo they belong to.
@@ -543,7 +528,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char *match) - cmp_type = HY_PKG_REPONAME
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const char **matches) - cmp_type = HY_PKG_REPONAME
-    PackageQuery & filter_repo_id(
+    void filter_repo_id(
         const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
     /// Filter packages by advisories they are included in.
@@ -554,25 +539,25 @@ public:
     /// @since 5.0
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, const DnfPackageSet *pset) - cmp_type = HY_PKG_ADVISORY/_BUG/_CVE/_SEVERITY/_TYPE
-    PackageQuery & filter_advisories(
+    void filter_advisories(
         const libdnf::advisory::AdvisoryQuery & advisory_query,
         libdnf::sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    PackageQuery & filter_installed();
+    void filter_installed();
 
-    PackageQuery & filter_available();
+    void filter_available();
 
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_UPGRADES
-    PackageQuery & filter_upgrades();
+    void filter_upgrades();
 
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_DOWNGRADES
-    PackageQuery & filter_downgrades();
+    void filter_downgrades();
 
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_UPGRADABLE
-    PackageQuery & filter_upgradable();
+    void filter_upgradable();
 
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_DOWNGRADABLE
-    PackageQuery & filter_downgradable();
+    void filter_downgradable();
 
     /// Group packages by `name` and `arch`. Then within each group, keep packages that correspond with up to `limit` of (all but) latest `evr`s in the group.
     ///
@@ -582,7 +567,7 @@ public:
     //
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_LATEST
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_LATEST_PER_ARCH
-    PackageQuery & filter_latest_evr(int limit = 1);
+    void filter_latest_evr(int limit = 1);
 
     /// Group packages by `name` and `arch`. Then within each group, keep packages that belong to a repo with the highest priority (the lowest number).
     /// The filter works only on available packages, installed packages are not affected.
@@ -593,7 +578,7 @@ public:
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_OBSOLETES_BY_PRIORITY
     // @replaces libdnf/sack/query.hpp:method:addFilter(int keyname, int cmp_type, int match) - cmp_type = HY_PKG_LATEST_PER_ARCH_BY_PRIORITY
     // TODO(dmach): consider removing the installed packages during the filtering
-    PackageQuery & filter_priority();
+    void filter_priority();
 
     // TODO(jmracek) return std::pair<bool, std::unique_ptr<libdnf::rpm::Nevra>>
     // @replaces libdnf/sack/query.hpp:method:std::pair<bool, std::unique_ptr<Nevra>> filterSubject(const char * subject, HyForm * forms, bool icase, bool with_nevra, bool with_provides, bool with_filenames);

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -153,65 +153,49 @@ static void filter_reference_by_type_and_id(
     }
 }
 
-AdvisoryQuery & AdvisoryQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp_type) {
+void AdvisoryQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(
         *get_pool(base),
         SOLVABLE_NAME,
         *p_impl,
         cmp_type,
         {std::string(libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX) + pattern});
-
-    return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+void AdvisoryQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
     std::vector<std::string> prefixed_patterns;
     for (std::string pattern : patterns) {
         prefixed_patterns.push_back(std::string(libdnf::solv::SOLVABLE_NAME_ADVISORY_PREFIX) + pattern);
     }
     filter_dataiterator_internal(*get_pool(base), SOLVABLE_NAME, *p_impl, cmp_type, prefixed_patterns);
-
-    return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::filter_type(const std::string & type, sack::QueryCmp cmp_type) {
+void AdvisoryQuery::filter_type(const std::string & type, sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(*get_pool(base), SOLVABLE_PATCHCATEGORY, *p_impl, cmp_type, {type});
-
-    return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::filter_type(const std::vector<std::string> & types, sack::QueryCmp cmp_type) {
+void AdvisoryQuery::filter_type(const std::vector<std::string> & types, sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(*get_pool(base), SOLVABLE_PATCHCATEGORY, *p_impl, cmp_type, types);
-
-    return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::filter_reference(
+void AdvisoryQuery::filter_reference(
     const std::string & pattern, sack::QueryCmp cmp_type, const std::optional<std::string> type) {
     filter_reference_by_type_and_id(get_pool(base), *p_impl, cmp_type, {pattern}, type);
-
-    return *this;
 }
-AdvisoryQuery & AdvisoryQuery::filter_reference(
+void AdvisoryQuery::filter_reference(
     const std::vector<std::string> & patterns, sack::QueryCmp cmp_type, const std::optional<std::string> type) {
     filter_reference_by_type_and_id(get_pool(base), *p_impl, cmp_type, patterns, type);
-
-    return *this;
 }
 
-AdvisoryQuery & AdvisoryQuery::filter_severity(const std::string & pattern, sack::QueryCmp cmp_type) {
+void AdvisoryQuery::filter_severity(const std::string & pattern, sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(*get_pool(base), UPDATE_SEVERITY, *p_impl, cmp_type, {pattern});
-
-    return *this;
 }
-AdvisoryQuery & AdvisoryQuery::filter_severity(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
+void AdvisoryQuery::filter_severity(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(*get_pool(base), UPDATE_SEVERITY, *p_impl, cmp_type, patterns);
-
-    return *this;
 }
 
 //TODO(amatej): this might not be needed and could be possibly removed
-AdvisoryQuery & AdvisoryQuery::filter_packages(const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
+void AdvisoryQuery::filter_packages(const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
     auto & pool = get_pool(base);
     libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
     std::vector<AdvisoryPackage> adv_pkgs = get_advisory_packages_sorted_by_id();
@@ -257,8 +241,6 @@ AdvisoryQuery & AdvisoryQuery::filter_packages(const libdnf::rpm::PackageSet & p
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
 std::vector<AdvisoryPackage> AdvisoryQuery::get_advisory_packages(

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -732,7 +732,8 @@ void Goal::Impl::add_up_down_distrosync_to_goal(
             rpm_goal.add_distro_sync(tmp_queue, strict, best, clean_requirements_on_remove);
             break;
         case GoalAction::DOWNGRADE: {
-            query.filter_available().filter_downgrades();
+            query.filter_available();
+            query.filter_downgrades();
             auto & pool = get_pool(base);
             std::vector<Solvable *> tmp_solvables;
             for (auto pkg_id : *query.p_impl) {

--- a/libdnf/repo/repo_query.cpp
+++ b/libdnf/repo/repo_query.cpp
@@ -40,7 +40,6 @@ struct Get {
 
 RepoQuery::RepoQuery(const BaseWeakPtr & base) : RepoQuery(*base) {}
 
-
 RepoQuery::RepoQuery(Base & base) : base{base.get_weak_ptr()} {
     // copy all repos from RepoSack to the this object
     auto sack = base.get_repo_sack();
@@ -49,51 +48,37 @@ RepoQuery::RepoQuery(Base & base) : base{base.get_weak_ptr()} {
     }
 }
 
-
-RepoQuery & RepoQuery::filter_enabled(bool enabled) {
+void RepoQuery::filter_enabled(bool enabled) {
     filter(Get::enabled, enabled, sack::QueryCmp::EQ);
-    return *this;
 }
 
-
-RepoQuery & RepoQuery::filter_expired(bool expired) {
+void RepoQuery::filter_expired(bool expired) {
     filter(Get::expired, expired, sack::QueryCmp::EQ);
-    return *this;
 }
 
-
-RepoQuery & RepoQuery::filter_id(const std::string & pattern, sack::QueryCmp cmp) {
+void RepoQuery::filter_id(const std::string & pattern, sack::QueryCmp cmp) {
     filter(Get::id, pattern, cmp);
-    return *this;
 }
 
-
-RepoQuery & RepoQuery::filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
+void RepoQuery::filter_id(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
     filter(Get::id, patterns, cmp);
-    return *this;
 }
 
-
-RepoQuery & RepoQuery::filter_local(bool local) {
+void RepoQuery::filter_local(bool local) {
     filter(Get::local, local, sack::QueryCmp::EQ);
-    return *this;
 }
 
-
-RepoQuery & RepoQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp) {
+void RepoQuery::filter_name(const std::string & pattern, sack::QueryCmp cmp) {
     filter(Get::name, pattern, cmp);
-    return *this;
 }
 
 
-RepoQuery & RepoQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
+void RepoQuery::filter_name(const std::vector<std::string> & patterns, sack::QueryCmp cmp) {
     filter(Get::name, patterns, cmp);
-    return *this;
 }
 
-RepoQuery & RepoQuery::filter_type(Repo::Type type, sack::QueryCmp cmp) {
+void RepoQuery::filter_type(Repo::Type type, sack::QueryCmp cmp) {
     filter(Get::type, static_cast<int64_t>(type), cmp);
-    return *this;
 }
 
 }  // namespace libdnf::repo

--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -296,7 +296,7 @@ inline static void filter_glob_internal(
     }
 }
 
-PackageQuery & PackageQuery::filter_name(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_name(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     auto & pool = get_pool(p_impl->base);
     auto sack = p_impl->base->get_rpm_package_sack();
     libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
@@ -381,10 +381,9 @@ PackageQuery & PackageQuery::filter_name(const std::vector<std::string> & patter
     } else {
         *p_impl &= filter_result;
     }
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_name(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_name(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
@@ -412,10 +411,9 @@ PackageQuery & PackageQuery::filter_name(const PackageSet & package_set, libdnf:
     } else {
         *p_impl &= filter_result;
     }
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_name_arch(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_name_arch(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
@@ -444,7 +442,6 @@ PackageQuery & PackageQuery::filter_name_arch(const PackageSet & package_set, li
     } else {
         *p_impl &= filter_result;
     }
-    return *this;
 }
 
 inline static bool cmp_gt(int cmp) {
@@ -485,7 +482,7 @@ inline static void filter_evr_internal(
     query_result &= filter_result;
 }
 
-PackageQuery & PackageQuery::filter_evr(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_evr(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     auto & pool = get_pool(p_impl->base);
     switch (cmp_type) {
         case libdnf::sack::QueryCmp::GT:
@@ -506,10 +503,9 @@ PackageQuery & PackageQuery::filter_evr(const std::vector<std::string> & pattern
         default:
             libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_arch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_arch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     auto & pool = get_pool(p_impl->base);
     libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
@@ -555,8 +551,6 @@ PackageQuery & PackageQuery::filter_arch(const std::vector<std::string> & patter
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
 namespace {
@@ -679,7 +673,7 @@ inline static void filter_nevra_internal(
 
 }  // namespace
 
-PackageQuery & PackageQuery::filter_nevra(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_nevra(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -703,11 +697,9 @@ PackageQuery & PackageQuery::filter_nevra(const std::vector<std::string> & patte
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_nevra(const libdnf::rpm::Nevra & pattern, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_nevra(const libdnf::rpm::Nevra & pattern, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -726,11 +718,9 @@ PackageQuery & PackageQuery::filter_nevra(const libdnf::rpm::Nevra & pattern, li
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_nevra(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_nevra(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     if (cmp_type != sack::QueryCmp::EQ && cmp_type != sack::QueryCmp::NEQ) {
         libdnf_throw_assert_unsupported_query_cmp_type(cmp_type);
     }
@@ -759,7 +749,6 @@ PackageQuery & PackageQuery::filter_nevra(const PackageSet & package_set, libdnf
     } else {
         *p_impl &= filter_result;
     }
-    return *this;
 }
 
 template <bool (*cmp_fnc)(int value_to_cmp)>
@@ -780,8 +769,7 @@ inline static void filter_version_internal(
     solv_free(formated_c_pattern);
 }
 
-PackageQuery & PackageQuery::filter_version(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_version(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -829,8 +817,6 @@ PackageQuery & PackageQuery::filter_version(
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
 template <bool (*cmp_fnc)(int value_to_cmp)>
@@ -851,8 +837,7 @@ inline static void filter_release_internal(
     solv_free(formated_c_pattern);
 }
 
-PackageQuery & PackageQuery::filter_release(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_release(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -900,12 +885,9 @@ PackageQuery & PackageQuery::filter_release(
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_repo_id(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_repo_id(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -963,12 +945,9 @@ PackageQuery & PackageQuery::filter_repo_id(
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_sourcerpm(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_sourcerpm(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1024,12 +1003,9 @@ PackageQuery & PackageQuery::filter_sourcerpm(
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_epoch(
-    const std::vector<unsigned long> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_epoch(const std::vector<unsigned long> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1100,11 +1076,9 @@ PackageQuery & PackageQuery::filter_epoch(
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_epoch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_epoch(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1152,8 +1126,6 @@ PackageQuery & PackageQuery::filter_epoch(const std::vector<std::string> & patte
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
 static void filter_dataiterator(
@@ -1233,34 +1205,23 @@ static void filter_dataiterator_internal(
     }
 }
 
-PackageQuery & PackageQuery::filter_file(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_file(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(*get_pool(p_impl->base), SOLVABLE_FILELIST, *p_impl, cmp_type, patterns);
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_description(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_description(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(*get_pool(p_impl->base), SOLVABLE_DESCRIPTION, *p_impl, cmp_type, patterns);
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_summary(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_summary(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(*get_pool(p_impl->base), SOLVABLE_SUMMARY, *p_impl, cmp_type, patterns);
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_url(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_url(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     filter_dataiterator_internal(*get_pool(p_impl->base), SOLVABLE_URL, *p_impl, cmp_type, patterns);
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_location(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_location(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1293,11 +1254,9 @@ PackageQuery & PackageQuery::filter_location(
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_provides(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_provides(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1316,8 +1275,6 @@ PackageQuery & PackageQuery::filter_provides(const ReldepList & reldep_list, lib
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
 /// Provide libdnf::sack::QueryCmp without NOT flag
@@ -1353,8 +1310,7 @@ void PackageQuery::PQImpl::str2reldep_internal(
     }
 }
 
-PackageQuery & PackageQuery::filter_provides(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_provides(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not = (cmp_type & libdnf::sack::QueryCmp::NOT) == libdnf::sack::QueryCmp::NOT;
     if (cmp_not) {
         // Removal of NOT CmpType makes following comparissons easier and effective
@@ -1366,9 +1322,9 @@ PackageQuery & PackageQuery::filter_provides(
     PQImpl::str2reldep_internal(reldep_list, cmp_type, patterns);
 
     if (cmp_not) {
-        return filter_provides(reldep_list, libdnf::sack::QueryCmp::NEQ);
+        filter_provides(reldep_list, libdnf::sack::QueryCmp::NEQ);
     } else {
-        return filter_provides(reldep_list, libdnf::sack::QueryCmp::EQ);
+        filter_provides(reldep_list, libdnf::sack::QueryCmp::EQ);
     }
 }
 
@@ -1778,51 +1734,39 @@ void PackageQuery::PQImpl::filter_nevra(
     }
 }
 
-PackageQuery & PackageQuery::filter_conflicts(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_conflicts(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_CONFLICTS, cmp_type, reldep_list);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_conflicts(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_conflicts(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_CONFLICTS, cmp_type, patterns);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_conflicts(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_conflicts(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_CONFLICTS, cmp_type, package_set);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_enhances(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_enhances(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_ENHANCES, cmp_type, reldep_list);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_enhances(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_enhances(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_ENHANCES, cmp_type, patterns);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_enhances(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_enhances(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_ENHANCES, cmp_type, package_set);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_obsoletes(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_obsoletes(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_OBSOLETES, cmp_type, reldep_list);
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_obsoletes(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_obsoletes(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_OBSOLETES, cmp_type, patterns);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_obsoletes(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_obsoletes(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     bool cmp_not;
     switch (cmp_type) {
         case libdnf::sack::QueryCmp::EQ:
@@ -1874,75 +1818,57 @@ PackageQuery & PackageQuery::filter_obsoletes(const PackageSet & package_set, li
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_recommends(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_recommends(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_RECOMMENDS, cmp_type, reldep_list);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_recommends(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_recommends(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_RECOMMENDS, cmp_type, patterns);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_recommends(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_recommends(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_RECOMMENDS, cmp_type, package_set);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_requires(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_requires(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_REQUIRES, cmp_type, reldep_list);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_requires(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_requires(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_REQUIRES, cmp_type, patterns);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_requires(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_requires(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_REQUIRES, cmp_type, package_set);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_suggests(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_suggests(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_SUGGESTS, cmp_type, reldep_list);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_suggests(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_suggests(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_SUGGESTS, cmp_type, patterns);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_suggests(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_suggests(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_SUGGESTS, cmp_type, package_set);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_supplements(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_supplements(const ReldepList & reldep_list, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_SUPPLEMENTS, cmp_type, reldep_list);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_supplements(
-    const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_supplements(const std::vector<std::string> & patterns, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_SUPPLEMENTS, cmp_type, patterns);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_supplements(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
+void PackageQuery::filter_supplements(const PackageSet & package_set, libdnf::sack::QueryCmp cmp_type) {
     PQImpl::filter_reldep(*this, SOLVABLE_SUPPLEMENTS, cmp_type, package_set);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_advisories(
+void PackageQuery::filter_advisories(
     const libdnf::advisory::AdvisoryQuery & advisory_query, libdnf::sack::QueryCmp cmp_type) {
     auto & pool = get_pool(p_impl->base);
 
@@ -2005,16 +1931,14 @@ PackageQuery & PackageQuery::filter_advisories(
     } else {
         *p_impl &= filter_result;
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_installed() {
+void PackageQuery::filter_installed() {
     auto & pool = get_pool(p_impl->base);
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
         (*p_impl).clear();
-        return *this;
+        return;
     }
     libdnf::solv::SolvMap filter_result(pool.get_nsolvables());
     auto it = p_impl->begin();
@@ -2032,14 +1956,13 @@ PackageQuery & PackageQuery::filter_installed() {
     // TODO(jrohel): The optimization replaces the original query_result buffer. Is it OK?
     // Or we need to use a slower version "*p_impl &= filter_result;"
     p_impl->swap(filter_result);
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_available() {
+void PackageQuery::filter_available() {
     auto & pool = get_pool(p_impl->base);
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
-        return *this;
+        return;
     }
     auto it = p_impl->begin();
     auto end = p_impl->end();
@@ -2053,15 +1976,14 @@ PackageQuery & PackageQuery::filter_available() {
             break;
         }
     }
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_upgrades() {
+void PackageQuery::filter_upgrades() {
     auto & pool = get_pool(p_impl->base);
     auto * installed_repo = pool->installed;
     if (installed_repo == nullptr) {
         clear();
-        return *this;
+        return;
     }
 
     p_impl->base->get_rpm_package_sack()->p_impl->make_provides_ready();
@@ -2076,17 +1998,15 @@ PackageQuery & PackageQuery::filter_upgrades() {
             p_impl->remove_unsafe(candidate_id);
         }
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_downgrades() {
+void PackageQuery::filter_downgrades() {
     auto & pool = get_pool(p_impl->base);
     auto * installed_repo = pool->installed;
 
     if (pool->installed == nullptr) {
         clear();
-        return *this;
+        return;
     }
 
     p_impl->base->get_rpm_package_sack()->p_impl->make_provides_ready();
@@ -2101,17 +2021,15 @@ PackageQuery & PackageQuery::filter_downgrades() {
             p_impl->remove_unsafe(candidate_id);
         }
     }
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_upgradable() {
+void PackageQuery::filter_upgradable() {
     auto & pool = get_pool(p_impl->base);
     auto * installed_repo = pool->installed;
 
     if (pool->installed == nullptr) {
         clear();
-        return *this;
+        return;
     }
 
     auto sack = p_impl->base->get_rpm_package_sack();
@@ -2140,17 +2058,15 @@ PackageQuery & PackageQuery::filter_upgradable() {
         }
     }
     *p_impl &= filter_result;
-
-    return *this;
 }
 
-PackageQuery & PackageQuery::filter_downgradable() {
+void PackageQuery::filter_downgradable() {
     auto & pool = get_pool(p_impl->base);
     auto * installed_repo = pool->installed;
 
     if (pool->installed == nullptr) {
         clear();
-        return *this;
+        return;
     }
 
     auto sack = p_impl->base->get_rpm_package_sack();
@@ -2179,8 +2095,6 @@ PackageQuery & PackageQuery::filter_downgradable() {
         }
     }
     *p_impl &= filter_result;
-
-    return *this;
 }
 
 
@@ -2240,7 +2154,7 @@ static int latest_cmp(const Id * ap, const Id * bp, libdnf::solv::Pool * pool) {
     return *ap - *bp;
 }
 
-PackageQuery & PackageQuery::filter_latest_evr(int limit) {
+void PackageQuery::filter_latest_evr(int limit) {
     auto & pool = get_pool(p_impl->base);
 
     libdnf::solv::IdQueue samename;
@@ -2271,8 +2185,6 @@ PackageQuery & PackageQuery::filter_latest_evr(int limit) {
     if (start_block != -1) {  // Add last block to the map
         add_latest_to_map(pool, *p_impl, samename, start_block, i, limit);
     }
-
-    return *this;
 }
 
 static inline bool priority_solvable_cmp_key(const Solvable * first, const Solvable * second) {
@@ -2285,7 +2197,7 @@ static inline bool priority_solvable_cmp_key(const Solvable * first, const Solva
     return first->repo->priority > second->repo->priority;
 }
 
-PackageQuery & PackageQuery::filter_priority() {
+void PackageQuery::filter_priority() {
     auto & pool = get_pool(p_impl->base);
 
     std::vector<Solvable *> sorted_priority;
@@ -2314,7 +2226,6 @@ PackageQuery & PackageQuery::filter_priority() {
             p_impl->add_unsafe(pool.solvable2id(candidate));
         }
     }
-    return *this;
 }
 
 std::pair<bool, libdnf::rpm::Nevra> PackageQuery::resolve_pkg_spec(

--- a/microdnf/commands/advisory/advisory_info.cpp
+++ b/microdnf/commands/advisory/advisory_info.cpp
@@ -75,14 +75,17 @@ void AdvisoryInfoCommand::run() {
     auto adv_q_updates = libdnf::advisory::AdvisoryQuery(ctx.base);
 
     if (installed->get_value() || all->get_value()) {
-        auto installed_package_query = package_query.filter_installed();
+        auto installed_package_query = package_query;
+        installed_package_query.filter_installed();
         adv_q_installed.filter_packages(installed_package_query, QueryCmp::LTE);
     }
 
     // Default if nothing specified
     if (available->get_value() || all->get_value() ||
         (!installed->get_value() && !available->get_value() && !updates->get_value())) {
-        auto installed_package_query = package_query.filter_installed().filter_latest_evr();
+        auto installed_package_query = package_query;
+        installed_package_query.filter_installed();
+        installed_package_query.filter_latest_evr();
         //TODO(amatej): https://github.com/rpm-software-management/dnf/pull/1485, show for currently running
         //kernel and if it is not the latests one show also for the latest kernel
         //auto kernel_id = ctx.base.get_rpm_package_sack()->p_impl->get_running_kernel();
@@ -92,7 +95,8 @@ void AdvisoryInfoCommand::run() {
     }
 
     if (updates->get_value()) {
-        auto upgradable_package_query = package_query.filter_upgradable();
+        auto upgradable_package_query = package_query;
+        upgradable_package_query.filter_upgradable();
         adv_q_updates.filter_packages(upgradable_package_query, QueryCmp::GT);
     }
 

--- a/microdnf/commands/advisory/advisory_list.cpp
+++ b/microdnf/commands/advisory/advisory_list.cpp
@@ -76,14 +76,17 @@ void AdvisoryListCommand::run() {
     std::vector<libdnf::advisory::AdvisoryPackage> installed_pkgs;
 
     if (installed->get_value() || all->get_value()) {
-        auto installed_package_query = package_query.filter_installed();
+        auto installed_package_query = package_query;
+        installed_package_query.filter_installed();
         installed_pkgs = advisory_query.get_advisory_packages(installed_package_query, QueryCmp::LTE);
     }
 
     // Default if nothing specified
     if (available->get_value() || all->get_value() ||
         (!installed->get_value() && !available->get_value() && !updates->get_value())) {
-        auto installed_package_query = package_query.filter_installed().filter_latest_evr();
+        auto installed_package_query = package_query;
+        installed_package_query.filter_installed();
+        installed_package_query.filter_latest_evr();
         //TODO(amatej): https://github.com/rpm-software-management/dnf/pull/1485, show for currently running
         //kernel and if it is not the latests one show also for the latest kernel
         //auto kernel_id = ctx.base.get_rpm_package_sack()->p_impl->get_running_kernel();
@@ -93,7 +96,8 @@ void AdvisoryListCommand::run() {
     }
 
     if (updates->get_value()) {
-        auto upgradable_package_query = package_query.filter_upgradable();
+        auto upgradable_package_query = package_query;
+        upgradable_package_query.filter_upgradable();
         pkgs = advisory_query.get_advisory_packages(upgradable_package_query, QueryCmp::GT);
     }
 

--- a/microdnf/commands/group/group_info.cpp
+++ b/microdnf/commands/group/group_info.cpp
@@ -63,9 +63,10 @@ void GroupInfoCommand::run() {
 
     // Filter by patterns if given
     if (group_specs_str.size() > 0) {
-        auto query_names = libdnf::comps::GroupQuery(query);
+        libdnf::comps::GroupQuery query_names(query);
+        query_names.filter_name(group_specs_str, libdnf::sack::QueryCmp::IGLOB);
         query.filter_groupid(group_specs_str, libdnf::sack::QueryCmp::IGLOB);
-        query |= query_names.filter_name(group_specs_str, libdnf::sack::QueryCmp::IGLOB);
+        query |= query_names;
     } else if (not hidden->get_value()) {
         // Filter uservisible only if patterns are not given
         query.filter_uservisible(true);

--- a/microdnf/commands/group/group_list.cpp
+++ b/microdnf/commands/group/group_list.cpp
@@ -62,9 +62,10 @@ void GroupListCommand::run() {
 
     // Filter by patterns if given
     if (group_specs_str.size() > 0) {
-        auto query_names = libdnf::comps::GroupQuery(query);
+        libdnf::comps::GroupQuery query_names(query);
+        query_names.filter_name(group_specs_str, libdnf::sack::QueryCmp::IGLOB);
         query.filter_groupid(group_specs_str, libdnf::sack::QueryCmp::IGLOB);
-        query |= query_names.filter_name(group_specs_str, libdnf::sack::QueryCmp::IGLOB);
+        query |= query_names;
     } else if (not hidden->get_value()) {
         // Filter uservisible only if patterns are not given
         query.filter_uservisible(true);

--- a/microdnf/commands/repo/repo_list.cpp
+++ b/microdnf/commands/repo/repo_list.cpp
@@ -74,10 +74,12 @@ void RepoListCommand::run() {
     auto repo_specs_str = repo_specs->get_value();
     if (repo_specs_str.size() > 0) {
         auto query_names = query;
+        // filter by repo Name
+        query_names.filter_name(repo_specs_str, libdnf::sack::QueryCmp::IGLOB);
         // filter by repo ID
         query.filter_id(repo_specs_str, libdnf::sack::QueryCmp::IGLOB);
-        // filter by repo Name
-        query |= query_names.filter_name(repo_specs_str, libdnf::sack::QueryCmp::IGLOB);
+        // union the results
+        query |= query_names;
     }
 
     query.filter_type(libdnf::repo::Repo::Type::AVAILABLE);

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -196,7 +196,8 @@ void Context::apply_repository_setopts() {
         auto last_dot_pos = setopt.first.rfind('.');
         auto repo_pattern = setopt.first.substr(0, last_dot_pos);
         libdnf::repo::RepoQuery query(base);
-        query.filter_id(repo_pattern, libdnf::sack::QueryCmp::GLOB).filter_type(libdnf::repo::Repo::Type::AVAILABLE);
+        query.filter_id(repo_pattern, libdnf::sack::QueryCmp::GLOB);
+        query.filter_type(libdnf::repo::Repo::Type::AVAILABLE);
         auto key = setopt.first.substr(last_dot_pos + 1);
         for (auto & repo : query) {
             try {
@@ -218,7 +219,8 @@ void Context::print_info(const char * msg) {
 
 void Context::load_repos(bool load_system, libdnf::repo::Repo::LoadFlags flags) {
     libdnf::repo::RepoQuery repos(base);
-    repos.filter_enabled(true).filter_type(libdnf::repo::Repo::Type::SYSTEM, libdnf::sack::QueryCmp::NEQ);
+    repos.filter_enabled(true);
+    repos.filter_type(libdnf::repo::Repo::Type::SYSTEM, libdnf::sack::QueryCmp::NEQ);
 
     for (auto & repo : repos) {
         auto callback = get_quiet() ? std::make_unique<microdnf::KeyImportRepoCB>(base.get_config())
@@ -679,7 +681,8 @@ std::vector<std::string> match_available_pkgs(Context & ctx, const std::string &
     ctx.apply_repository_setopts();
 
     libdnf::repo::RepoQuery enabled_repos(ctx.base);
-    enabled_repos.filter_enabled(true).filter_type(libdnf::repo::Repo::Type::AVAILABLE);
+    enabled_repos.filter_enabled(true);
+    enabled_repos.filter_type(libdnf::repo::Repo::Type::AVAILABLE);
     for (auto & repo : enabled_repos.get_data()) {
         repo->set_sync_strategy(libdnf::repo::Repo::SyncStrategy::ONLY_CACHE);
         repo->get_config().skip_if_unavailable().set(libdnf::Option::Priority::RUNTIME, true);

--- a/test/libdnf/advisory/test_advisory.cpp
+++ b/test/libdnf/advisory/test_advisory.cpp
@@ -40,28 +40,32 @@ void AdvisoryAdvisoryTest::setUp() {
 
 void AdvisoryAdvisoryTest::test_get_name() {
     // Tests get_name method
-    libdnf::advisory::AdvisoryQuery advisories = libdnf::advisory::AdvisoryQuery(base).filter_type("security");
+    libdnf::advisory::AdvisoryQuery advisories(base);
+    advisories.filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     CPPUNIT_ASSERT_EQUAL(advisory.get_name(), std::string("DNF-2019-1"));
 }
 
 void AdvisoryAdvisoryTest::test_get_type() {
     // Tests get_type method
-    libdnf::advisory::AdvisoryQuery advisories = libdnf::advisory::AdvisoryQuery(base).filter_type("security");
+    libdnf::advisory::AdvisoryQuery advisories(base);
+    advisories.filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     CPPUNIT_ASSERT_EQUAL(advisory.get_type(), std::string("security"));
 }
 
 void AdvisoryAdvisoryTest::test_get_severity() {
     // Tests get_severity method
-    libdnf::advisory::AdvisoryQuery advisories = libdnf::advisory::AdvisoryQuery(base).filter_type("security");
+    libdnf::advisory::AdvisoryQuery advisories(base);
+    advisories.filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     CPPUNIT_ASSERT_EQUAL(advisory.get_severity(), std::string("moderate"));
 }
 
 void AdvisoryAdvisoryTest::test_get_references() {
     // Tests get_references method
-    libdnf::advisory::AdvisoryQuery advisories = libdnf::advisory::AdvisoryQuery(base).filter_type("security");
+    libdnf::advisory::AdvisoryQuery advisories(base);
+    advisories.filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     std::vector<libdnf::advisory::AdvisoryReference> refs = advisory.get_references();
     CPPUNIT_ASSERT_EQUAL(1lu, refs.size());
@@ -75,7 +79,8 @@ void AdvisoryAdvisoryTest::test_get_references() {
 
 void AdvisoryAdvisoryTest::test_get_collections() {
     // Tests get_collections method
-    libdnf::advisory::AdvisoryQuery advisories = libdnf::advisory::AdvisoryQuery(base).filter_type("security");
+    libdnf::advisory::AdvisoryQuery advisories(base);
+    advisories.filter_type("security");
     libdnf::advisory::Advisory advisory = *advisories.begin();
     std::vector<libdnf::advisory::AdvisoryCollection> colls = advisory.get_collections();
     CPPUNIT_ASSERT_EQUAL(1lu, colls.size());
@@ -91,7 +96,8 @@ void AdvisoryAdvisoryTest::test_get_collections() {
     CPPUNIT_ASSERT_EQUAL(std::string("perl-DBI"), mods[0].get_name());
     CPPUNIT_ASSERT_EQUAL(std::string("ethereum"), mods[1].get_name());
 
-    auto adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("DNF-2020-1");
+    libdnf::advisory::AdvisoryQuery adv_query(base);
+    adv_query.filter_name("DNF-2020-1");
     CPPUNIT_ASSERT_EQUAL(1lu, adv_query.size());
     colls = (*adv_query.begin()).get_collections();
     CPPUNIT_ASSERT_EQUAL(2lu, colls.size());

--- a/test/libdnf/advisory/test_advisory_module.cpp
+++ b/test/libdnf/advisory/test_advisory_module.cpp
@@ -33,7 +33,9 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryModuleTest, "AdvisoryAdvis
 void AdvisoryAdvisoryModuleTest::setUp() {
     BaseTestCase::setUp();
     BaseTestCase::add_repo_repomd("repomd-repo1");
-    auto advisory = *(libdnf::advisory::AdvisoryQuery(base).filter_name("DNF-2019-1").begin());
+    libdnf::advisory::AdvisoryQuery advisories(base);
+    advisories.filter_name("DNF-2019-1");
+    libdnf::advisory::Advisory advisory = *advisories.begin();
     std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
     modules = collections[0].get_modules();
 }

--- a/test/libdnf/advisory/test_advisory_package.cpp
+++ b/test/libdnf/advisory/test_advisory_package.cpp
@@ -33,7 +33,9 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryPackageTest, "AdvisoryAdvi
 void AdvisoryAdvisoryPackageTest::setUp() {
     BaseTestCase::setUp();
     BaseTestCase::add_repo_repomd("repomd-repo1");
-    auto advisory = *(libdnf::advisory::AdvisoryQuery(base).filter_name("DNF-2019-1").begin());
+    libdnf::advisory::AdvisoryQuery advisories(base);
+    advisories.filter_name("DNF-2019-1");
+    libdnf::advisory::Advisory advisory = *advisories.begin();
     std::vector<libdnf::advisory::AdvisoryCollection> collections = advisory.get_collections();
     packages = collections[0].get_packages();
 }

--- a/test/libdnf/advisory/test_advisory_query.cpp
+++ b/test/libdnf/advisory/test_advisory_query.cpp
@@ -48,32 +48,36 @@ void AdvisoryAdvisoryQueryTest::test_size() {
 
 void AdvisoryAdvisoryQueryTest::test_filter_name() {
     // Tests filter_name method
-    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
+    AdvisoryQuery adv_query(base);
+    adv_query.filter_name("*2020-1", libdnf::sack::QueryCmp::GLOB);
     std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_name("DNF-20*", libdnf::sack::QueryCmp::GLOB);
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_name(
-        std::vector<std::string>{"DNF-2019-1", "DNF-2020-1"}, libdnf::sack::QueryCmp::EQ);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_name(std::vector<std::string>{"DNF-2019-1", "DNF-2020-1"}, libdnf::sack::QueryCmp::EQ);
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_type() {
     // Tests filter_type method
-    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_type("bugfix");
+    AdvisoryQuery adv_query(base);
+    adv_query.filter_type("bugfix");
     std::vector<Advisory> expected = {get_advisory("DNF-2020-1"), get_advisory("PKG-OLDER")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_type("enhancement");
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_type("enhancement");
     expected = {get_advisory("PKG-NEWER")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query =
-        AdvisoryQuery(base).filter_type(std::vector<std::string>{"bugfix", "security"}, libdnf::sack::QueryCmp::EQ);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_type(std::vector<std::string>{"bugfix", "security"}, libdnf::sack::QueryCmp::EQ);
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1"), get_advisory("PKG-OLDER")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
@@ -82,91 +86,105 @@ void AdvisoryAdvisoryQueryTest::test_filter_packages() {
     // Tests filter_packages method
     libdnf::rpm::PackageQuery pkg_query(base);
 
-    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
+    AdvisoryQuery adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(pkg_query, libdnf::sack::QueryCmp::GT);
     std::vector<Advisory> expected = {get_advisory("PKG-NEWER")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(pkg_query, libdnf::sack::QueryCmp::GTE);
     expected = {get_advisory("DNF-2019-1"), get_advisory("PKG-NEWER")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(pkg_query, libdnf::sack::QueryCmp::EQ);
     expected = {get_advisory("DNF-2019-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(pkg_query, libdnf::sack::QueryCmp::LTE);
     expected = {get_advisory("DNF-2019-1"), get_advisory("PKG-OLDER")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_packages(pkg_query, libdnf::sack::QueryCmp::LT);
     expected = {get_advisory("PKG-OLDER")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_cve() {
     // Tests filter_reference method with cve
-    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_reference("3333", libdnf::sack::QueryCmp::EQ, "cve");
+    AdvisoryQuery adv_query(base);
+    adv_query.filter_reference("3333", libdnf::sack::QueryCmp::EQ, "cve");
     std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_reference(
-        std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "cve");
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_reference(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "cve");
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_reference(
-        std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ, "cve");
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_reference(std::vector<std::string>{"1111", "4444"}, libdnf::sack::QueryCmp::EQ, "cve");
     expected = {get_advisory("DNF-2019-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB, "cve");
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_reference("*", libdnf::sack::QueryCmp::GLOB, "cve");
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_bugzilla() {
     // Tests filter_reference method with bugzilla
-    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_reference("2222", libdnf::sack::QueryCmp::EQ, "bugzilla");
+    AdvisoryQuery adv_query(base);
+    adv_query.filter_reference("2222", libdnf::sack::QueryCmp::EQ, "bugzilla");
     std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_reference(
-        std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "bugzilla");
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_reference(std::vector<std::string>{"1111", "3333"}, libdnf::sack::QueryCmp::EQ, "bugzilla");
     expected = {};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB, "bugzilla");
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_reference("*", libdnf::sack::QueryCmp::GLOB, "bugzilla");
     expected = {get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_reference() {
     // Tests filter_reference method without type specified
-    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_reference("2222");
+    AdvisoryQuery adv_query(base);
+    adv_query.filter_reference("2222");
     std::vector<Advisory> expected = {get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_reference(std::vector<std::string>{"1111", "3333"});
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_reference(std::vector<std::string>{"1111", "3333"});
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_reference("*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_reference("*", libdnf::sack::QueryCmp::GLOB);
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_reference("none*", libdnf::sack::QueryCmp::GLOB);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_reference("none*", libdnf::sack::QueryCmp::GLOB);
     expected = {};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }
 
 void AdvisoryAdvisoryQueryTest::test_filter_severity() {
     // Tests filter_severity method
-    AdvisoryQuery adv_query = AdvisoryQuery(base).filter_severity("moderate", libdnf::sack::QueryCmp::EQ);
+    AdvisoryQuery adv_query(base);
+    adv_query.filter_severity("moderate", libdnf::sack::QueryCmp::EQ);
     std::vector<Advisory> expected = {get_advisory("DNF-2019-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 
-    adv_query = AdvisoryQuery(base).filter_severity(
-        std::vector<std::string>{"moderate", "critical"}, libdnf::sack::QueryCmp::EQ);
+    adv_query = AdvisoryQuery(base);
+    adv_query.filter_severity(std::vector<std::string>{"moderate", "critical"}, libdnf::sack::QueryCmp::EQ);
     expected = {get_advisory("DNF-2019-1"), get_advisory("DNF-2020-1")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(adv_query));
 }

--- a/test/libdnf/advisory/test_advisory_reference.cpp
+++ b/test/libdnf/advisory/test_advisory_reference.cpp
@@ -36,7 +36,9 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(AdvisoryAdvisoryReferenceTest, "AdvisoryAd
 void AdvisoryAdvisoryReferenceTest::setUp() {
     BaseTestCase::setUp();
     BaseTestCase::add_repo_repomd("repomd-repo1");
-    auto advisory = *(libdnf::advisory::AdvisoryQuery(base).filter_name("DNF-2019-1").begin());
+    libdnf::advisory::AdvisoryQuery advisories(base);
+    advisories.filter_name("DNF-2019-1");
+    libdnf::advisory::Advisory advisory = *advisories.begin();
     references = advisory.get_references();
 }
 

--- a/test/libdnf/base/test_goal.cpp
+++ b/test/libdnf/base/test_goal.cpp
@@ -218,7 +218,8 @@ void BaseGoalTest::test_install_installed_pkg() {
     add_system_pkg("repos-rpm/rpm-repo1/one-1-1.noarch.rpm", TransactionItemReason::DEPENDENCY);
 
     libdnf::rpm::PackageQuery query(base);
-    query.filter_available().filter_nevra({"one-0:1-1.noarch"});
+    query.filter_available();
+    query.filter_nevra({"one-0:1-1.noarch"});
 
     std::vector<libdnf::rpm::Package> expected = {get_pkg("one-0:1-1.noarch")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
@@ -437,7 +438,8 @@ void BaseGoalTest::test_install_or_reinstall() {
 
     libdnf::Goal goal(base);
     libdnf::rpm::PackageQuery query(base);
-    query.filter_available().filter_nevra({"one-0:1-1.noarch"});
+    query.filter_available();
+    query.filter_nevra({"one-0:1-1.noarch"});
     CPPUNIT_ASSERT_EQUAL(1lu, query.size());
     goal.add_rpm_install_or_reinstall(query);
     auto transaction = goal.resolve(false);

--- a/test/libdnf/repo/test_package_downloader.cpp
+++ b/test/libdnf/repo/test_package_downloader.cpp
@@ -60,7 +60,9 @@ void PackageDownloaderTest::test_package_downloader() {
     auto repo = add_repo_rpm("rpm-repo1");
 
     libdnf::rpm::PackageQuery query(base);
-    query.filter_name({"one"}).filter_version({"2"}).filter_arch({"noarch"});
+    query.filter_name({"one"});
+    query.filter_version({"2"});
+    query.filter_arch({"noarch"});
     CPPUNIT_ASSERT_EQUAL(1lu, query.size());
 
     auto downloader = libdnf::repo::PackageDownloader();

--- a/test/libdnf/rpm/test_package_query.cpp
+++ b/test/libdnf/rpm/test_package_query.cpp
@@ -471,8 +471,9 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::EQ with equal advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("DNF-2019-1");
-        PackageQuery query(base);
+        libdnf::advisory::AdvisoryQuery adv_query(base);
+        adv_query.filter_name("DNF-2019-1");
+        libdnf::rpm::PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
         CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));
@@ -480,7 +481,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::GT with older advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-OLDER");
+        libdnf::advisory::AdvisoryQuery adv_query(base);
+        adv_query.filter_name("PKG-OLDER");
         PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::GT);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
@@ -489,7 +491,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::LTE with older advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-OLDER");
+        libdnf::advisory::AdvisoryQuery adv_query(base);
+        adv_query.filter_name("PKG-OLDER");
         PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::LTE);
         std::vector<Package> expected = {};
@@ -498,7 +501,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::LT with newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-NEWER");
+        libdnf::advisory::AdvisoryQuery adv_query(base);
+        adv_query.filter_name("PKG-NEWER");
         PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::LT);
         std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
@@ -507,7 +511,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::GTE with newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query = libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-NEWER");
+        libdnf::advisory::AdvisoryQuery adv_query(base);
+        adv_query.filter_name("PKG-NEWER");
         PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::GTE);
         std::vector<Package> expected = {};
@@ -516,8 +521,8 @@ void RpmPackageQueryTest::test_filter_advisories() {
 
     {
         // Test QueryCmp::EQ with older and newer advisory pkg
-        libdnf::advisory::AdvisoryQuery adv_query =
-            libdnf::advisory::AdvisoryQuery(base).filter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
+        libdnf::advisory::AdvisoryQuery adv_query(base);
+        adv_query.filter_name("PKG-*", libdnf::sack::QueryCmp::IGLOB);
         ;
         PackageQuery query(base);
         query.filter_advisories(adv_query, libdnf::sack::QueryCmp::EQ);
@@ -530,13 +535,13 @@ void RpmPackageQueryTest::test_filter_chain() {
     add_repo_solv("solv-repo1");
 
     PackageQuery query(base);
-    query.filter_name({"pkg"})
-        .filter_epoch({"0"})
-        .filter_version({"1.2"})
-        .filter_release({"3"})
-        .filter_arch({"x86_64"})
-        .filter_provides({"foo"}, libdnf::sack::QueryCmp::NEQ)
-        .filter_requires({"foo"}, libdnf::sack::QueryCmp::NEQ);
+    query.filter_name({"pkg"});
+    query.filter_epoch({"0"});
+    query.filter_version({"1.2"});
+    query.filter_release({"3"});
+    query.filter_arch({"x86_64"});
+    query.filter_provides({"foo"}, libdnf::sack::QueryCmp::NEQ);
+    query.filter_requires({"foo"}, libdnf::sack::QueryCmp::NEQ);
 
     std::vector<Package> expected = {get_pkg("pkg-0:1.2-3.x86_64")};
     CPPUNIT_ASSERT_EQUAL(expected, to_vector(query));

--- a/test/python3/libdnf/repo/test_package_downloader.py
+++ b/test/python3/libdnf/repo/test_package_downloader.py
@@ -28,7 +28,9 @@ class TestPackageDownloader(base_test_case.BaseTestCase):
         repo = self.add_repo_rpm("rpm-repo1")
 
         query = libdnf.rpm.PackageQuery(self.base)
-        query.filter_name(["one"]).filter_version(["2"]).filter_arch(["noarch"])
+        query.filter_name(["one"])
+        query.filter_version(["2"])
+        query.filter_arch(["noarch"])
         self.assertEqual(query.size(), 1)
 
         downloader = libdnf.repo.PackageDownloader()

--- a/test/ruby/libdnf/repo/test_package_downloader.rb
+++ b/test/ruby/libdnf/repo/test_package_downloader.rb
@@ -61,7 +61,9 @@ class TestPackageDownloader < BaseTestCase
         repo = add_repo_rpm("rpm-repo1")
 
         query = Rpm::PackageQuery.new(@base)
-        query.filter_name(["one"]).filter_version(["2"]).filter_arch(["noarch"])
+        query.filter_name(["one"])
+        query.filter_version(["2"])
+        query.filter_arch(["noarch"])
         assert_equal(1, query.size())
 
         downloader = Repo::PackageDownloader.new()


### PR DESCRIPTION
Query filters returned a reference to themselves. This is confusing for some Python users (they expect a new object to be returned, not a reference to themselves).
With this commit, query filters no longer return a reference to themselves. As a result, we have lost the ability to chain query filters. But we choose a stricter code variant to avoid usage errors.

I also prepared a PR https://github.com/rpm-software-management/libdnf/pull/1440 , which supports methods that return reference to *this (self) in Python. But as I wrote above it is confusing for some users.