### PR TITLE
[dnf5] Considered map usage improvements

### DIFF
--- a/include/libdnf/rpm/package.hpp
+++ b/include/libdnf/rpm/package.hpp
@@ -406,6 +406,10 @@ public:
     // @replaces dnf:dnf/package.py:attribute:Package.installed
     bool is_installed() const;
 
+    /// @return `true` if the package is excluded, `false` otherwise.
+    /// @since 5.0
+    bool is_excluded() const;
+
     /// TODO is_local
     // @replaces dnf:dnf/package.py:method:Package.localPkg(self)
     // @replaces libdnf:libdnf/dnf-package.h:function:dnf_package_is_local(DnfPackage * pkg)

--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -912,6 +912,7 @@ base::Transaction Goal::resolve(bool allow_erasing) {
     pool_setarch(*pool, "x86_64");
     auto ret = GoalProblem::NO_PROBLEM;
 
+    sack->p_impl->recompute_considered_in_pool();
     sack->p_impl->make_provides_ready();
     // TODO(jmracek) Apply modules first
     // TODO(jmracek) Apply comps second or later

--- a/libdnf/rpm/package.cpp
+++ b/libdnf/rpm/package.cpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/rpm/package.hpp"
 
+#include "package_sack_impl.hpp"
 #include "reldep_list_impl.hpp"
 #include "solv/pool.hpp"
 
@@ -277,6 +278,11 @@ std::string Package::get_package_path() const {
 
 bool Package::is_installed() const {
     return get_pool(base).is_installed(id.id);
+}
+
+bool Package::is_excluded() const {
+    base->get_rpm_package_sack()->p_impl->recompute_considered_in_pool();
+    return get_pool(base).is_solvable_excluded(id.id);
 }
 
 unsigned long long Package::get_hdr_end() const {

--- a/libdnf/rpm/package_sack.cpp
+++ b/libdnf/rpm/package_sack.cpp
@@ -53,6 +53,10 @@ void PackageSack::Impl::make_provides_ready() {
         return;
     }
 
+    // Temporarily replaces the considered map with an empty one. Ignores "excludes" during calculation provides.
+    libdnf::solv::SolvMap original_considered_map(0);
+    get_pool(base).swap_considered_map(original_considered_map);
+
     base->get_repo_sack()->internalize_repos();
 
     auto & pool = get_pool(base);
@@ -80,6 +84,9 @@ void PackageSack::Impl::make_provides_ready() {
 
     pool_createwhatprovides(*pool);
     provides_ready = true;
+
+    // Sets the original considered map.
+    get_pool(base).swap_considered_map(original_considered_map);
 }
 
 void PackageSack::Impl::setup_excludes_includes(bool only_main) {

--- a/libdnf/rpm/package_sack.cpp
+++ b/libdnf/rpm/package_sack.cpp
@@ -239,9 +239,10 @@ void PackageSack::Impl::recompute_considered_in_pool() {
 
     auto considered = compute_considered_map(libdnf::sack::ExcludeFlags::APPLY_EXCLUDES);
     if (considered) {
-        get_pool(base).set_considered_map(std::move(*considered));
+        get_pool(base).swap_considered_map(*considered);
     } else {
-        get_pool(base).drop_considered_map();
+        libdnf::solv::SolvMap empty_map(0);
+        get_pool(base).swap_considered_map(empty_map);
     }
 
     considered_uptodate = true;

--- a/libdnf/solv/pool.hpp
+++ b/libdnf/solv/pool.hpp
@@ -192,6 +192,10 @@ public:
 
     bool is_installed(Id id) const { return is_installed(id2solvable(id)); }
 
+    /// Returns `true` if solvable with `id` is excluded.
+    /// The return value is undefined for invalid `id`. Valid range for `id` in [1, nsolvables).
+    bool is_solvable_excluded(Id id) const { return is_considered_map_active() && !considered.contains(id); }
+
     repo::Repo & get_repo(Id id) const { return solv::get_repo(id2solvable(id)); }
 
     const char * get_sourcerpm(Id id) const;


### PR DESCRIPTION
* Fix: `recompute_considered_in_pool` must be called in the `Goal::resolve` to apply excludes.
* solv::Pool: `swap_considered_map` method
* Ignore considered map in the `rpm::PackageSack::Impl::make_provides_ready` to calculate provides for all packages, including excluded packages.
* rpm::Package: Add `is_excluded` method

    

