### PR TITLE
[dnf5] libdnf/repo/solv_repo: Re-introduce solv cache reloading

### DIFF
--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -83,7 +83,7 @@ private:
     bool load_solv_cache(const char * type, int flags);
 
     /// Writes libsolv's .solv cache file with main libsolv repodata.
-    void write_main();
+    void write_main(bool load_after_write);
 
     /// Writes libsolv's .solvx cache file with extended libsolv repodata.
     void write_ext(Id repodata_id, RepodataType type);


### PR DESCRIPTION
Libsolv loads some data from the .solv cache files lazily, so the reloading means reducing the memory footprint until (and if) the data are required to be loaded.

@mlschroe sorry to be bothering again, could you please have a look at this too? Basically a revert of https://github.com/rpm-software-management/libdnf/commit/13d62fa0f26996f8d9b815101f10a10d70eac8cc with added comps support and some cleanups. We've had that code for ages, but it seems it might be hackish again, I'm not sure it does the right thing. Thank you!