### PR TITLE
[dnf5] Support for rpm transaction flags

### DIFF
--- a/bindings/libdnf/base.i
+++ b/bindings/libdnf/base.i
@@ -37,6 +37,7 @@
 %ignore libdnf::get_pool;
 
 %include "libdnf/base/base.hpp"
+%ignore libdnf::base::TransactionError;
 %include "libdnf/base/transaction.hpp"
 %include "libdnf/base/transaction_package.hpp"
 %include "libdnf/base/goal.hpp"

--- a/dnfdaemon-server/callbacks.hpp
+++ b/dnfdaemon-server/callbacks.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf/repo/package_downloader.hpp>
 #include <libdnf/repo/repo_callbacks.hpp>
-#include <libdnf/rpm/transaction.hpp>
+#include <libdnf/rpm/transaction_callbacks.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
 #include <chrono>

--- a/dnfdaemon-server/services/goal/goal.cpp
+++ b/dnfdaemon-server/services/goal/goal.cpp
@@ -28,7 +28,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <fmt/format.h>
 #include <libdnf/repo/package_downloader.hpp>
-#include <libdnf/rpm/transaction.hpp>
 #include <libdnf/transaction/transaction_item.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 

--- a/dnfdaemon-server/transaction.cpp
+++ b/dnfdaemon-server/transaction.cpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "transaction.hpp"
 
 #include <libdnf/common/exception.hpp>
+#include <libdnf/rpm/transaction_callbacks.hpp>
 
 #include <type_traits>
 

--- a/dnfdaemon-server/transaction.hpp
+++ b/dnfdaemon-server/transaction.hpp
@@ -21,7 +21,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNFDAEMON_SERVER_SERVICES_RPM_TRANSACTION_HPP
 
 #include <libdnf/base/transaction_package.hpp>
-#include <libdnf/rpm/transaction.hpp>
 #include <sdbus-c++/sdbus-c++.h>
 
 #include <string>

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -26,7 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/log_event.hpp"
 #include "libdnf/base/solver_problems.hpp"
 #include "libdnf/base/transaction_package.hpp"
-#include "libdnf/rpm/transaction.hpp"
+#include "libdnf/rpm/transaction_callbacks.hpp"
 
 #include <optional>
 

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -33,6 +33,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace libdnf::base {
 
+
+class TransactionError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf::base"; }
+    const char * get_name() const noexcept override { return "TransactionError"; }
+};
+
+
 class Transaction {
 public:
     enum class TransactionRunResult {

--- a/include/libdnf/rpm/transaction.hpp
+++ b/include/libdnf/rpm/transaction.hpp
@@ -26,6 +26,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/base/base_weak.hpp"
 #include "libdnf/base/transaction_package.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/rpm/transaction_callbacks.hpp"
 
 #include <memory>
 
@@ -63,55 +64,6 @@ private:
     explicit RpmHeader(void * hdr);
     void * header;
 };
-
-
-// suppress "unused-parameter" warnings because TransactionCallbacks is a virtual class
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
-/// Base class for Transaction callbacks
-/// User implements Transaction callbacks by inheriting this class and overriding its methods.
-class TransactionCallbacks {
-public:
-    /// Scriptlet type
-    // TODO(jrohel): Are all scriptlets types present and correct?
-    enum class ScriptType {
-        UNKNOWN,
-        PRE_INSTALL,            // "%pre"
-        POST_INSTALL,           // "%post"
-        PRE_UNINSTALL,          // "%preun"
-        POST_UNINSTALL,         // "%postun"
-        PRE_TRANSACTION,        // "%pretrans"
-        POST_TRANSACTION,       // "%posttrans"
-        TRIGGER_PRE_INSTALL,    // "%triggerprein"
-        TRIGGER_INSTALL,        // "%triggerin"
-        TRIGGER_UNINSTALL,      // "%triggerun"
-        TRIGGER_POST_UNINSTALL  // "%triggerpostun"
-    };
-
-    virtual ~TransactionCallbacks() = default;
-
-    virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void install_start(const TransactionItem & item, uint64_t total) {}
-    virtual void install_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void transaction_progress(uint64_t amount, uint64_t total) {}
-    virtual void transaction_start(uint64_t total) {}
-    virtual void transaction_stop(uint64_t total) {}
-    virtual void uninstall_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void uninstall_start(const TransactionItem & item, uint64_t total) {}
-    virtual void uninstall_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void unpack_error(const TransactionItem & item) {}
-    virtual void cpio_error(const TransactionItem & item) {}
-    virtual void script_error(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code) {}
-    virtual void script_start(const TransactionItem * item, Nevra nevra, ScriptType type) {}
-    virtual void script_stop(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code) {}
-    virtual void elem_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
-    virtual void verify_progress(uint64_t amount, uint64_t total) {}
-    virtual void verify_start(uint64_t total) {}
-    virtual void verify_stop(uint64_t total) {}
-};
-
-#pragma GCC diagnostic pop
 
 
 class RpmProblem {

--- a/include/libdnf/rpm/transaction_callbacks.hpp
+++ b/include/libdnf/rpm/transaction_callbacks.hpp
@@ -1,0 +1,86 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef LIBDNF_RPM_TRANSACTION_CALLBACKS_HPP
+#define LIBDNF_RPM_TRANSACTION_CALLBACKS_HPP
+
+#include "libdnf/base/transaction_package.hpp"
+
+#include <cstdint>
+
+namespace libdnf::rpm {
+
+
+/// Class represents one item in transaction set.
+using TransactionItem = base::TransactionPackage;
+
+
+// suppress "unused-parameter" warnings because TransactionCallbacks is a virtual class
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+/// Base class for Transaction callbacks
+/// User implements Transaction callbacks by inheriting this class and overriding its methods.
+class TransactionCallbacks {
+public:
+    /// Scriptlet type
+    // TODO(jrohel): Are all scriptlets types present and correct?
+    enum class ScriptType {
+        UNKNOWN,
+        PRE_INSTALL,            // "%pre"
+        POST_INSTALL,           // "%post"
+        PRE_UNINSTALL,          // "%preun"
+        POST_UNINSTALL,         // "%postun"
+        PRE_TRANSACTION,        // "%pretrans"
+        POST_TRANSACTION,       // "%posttrans"
+        TRIGGER_PRE_INSTALL,    // "%triggerprein"
+        TRIGGER_INSTALL,        // "%triggerin"
+        TRIGGER_UNINSTALL,      // "%triggerun"
+        TRIGGER_POST_UNINSTALL  // "%triggerpostun"
+    };
+
+    virtual ~TransactionCallbacks() = default;
+
+    virtual void install_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
+    virtual void install_start(const TransactionItem & item, uint64_t total) {}
+    virtual void install_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
+    virtual void transaction_progress(uint64_t amount, uint64_t total) {}
+    virtual void transaction_start(uint64_t total) {}
+    virtual void transaction_stop(uint64_t total) {}
+    virtual void uninstall_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
+    virtual void uninstall_start(const TransactionItem & item, uint64_t total) {}
+    virtual void uninstall_stop(const TransactionItem & item, uint64_t amount, uint64_t total) {}
+    virtual void unpack_error(const TransactionItem & item) {}
+    virtual void cpio_error(const TransactionItem & item) {}
+    virtual void script_error(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code) {}
+    virtual void script_start(const TransactionItem * item, Nevra nevra, ScriptType type) {}
+    virtual void script_stop(const TransactionItem * item, Nevra nevra, ScriptType type, uint64_t return_code) {}
+    virtual void elem_progress(const TransactionItem & item, uint64_t amount, uint64_t total) {}
+    virtual void verify_progress(uint64_t amount, uint64_t total) {}
+    virtual void verify_start(uint64_t total) {}
+    virtual void verify_stop(uint64_t total) {}
+};
+
+#pragma GCC diagnostic pop
+
+
+}  // namespace libdnf::rpm
+
+#endif  // LIBDNF_RPM_TRANSACTION_CALLBACKS_HPP

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -18,6 +18,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
+#include "rpm/transaction.hpp"
+
 #include "rpm/package_set_impl.hpp"
 #include "solv/pool.hpp"
 #include "solver_problems_internal.hpp"
@@ -30,7 +32,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/exception.hpp"
 #include "libdnf/common/proc.hpp"
 #include "libdnf/rpm/package_query.hpp"
-#include "libdnf/rpm/transaction.hpp"
 
 #include <fmt/format.h>
 

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -30,6 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/common/exception.hpp"
 #include "libdnf/common/proc.hpp"
 #include "libdnf/rpm/package_query.hpp"
+#include "libdnf/rpm/transaction.hpp"
 
 #include <fmt/format.h>
 

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -18,14 +18,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 
-#include "libdnf/base/transaction.hpp"
+#include "transaction.hpp"
 
 #include "package_set_impl.hpp"
 #include "rpm_log_guard.hpp"
 #include "utils/bgettext/bgettext-lib.h"
 
+#include "libdnf/base/transaction.hpp"
 #include "libdnf/common/exception.hpp"
-#include "libdnf/rpm/transaction.hpp"
 #include "libdnf/transaction/transaction_item_action.hpp"
 #include "libdnf/utils/to_underlying.hpp"
 

--- a/libdnf/rpm/transaction.cpp
+++ b/libdnf/rpm/transaction.cpp
@@ -36,7 +36,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <rpm/rpmlib.h>
 #include <rpm/rpmpgp.h>
 #include <rpm/rpmtag.h>
-#include <rpm/rpmts.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -142,8 +141,8 @@ std::string RpmProblem::get_alt_nevr() const {
     return rpmProblemGetAltNEVR(p_impl->problem);
 }
 
-RpmProblem::Type RpmProblem::get_type() const {
-    return static_cast<Type>(rpmProblemGetType(p_impl->problem));
+rpmProblemType RpmProblem::get_type() const {
+    return rpmProblemGetType(p_impl->problem);
 }
 
 const TransactionItem * RpmProblem::get_transaction_item() const {

--- a/libdnf/rpm/transaction.hpp
+++ b/libdnf/rpm/transaction.hpp
@@ -21,11 +21,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef LIBDNF_RPM_TRANSACTION_HPP
 #define LIBDNF_RPM_TRANSACTION_HPP
 
-#include "package.hpp"
 
 #include "libdnf/base/base_weak.hpp"
 #include "libdnf/base/transaction_package.hpp"
 #include "libdnf/common/exception.hpp"
+#include "libdnf/rpm/package.hpp"
 #include "libdnf/rpm/transaction_callbacks.hpp"
 
 #include <memory>

--- a/libdnf/rpm/transaction.hpp
+++ b/libdnf/rpm/transaction.hpp
@@ -28,6 +28,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/rpm/package.hpp"
 #include "libdnf/rpm/transaction_callbacks.hpp"
 
+#include <rpm/rpmts.h>
+
 #include <memory>
 
 
@@ -68,24 +70,6 @@ private:
 
 class RpmProblem {
 public:
-    /// Enumerate transaction set problem types.
-    // TODO(jrohel): check value with librpm (static_assert?)
-    enum class Type {
-        BADARCH,            // package ... is for a different architecture
-        BADOS,              // package ... is for a different operating system
-        PKG_INSTALLED,      // package ... is already installed
-        BADRELOCATE,        // path ... is not relocatable for package ...
-        REQUIRES,           // package ... has unsatisfied Requires: ...
-        CONFLICT,           // package ... has unsatisfied Conflicts: ...
-        NEW_FILE_CONFLICT,  // file ... conflicts between attempted installs of ...
-        FILE_CONFLICT,      // file ... from install of ... conflicts with file from package ...
-        OLDPACKAGE,         // package ... (which is newer than ...) is already installed
-        DISKSPACE,          // installing package ... needs ... on the ... filesystem
-        DISKNODES,          // installing package ... needs ... on the ... filesystem
-        OBSOLETES,          // package ... is obsoleted by ...
-        VERIFY              // package did not pass verification
-    };
-
     ~RpmProblem();
 
     bool operator==(RpmProblem & other) const noexcept;
@@ -98,7 +82,7 @@ public:
     std::string get_alt_nevr() const;
 
     /// Return type of problem (dependency, diskpace etc)
-    Type get_type() const;
+    rpmProblemType get_type() const;
 
     /// Return pointer to transaction item associated to the problem or nullptr.
     const TransactionItem * get_transaction_item() const;
@@ -179,11 +163,6 @@ public:
 
 class Transaction {
 public:
-    // TODO(jrohel): Define enums or flag setters/getters
-    using rpmVSFlags = uint32_t;
-    using rpmtransFlags = uint32_t;
-    using rpm_tid_t = uint32_t;
-
     explicit Transaction(Base & base);
     explicit Transaction(const BaseWeakPtr & base);
     Transaction(const Transaction &) = delete;

--- a/microdnf/commands/downgrade/downgrade.cpp
+++ b/microdnf/commands/downgrade/downgrade.cpp
@@ -29,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
-#include <libdnf/rpm/transaction.hpp>
 
 #include <filesystem>
 #include <iostream>

--- a/microdnf/commands/download/download.cpp
+++ b/microdnf/commands/download/download.cpp
@@ -26,7 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
-#include <libdnf/rpm/transaction.hpp>
 
 #include <filesystem>
 #include <iostream>

--- a/microdnf/commands/install/install.cpp
+++ b/microdnf/commands/install/install.cpp
@@ -29,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
-#include <libdnf/rpm/transaction.hpp>
 
 #include <filesystem>
 #include <iostream>

--- a/microdnf/commands/reinstall/reinstall.cpp
+++ b/microdnf/commands/reinstall/reinstall.cpp
@@ -29,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
-#include <libdnf/rpm/transaction.hpp>
 
 #include <filesystem>
 #include <iostream>

--- a/microdnf/commands/remove/remove.cpp
+++ b/microdnf/commands/remove/remove.cpp
@@ -29,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
-#include <libdnf/rpm/transaction.hpp>
 
 #include <iostream>
 

--- a/microdnf/commands/upgrade/upgrade.cpp
+++ b/microdnf/commands/upgrade/upgrade.cpp
@@ -29,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
-#include <libdnf/rpm/transaction.hpp>
 
 #include <filesystem>
 #include <iostream>

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -29,7 +29,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/repo/package_downloader.hpp>
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
-#include <libdnf/rpm/transaction.hpp>
 
 #include <filesystem>
 #include <iostream>

--- a/microdnf/context.cpp
+++ b/microdnf/context.cpp
@@ -44,6 +44,15 @@ namespace fs = std::filesystem;
 namespace microdnf {
 
 bool userconfirm(libdnf::ConfigMain & config) {
+    for (const auto & tsflag : config.tsflags().get_value()) {
+        if (tsflag == "test") {
+            std::cout << "Test mode enabled: Only package downloads, gpg key installations and transaction checks will "
+                         "be performed."
+                      << std::endl;
+            break;
+        }
+    }
+
     // "assumeno" takes precedence over "assumeyes"
     if (config.assumeno().get_value()) {
         return false;

--- a/microdnf/include/microdnf/context.hpp
+++ b/microdnf/include/microdnf/context.hpp
@@ -25,7 +25,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf-cli/session.hpp>
 #include <libdnf/base/base.hpp>
 #include <libdnf/base/transaction.hpp>
-#include <libdnf/rpm/transaction.hpp>
 
 #include <memory>
 #include <string>

--- a/microdnf/main.cpp
+++ b/microdnf/main.cpp
@@ -363,6 +363,24 @@ static void set_commandline_args(Context & ctx) {
     add_new_named_arg_alias(*no_best, "nobest", "nobest", '\0', options_aliases_group, no_best_conflict_args);
 
     {
+        auto no_docs = ctx.get_argument_parser().add_new_named_arg("no-docs");
+        no_docs->set_long_name("no-docs");
+        no_docs->set_short_description(
+            "Don't install files that are marked as documentation (which includes man pages and texinfo documents)");
+        no_docs->set_parse_hook_func([&ctx](
+                                         [[maybe_unused]] ArgumentParser::NamedArg * arg,
+                                         [[maybe_unused]] const char * option,
+                                         [[maybe_unused]] const char * value) {
+            auto & conf = ctx.base.get_config();
+            conf.opt_binds().at("tsflags").new_string(libdnf::Option::Priority::COMMANDLINE, "nodocs");
+            return true;
+        });
+        global_options_group->register_argument(no_docs);
+
+        add_new_named_arg_alias(*no_docs, "nodocs", "nodocs", '\0', options_aliases_group);
+    }
+
+    {
         auto exclude = ctx.get_argument_parser().add_new_named_arg("exclude");
         exclude->set_long_name("exclude");
         exclude->set_short_name('x');

--- a/test/libdnf/rpm/test_transaction.cpp
+++ b/test/libdnf/rpm/test_transaction.cpp
@@ -24,7 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/base/goal.hpp"
 #include "libdnf/repo/package_downloader.hpp"
-#include "libdnf/rpm/transaction.hpp"
+#include "libdnf/rpm/transaction_callbacks.hpp"
 
 
 CPPUNIT_TEST_SUITE_REGISTRATION(RpmTransactionTest);


### PR DESCRIPTION
Supported tsflags:
`test`, `nodocs`, `noscripts`, `notriggers`, `justdb`, `nocontext`, `nocaps`, `nocrypto`
The same set of flags is supportd in the old dnf.

microdnf: Inform about the transaction testing mode
microdnf: Added cmdline '--no-docs' (and '--nodocs') option, which adds `nodocs` flag to tsflags.

rpm::Transaction::run: Fix execution without callback class set
Move rpm::TransactionCallbacks class to separate header file
Make "rpm/transaction.hpp" file private.