### PR TITLE
[dnf5] Save ".solv" and ".solvx" files to repository cache directory

### DIFF
--- a/libdnf/repo/solv_repo.hpp
+++ b/libdnf/repo/solv_repo.hpp
@@ -29,6 +29,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <solv/repo.h>
 
+#include <filesystem>
+
 
 const constexpr int CHKSUM_BYTES = 32;
 
@@ -87,7 +89,7 @@ private:
     void write_ext(Id repodata_id, RepodataType type);
 
     std::string solv_file_name(const char * type = nullptr);
-    std::string solv_file_path(const char * type = nullptr);
+    std::filesystem::path solv_file_path(const char * type = nullptr);
 
     libdnf::BaseWeakPtr base;
     const ConfigRepo & config;


### PR DESCRIPTION
Stores solvable files in the appropriate repository's cache directory.

Prior to this modification, solvable files for all repositories were stored in a single dnf cache directory. That was not practical. Because the names of the solvable files are "repoid.solv" and "repoid-{type}.solvx", the solvable files of the repositories with the same id were overwritten - for example, the same repository for different releasever.