### PR TITLE
context: avoid prefixing vars directories

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -3785,7 +3785,7 @@ dnf_context_load_vars(DnfContext * context)
     auto priv = GET_PRIVATE(context);
     priv->vars->clear();
     for (auto dir = dnf_context_get_vars_dir(context); *dir; ++dir)
-        ConfigMain::addVarsFromDir(*priv->vars, std::string(priv->install_root) + *dir);
+        ConfigMain::addVarsFromDir(*priv->vars, *dir);
     ConfigMain::addVarsFromEnv(*priv->vars);
     priv->varsCached = true;
 }


### PR DESCRIPTION
This drops the internal prefixing logic for vars directories, thus
avoiding the prepended `install_root` path prefix on all entries.
It also results in aligning the behaviors of `dnf_context_set_vars_dir()`
and `dnf_context_set_repos_dir()`.

Existing consumers in the wild are not really expecting this kind
of prefixing to happen internally. Additionally, developers seem to
naturally assume that the lookalike APIs for repos-dir and vars-dir
behave in the same way.

Ref: https://github.com/coreos/rpm-ostree/issues/3241
Ref: https://github.com/PackageKit/PackageKit/pull/369/files#r863937752
Closes: https://github.com/rpm-software-management/libdnf/issues/1503