### PR TITLE
[MINOR] Change usage of libsolv flags without changing results

### DIFF
--- a/libdnf/rpm/package_query.cpp
+++ b/libdnf/rpm/package_query.cpp
@@ -2293,7 +2293,7 @@ std::pair<bool, libdnf::rpm::Nevra> PackageQuery::resolve_pkg_spec(
         filter_dataiterator(
             *pool,
             SOLVABLE_FILELIST,
-            SEARCH_FILES | SEARCH_COMPLETE_FILELIST | SEARCH_STRING | (glob ? SEARCH_GLOB : 0),
+            SEARCH_FILES | SEARCH_COMPLETE_FILELIST | (glob ? SEARCH_GLOB : SEARCH_STRING),
             *p_impl,
             filter_result,
             pkg_spec.c_str());


### PR DESCRIPTION
The change unify the schema of usage flags with
filter_dataiterator_internal(). The change will not change the result
because:

SEARCH_STRING | SEARCH_GLOB = SEARCH_GLOB
001 | 101 = 101