### PR TITLE
[dnf5] Improve file/directory paths argument completion

### DIFF
--- a/libdnf-cli/argument_parser.cpp
+++ b/libdnf-cli/argument_parser.cpp
@@ -130,7 +130,7 @@ int ArgumentParser::PositionalArg::parse(const char * option, int argc, const ch
                     auto result = complete_hook(argv[i]);
                     if (result.size() == 1) {
                         if (result[0] != option) {
-                            std::cout << result[0] + ' ' << std::endl;
+                            std::cout << result[0] << std::endl;
                         }
                     } else {
                         for (const auto & line : result) {
@@ -357,7 +357,7 @@ void ArgumentParser::Command::print_complete(
                     if (result[0] == arg) {
                         return;
                     }
-                    std::cout << result[0] + ' ' << std::endl;
+                    std::cout << result[0] << std::endl;
                     return;
                 }
                 for (const auto & line : result) {


### PR DESCRIPTION
* Do not add a space to the end while completing a positional argument.
* Adds only directories that contain files that match the pattern or contain subdirectories.
* Skips hidden paths (starting with a dot) unless explicitly requested to complete them.

