### PR TITLE
[dnf5] microdnf: `clean` command

### DIFF
--- a/microdnf/commands/clean/clean.cpp
+++ b/microdnf/commands/clean/clean.cpp
@@ -1,0 +1,148 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "clean.hpp"
+
+#include "microdnf/context.hpp"
+
+#include <libdnf/repo/repo_cache.hpp>
+
+#include <filesystem>
+#include <iostream>
+
+
+namespace fs = std::filesystem;
+
+
+namespace microdnf {
+
+
+namespace {
+
+struct CacheType {
+    std::string name;
+    std::string description;
+    CleanCommand::Actions action;
+};
+
+const CacheType CACHE_TYPES[]{
+    {"all", "Delete all cached data from the repositories cache", CleanCommand::CLEAN_ALL},
+    {"packages", "Delete packages from the repositories cache", CleanCommand::CLEAN_PACKAGES},
+    {"metadata",
+     "Delete the metadata and dbcache from the repositories cache",
+     static_cast<CleanCommand::Actions>(CleanCommand::CLEAN_METADATA | CleanCommand::CLEAN_DBCACHE)},
+    {"dbcache", "Delete dbcache from the repositories cache", CleanCommand::CLEAN_DBCACHE},
+    {"expire-cache", "Mark the repositories cache as expired", CleanCommand::EXPIRE_CACHE}};
+
+}  // namespace
+
+
+using namespace libdnf::cli;
+
+
+CleanCommand::CleanCommand(Command & parent) : Command(parent, "clean") {
+    auto & ctx = static_cast<Context &>(get_session());
+    auto & parser = ctx.get_argument_parser();
+
+    auto & cmd = *get_argument_parser_command();
+    cmd.set_short_description("Remove or expire cached data");
+
+    auto cache_types =
+        parser.add_new_positional_arg("cache_types", ArgumentParser::PositionalArg::AT_LEAST_ONE, nullptr, nullptr);
+    cache_types->set_short_description("List of cache types to clean up");
+
+    cache_types->set_parse_hook_func(
+        // Parses arguments and sets the appropriate bits in the required_actions.
+        // An exception is thrown if an unknown argument is found.
+        [this]([[maybe_unused]] ArgumentParser::PositionalArg * arg, int argc, const char * const argv[]) {
+            for (int i = 0; i < argc; ++i) {
+                const std::string_view cache_type{argv[i]};
+                bool found{false};
+                for (const auto & type : CACHE_TYPES) {
+                    if (cache_type == type.name) {
+                        required_actions = static_cast<Actions>(required_actions | type.action);
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    throw std::runtime_error(fmt::format("Unknown cache type \"{}\"", argv[i]));
+                }
+            }
+            return true;
+        });
+
+    cache_types->set_complete_hook_func([](const char * arg) {
+        // Support for action/type_cache autocomplete on the command line.
+        const std::string_view to_complete{arg};
+        std::string last;
+        std::vector<std::string> cache_types;
+        for (const auto & type : CACHE_TYPES) {
+            if (type.name.compare(0, to_complete.length(), to_complete) == 0) {
+                cache_types.emplace_back(fmt::format("{:15} ({})", type.name, type.description));
+                last = type.name;
+            }
+        }
+        if (cache_types.size() == 1) {
+            cache_types[0] = last + " ";
+        }
+        return cache_types;
+    });
+
+    cmd.register_positional_arg(cache_types);
+}
+
+
+void CleanCommand::run() {
+    auto & ctx = static_cast<Context &>(get_session());
+    fs::path cachedir{ctx.base.get_config().cachedir().get_value()};
+
+    libdnf::repo::RepoCache::RemoveStatistics statistics{};
+    for (const auto & dir_entry : std::filesystem::directory_iterator(cachedir)) {
+        libdnf::repo::RepoCache cache(ctx.base.get_weak_ptr(), dir_entry.path());
+
+        if (required_actions & CLEAN_ALL) {
+            statistics += cache.remove_all();
+            continue;
+        }
+        if (required_actions & CLEAN_METADATA) {
+            statistics += cache.remove_metadata();
+        }
+        if (required_actions & CLEAN_PACKAGES) {
+            statistics += cache.remove_packages();
+        }
+        if (required_actions & CLEAN_DBCACHE) {
+            statistics += cache.remove_solv_files();
+        }
+        if (required_actions & EXPIRE_CACHE) {
+            cache.write_attribute(libdnf::repo::RepoCache::ATTRIBUTE_EXPIRED);
+        }
+    }
+
+    std::cout << fmt::format(
+                     "Removed {} files, {} directories. {} errors occurred.",
+                     statistics.files_removed,
+                     statistics.dirs_removed,
+                     statistics.errors)
+              << std::endl;
+}
+
+
+}  // namespace microdnf

--- a/microdnf/commands/clean/clean.hpp
+++ b/microdnf/commands/clean/clean.hpp
@@ -1,0 +1,55 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef MICRODNF_COMMANDS_CLEAN_CLEAN_HPP
+#define MICRODNF_COMMANDS_CLEAN_CLEAN_HPP
+
+
+#include <libdnf-cli/session.hpp>
+
+#include <memory>
+
+
+namespace microdnf {
+
+
+class CleanCommand : public libdnf::cli::session::Command {
+public:
+    explicit CleanCommand(Command & parent);
+    void run() override;
+
+    enum Actions : unsigned {
+        NONE = 0,
+        CLEAN_ALL = 1 << 0,
+        CLEAN_PACKAGES = 1 << 1,
+        CLEAN_DBCACHE = 1 << 2,
+        CLEAN_METADATA = 1 << 3,
+        EXPIRE_CACHE = 1 << 4
+    };
+
+private:
+    Actions required_actions = NONE;
+};
+
+
+}  // namespace microdnf
+
+
+#endif  // MICRODNF_COMMANDS_CLEAN_CLEAN_HPP

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -25,6 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/aliases/repoinfo.hpp"
 #include "commands/aliases/repolist.hpp"
 #include "commands/aliases/upgrade_minimal.hpp"
+#include "commands/clean/clean.hpp"
 #include "commands/distro-sync/distro-sync.hpp"
 #include "commands/downgrade/downgrade.hpp"
 #include "commands/download/download.hpp"
@@ -109,6 +110,7 @@ inline RootCommand::RootCommand(libdnf::cli::session::Session & session) : Comma
     register_subcommand(std::make_unique<RepoCommand>(*this), subcommands_group);
     register_subcommand(std::make_unique<AdvisoryCommand>(*this), subcommands_group);
 
+    register_subcommand(std::make_unique<CleanCommand>(*this));
     register_subcommand(std::make_unique<DownloadCommand>(*this));
 
     // aliases


### PR DESCRIPTION
* Supported cache types:
  `all` - Delete all cached data from the repositories cache
  `metadata` - Delete the metadata and dbcache from the repositories cache
  `packages` - Delete packages from the repositories cache
  `dbcache` - Delete dbcache from the repositories cache (".solv" and ".solvx" files)
  `expire-cache` - Mark the repositories cache as expired