### PR TITLE
[dnf5] Use libsolv repowriter, properly limit solvables range for writing cache files

### DIFF
--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -452,8 +452,6 @@ void Repo::load_available_repo(LoadFlags flags) {
         solv_repo->load_repo_ext(RepodataType::PRESTO, *downloader.get());
     }
 
-    // updateinfo must come *after* all other extensions, as it is not a real
-    // extension, but contains a new set of packages
     if (any(flags & LoadFlags::UPDATEINFO)) {
         solv_repo->load_repo_ext(RepodataType::UPDATEINFO, *downloader.get());
     }

--- a/libdnf/repo/solv_repo.cpp
+++ b/libdnf/repo/solv_repo.cpp
@@ -212,6 +212,9 @@ void SolvRepo::load_repo_ext(RepodataType type, const RepoDownloader & downloade
         if (type == RepodataType::UPDATEINFO) {
             updateinfo_solvables_start = solvables_start;
             updateinfo_solvables_end = pool->nsolvables;
+        } else if (type == RepodataType::COMPS) {
+            comps_solvables_start = solvables_start;
+            comps_solvables_end = pool->nsolvables;
         }
 
         return;
@@ -235,7 +238,10 @@ void SolvRepo::load_repo_ext(RepodataType type, const RepoDownloader & downloade
             }
             break;
         case RepodataType::COMPS:
-            res = repo_add_comps(repo, ext_file.get(), 0);
+            if ((res = repo_add_comps(repo, ext_file.get(), 0)) == 0) {
+                comps_solvables_start = solvables_start;
+                comps_solvables_end = pool->nsolvables;
+            }
             break;
         case RepodataType::OTHER:
             res = repo_add_rpmmd(repo, ext_file.get(), 0, REPO_EXTEND_SOLVABLES);
@@ -452,6 +458,8 @@ void SolvRepo::write_ext(Id repodata_id, RepodataType type) {
 
     if (type == RepodataType::UPDATEINFO) {
         repowriter_set_solvablerange(writer, updateinfo_solvables_start, updateinfo_solvables_end);
+    } else if (type == RepodataType::COMPS) {
+        repowriter_set_solvablerange(writer, comps_solvables_start, comps_solvables_end);
     } else {
         repowriter_set_flags(writer, REPOWRITER_NO_STORAGE_SOLVABLE);
     }

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -99,6 +99,10 @@ private:
 
     bool needs_internalizing{false};
 
+    /// Ranges of solvables for different types of data, used for writing libsolv cache files
+    int updateinfo_solvables_start{0};
+    int updateinfo_solvables_end{0};
+
 public:
     ::Repo * repo{nullptr};  // libsolv pool retains ownership
 };

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -75,11 +75,6 @@ public:
     // Checksum of data in .solv file. Used for validity check of .solvx files.
     unsigned char checksum[CHKSUM_BYTES];
 
-    // the following three elements are needed for repo cache (.solv and .solvx updateinfo) writting
-    int main_nsolvables{0};
-    int main_nrepodata{0};
-    int main_end{0};
-
     void set_needs_internalizing() { needs_internalizing = true; };
 
 private:
@@ -100,6 +95,8 @@ private:
     bool needs_internalizing{false};
 
     /// Ranges of solvables for different types of data, used for writing libsolv cache files
+    int main_solvables_start{0};
+    int main_solvables_end{0};
     int updateinfo_solvables_start{0};
     int updateinfo_solvables_end{0};
 

--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -97,6 +97,8 @@ private:
     /// Ranges of solvables for different types of data, used for writing libsolv cache files
     int main_solvables_start{0};
     int main_solvables_end{0};
+    int comps_solvables_start{0};
+    int comps_solvables_end{0};
     int updateinfo_solvables_start{0};
     int updateinfo_solvables_end{0};
 


### PR DESCRIPTION
Removes the hackish overwriting of libsolv's Repo attributes for writing the cache files, instead we now store the ranges of the different types of solvables we load and limit the repowriter to those ranges when writing the corresponding .solv cache files.