### PR TITLE
[dnf5] Allow specifying unitests to run on CLI, add TempDir::release() method

### DIFF
--- a/libdnf/utils/fs/temp.cpp
+++ b/libdnf/utils/fs/temp.cpp
@@ -52,11 +52,18 @@ TempDir::TempDir(std::filesystem::path destdir, const std::string & name_prefix)
 
 TempDir::~TempDir() {
     try {
-        std::filesystem::remove_all(path);
+        if (!path.empty()) {
+            std::filesystem::remove_all(path);
+        }
     } catch (std::exception &) {
         // catch an exception that shouldn't be raised in a destructor
         // TODO(lukash) consider logging or printing the exception
     }
+}
+
+
+void TempDir::release() noexcept {
+    path = "";
 }
 
 

--- a/libdnf/utils/fs/temp.hpp
+++ b/libdnf/utils/fs/temp.hpp
@@ -43,6 +43,11 @@ public:
     TempDir & operator=(const TempDir &) = delete;
 
     ~TempDir();
+
+    /// Releases the temporary directory, meaning it will no longer be deleted
+    /// on destruction.
+    void release() noexcept;
+
     const std::filesystem::path & get_path() const noexcept { return path; }
 
 private:

--- a/test/libdnf-cli/CMakeLists.txt
+++ b/test/libdnf-cli/CMakeLists.txt
@@ -18,4 +18,4 @@ target_link_directories(run_tests_cli PUBLIC ${CMAKE_BINARY_DIR}/libdnf)
 target_link_libraries(run_tests_cli stdc++ libdnf libdnf-cli cppunit)
 
 
-add_test(NAME test_libdnf_cli COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tests_cli DEPENDS run_tests_cli COMMENT "Running libdnf-cli C++ tests...")
+add_test(NAME test_libdnf_cli COMMAND run_tests_cli)

--- a/test/libdnf/CMakeLists.txt
+++ b/test/libdnf/CMakeLists.txt
@@ -28,4 +28,4 @@ if(WITH_PERFORMANCE_TESTS)
 endif()
 
 
-add_test(NAME test_libdnf COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tests DEPENDS run_tests COMMENT "Running libdnf C++ tests...")
+add_test(NAME test_libdnf COMMAND run_tests)

--- a/test/libdnf/run_tests.cpp
+++ b/test/libdnf/run_tests.cpp
@@ -89,7 +89,7 @@ public:
 };
 
 
-int main() {
+int main(int argc, char * argv[]) {
     // Create the event manager and test controller
     CPPUNIT_NS::TestResult controller;
 
@@ -110,10 +110,16 @@ int main() {
     CPPUNIT_NS::BriefTestProgressListener progress;
     controller.addListener(&progress);
 
+    std::string test_path;
+
+    if (argc > 1) {
+        test_path = argv[1];
+    }
+
     // Add the top suite to the test runner
     CPPUNIT_NS::TestRunner runner;
     runner.addTest(CPPUNIT_NS::TestFactoryRegistry::getRegistry().makeTest());
-    runner.run(controller);
+    runner.run(controller, test_path);
 
     // Print test in a compiler compatible format.
     CPPUNIT_NS::CompilerOutputter outputter(&result, CPPUNIT_NS::stdCOut());

--- a/test/tutorial/CMakeLists.txt
+++ b/test/tutorial/CMakeLists.txt
@@ -11,4 +11,4 @@ add_executable(run_tests_tutorial ${TEST_TUTORIAL_SOURCES})
 target_link_libraries(run_tests_tutorial stdc++ libdnf libdnf-cli cppunit)
 
 
-add_test(NAME test_tutorial COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tests_tutorial DEPENDS run_tests_cli COMMENT "Testing tutorial code snippets...")
+add_test(NAME test_tutorial COMMAND run_tests_tutorial)


### PR DESCRIPTION
A couple of small improvements for running tests.