### PR TITLE
[dnf5] microdnf: Implement "swap" command; ignore argparse error after "--help"

### DIFF
--- a/microdnf/commands/swap/swap.cpp
+++ b/microdnf/commands/swap/swap.cpp
@@ -22,8 +22,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "context.hpp"
 
-#include <libdnf/conf/option_string.hpp>
+#include <libdnf-cli/output/transaction_table.hpp>
+#include <libdnf/base/goal.hpp>
 
+#include <iostream>
 
 namespace fs = std::filesystem;
 
@@ -41,22 +43,69 @@ SwapCommand::SwapCommand(Command & parent) : Command(parent, "swap") {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Remove software and install another in one transaction");
 
-    patterns = parser.add_new_values();
-    auto patterns_arg = parser.add_new_positional_arg(
-        "patterns",
-        ArgumentParser::PositionalArg::UNLIMITED,
-        parser.add_init_value(std::unique_ptr<libdnf::Option>(new libdnf::OptionString(nullptr))),
-        patterns);
-    patterns_arg->set_short_description("Patterns");
-    cmd.register_positional_arg(patterns_arg);
+    auto remove_spec_arg = parser.add_new_positional_arg("remove_spec", 1, nullptr, nullptr);
+    remove_spec_arg->set_short_description("The spec that will be removed");
+    remove_spec_arg->set_parse_hook_func([this](
+                                             [[maybe_unused]] ArgumentParser::PositionalArg * arg,
+                                             [[maybe_unused]] int argc,
+                                             const char * const argv[]) {
+        remove_pkg_spec = argv[0];
+        return true;
+    });
+    remove_spec_arg->set_complete_hook_func(
+        [&ctx](const char * arg) { return match_specs(ctx, arg, true, false, false, true); });
+    cmd.register_positional_arg(remove_spec_arg);
+
+    auto install_spec_arg = parser.add_new_positional_arg("install_spec", 1, nullptr, nullptr);
+    install_spec_arg->set_short_description("The spec that will be installed");
+    install_spec_arg->set_parse_hook_func(
+        [this]([[maybe_unused]] ArgumentParser::PositionalArg * arg, int argc, const char * const argv[]) {
+            parse_add_specs(argc, argv, install_pkg_specs, install_pkg_file_paths);
+            return true;
+        });
+    install_spec_arg->set_complete_hook_func(
+        [&ctx](const char * arg) { return match_specs(ctx, arg, false, true, true, false); });
+    cmd.register_positional_arg(install_spec_arg);
 }
 
 
 void SwapCommand::run() {
-    // auto & ctx = static_cast<Context &>(get_session());
-    // auto & package_sack = *ctx.base.get_rpm_package_sack();
+    auto & ctx = static_cast<Context &>(get_session());
 
-    // TODO(dmach): implement
+    ctx.load_repos(true);
+
+    std::vector<std::string> error_messages;
+    const auto cmdline_packages = ctx.add_cmdline_packages(install_pkg_file_paths, error_messages);
+    for (const auto & msg : error_messages) {
+        std::cout << msg << std::endl;
+    }
+
+    std::cout << std::endl;
+
+    libdnf::Goal goal(ctx.base);
+    for (const auto & pkg : cmdline_packages) {
+        goal.add_rpm_install(pkg);
+    }
+    for (const auto & spec : install_pkg_specs) {
+        goal.add_rpm_install(spec);
+    }
+    goal.add_rpm_remove(remove_pkg_spec);
+
+    auto transaction = goal.resolve(false);
+    if (transaction.get_problems() != libdnf::GoalProblem::NO_PROBLEM) {
+        return;
+    }
+
+    if (!libdnf::cli::output::print_transaction_table(transaction)) {
+        return;
+    }
+
+    if (!userconfirm(ctx.base.get_config())) {
+        std::cout << "Operation aborted." << std::endl;
+        return;
+    }
+
+    ctx.download_and_run(transaction);
 }
 
 

--- a/microdnf/commands/swap/swap.hpp
+++ b/microdnf/commands/swap/swap.hpp
@@ -23,22 +23,24 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 #include <libdnf-cli/session.hpp>
-#include <libdnf/conf/option_bool.hpp>
 
-#include <memory>
 #include <vector>
 
 
 namespace microdnf {
 
 
+// TODO(jrohel): The "swap" command may be removed in the future in favor of a more powerful command (eg "do"),
+//               which will allow multiple actions to be combined in one transaction.
 class SwapCommand : public libdnf::cli::session::Command {
 public:
     explicit SwapCommand(Command & parent);
     void run() override;
 
 private:
-    std::vector<std::unique_ptr<libdnf::Option>> * patterns{nullptr};
+    std::string remove_pkg_spec;
+    std::vector<std::string> install_pkg_specs;
+    std::vector<std::string> install_pkg_file_paths;
 };
 
 


### PR DESCRIPTION
* Implement "swap" command - The "swap" command may be removed in the future in favor of a more powerful command (eg "do"), which will allow multiple actions to be combined in one transaction.

* Ignore argument parsing errors after "--help"
Example:
The `swap` command requires 2 positional arguments - "remove_spec" and "install_spec".
`microdnf swap --help` prints help for the `swap` command.
Prior to this change, the error `Missing positional argument "remove_spec" for command "swap"` was printed.