### PR TITLE
Increase required rpm version since we use `rpmdbCookie()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ pkg_check_modules(LIBMODULEMD REQUIRED modulemd-2.0>=2.11.2)
 pkg_check_modules(REPO REQUIRED librepo>=1.13.0)
 include_directories(${REPO_INCLUDE_DIRS})
 link_directories(${REPO_LIBRARY_DIRS})
-pkg_check_modules(RPM REQUIRED rpm>=4.11.0)
+pkg_check_modules(RPM REQUIRED rpm>=4.15.0)
 pkg_check_modules(SMARTCOLS REQUIRED smartcols)
 pkg_check_modules(SQLite3 REQUIRED sqlite3)
 

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -73,7 +73,7 @@ BuildRequires:  valgrind
 %endif
 BuildRequires:  pkgconfig(gio-unix-2.0) >= 2.46.0
 BuildRequires:  pkgconfig(gtk-doc)
-BuildRequires:  rpm-devel >= 4.11.0
+BuildRequires:  rpm-devel >= 4.15.0
 %if %{with rhsm}
 BuildRequires:  pkgconfig(librhsm) >= 0.0.3
 %endif


### PR DESCRIPTION
Since commit https://github.com/rpm-software-management/libdnf/commit/6fd718ba8dff16b93679028ddbc0a4aa87dfade3
we use `rpmdbCookie()` which has became available in rpm 4.15:
https://rpm.org/wiki/Releases/4.15.0