### PR TITLE
[dnf5] Use cache directory "/var/cache/libdnf" instead of "/var/cache/dnf"

### DIFF
--- a/include/libdnf/conf/const.hpp
+++ b/include/libdnf/conf/const.hpp
@@ -27,7 +27,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf {
 
 constexpr const char * PERSISTDIR = "/var/lib/dnf";
-constexpr const char * SYSTEM_CACHEDIR = "/var/cache/dnf";
+constexpr const char * SYSTEM_CACHEDIR = "/var/cache/libdnf";
 
 constexpr const char * CONF_FILENAME = "/etc/dnf/dnf.conf";
 constexpr const char * CONF_DIRECTORY = "/etc/dnf/conf.d";

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -118,7 +118,7 @@ Package management library
 %files
 %{_libdir}/libdnf.so.*
 %license lgpl-2.1.txt
-
+%{_var}/cache/libdnf/
 
 # ========== libdnf-cli ==========
 

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -107,3 +107,6 @@ list(JOIN LIBDNF_PC_REQUIRES_PRIVATE ", " LIBDNF_PC_REQUIRES_PRIVATE_STRING)
 # create a .pc file
 configure_file("libdnf.pc.in" ${CMAKE_CURRENT_BINARY_DIR}/libdnf.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libdnf.pc DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
+
+# Makes an empty directory for libdnf cache
+install(DIRECTORY DESTINATION ${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/cache/libdnf)


### PR DESCRIPTION
The "/var/cache/dnf" directory uses DNF4. The directory structure of the libdnf5 cache will be different. It is better to use a different
directory. I suggest "/var/cache/libdnf" (it will be used by libdnf clients - microdnf, dnfdaemon, ...)