### PR TITLE
[dnf5] Add security filters and other advisory options

### DIFF
--- a/common/utils/string.hpp
+++ b/common/utils/string.hpp
@@ -94,6 +94,14 @@ inline std::string tolower(const std::string & s) {
     return result;
 }
 
+inline std::string format_epoch(unsigned long long epoch_num) {
+    const time_t epoch = static_cast<time_t>(epoch_num);
+    struct tm * ptm = gmtime(&epoch);
+    char buffer[20];
+    strftime(buffer, 20, "%F %T", ptm);
+    return std::string(buffer);
+}
+
 }  // namespace libdnf::utils::string
 
 #endif  // LIBDNF_UTILS_STRING_HPP

--- a/common/utils/string.hpp
+++ b/common/utils/string.hpp
@@ -87,6 +87,13 @@ std::vector<std::string> rsplit(const std::string & str, const std::string & del
 std::vector<std::string> split(
     const std::string & str, const std::string & delimiter, std::size_t limit = std::string::npos);
 
+
+inline std::string tolower(const std::string & s) {
+    std::string result = s;
+    std::for_each(result.begin(), result.end(), [](char & c) { c = static_cast<char>(::tolower(c)); });
+    return result;
+}
+
 }  // namespace libdnf::utils::string
 
 #endif  // LIBDNF_UTILS_STRING_HPP

--- a/dnf5/commands/advisory/advisory_list.cpp
+++ b/dnf5/commands/advisory/advisory_list.cpp
@@ -52,7 +52,13 @@ void AdvisoryListCommand::process_and_print_queries(
         not_installed_pkgs = advisories.get_advisory_packages(packages, libdnf::sack::QueryCmp::GT);
     }
 
-    libdnf::cli::output::print_advisorylist_table(not_installed_pkgs, installed_pkgs);
+    if (with_bz->get_value()) {
+        libdnf::cli::output::print_advisorylist_references_table(not_installed_pkgs, installed_pkgs, "bugzilla");
+    } else if (with_cve->get_value()) {
+        libdnf::cli::output::print_advisorylist_references_table(not_installed_pkgs, installed_pkgs, "cve");
+    } else {
+        libdnf::cli::output::print_advisorylist_table(not_installed_pkgs, installed_pkgs);
+    }
 }
 
 }  // namespace dnf5

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -47,6 +47,9 @@ void AdvisorySubCommand::set_argument_parser() {
     advisory_bz = std::make_unique<BzOption>(*this);
     advisory_cve = std::make_unique<CveOption>(*this);
 
+    with_bz = std::make_unique<AdvisoryWithBzOption>(*this);
+    with_cve = std::make_unique<AdvisoryWithCveOption>(*this);
+
     auto conflict_args = parser.add_conflict_args_group(std::unique_ptr<std::vector<ArgumentParser::Argument *>>(
         new std::vector<ArgumentParser::Argument *>{all->arg, available->arg, installed->arg, updates->arg}));
 
@@ -99,6 +102,13 @@ void AdvisorySubCommand::run() {
         advisory_cve->get_value());
 
     auto advisories = advisories_opt.value_or(libdnf::advisory::AdvisoryQuery(ctx.base));
+
+    if (with_bz->get_value()) {
+        advisories.filter_reference("*", libdnf::sack::QueryCmp::IGLOB, {"bugzilla"});
+    }
+    if (with_cve->get_value()) {
+        advisories.filter_reference("*", libdnf::sack::QueryCmp::IGLOB, {"cve"});
+    }
 
     process_and_print_queries(ctx, advisories, package_query);
 }

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -48,6 +48,8 @@ protected:
     std::unique_ptr<AdvisoryUpdatesOption> updates{nullptr};
     std::unique_ptr<AdvisoryContainsPkgsOption> contains_pkgs{nullptr};
     std::unique_ptr<AdvisorySpecArguments> advisory_specs{nullptr};
+    std::unique_ptr<AdvisoryWithBzOption> with_bz{nullptr};
+    std::unique_ptr<AdvisoryWithCveOption> with_cve{nullptr};
 
     AdvisorySubCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_SUBCOMMAND_HPP
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_SUBCOMMAND_HPP
 
+#include "../advisory_shared.hpp"
 #include "arguments.hpp"
 
 #include <dnf5/context.hpp>
@@ -49,6 +50,15 @@ protected:
     std::unique_ptr<AdvisorySpecArguments> advisory_specs{nullptr};
 
     AdvisorySubCommand(Command & parent, const std::string & name) : Command(parent, name) {}
+
+protected:
+    std::unique_ptr<SecurityOption> advisory_security{nullptr};
+    std::unique_ptr<BugfixOption> advisory_bugfix{nullptr};
+    std::unique_ptr<EnhancementOption> advisory_enhancement{nullptr};
+    std::unique_ptr<NewpackageOption> advisory_newpackage{nullptr};
+    std::unique_ptr<AdvisorySeverityOption> advisory_severity{nullptr};
+    std::unique_ptr<BzOption> advisory_bz{nullptr};
+    std::unique_ptr<CveOption> advisory_cve{nullptr};
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/advisory/arguments.hpp
+++ b/dnf5/commands/advisory/arguments.hpp
@@ -95,4 +95,18 @@ public:
 }  // namespace dnf5
 
 
+class AdvisoryWithBzOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit AdvisoryWithBzOption(libdnf::cli::session::Command & command)
+        : BoolOption(command, "with-bz", '\0', _("Show only advisories referencing a bugzilla."), false) {}
+};
+
+
+class AdvisoryWithCveOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit AdvisoryWithCveOption(libdnf::cli::session::Command & command)
+        : BoolOption(command, "with-cve", '\0', _("Show only advisories referencing a CVE."), false) {}
+};
+
+
 #endif  // DNF5_COMMANDS_ADVISORY_ARGUMENTS_HPP

--- a/dnf5/commands/advisory_shared.hpp
+++ b/dnf5/commands/advisory_shared.hpp
@@ -1,0 +1,201 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef DNF5_COMMANDS_ARGUMENTS_HPP
+#define DNF5_COMMANDS_ARGUMENTS_HPP
+
+
+#include "utils/bgettext/bgettext-lib.h"
+#include "utils/string.hpp"
+
+#include "libdnf/base/base_weak.hpp"
+
+#include <libdnf-cli/session.hpp>
+#include <libdnf/advisory/advisory_query.hpp>
+
+#include <optional>
+
+
+namespace dnf5 {
+
+inline std::optional<libdnf::advisory::AdvisoryQuery> advisory_query_from_cli_input(
+    libdnf::Base & base,
+    const std::vector<std::string> & advisory_names,
+    bool advisory_security,
+    bool advisory_bugfix,
+    bool advisory_enhancement,
+    bool advisory_newpackage,
+    const std::vector<std::string> & advisory_severities,
+    const std::vector<std::string> & advisory_bzs,
+    const std::vector<std::string> & advisory_cves) {
+    std::vector<std::string> advisory_types;
+    if (advisory_security) {
+        advisory_types.emplace_back("security");
+    }
+    if (advisory_bugfix) {
+        advisory_types.emplace_back("bugfix");
+    }
+    if (advisory_enhancement) {
+        advisory_types.emplace_back("enhancement");
+    }
+    if (advisory_newpackage) {
+        advisory_types.emplace_back("newpackage");
+    }
+
+    if (!advisory_types.empty() || !advisory_severities.empty() || !advisory_names.empty() || !advisory_bzs.empty() ||
+        !advisory_cves.empty()) {
+        auto advisories = libdnf::advisory::AdvisoryQuery(base);
+        advisories.clear();
+        // Filter by advisory name
+        if (!advisory_names.empty()) {
+            auto advisories_names = libdnf::advisory::AdvisoryQuery(base);
+            advisories_names.filter_name(advisory_names);
+            advisories |= advisories_names;
+        }
+
+        // Filter by advisory type
+        if (!advisory_types.empty()) {
+            auto advisories_types = libdnf::advisory::AdvisoryQuery(base);
+            advisories_types.filter_type(advisory_types);
+            advisories |= advisories_types;
+        }
+
+        // Filter by advisory severity
+        if (!advisory_severities.empty()) {
+            auto advisories_severities = libdnf::advisory::AdvisoryQuery(base);
+            advisories_severities.filter_severity(advisory_severities);
+            advisories |= advisories_severities;
+        }
+
+        // Filter by advisory bz
+        if (!advisory_bzs.empty()) {
+            auto advisories_bzs = libdnf::advisory::AdvisoryQuery(base);
+            advisories_bzs.filter_reference(advisory_bzs, libdnf::sack::QueryCmp::EQ, {"bugzilla"});
+            advisories |= advisories_bzs;
+        }
+
+        // Filter by advisory cve
+        if (!advisory_cves.empty()) {
+            auto advisories_cves = libdnf::advisory::AdvisoryQuery(base);
+            advisories_cves.filter_reference(advisory_cves, libdnf::sack::QueryCmp::EQ, {"cve"});
+            advisories |= advisories_cves;
+        }
+
+        return advisories;
+    }
+
+    return std::nullopt;
+}
+
+class AdvisoryOption : public libdnf::cli::session::StringListOption {
+public:
+    explicit AdvisoryOption(libdnf::cli::session::Command & command)
+        : StringListOption(
+              command,
+              "advisories",
+              '\0',
+              _("Consider only content contained in advisories with specified name. List option."),
+              _("ADVISORY_NAME,...")) {}
+};
+
+
+class SecurityOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit SecurityOption(libdnf::cli::session::Command & command)
+        : BoolOption(command, "security", '\0', _("Consider only content contained in security advisories."), false) {}
+};
+
+
+class BugfixOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit BugfixOption(libdnf::cli::session::Command & command)
+        : BoolOption(command, "bugfix", '\0', _("Consider only content contained in bugfix advisories."), false) {}
+};
+
+
+class EnhancementOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit EnhancementOption(libdnf::cli::session::Command & command)
+        : BoolOption(
+              command, "enhancement", '\0', _("Consider only content contained in enhancement advisories."), false) {}
+};
+
+
+class NewpackageOption : public libdnf::cli::session::BoolOption {
+public:
+    explicit NewpackageOption(libdnf::cli::session::Command & command)
+        : BoolOption(
+              command, "newpackage", '\0', _("Consider only content contained in newpackage advisories."), false) {}
+};
+
+
+class AdvisorySeverityOption : public libdnf::cli::session::StringListOption {
+public:
+    explicit AdvisorySeverityOption(libdnf::cli::session::Command & command)
+        : StringListOption(
+              command,
+              "advisory-severities",
+              '\0',
+              _("Consider only content contained in advisories with specified severity. List option. Can be "
+                "\"critical\", \"important\", \"moderate\", \"low\", \"none\"."),
+              _("ADVISORY_SEVERITY,..."),
+              "critical|important|moderate|low|none",
+              true) {}
+
+    std::vector<std::string> get_value() const {
+        auto vals = StringListOption::get_value();
+        std::transform(vals.begin(), vals.end(), vals.begin(), [](std::string val) -> std::string {
+            val = libdnf::utils::string::tolower(val);
+            val[0] = static_cast<char>(std::toupper(val[0]));
+            return val;
+        });
+
+        return vals;
+    }
+};
+
+class BzOption : public libdnf::cli::session::StringListOption {
+public:
+    explicit BzOption(libdnf::cli::session::Command & command)
+        : StringListOption(
+              command,
+              "bzs",
+              '\0',
+              _("Consider only content contained in advisories that fix a Bugzilla ID, Eg. 123123. List option."),
+              _("BUGZILLA_ID,...")) {}
+};
+
+class CveOption : public libdnf::cli::session::StringListOption {
+public:
+    explicit CveOption(libdnf::cli::session::Command & command)
+        : StringListOption(
+              command,
+              "cves",
+              '\0',
+              _("Consider only content contained in advisories that fix a CVE (Common Vulnerabilities and Exposures) "
+                "ID, Eg. CVE-2201-0123. List option."),
+              _("CVE_ID,...")) {}
+};
+
+
+}  // namespace dnf5
+
+
+#endif  // DNF5_COMMANDS_ARGUMENTS_HPP

--- a/dnf5/commands/advisory_shared.hpp
+++ b/dnf5/commands/advisory_shared.hpp
@@ -112,7 +112,10 @@ public:
               "advisories",
               '\0',
               _("Consider only content contained in advisories with specified name. List option."),
-              _("ADVISORY_NAME,...")) {}
+              _("ADVISORY_NAME,...")) {
+        auto * alias = arg->add_alias("advisory", "advisory", '\0', nullptr);
+        command.get_argument_parser_command()->register_named_arg(alias);
+    }
 };
 
 
@@ -159,6 +162,7 @@ public:
               "critical|important|moderate|low|none",
               true) {}
 
+
     std::vector<std::string> get_value() const {
         auto vals = StringListOption::get_value();
         std::transform(vals.begin(), vals.end(), vals.begin(), [](std::string val) -> std::string {
@@ -179,7 +183,10 @@ public:
               "bzs",
               '\0',
               _("Consider only content contained in advisories that fix a Bugzilla ID, Eg. 123123. List option."),
-              _("BUGZILLA_ID,...")) {}
+              _("BUGZILLA_ID,...")) {
+        auto * alias = arg->add_alias("bz", "bz", '\0', nullptr);
+        command.get_argument_parser_command()->register_named_arg(alias);
+    }
 };
 
 class CveOption : public libdnf::cli::session::StringListOption {
@@ -191,7 +198,10 @@ public:
               '\0',
               _("Consider only content contained in advisories that fix a CVE (Common Vulnerabilities and Exposures) "
                 "ID, Eg. CVE-2201-0123. List option."),
-              _("CVE_ID,...")) {}
+              _("CVE_ID,...")) {
+        auto * alias = arg->add_alias("cve", "cve", '\0', nullptr);
+        command.get_argument_parser_command()->register_named_arg(alias);
+    }
 };
 
 

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -21,6 +21,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_REPOQUERY_REPOQUERY_HPP
 #define DNF5_COMMANDS_REPOQUERY_REPOQUERY_HPP
 
+#include "../advisory_shared.hpp"
+
 #include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
@@ -47,6 +49,15 @@ private:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
     std::vector<libdnf::rpm::Package> cmdline_packages;
+
+    std::unique_ptr<AdvisoryOption> advisory_name{nullptr};
+    std::unique_ptr<SecurityOption> advisory_security{nullptr};
+    std::unique_ptr<BugfixOption> advisory_bugfix{nullptr};
+    std::unique_ptr<EnhancementOption> advisory_enhancement{nullptr};
+    std::unique_ptr<NewpackageOption> advisory_newpackage{nullptr};
+    std::unique_ptr<AdvisorySeverityOption> advisory_severity{nullptr};
+    std::unique_ptr<BzOption> advisory_bz{nullptr};
+    std::unique_ptr<CveOption> advisory_cve{nullptr};
 };
 
 

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -338,6 +338,14 @@ public:
         /// Gets help text for argument value.
         const std::string & get_arg_value_help() const noexcept { return arg_value_help; }
 
+        /// Create alias for this named arg. The alias is not shown in completion.
+        /// The conflicting args of the alias are copied to match the current conflicting args of this named arg.
+        libdnf::cli::ArgumentParser::NamedArg * add_alias(
+            const std::string & id,
+            const std::string & long_name,
+            char short_name,
+            libdnf::cli::ArgumentParser::Group * group);
+
     private:
         friend class ArgumentParser;
 

--- a/include/libdnf-cli/output/advisorylist.hpp
+++ b/include/libdnf-cli/output/advisorylist.hpp
@@ -22,6 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_CLI_OUTPUT_ADVISORYLIST_HPP
 
 #include "libdnf/advisory/advisory_package.hpp"
+#include "libdnf/advisory/advisory_reference.hpp"
 
 namespace libdnf::cli::output {
 
@@ -29,6 +30,10 @@ void print_advisorylist_table(
     std::vector<libdnf::advisory::AdvisoryPackage> & advisory_package_list_not_installed,
     std::vector<libdnf::advisory::AdvisoryPackage> & advisory_package_list_installed);
 
+void print_advisorylist_references_table(
+    std::vector<libdnf::advisory::AdvisoryPackage> & advisory_package_list_not_installed,
+    std::vector<libdnf::advisory::AdvisoryPackage> & advisory_package_list_installed,
+    std::string reference_type);
 
 }  // namespace libdnf::cli::output
 

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -179,6 +179,15 @@ public:
         const std::string & desc,
         const std::string & help);
 
+    explicit StringListOption(
+        libdnf::cli::session::Command & command,
+        const std::string & long_name,
+        char short_name,
+        const std::string & desc,
+        const std::string & help,
+        const std::string & allowed_values_regex,
+        const bool icase);
+
     /// @return Parsed value.
     /// @since 5.0
     std::vector<std::string> get_value() const { return conf->get_value(); }

--- a/include/libdnf/advisory/advisory_query.hpp
+++ b/include/libdnf/advisory/advisory_query.hpp
@@ -77,16 +77,19 @@ public:
         sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ,
         const std::optional<std::string> type = {});
 
-    void filter_severity(const std::string & pattern, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+    /// Filter Advisories by severity
+    ///
+    /// @param severity     Possible severities are: "critical", "important", "moderate", "low", "none".
+    /// @param cmp_type     What comparator to use with severity, allows: EQ.
+    void filter_severity(const std::string & severity, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
     void filter_severity(
-        const std::vector<std::string> & patterns, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
+        const std::vector<std::string> & severities, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 
-    //TODO(amatej): this might not be needed and could be possibly removed
-    /// Filter out advisories that don't contain at least one package fulfilling the cmp_type condition when compated to input packages
+    /// Filter out advisories that don't contain at least one AdvisoryPackage that has a counterpart Package in package_set
+    /// such that they have matching name and architecture and also their epoch-version-release complies to cmp_type.
     ///
     /// @param package_set  libdnf::rpm::PackageSet used when filtering.
-    /// @param cmp_type     Condition to fulfill with packages.
-    /// @return This AdvisoryQuery with applied filter.
+    /// @param cmp_type     Condition to fulfill when comparing epoch-version-release of packages.
     void filter_packages(
         const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type = libdnf::sack::QueryCmp::EQ);
 

--- a/libdnf-cli/output/advisoryinfo.cpp
+++ b/libdnf-cli/output/advisoryinfo.cpp
@@ -35,7 +35,7 @@ void AdvisoryInfo::add_advisory(libdnf::advisory::Advisory & advisory) {
     add_line("Type", advisory.get_type());
     add_line("Status", advisory.get_status());
     add_line("Vendor", advisory.get_vendor());
-    add_line("Buildtime", std::to_string(advisory.get_buildtime()));
+    add_line("Issued", libdnf::utils::string::format_epoch(advisory.get_buildtime()));
     add_lines("Description", libdnf::utils::string::split(advisory.get_description(), "\n"));
     add_line("Message", advisory.get_message());
     add_line("Rights", advisory.get_rights());

--- a/libdnf-cli/output/advisorysummary.cpp
+++ b/libdnf-cli/output/advisorysummary.cpp
@@ -48,8 +48,11 @@ void print_advisorysummary_table(const libdnf::advisory::AdvisoryQuery & advisor
     security_moderate.filter_severity("Moderate");
     libdnf::advisory::AdvisoryQuery security_low{securities};
     security_low.filter_severity("Low");
-    libdnf::advisory::AdvisoryQuery security_none{securities};
-    security_none.filter_severity("None");
+    libdnf::advisory::AdvisoryQuery security_other{securities};
+    security_other -= security_critical;
+    security_other -= security_important;
+    security_other -= security_moderate;
+    security_other -= security_low;
 
     libdnf::advisory::AdvisoryQuery others{advisories};
     others -= bugfixes;
@@ -61,12 +64,12 @@ void print_advisorysummary_table(const libdnf::advisory::AdvisoryQuery & advisor
     output_table.add_line("Important", security_important.size(), nullptr, security_row);
     output_table.add_line("Moderate", security_moderate.size(), nullptr, security_row);
     output_table.add_line("Low", security_low.size(), nullptr, security_row);
-    output_table.add_line("None", security_none.size(), nullptr, security_row);
+    output_table.add_line("Other", security_other.size(), nullptr, security_row);
 
     output_table.add_line("Bugfix", bugfixes.size(), nullptr);
     output_table.add_line("Enhancement", enhancements.size(), nullptr);
 
-    output_table.add_line("Others", others.size(), nullptr);
+    output_table.add_line("Other", others.size(), nullptr);
 
     output_table.print();
 }

--- a/libdnf-cli/session.cpp
+++ b/libdnf-cli/session.cpp
@@ -125,10 +125,12 @@ StringListOption::StringListOption(
     const std::string & long_name,
     char short_name,
     const std::string & desc,
-    const std::string & help) {
+    const std::string & help,
+    const std::string & allowed_values_regex,
+    const bool icase) {
     auto & parser = command.get_session().get_argument_parser();
-    conf = dynamic_cast<libdnf::OptionStringList *>(
-        parser.add_init_value(std::make_unique<libdnf::OptionStringList>(std::vector<std::string>())));
+    conf = dynamic_cast<libdnf::OptionStringList *>(parser.add_init_value(
+        std::make_unique<libdnf::OptionStringList>(std::vector<std::string>(), allowed_values_regex, icase)));
     arg = parser.add_new_named_arg(long_name);
 
     if (!long_name.empty()) {
@@ -146,6 +148,15 @@ StringListOption::StringListOption(
 
     command.get_argument_parser_command()->register_named_arg(arg);
 }
+
+
+StringListOption::StringListOption(
+    libdnf::cli::session::Command & command,
+    const std::string & long_name,
+    char short_name,
+    const std::string & desc,
+    const std::string & help)
+    : StringListOption(command, long_name, short_name, desc, help, "", false) {}
 
 
 StringArgumentList::StringArgumentList(

--- a/libdnf-cli/session.cpp
+++ b/libdnf-cli/session.cpp
@@ -144,7 +144,17 @@ StringListOption::StringListOption(
     arg->set_short_description(desc);
     arg->set_arg_value_help(help);
     arg->set_has_value(true);
-    arg->link_value(conf);
+    arg->set_parse_hook_func(
+        [this](
+            [[maybe_unused]] ArgumentParser::NamedArg * arg, [[maybe_unused]] const char * option, const char * value) {
+            std::string conf_str_value = conf->get_value_string();
+            if (!conf_str_value.empty()) {
+                conf_str_value.append(",");
+            }
+            conf_str_value.append(value);
+            conf->set(libdnf::Option::Priority::COMMANDLINE, conf_str_value);
+            return true;
+        });
 
     command.get_argument_parser_command()->register_named_arg(arg);
 }

--- a/libdnf/advisory/advisory_query.cpp
+++ b/libdnf/advisory/advisory_query.cpp
@@ -187,14 +187,13 @@ void AdvisoryQuery::filter_reference(
     filter_reference_by_type_and_id(get_pool(base), *p_impl, cmp_type, patterns, type);
 }
 
-void AdvisoryQuery::filter_severity(const std::string & pattern, sack::QueryCmp cmp_type) {
-    filter_dataiterator_internal(*get_pool(base), UPDATE_SEVERITY, *p_impl, cmp_type, {pattern});
+void AdvisoryQuery::filter_severity(const std::string & severity, sack::QueryCmp cmp_type) {
+    filter_dataiterator_internal(*get_pool(base), UPDATE_SEVERITY, *p_impl, cmp_type, {severity});
 }
-void AdvisoryQuery::filter_severity(const std::vector<std::string> & patterns, sack::QueryCmp cmp_type) {
-    filter_dataiterator_internal(*get_pool(base), UPDATE_SEVERITY, *p_impl, cmp_type, patterns);
+void AdvisoryQuery::filter_severity(const std::vector<std::string> & severities, sack::QueryCmp cmp_type) {
+    filter_dataiterator_internal(*get_pool(base), UPDATE_SEVERITY, *p_impl, cmp_type, severities);
 }
 
-//TODO(amatej): this might not be needed and could be possibly removed
 void AdvisoryQuery::filter_packages(const libdnf::rpm::PackageSet & package_set, sack::QueryCmp cmp_type) {
     auto & pool = get_pool(base);
     libdnf::solv::SolvMap filter_result(pool.get_nsolvables());

--- a/libdnf/common/sack/match_string.cpp
+++ b/libdnf/common/sack/match_string.cpp
@@ -33,13 +33,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf::sack {
 
 
-inline std::string tolower(const std::string & s) {
-    std::string result = s;
-    std::for_each(result.begin(), result.end(), [](char & c) { c = static_cast<char>(::tolower(c)); });
-    return result;
-}
-
-
 bool match_string(const std::string & value, QueryCmp cmp, const std::string & pattern) {
     bool result = false;
 
@@ -48,7 +41,7 @@ bool match_string(const std::string & value, QueryCmp cmp, const std::string & p
             result = value == pattern;
             break;
         case QueryCmp::IEXACT:
-            result = tolower(value) == tolower(pattern);
+            result = libdnf::utils::string::tolower(value) == libdnf::utils::string::tolower(pattern);
             break;
         case QueryCmp::GLOB:
             result = fnmatch(pattern.c_str(), value.c_str(), FNM_EXTMATCH) == 0;
@@ -66,19 +59,22 @@ bool match_string(const std::string & value, QueryCmp cmp, const std::string & p
             result = value.find(pattern) != std::string::npos;
             break;
         case QueryCmp::ICONTAINS:
-            result = tolower(value).find(tolower(pattern)) != std::string::npos;
+            result = libdnf::utils::string::tolower(value).find(libdnf::utils::string::tolower(pattern)) !=
+                     std::string::npos;
             break;
         case QueryCmp::STARTSWITH:
             result = libdnf::utils::string::starts_with(value, pattern);
             break;
         case QueryCmp::ISTARTSWITH:
-            result = libdnf::utils::string::starts_with(tolower(value), tolower(pattern));
+            result = libdnf::utils::string::starts_with(
+                libdnf::utils::string::tolower(value), libdnf::utils::string::tolower(pattern));
             break;
         case QueryCmp::ENDSWITH:
             result = libdnf::utils::string::ends_with(value, pattern);
             break;
         case QueryCmp::IENDSWITH:
-            result = libdnf::utils::string::ends_with(tolower(value), tolower(pattern));
+            result = libdnf::utils::string::ends_with(
+                libdnf::utils::string::tolower(value), libdnf::utils::string::tolower(pattern));
             break;
         default:
             libdnf_assert(cmp - QueryCmp::NOT - QueryCmp::ICASE, "NOT and ICASE modifiers cannot be used standalone");


### PR DESCRIPTION
This breaks dnf4 compatibility and renames several general options: (OUTDATED)

| dnf4         | dnf5     | 
|--------------|-----------|
|`--advisory=<advisory>, --advisories=<advisory>` | `--advisory-name-filter=ADVISORY_NAME` |
|`--security`, `--bugfix`, `--enhancement` and `--newpackage`  | `--advisory-type-filter=ADVISORY_TYPE` |
|` --sec-severity=<severity>, --secseverity=<severity>` | `--advisory-severity-filter=ADVISORY_SEVERITY` (filter no longer limited to security advisories, but in order to replicate it another option is needed) |
| `--cve=<cves>, --cves=<cves>` | `--advisory-cve-filter=CVE_ID` |
| `--bz=<bugzilla>, --bzs=<bugzilla>` | `--advisory-bz-filter=BUGZILLA_ID`|


These options are shared between: `advisory`, `install`, `upgrade`, `repoquery` commands.

`advisory` command specific options `--with-bz` and `--with-cve` stay the same.