### PR TITLE
context: Substitute all repository config options (RhBug:2076853)

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1191,7 +1191,6 @@ dnf_repo_setup(DnfRepo *repo, GError **error) try
     DnfRepoEnabled enabled = DNF_REPO_ENABLED_NONE;
     g_autofree gchar *basearch = NULL;
     g_autofree gchar *release = NULL;
-    g_autofree gchar *testdatadir = NULL;
 
     basearch = g_key_file_get_string(priv->keyfile, "general", "arch", NULL);
     if (basearch == NULL)
@@ -1230,8 +1229,6 @@ dnf_repo_setup(DnfRepo *repo, GError **error) try
     for (const auto & item : libdnf::dnf_context_get_vars(priv->context))
         priv->urlvars = lr_urlvars_set(priv->urlvars, item.first.c_str(), item.second.c_str());
 
-    testdatadir = dnf_realpath(TESTDATADIR);
-    priv->urlvars = lr_urlvars_set(priv->urlvars, "testdatadir", testdatadir);
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_VARSUB, priv->urlvars))
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_GNUPGHOMEDIR, priv->keyring))

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -83,6 +83,7 @@ typedef struct
     LrHandle        *repo_handle;
     LrResult        *repo_result;
     LrUrlVars       *urlvars;
+    bool            unit_test_mode;  /* ugly hack for unit tests */
 } DnfRepoPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(DnfRepo, dnf_repo, G_TYPE_OBJECT)
@@ -847,8 +848,11 @@ dnf_repo_conf_reset(libdnf::ConfigRepo &config)
 
 /* Loads repository configuration from GKeyFile */
 static void
-dnf_repo_conf_from_gkeyfile(libdnf::ConfigRepo &config, const char *repoId, GKeyFile *gkeyFile)
+dnf_repo_conf_from_gkeyfile(DnfRepo *repo, const char *repoId, GKeyFile *gkeyFile)
 {
+    DnfRepoPrivate *priv = GET_PRIVATE(repo);
+    auto & config = *priv->repo->getConfig();
+
     // Reset to the initial state before reloading the configuration.
     dnf_repo_conf_reset(config);
 
@@ -883,20 +887,31 @@ dnf_repo_conf_from_gkeyfile(libdnf::ConfigRepo &config, const char *repoId, GKey
                         // list can be ['value1', 'value2, value3'] therefore we first join
                         // to have 'value1, value2, value3'
                         g_autofree gchar * tmp_strval = g_strjoinv(",", list);
+
+                        // Substitute vars.
+                        g_autofree gchar *subst_value = dnf_repo_substitute(repo, tmp_strval);
+
+                        if (strcmp(key, "baseurl") == 0 && strstr(tmp_strval, "file://$testdatadir") != NULL) {
+                            priv->unit_test_mode = true;
+                        }
+
                         try {
-                            optionItem.newString(libdnf::Option::Priority::REPOCONFIG, tmp_strval);
+                            optionItem.newString(libdnf::Option::Priority::REPOCONFIG, subst_value);
                         } catch (const std::exception & ex) {
-                            g_debug("Invalid configuration value: %s = %s in %s; %s", key, value.c_str(), repoId, ex.what());
+                            g_debug("Invalid configuration value: %s = %s in %s; %s", key, subst_value, repoId, ex.what());
                         }
                     }
 
                 } else {
-
                     // process other (non list) options
+
+                    // Substitute vars.
+                    g_autofree gchar *subst_value = dnf_repo_substitute(repo, value.c_str());
+
                     try {
-                        optionItem.newString(libdnf::Option::Priority::REPOCONFIG, value);
+                        optionItem.newString(libdnf::Option::Priority::REPOCONFIG, subst_value);
                     } catch (const std::exception & ex) {
-                        g_debug("Invalid configuration value: %s = %s in %s; %s", key, value.c_str(), repoId, ex.what());
+                        g_debug("Invalid configuration value: %s = %s in %s; %s", key, subst_value, repoId, ex.what());
                     }
 
                 }
@@ -950,7 +965,7 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, gboolean reloadFromGKeyFile, GError **e
 
     // Reload repository configuration from keyfile.
     if (reloadFromGKeyFile) {
-        dnf_repo_conf_from_gkeyfile(*conf, repoId, priv->keyfile);
+        dnf_repo_conf_from_gkeyfile(repo, repoId, priv->keyfile);
         dnf_repo_apply_setopts(*conf, repoId);
     }
 
@@ -996,8 +1011,9 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, gboolean reloadFromGKeyFile, GError **e
         g_autofree gchar *url = NULL;
         url = lr_prepend_url_protocol(baseurls[0]);
         if (url != NULL && strncasecmp(url, "file://", 7) == 0) {
-            if (g_strstr_len(url, -1, "$testdatadir") == NULL)
+            if (!priv->unit_test_mode) {
                 priv->kind = DNF_REPO_KIND_LOCAL;
+            }
             g_free(priv->location);
             g_free(priv->keyring);
             priv->location = dnf_repo_substitute(repo, url + 7);
@@ -1224,7 +1240,7 @@ dnf_repo_setup(DnfRepo *repo, GError **error) try
     auto repoId = priv->repo->getId().c_str();
 
     auto conf = priv->repo->getConfig();
-    dnf_repo_conf_from_gkeyfile(*conf, repoId, priv->keyfile);
+    dnf_repo_conf_from_gkeyfile(repo, repoId, priv->keyfile);
     dnf_repo_apply_setopts(*conf, repoId);
 
     auto sslverify = conf->sslverify().getValue();

--- a/tests/libdnf/dnf-self-test.c
+++ b/tests/libdnf/dnf-self-test.c
@@ -1225,6 +1225,9 @@ main(int argc, char **argv)
     g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
     g_log_set_always_fatal (G_LOG_FATAL_MASK);
 
+    /* Sets a variable to replace in repository configurations. */
+    g_setenv("DNF_VAR_testdatadir", TESTDATADIR, TRUE);
+
     /* tests go here */
     g_test_add_func("/libdnf/repo_loader{gpg-asc}", dnf_repo_loader_gpg_asc_func);
     g_test_add_func("/libdnf/repo_loader{gpg-wrong-asc}", dnf_repo_loader_gpg_wrong_asc_func);


### PR DESCRIPTION
It also solves the problem: Substitution of variables in `baseurl` does not work (in the case of the variable used at the beginning of baseurl) in microdnf and PackageKit unless `metalink` or `mirrorlist` is set at the same time.

Related to the microdnf issue: https://github.com/rpm-software-management/microdnf/issues/122