### PR TITLE
[dnf5] Advisory commands

### DIFF
--- a/dnf5/commands/advisory/advisory.cpp
+++ b/dnf5/commands/advisory/advisory.cpp
@@ -33,8 +33,9 @@ namespace dnf5 {
 
 using namespace libdnf::cli;
 
+AdvisoryCommand::AdvisoryCommand(Command & parent) : AdvisoryCommand(parent, "advisory") {}
 
-AdvisoryCommand::AdvisoryCommand(Command & parent) : Command(parent, "advisory") {
+AdvisoryCommand::AdvisoryCommand(Command & parent, const std::string & name) : Command(parent, name) {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
 

--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -58,6 +58,8 @@ void AdvisoryInfoCommand::process_and_print_queries(
         packages.filter_installed();
         packages.filter_latest_evr();
 
+        add_running_kernel_packages(ctx.base, packages);
+
         advisories.filter_packages(packages, libdnf::sack::QueryCmp::GT);
     }
 

--- a/dnf5/commands/advisory/advisory_info.hpp
+++ b/dnf5/commands/advisory/advisory_info.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_INFO_HPP
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_INFO_HPP
 
+#include "advisory_subcommand.hpp"
 #include "arguments.hpp"
 
 #include <libdnf-cli/session.hpp>
@@ -32,20 +33,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class AdvisoryInfoCommand : public libdnf::cli::session::Command {
+class AdvisoryInfoCommand : public AdvisorySubCommand {
 public:
     explicit AdvisoryInfoCommand(Command & parent);
-    void run() override;
-
-    std::unique_ptr<AdvisoryAvailableOption> available{nullptr};
-    std::unique_ptr<AdvisoryInstalledOption> installed{nullptr};
-    std::unique_ptr<AdvisoryAllOption> all{nullptr};
-    std::unique_ptr<AdvisoryUpdatesOption> updates{nullptr};
-    std::unique_ptr<AdvisorySpecArguments> package_specs{nullptr};
 
 protected:
-    // to be used by an alias command only
-    explicit AdvisoryInfoCommand(Command & parent, const std::string & name);
+    void process_and_print_queries(
+        Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) override;
 };
 
 

--- a/dnf5/commands/advisory/advisory_list.cpp
+++ b/dnf5/commands/advisory/advisory_list.cpp
@@ -58,6 +58,8 @@ void AdvisoryListCommand::process_and_print_queries(
         packages.filter_installed();
         packages.filter_latest_evr();
 
+        add_running_kernel_packages(ctx.base, packages);
+
         not_installed_pkgs = advisories.get_advisory_packages(packages, libdnf::sack::QueryCmp::GT);
     }
 

--- a/dnf5/commands/advisory/advisory_list.cpp
+++ b/dnf5/commands/advisory/advisory_list.cpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf-cli/output/advisorylist.hpp"
 
+#include <libdnf/advisory/advisory_package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 
 #include <filesystem>
@@ -36,73 +37,31 @@ namespace dnf5 {
 using namespace libdnf::cli;
 
 
-AdvisoryListCommand::AdvisoryListCommand(Command & parent) : AdvisoryListCommand(parent, "list") {}
+AdvisoryListCommand::AdvisoryListCommand(Command & parent) : AdvisorySubCommand(parent, "list", _("List advisories")) {}
 
-
-AdvisoryListCommand::AdvisoryListCommand(Command & parent, const std::string & name) : Command(parent, name) {
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("List advisories");
-
-    available = std::make_unique<AdvisoryAvailableOption>(*this);
-    installed = std::make_unique<AdvisoryInstalledOption>(*this);
-    all = std::make_unique<AdvisoryAllOption>(*this);
-    updates = std::make_unique<AdvisoryUpdatesOption>(*this);
-    // TODO(amatej): set_conflicting_args({available, installed, all, updates});
-
-    package_specs = std::make_unique<AdvisorySpecArguments>(*this);
-}
-
-
-//TODO(amatej): the run is duplicated over all advisory commands?
-void AdvisoryListCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
-
-    ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::UPDATEINFO);
-
-    using QueryCmp = libdnf::sack::QueryCmp;
-
-    libdnf::rpm::PackageQuery package_query(ctx.base);
-
-    auto package_specs_str = package_specs->get_value();
-
-    // Filter by patterns if given
-    if (package_specs_str.size() > 0) {
-        package_query.filter_name(package_specs_str, QueryCmp::IGLOB);
-    }
-
-    auto advisory_query = libdnf::advisory::AdvisoryQuery(ctx.base);
-
-    std::vector<libdnf::advisory::AdvisoryPackage> pkgs;
+void AdvisoryListCommand::process_and_print_queries(
+    Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) {
     std::vector<libdnf::advisory::AdvisoryPackage> installed_pkgs;
+    std::vector<libdnf::advisory::AdvisoryPackage> not_installed_pkgs;
 
-    if (installed->get_value() || all->get_value()) {
-        auto installed_package_query = package_query;
-        installed_package_query.filter_installed();
-        installed_pkgs = advisory_query.get_advisory_packages(installed_package_query, QueryCmp::LTE);
+    if (all->get_value()) {
+        packages.filter_installed();
+        installed_pkgs = advisories.get_advisory_packages(packages, libdnf::sack::QueryCmp::LTE);
+        not_installed_pkgs = advisories.get_advisory_packages(packages, libdnf::sack::QueryCmp::GT);
+    } else if (installed->get_value()) {
+        packages.filter_installed();
+        installed_pkgs = advisories.get_advisory_packages(packages, libdnf::sack::QueryCmp::LTE);
+    } else if (updates->get_value()) {
+        packages.filter_upgradable();
+        not_installed_pkgs = advisories.get_advisory_packages(packages, libdnf::sack::QueryCmp::GT);
+    } else {  // available is the default
+        packages.filter_installed();
+        packages.filter_latest_evr();
+
+        not_installed_pkgs = advisories.get_advisory_packages(packages, libdnf::sack::QueryCmp::GT);
     }
 
-    // Default if nothing specified
-    if (available->get_value() || all->get_value() ||
-        (!installed->get_value() && !available->get_value() && !updates->get_value())) {
-        auto installed_package_query = package_query;
-        installed_package_query.filter_installed();
-        installed_package_query.filter_latest_evr();
-        //TODO(amatej): https://github.com/rpm-software-management/dnf/pull/1485, show for currently running
-        //kernel and if it is not the latests one show also for the latest kernel
-        //auto kernel_id = ctx.base.get_rpm_package_sack()->p_impl->get_running_kernel();
-        //Use rpm::PackageId Goal::get_running_kernel_internal()?
-
-        pkgs = advisory_query.get_advisory_packages(installed_package_query, QueryCmp::GT);
-    }
-
-    if (updates->get_value()) {
-        auto upgradable_package_query = package_query;
-        upgradable_package_query.filter_upgradable();
-        pkgs = advisory_query.get_advisory_packages(upgradable_package_query, QueryCmp::GT);
-    }
-
-    libdnf::cli::output::print_advisorylist_table(pkgs, installed_pkgs);
+    libdnf::cli::output::print_advisorylist_table(not_installed_pkgs, installed_pkgs);
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/advisory/advisory_list.hpp
+++ b/dnf5/commands/advisory/advisory_list.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_LIST_HPP
 
 
+#include "advisory_subcommand.hpp"
 #include "arguments.hpp"
 
 #include <libdnf-cli/session.hpp>
@@ -34,20 +35,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class AdvisoryListCommand : public libdnf::cli::session::Command {
+class AdvisoryListCommand : public AdvisorySubCommand {
 public:
     explicit AdvisoryListCommand(Command & parent);
-    void run() override;
-
-    std::unique_ptr<AdvisoryAvailableOption> available{nullptr};
-    std::unique_ptr<AdvisoryInstalledOption> installed{nullptr};
-    std::unique_ptr<AdvisoryAllOption> all{nullptr};
-    std::unique_ptr<AdvisoryUpdatesOption> updates{nullptr};
-    std::unique_ptr<AdvisorySpecArguments> package_specs{nullptr};
 
 protected:
-    // to be used by an alias command only
-    explicit AdvisoryListCommand(Command & parent, const std::string & name);
+    void process_and_print_queries(
+        Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) override;
 };
 
 

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -50,6 +50,7 @@ AdvisorySubCommand::AdvisorySubCommand(
     installed = std::make_unique<AdvisoryInstalledOption>(*this);
     updates = std::make_unique<AdvisoryUpdatesOption>(*this);
     advisory_specs = std::make_unique<AdvisorySpecArguments>(*this);
+    contains_pkgs = std::make_unique<AdvisoryContainsPkgsOption>(*this);
 
     auto conflict_args = parser.add_conflict_args_group(std::unique_ptr<std::vector<ArgumentParser::Argument *>>(
         new std::vector<ArgumentParser::Argument *>{all->arg, available->arg, installed->arg, updates->arg}));
@@ -80,6 +81,11 @@ void AdvisorySubCommand::run() {
     ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::UPDATEINFO);
 
     libdnf::rpm::PackageQuery package_query(ctx.base);
+    auto package_specs_strs = contains_pkgs->get_value();
+    // Filter packages by name patterns if given
+    if (package_specs_strs.size() > 0) {
+        package_query.filter_name(package_specs_strs, libdnf::sack::QueryCmp::IGLOB);
+    }
 
     auto advisories = libdnf::advisory::AdvisoryQuery(ctx.base);
     auto advisory_specs_strs = advisory_specs->get_value();

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -60,6 +60,20 @@ AdvisorySubCommand::AdvisorySubCommand(
     updates->arg->set_conflict_arguments(conflict_args);
 }
 
+// There can be multiple versions of kernel installed at the same time.
+// When the running kernel has available advisories show them because the system
+// is vulnerable (even if the newer fixed version of kernel is already installed).
+// DNF4 bug with behavior description: https://bugzilla.redhat.com/show_bug.cgi?id=1728004
+void AdvisorySubCommand::add_running_kernel_packages(libdnf::Base & base, libdnf::rpm::PackageQuery & package_query) {
+    auto kernel = base.get_rpm_package_sack()->get_running_kernel();
+    if (kernel.get_id().id > 0) {
+        libdnf::rpm::PackageQuery kernel_query(base);
+        kernel_query.filter_sourcerpm({kernel.get_sourcerpm()});
+        kernel_query.filter_installed();
+        package_query |= kernel_query;
+    }
+}
+
 void AdvisorySubCommand::run() {
     auto & ctx = static_cast<Context &>(get_session());
 

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -49,6 +49,7 @@ protected:
     std::unique_ptr<AdvisoryInstalledOption> installed{nullptr};
     std::unique_ptr<AdvisoryAllOption> all{nullptr};
     std::unique_ptr<AdvisoryUpdatesOption> updates{nullptr};
+    std::unique_ptr<AdvisoryContainsPkgsOption> contains_pkgs{nullptr};
     std::unique_ptr<AdvisorySpecArguments> advisory_specs{nullptr};
 
     AdvisorySubCommand(Command & parent, const std::string & name, const std::string & short_description);

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -18,10 +18,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
-#ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_SUMMARY_HPP
-#define DNF5_COMMANDS_ADVISORY_ADVISORY_SUMMARY_HPP
+#ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_SUBCOMMAND_HPP
+#define DNF5_COMMANDS_ADVISORY_ADVISORY_SUBCOMMAND_HPP
 
-#include "advisory_subcommand.hpp"
+#include "arguments.hpp"
 #include "dnf5/context.hpp"
 
 #include "libdnf/advisory/advisory_query.hpp"
@@ -35,17 +35,25 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class AdvisorySummaryCommand : public AdvisorySubCommand {
+class AdvisorySubCommand : public libdnf::cli::session::Command {
 public:
-    explicit AdvisorySummaryCommand(Command & parent);
+    void run() override;
 
 protected:
-    void process_and_print_queries(
-        Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) override;
+    virtual void process_and_print_queries(
+        Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) = 0;
+
+    std::unique_ptr<AdvisoryAvailableOption> available{nullptr};
+    std::unique_ptr<AdvisoryInstalledOption> installed{nullptr};
+    std::unique_ptr<AdvisoryAllOption> all{nullptr};
+    std::unique_ptr<AdvisoryUpdatesOption> updates{nullptr};
+    std::unique_ptr<AdvisorySpecArguments> advisory_specs{nullptr};
+
+    AdvisorySubCommand(Command & parent, const std::string & name, const std::string & short_description);
 };
 
 
 }  // namespace dnf5
 
 
-#endif  // DNF5_COMMANDS_ADVISORY_ADVISORY_SUMMARY_HPP
+#endif  // DNF5_COMMANDS_ADVISORY_ADVISORY_SUBCOMMAND_HPP

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -43,6 +43,8 @@ protected:
     virtual void process_and_print_queries(
         Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) = 0;
 
+    void add_running_kernel_packages(libdnf::Base & base, libdnf::rpm::PackageQuery & package_query);
+
     std::unique_ptr<AdvisoryAvailableOption> available{nullptr};
     std::unique_ptr<AdvisoryInstalledOption> installed{nullptr};
     std::unique_ptr<AdvisoryAllOption> all{nullptr};

--- a/dnf5/commands/advisory/advisory_summary.cpp
+++ b/dnf5/commands/advisory/advisory_summary.cpp
@@ -62,6 +62,8 @@ void AdvisorySummaryCommand::process_and_print_queries(
         packages.filter_installed();
         packages.filter_latest_evr();
 
+        add_running_kernel_packages(ctx.base, packages);
+
         advisories.filter_packages(packages, libdnf::sack::QueryCmp::GT);
         mode = _("Available");
     }

--- a/dnf5/commands/advisory/arguments.hpp
+++ b/dnf5/commands/advisory/arguments.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 class AdvisoryAllOption : public libdnf::cli::session::BoolOption {
 public:
     explicit AdvisoryAllOption(libdnf::cli::session::Command & command)
-        : BoolOption(command, "all", '\0', _("Show advisories about any version of installed packages."), false) {}
+        : BoolOption(command, "all", '\0', _("Show advisories containing any version of installed packages."), false) {}
 };
 
 
@@ -41,7 +41,11 @@ class AdvisoryAvailableOption : public libdnf::cli::session::BoolOption {
 public:
     explicit AdvisoryAvailableOption(libdnf::cli::session::Command & command)
         : BoolOption(
-              command, "available", '\0', _("Show advisories about newer versions of installed packages."), false) {}
+              command,
+              "available",
+              '\0',
+              _("Show advisories containing newer versions of installed packages."),
+              false) {}
 };
 
 
@@ -52,7 +56,7 @@ public:
               command,
               "installed",
               '\0',
-              _("Show advisories about equal and older versions of installed packages."),
+              _("Show advisories containing equal and older versions of installed packages."),
               false) {}
 };
 
@@ -64,8 +68,21 @@ public:
               command,
               "updates",
               '\0',
-              _("Show advisories about newer versions of installed packages for which a newer version is available."),
+              _("Show advisories containing newer versions of installed packages for which a newer version is "
+                "available."),
               false) {}
+};
+
+
+class AdvisoryContainsPkgsOption : public libdnf::cli::session::StringListOption {
+public:
+    explicit AdvisoryContainsPkgsOption(libdnf::cli::session::Command & command)
+        : StringListOption(
+              command,
+              "contains-pkgs",
+              '\0',
+              _("Show only advisories containing packages with specified names. List option, supports globs."),
+              _("PACKAGE_NAME,...")) {}
 };
 
 

--- a/dnf5/commands/advisory/arguments.hpp
+++ b/dnf5/commands/advisory/arguments.hpp
@@ -69,11 +69,10 @@ public:
 };
 
 
-//TODO(amatej): What should be the StringArgumentList used for? just package spec? current dnf also matches AdvisoryIds
 class AdvisorySpecArguments : public libdnf::cli::session::StringArgumentList {
 public:
     explicit AdvisorySpecArguments(libdnf::cli::session::Command & command)
-        : StringArgumentList(command, "package-spec", _("Package spec present in advisories.")) {}
+        : StringArgumentList(command, "advisory-spec", _("List of patterns matched against advisory names.")) {}
 };
 
 

--- a/dnf5/commands/aliases/updateinfo.hpp
+++ b/dnf5/commands/aliases/updateinfo.hpp
@@ -18,33 +18,26 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
-#ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_HPP
-#define DNF5_COMMANDS_ADVISORY_ADVISORY_HPP
+#ifndef DNF5_COMMANDS_ALIASES_UPDATEINFO_HPP
+#define DNF5_COMMANDS_ALIASES_UPDATEINFO_HPP
 
 
-#include <libdnf-cli/session.hpp>
-#include <libdnf/conf/option_bool.hpp>
-#include <libdnf/conf/option_enum.hpp>
-
-#include <memory>
-#include <vector>
+#include "commands/advisory/advisory.hpp"
 
 
 namespace dnf5 {
 
 
-class AdvisoryCommand : public libdnf::cli::session::Command {
+class UpdateinfoAlias : public AdvisoryCommand {
 public:
-    explicit AdvisoryCommand(Command & parent);
-    void run() override;
-
-protected:
-    // to be used by an alias command only
-    explicit AdvisoryCommand(Command & parent, const std::string & name);
+    explicit UpdateinfoAlias(Command & parent) : AdvisoryCommand(parent, "updateinfo") {
+        auto & cmd = *get_argument_parser_command();
+        cmd.set_short_description("Alias for 'advisory'");
+    }
 };
 
 
 }  // namespace dnf5
 
 
-#endif  // DNF5_COMMANDS_ADVISORY_ADVISORY_HPP
+#endif  // DNF5_COMMANDS_ALIASES_UPDATEINFO_HPP

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -38,7 +38,8 @@ using namespace libdnf::cli;
 RepoInfoCommand::RepoInfoCommand(Command & parent) : RepoInfoCommand(parent, "info") {}
 
 
-RepoInfoCommand::RepoInfoCommand(Command & parent, const std::string & name) : RepoListCommand(parent, name) {}
+RepoInfoCommand::RepoInfoCommand(Command & parent, const std::string & name)
+    : RepoListCommand(parent, name, "Print details about repositories") {}
 
 
 void RepoInfoCommand::print(const libdnf::repo::RepoQuery & query, [[maybe_unused]] bool with_status) {

--- a/dnf5/commands/repo/repo_list.cpp
+++ b/dnf5/commands/repo/repo_list.cpp
@@ -35,13 +35,17 @@ using namespace libdnf::cli;
 
 RepoListCommand::RepoListCommand(Command & parent) : RepoListCommand(parent, "list") {}
 
+RepoListCommand::RepoListCommand(Command & parent, const std::string & name)
+    : RepoListCommand(parent, name, "List repositories") {}
 
-RepoListCommand::RepoListCommand(Command & parent, const std::string & name) : Command(parent, name) {
+//TODO(amatej): Find a different way of sharing code rather than repoinfo inheriting from repolist
+RepoListCommand::RepoListCommand(Command & parent, const std::string & name, const std::string & short_description)
+    : Command(parent, name) {
     auto & ctx = static_cast<Context &>(get_session());
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("List defined repositories");
+    cmd.set_short_description(short_description);
 
     all = std::make_unique<RepoAllOption>(*this);
     enabled = std::make_unique<RepoEnabledOption>(*this);

--- a/dnf5/commands/repo/repo_list.hpp
+++ b/dnf5/commands/repo/repo_list.hpp
@@ -49,6 +49,7 @@ public:
 protected:
     // to be used by an alias command only
     explicit RepoListCommand(Command & parent, const std::string & name);
+    explicit RepoListCommand(Command & parent, const std::string & name, const std::string & short_description);
 };
 
 

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -24,6 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "commands/aliases/grouplist.hpp"
 #include "commands/aliases/repoinfo.hpp"
 #include "commands/aliases/repolist.hpp"
+#include "commands/aliases/updateinfo.hpp"
 #include "commands/aliases/upgrade_minimal.hpp"
 #include "commands/clean/clean.hpp"
 #include "commands/distro-sync/distro-sync.hpp"
@@ -125,6 +126,7 @@ inline RootCommand::RootCommand(libdnf::cli::session::Session & session) : Comma
     register_subcommand(std::make_unique<GrouplistAlias>(*this), aliases_group);
     register_subcommand(std::make_unique<RepoinfoAlias>(*this), aliases_group);
     register_subcommand(std::make_unique<RepolistAlias>(*this), aliases_group);
+    register_subcommand(std::make_unique<UpdateinfoAlias>(*this), aliases_group);
     register_subcommand(std::make_unique<UpgradeMinimalAlias>(*this), aliases_group);
 
     auto & context = static_cast<Context &>(session);

--- a/include/libdnf-cli/output/advisorylist.hpp
+++ b/include/libdnf-cli/output/advisorylist.hpp
@@ -26,7 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::cli::output {
 
 void print_advisorylist_table(
-    std::vector<libdnf::advisory::AdvisoryPackage> & advisory_package_list,
+    std::vector<libdnf::advisory::AdvisoryPackage> & advisory_package_list_not_installed,
     std::vector<libdnf::advisory::AdvisoryPackage> & advisory_package_list_installed);
 
 

--- a/include/libdnf-cli/output/advisorysummary.hpp
+++ b/include/libdnf-cli/output/advisorysummary.hpp
@@ -1,0 +1,32 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef LIBDNF_CLI_OUTPUT_ADVISORYSUMMARY_HPP
+#define LIBDNF_CLI_OUTPUT_ADVISORYSUMMARY_HPP
+
+#include "libdnf/advisory/advisory_query.hpp"
+
+namespace libdnf::cli::output {
+
+void print_advisorysummary_table(const libdnf::advisory::AdvisoryQuery & advisories, const std::string & mode);
+
+}  // namespace libdnf::cli::output
+
+#endif  // LIBDNF_CLI_OUTPUT_ADVISORYSUMMARY_HPP

--- a/include/libdnf-cli/output/key_value_table.hpp
+++ b/include/libdnf-cli/output/key_value_table.hpp
@@ -36,7 +36,6 @@ public:
     ~KeyValueTable();
     void print();
 
-protected:
     struct libscols_line * add_line(
         const char * key, const char * value, const char * color = nullptr, struct libscols_line * parent = nullptr);
 
@@ -49,6 +48,12 @@ protected:
     struct libscols_line * add_line(
         const char * key,
         const std::vector<std::string> & value,
+        const char * color = nullptr,
+        struct libscols_line * parent = nullptr);
+
+    struct libscols_line * add_lines(
+        const char * key,
+        const std::vector<std::string> & values,
         const char * color = nullptr,
         struct libscols_line * parent = nullptr);
 

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf/conf/option_bool.hpp>
 #include <libdnf/conf/option_string.hpp>
+#include <libdnf/conf/option_string_list.hpp>
 
 
 namespace libdnf::cli::session {
@@ -141,6 +142,24 @@ public:
     // TODO(dmach): `arg` must be public, because it is used to define conflicting args
     //protected:
     libdnf::OptionBool * conf{nullptr};
+    libdnf::cli::ArgumentParser::NamedArg * arg{nullptr};
+};
+
+
+class StringListOption : public Option {
+public:
+    explicit StringListOption(
+        libdnf::cli::session::Command & command,
+        const std::string & long_name,
+        char short_name,
+        const std::string & desc,
+        const std::string & help);
+
+    /// @return Parsed value.
+    /// @since 5.0
+    std::vector<std::string> get_value() const { return conf->get_value(); }
+
+    libdnf::OptionStringList * conf{nullptr};
     libdnf::cli::ArgumentParser::NamedArg * arg{nullptr};
 };
 

--- a/include/libdnf/rpm/package_sack.hpp
+++ b/include/libdnf/rpm/package_sack.hpp
@@ -140,6 +140,8 @@ public:
     /// @since 5.0
     void clear_user_includes();
 
+    rpm::Package get_running_kernel();
+
 private:
     friend libdnf::Goal;
     friend Package;

--- a/libdnf-cli/output/advisoryinfo.cpp
+++ b/libdnf-cli/output/advisoryinfo.cpp
@@ -20,9 +20,10 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf-cli/output/advisoryinfo.hpp"
 
+#include "utils/string.hpp"
+
 #include "libdnf/advisory/advisory_collection.hpp"
 #include "libdnf/advisory/advisory_reference.hpp"
-
 
 namespace libdnf::cli::output {
 
@@ -35,7 +36,7 @@ void AdvisoryInfo::add_advisory(libdnf::advisory::Advisory & advisory) {
     add_line("Status", advisory.get_status());
     add_line("Vendor", advisory.get_vendor());
     add_line("Buildtime", std::to_string(advisory.get_buildtime()));
-    add_line("Description", advisory.get_description());
+    add_lines("Description", libdnf::utils::string::split(advisory.get_description(), "\n"));
     add_line("Message", advisory.get_message());
     add_line("Rights", advisory.get_rights());
 

--- a/libdnf-cli/output/advisorysummary.cpp
+++ b/libdnf-cli/output/advisorysummary.cpp
@@ -1,0 +1,75 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#include "libdnf-cli/output/advisorysummary.hpp"
+
+#include "libdnf-cli/output/key_value_table.hpp"
+
+#include <iostream>
+
+namespace libdnf::cli::output {
+
+
+void print_advisorysummary_table(const libdnf::advisory::AdvisoryQuery & advisories, const std::string & mode) {
+    KeyValueTable output_table;
+    std::cout << mode << " advisory information summary:" << std::endl;
+
+    libdnf::advisory::AdvisoryQuery bugfixes{advisories};
+    bugfixes.filter_type("bugfix");
+
+    libdnf::advisory::AdvisoryQuery enhancements{advisories};
+    enhancements.filter_type("enhancement");
+
+    libdnf::advisory::AdvisoryQuery securities{advisories};
+    securities.filter_type("security");
+
+    libdnf::advisory::AdvisoryQuery security_critical{securities};
+    security_critical.filter_severity("Critical");
+    libdnf::advisory::AdvisoryQuery security_important{securities};
+    security_important.filter_severity("Important");
+    libdnf::advisory::AdvisoryQuery security_moderate{securities};
+    security_moderate.filter_severity("Moderate");
+    libdnf::advisory::AdvisoryQuery security_low{securities};
+    security_low.filter_severity("Low");
+    libdnf::advisory::AdvisoryQuery security_none{securities};
+    security_none.filter_severity("None");
+
+    libdnf::advisory::AdvisoryQuery others{advisories};
+    others -= bugfixes;
+    others -= enhancements;
+    others -= securities;
+
+    auto security_row = output_table.add_line("Security", securities.size(), nullptr);
+    output_table.add_line("Critical", security_critical.size(), nullptr, security_row);
+    output_table.add_line("Important", security_important.size(), nullptr, security_row);
+    output_table.add_line("Moderate", security_moderate.size(), nullptr, security_row);
+    output_table.add_line("Low", security_low.size(), nullptr, security_row);
+    output_table.add_line("None", security_none.size(), nullptr, security_row);
+
+    output_table.add_line("Bugfix", bugfixes.size(), nullptr);
+    output_table.add_line("Enhancement", enhancements.size(), nullptr);
+
+    output_table.add_line("Others", others.size(), nullptr);
+
+    output_table.print();
+}
+
+
+}  // namespace libdnf::cli::output

--- a/libdnf-cli/output/key_value_table.cpp
+++ b/libdnf-cli/output/key_value_table.cpp
@@ -87,5 +87,19 @@ struct libscols_line * KeyValueTable::add_line(
     return add_line(key, libdnf::utils::string::join(value, " "), color, parent);
 }
 
+struct libscols_line * KeyValueTable::add_lines(
+    const char * key, const std::vector<std::string> & values, const char * color, struct libscols_line * parent) {
+    struct libscols_line * added_key_line = NULL;
+    if (!values.empty()) {
+        auto iterator = values.begin();
+        added_key_line = add_line(key, *iterator, color, parent);
+        iterator++;
+        for (; iterator != values.end(); ++iterator) {
+            add_line("", *iterator, color, parent);
+        }
+    }
+    return added_key_line;
+}
+
 
 }  // namespace libdnf::cli::output

--- a/libdnf-cli/session.cpp
+++ b/libdnf-cli/session.cpp
@@ -104,6 +104,34 @@ BoolOption::BoolOption(
 }
 
 
+StringListOption::StringListOption(
+    libdnf::cli::session::Command & command,
+    const std::string & long_name,
+    char short_name,
+    const std::string & desc,
+    const std::string & help) {
+    auto & parser = command.get_session().get_argument_parser();
+    conf = dynamic_cast<libdnf::OptionStringList *>(
+        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>())));
+    arg = parser.add_new_named_arg(long_name);
+
+    if (!long_name.empty()) {
+        arg->set_long_name(long_name);
+    }
+
+    if (short_name) {
+        arg->set_short_name(short_name);
+    }
+
+    arg->set_short_description(desc);
+    arg->set_arg_value_help(help);
+    arg->set_has_value(true);
+    arg->link_value(conf);
+
+    command.get_argument_parser_command()->register_named_arg(arg);
+}
+
+
 StringArgumentList::StringArgumentList(
     libdnf::cli::session::Command & command, const std::string & name, const std::string & desc) {
     auto & parser = command.get_session().get_argument_parser();

--- a/libdnf/rpm/package_sack_impl.hpp
+++ b/libdnf/rpm/package_sack_impl.hpp
@@ -80,9 +80,7 @@ public:
 
     void invalidate_provides() { provides_ready = false; }
 
-    PackageId get_running_kernel() const noexcept { return running_kernel; };
-
-    void set_running_kernel(PackageId kernel) { running_kernel = kernel; };
+    PackageId get_running_kernel_id();
 
     /// Sets excluded and included packages according to the configuration.
     ///


### PR DESCRIPTION
Adding advisory summary command.
Example output format:
```
Updating and loading repositories:
Repositories loaded.
Available advisory information summary:
Security    : 15
  Critical  : 0
  Important : 2
  Moderate  : 10
  Low       : 0
  None      : 3
Bugfix      : 44
Enhancement : 22
Others      : 14
```

Compared to dnf4 output:
```
Last metadata expiration check: 0:04:09 ago on Tue Apr  5 13:44:10 2022.
Updates Information Summary: available
    15 Security notice(s)
         2 Important Security notice(s)
        10 Moderate Security notice(s)
    44 Bugfix notice(s)
    22 Enhancement notice(s)
    14 other notice(s)
```
---

Positional argument for advisory commands is `advisory-spec` which is matched against advisory names.
Adding `--whatcontains` option to filter advisories by the packages they contain. This option could also be added to groups, to show all group that contain particular package name.

We still miss a bunch of options for the advisory commands for filtering (to match dnf4), but this PR it getting too complex.