### PR TITLE
 context: dnf_context_remove accepts `<package-spec>` as dnf, unify code, fix docs strings

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -2381,7 +2381,7 @@ dnf_context_run(DnfContext *context, GCancellable *cancellable, GError **error) 
 /**
  * dnf_context_install:
  * @context: a #DnfContext instance.
- * @name: A package or group name, e.g. "firefox" or "@gnome-desktop"
+ * @name: A package specification (NEVRA forms, provide, file provide, globs supported) e.g. "firefox"
  * @error: A #GError or %NULL
  *
  * Finds a remote package and marks it to be installed.
@@ -2424,12 +2424,12 @@ dnf_context_install(DnfContext *context, const gchar *name, GError **error) try
 /**
  * dnf_context_remove:
  * @context: a #DnfContext instance.
- * @name: A package or group name, e.g. "firefox" or "@gnome-desktop"
+ * @name: A package specification (NEVRA forms, provide, file provide, globs supported) e.g. "firefox"
  * @error: A #GError or %NULL
  *
  * Finds an installed package and marks it to be removed.
  *
- * If multiple packages are available then only the oldest package is removed.
+ * If multiple packages are available, all of them will be removed.
  *
  * Returns: %TRUE for success, %FALSE otherwise
  *
@@ -2472,7 +2472,7 @@ dnf_context_remove(DnfContext *context, const gchar *name, GError **error) try
 /**
  * dnf_context_update:
  * @context: a #DnfContext instance.
- * @name: A package or group name, e.g. "firefox" or "@gnome-desktop"
+ * @name: A package specification (NEVRA forms, provide, file provide, globs supported) e.g. "firefox"
  * @error: A #GError or %NULL
  *
  * Finds an installed and remote package and marks it to be updated.
@@ -2550,7 +2550,7 @@ dnf_context_update_all (DnfContext  *context,
 /**
  * dnf_context_distrosync:
  * @context: a #DnfContext instance.
- * @name: A package or group name, e.g. "firefox" or "@gnome-desktop"
+ * @name: A package specification (NEVRA forms, provide, file provide, globs supported) e.g. "firefox"
  * @error: A #GError or %NULL
  *
  * Finds an installed and remote package and marks it to be synchronized with remote version.

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -2393,10 +2393,9 @@ dnf_context_run(DnfContext *context, GCancellable *cancellable, GError **error) 
  * Since: 0.1.0
  **/
 gboolean
-dnf_context_install (DnfContext *context, const gchar *name, GError **error) try
+dnf_context_install(DnfContext *context, const gchar *name, GError **error) try
 {
     DnfContextPrivate *priv = GET_PRIVATE (context);
-    g_autoptr(GPtrArray) selector_matches = NULL;
 
     /* create sack and add sources */
     if (priv->sack == NULL) {
@@ -2407,7 +2406,7 @@ dnf_context_install (DnfContext *context, const gchar *name, GError **error) try
 
     g_auto(HySubject) subject = hy_subject_create(name);
     g_auto(HySelector) selector = hy_subject_get_best_selector(subject, priv->sack, NULL, FALSE, NULL);
-    selector_matches = hy_selector_matches(selector);
+    g_autoptr(GPtrArray) selector_matches = hy_selector_matches(selector);
     if (selector_matches->len == 0) {
         g_set_error(error,
                     DNF_ERROR,
@@ -2440,31 +2439,33 @@ gboolean
 dnf_context_remove(DnfContext *context, const gchar *name, GError **error) try
 {
     DnfContextPrivate *priv = GET_PRIVATE(context);
-    GPtrArray *pkglist;
-    hy_autoquery HyQuery query = NULL;
-    gboolean ret = TRUE;
-    guint i;
 
     /* create sack and add repos */
     if (priv->sack == NULL) {
         dnf_state_reset(priv->state);
-        ret = dnf_context_setup_sack(context, priv->state, error);
-        if (!ret)
+        if (!dnf_context_setup_sack(context, priv->state, error))
             return FALSE;
     }
 
-    /* find installed packages to remove */
-    query = hy_query_create(priv->sack);
-    query->installed();
-    hy_query_filter(query, HY_PKG_NAME, HY_EQ, name);
-    pkglist = hy_query_run(query);
+    libdnf::Query query(priv->sack, libdnf::Query::ExcludeFlags::APPLY_EXCLUDES);
+    query.installed();
+    auto ret = query.filterSubject(name, nullptr, false, true, true, true);
+    if (!ret.first) {
+        g_set_error(error,
+                    DNF_ERROR,
+                    DNF_ERROR_PACKAGE_NOT_FOUND,
+                    "No installed package matches '%s'", name);
+        return FALSE;
+    }
+
+    g_autoptr(GPtrArray) packages = query.run();
 
     /* add each package */
-    for (i = 0; i < pkglist->len; i++) {
-        auto pkg = static_cast<DnfPackage *>(g_ptr_array_index(pkglist, i));
+    for (guint i = 0; i < packages->len; i++) {
+        auto pkg = static_cast<DnfPackage *>(g_ptr_array_index(packages, i));
         hy_goal_erase(priv->goal, pkg);
     }
-    g_ptr_array_unref(pkglist);
+
     return TRUE;
 } CATCH_TO_GERROR(FALSE)
 
@@ -2495,8 +2496,7 @@ dnf_context_update(DnfContext *context, const gchar *name, GError **error) try
     }
 
     g_auto(HySubject) subject = hy_subject_create(name);
-    g_auto(HySelector) selector = hy_subject_get_best_selector(subject, priv->sack, NULL, FALSE,
-                                                               NULL);
+    g_auto(HySelector) selector = hy_subject_get_best_selector(subject, priv->sack, NULL, FALSE, NULL);
     g_autoptr(GPtrArray) selector_matches = hy_selector_matches(selector);
     if (selector_matches->len == 0) {
         g_set_error(error,
@@ -2506,8 +2506,14 @@ dnf_context_update(DnfContext *context, const gchar *name, GError **error) try
         return FALSE;
     }
 
-    if (hy_goal_upgrade_selector(priv->goal, selector))
+    int ret = hy_goal_upgrade_selector(priv->goal, selector);
+    if (ret != 0) {
+        g_set_error(error,
+                    DNF_ERROR,
+                    ret,
+                    "Ill-formed Selector '%s'", name);
         return FALSE;
+    }
 
     return TRUE;
 } CATCH_TO_GERROR(FALSE)


### PR DESCRIPTION
* Prior to change, the `dnf_context_remove` function only accepted the package name (without globs). It was not possible to enter more detailed specifications and thus, for example, select a specific version of the package to uninstall - for example, which kernel we want to uninstall.
This patch adds full `<package-spec>` support as in dnf, including support for globs (wildcards) and searching against 'provides' and 'file provides'.

* Better error handling for `hy_goal_upgrade_selector` in` dnf_context_update`.

* Unification of the function code `dnf_context_install`, `dnf_context_remove`,
`dnf_context_update`.

* fix docs strings - Functions do not support groups - only packages are supported. The `dnf_context_remove` function marks all matching packages for removal - not just the oldest one.

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1105

= changelog =
msg: context: Support `<package-spec>` (NEVRA forms, provides, file provides) including globs in the dnf_context_remove function
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2084602