### PR TITLE
rpm::Transaction: Handle new librpm `rpmElementType::TR_RESTORED`

### DIFF
--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -619,6 +619,11 @@ private:
                 case TR_RPMDB:
                     te_type = "package from_rpmdb";
                     break;
+                //case TR_RESTORED:
+                //TODO(jrohel): Newly added to librpm. What exactly does it do?
+                //    te_type = "package will be restored";
+                //    break;
+                default:;
             }
             libdnf_assert(
                 te_rpmdb_record_number != 0,


### PR DESCRIPTION
`rpmElementType::TR_RESTORED` has been added to librpm. This commit adds a `default` section to the `switch` to compile with both old and new librpm.