### PR TITLE
[dnf5] dnf5 command architecture

### DIFF
--- a/dnf5-plugins/builddep_plugin/builddep.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "builddep.hpp"
 
-#include "dnf5/context.hpp"
 #include "utils/bgettext/bgettext-mark-domain.h"
 #include "utils/string.hpp"
 
@@ -44,7 +43,7 @@ namespace dnf5 {
 using namespace libdnf::cli;
 
 BuildDepCommand::BuildDepCommand(Command & parent) : Command(parent, "builddep") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -165,7 +164,7 @@ bool BuildDepCommand::add_from_srpm_file(std::set<std::string> & specs, const ch
 
 
 bool BuildDepCommand::add_from_pkg(std::set<std::string> & specs, const std::string & pkg_spec) {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     libdnf::rpm::PackageQuery pkg_query(ctx.base);
     pkg_query.resolve_pkg_spec(
@@ -193,7 +192,7 @@ bool BuildDepCommand::add_from_pkg(std::set<std::string> & specs, const std::str
 }
 
 void BuildDepCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     if (!pkg_specs.empty()) {
         ctx.base.get_repo_sack()->enable_source_repos();

--- a/dnf5-plugins/builddep_plugin/builddep.hpp
+++ b/dnf5-plugins/builddep_plugin/builddep.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_BUILD_DEP_BUILD_DEP_HPP
 
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/base/goal.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
@@ -33,7 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class BuildDepCommand : public libdnf::cli::session::Command {
+class BuildDepCommand : public Command {
 public:
     explicit BuildDepCommand(Command & parent);
     void run() override;

--- a/dnf5-plugins/builddep_plugin/builddep.hpp
+++ b/dnf5-plugins/builddep_plugin/builddep.hpp
@@ -23,10 +23,8 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 
 #include <dnf5/context.hpp>
-#include <libdnf/base/goal.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
-#include <memory>
 #include <vector>
 
 
@@ -35,8 +33,11 @@ namespace dnf5 {
 
 class BuildDepCommand : public Command {
 public:
-    explicit BuildDepCommand(Command & parent);
+    explicit BuildDepCommand(Command & parent) : Command(parent, "builddep") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
+    void goal_resolved() override;
 
 private:
     void parse_builddep_specs(int specs_count, const char * const specs[]);

--- a/dnf5-plugins/builddep_plugin/builddep_cmd_plugin.cpp
+++ b/dnf5-plugins/builddep_plugin/builddep_cmd_plugin.cpp
@@ -33,21 +33,19 @@ public:
         return nullptr;
     }
 
-    void init(dnf5::Context * context) override { this->context = context; }
+    void init(Context * context) override { this->context = context; }
 
-    std::vector<std::unique_ptr<libdnf::cli::session::Command>> create_commands(
-        libdnf::cli::session::Command & parent) override;
+    std::vector<std::unique_ptr<Command>> create_commands(Command & parent) override;
 
     void finish() noexcept override {}
 
 private:
-    dnf5::Context * context;
+    Context * context;
 };
 
 
-std::vector<std::unique_ptr<libdnf::cli::session::Command>> BuildDepCmdPlugin::create_commands(
-    libdnf::cli::session::Command & parent) {
-    std::vector<std::unique_ptr<libdnf::cli::session::Command>> commands;
+std::vector<std::unique_ptr<Command>> BuildDepCmdPlugin::create_commands(Command & parent) {
+    std::vector<std::unique_ptr<Command>> commands;
     commands.push_back(std::make_unique<BuildDepCommand>(parent));
     return commands;
 }

--- a/dnf5-plugins/changelog_plugin/changelog.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog.cpp
@@ -17,27 +17,22 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "changelog.hpp"
 
 #include <libdnf/conf/option_string.hpp>
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
-#include <libdnf/rpm/package_set.hpp>
 
 #include <ctime>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-ChangelogCommand::ChangelogCommand(Command & parent) : Command(parent, "changelog") {
+void ChangelogCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
@@ -103,6 +98,12 @@ ChangelogCommand::ChangelogCommand(Command & parent) : Command(parent, "changelo
     cmd.register_positional_arg(keys);
 }
 
+void ChangelogCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    context.set_available_repos_load_flags(libdnf::repo::Repo::LoadFlags::ALL);
+}
 
 void ChangelogCommand::run() {
     auto & ctx = get_context();
@@ -110,8 +111,6 @@ void ChangelogCommand::run() {
     auto since = since_option->get_value();
     auto count = count_option->get_value();
     auto upgrades = upgrades_option->get_value();
-
-    ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::ALL);
 
     if (since > 0) {
         std::cout << "Listing changelogs since " << std::put_time(std::localtime(&since), "%c") << std::endl;
@@ -219,6 +218,5 @@ void ChangelogCommand::run() {
         }
     }
 }
-
 
 }  // namespace dnf5

--- a/dnf5-plugins/changelog_plugin/changelog.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "changelog.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf/conf/option_string.hpp>
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
@@ -40,7 +38,7 @@ using namespace libdnf::cli;
 
 
 ChangelogCommand::ChangelogCommand(Command & parent) : Command(parent, "changelog") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -107,7 +105,7 @@ ChangelogCommand::ChangelogCommand(Command & parent) : Command(parent, "changelo
 
 
 void ChangelogCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     auto since = since_option->get_value();
     auto count = count_option->get_value();

--- a/dnf5-plugins/changelog_plugin/changelog.hpp
+++ b/dnf5-plugins/changelog_plugin/changelog.hpp
@@ -17,10 +17,8 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_CHANGELOG_HPP
 #define DNF5_COMMANDS_CHANGELOG_HPP
-
 
 #include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
@@ -29,13 +27,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <vector>
 
-
 namespace dnf5 {
-
 
 class ChangelogCommand : public Command {
 public:
-    explicit ChangelogCommand(Command & parent);
+    explicit ChangelogCommand(Command & parent) : Command(parent, "changelog") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
 private:
@@ -45,8 +43,6 @@ private:
     std::vector<std::unique_ptr<libdnf::Option>> * pkgs_spec_to_show_options{nullptr};
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_CHANGELOG_HPP

--- a/dnf5-plugins/changelog_plugin/changelog.hpp
+++ b/dnf5-plugins/changelog_plugin/changelog.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_CHANGELOG_HPP
 
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 #include <libdnf/conf/option_number.hpp>
 
@@ -33,7 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class ChangelogCommand : public libdnf::cli::session::Command {
+class ChangelogCommand : public Command {
 public:
     explicit ChangelogCommand(Command & parent);
     void run() override;

--- a/dnf5-plugins/changelog_plugin/changelog_cmd_plugin.cpp
+++ b/dnf5-plugins/changelog_plugin/changelog_cmd_plugin.cpp
@@ -33,21 +33,19 @@ public:
         return nullptr;
     }
 
-    void init(dnf5::Context * context) override { this->context = context; }
+    void init(Context * context) override { this->context = context; }
 
-    std::vector<std::unique_ptr<libdnf::cli::session::Command>> create_commands(
-        libdnf::cli::session::Command & parent) override;
+    std::vector<std::unique_ptr<Command>> create_commands(Command & parent) override;
 
     void finish() noexcept override {}
 
 private:
-    dnf5::Context * context;
+    Context * context;
 };
 
 
-std::vector<std::unique_ptr<libdnf::cli::session::Command>> ChangelogCmdPlugin::create_commands(
-    libdnf::cli::session::Command & parent) {
-    std::vector<std::unique_ptr<libdnf::cli::session::Command>> commands;
+std::vector<std::unique_ptr<Command>> ChangelogCmdPlugin::create_commands(Command & parent) {
+    std::vector<std::unique_ptr<Command>> commands;
     commands.push_back(std::make_unique<ChangelogCommand>(parent));
     return commands;
 }

--- a/dnf5/commands/advisory/advisory.cpp
+++ b/dnf5/commands/advisory/advisory.cpp
@@ -23,36 +23,23 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "advisory_list.hpp"
 #include "advisory_summary.hpp"
 
-#include <libdnf/conf/option_string.hpp>
-
-
 namespace dnf5 {
 
+void AdvisoryCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Manage advisories");
+}
 
-using namespace libdnf::cli;
-
-AdvisoryCommand::AdvisoryCommand(Command & parent) : AdvisoryCommand(parent, "advisory") {}
-
-AdvisoryCommand::AdvisoryCommand(Command & parent, const std::string & name) : Command(parent, name) {
-    auto & ctx = get_context();
-    auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Manage advisories");
-
-    // query commands
-    auto * query_commands_advisory = parser.add_new_group("advisory_query_commands");
+void AdvisoryCommand::register_subcommands() {
+    auto * query_commands_advisory = get_context().get_argument_parser().add_new_group("advisory_query_commands");
     query_commands_advisory->set_header("Query Commands:");
-    cmd.register_group(query_commands_advisory);
+    get_argument_parser_command()->register_group(query_commands_advisory);
     register_subcommand(std::make_unique<AdvisoryListCommand>(*this), query_commands_advisory);
     register_subcommand(std::make_unique<AdvisoryInfoCommand>(*this), query_commands_advisory);
     register_subcommand(std::make_unique<AdvisorySummaryCommand>(*this), query_commands_advisory);
 }
 
-
-void AdvisoryCommand::run() {
+void AdvisoryCommand::pre_configure() {
     throw_missing_command();
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/advisory/advisory.cpp
+++ b/dnf5/commands/advisory/advisory.cpp
@@ -17,13 +17,11 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "advisory.hpp"
 
 #include "advisory_info.hpp"
 #include "advisory_list.hpp"
 #include "advisory_summary.hpp"
-#include "dnf5/context.hpp"
 
 #include <libdnf/conf/option_string.hpp>
 
@@ -36,7 +34,7 @@ using namespace libdnf::cli;
 AdvisoryCommand::AdvisoryCommand(Command & parent) : AdvisoryCommand(parent, "advisory") {}
 
 AdvisoryCommand::AdvisoryCommand(Command & parent, const std::string & name) : Command(parent, name) {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/advisory/advisory.hpp
+++ b/dnf5/commands/advisory/advisory.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_HPP
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 #include <libdnf/conf/option_enum.hpp>
 
@@ -33,7 +32,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class AdvisoryCommand : public libdnf::cli::session::Command {
+class AdvisoryCommand : public Command {
 public:
     explicit AdvisoryCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/advisory/advisory.hpp
+++ b/dnf5/commands/advisory/advisory.hpp
@@ -17,33 +17,25 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_HPP
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_HPP
 
 #include <dnf5/context.hpp>
-#include <libdnf/conf/option_bool.hpp>
-#include <libdnf/conf/option_enum.hpp>
-
-#include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class AdvisoryCommand : public Command {
 public:
-    explicit AdvisoryCommand(Command & parent);
-    void run() override;
+    explicit AdvisoryCommand(Command & parent) : AdvisoryCommand(parent, "advisory") {}
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
 
 protected:
     // to be used by an alias command only
-    explicit AdvisoryCommand(Command & parent, const std::string & name);
+    explicit AdvisoryCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_ADVISORY_ADVISORY_HPP

--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -17,26 +17,16 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "advisory_info.hpp"
 
 #include <libdnf-cli/output/advisoryinfo.hpp>
 #include <libdnf/rpm/package_query.hpp>
 
-#include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <set>
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
-
-
-AdvisoryInfoCommand::AdvisoryInfoCommand(Command & parent)
-    : AdvisorySubCommand(parent, "info", _("Print details about advisories")) {}
 
 void AdvisoryInfoCommand::process_and_print_queries(
     Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) {

--- a/dnf5/commands/advisory/advisory_info.cpp
+++ b/dnf5/commands/advisory/advisory_info.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "advisory_info.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/advisoryinfo.hpp>
 #include <libdnf/rpm/package_query.hpp>
 

--- a/dnf5/commands/advisory/advisory_info.hpp
+++ b/dnf5/commands/advisory/advisory_info.hpp
@@ -17,33 +17,27 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_INFO_HPP
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_INFO_HPP
 
 #include "advisory_subcommand.hpp"
-#include "arguments.hpp"
-
-#include <dnf5/context.hpp>
-
-#include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class AdvisoryInfoCommand : public AdvisorySubCommand {
 public:
-    explicit AdvisoryInfoCommand(Command & parent);
+    explicit AdvisoryInfoCommand(Command & parent) : AdvisorySubCommand(parent, "info") {}
+
+    void set_argument_parser() override {
+        AdvisorySubCommand::set_argument_parser();
+        get_argument_parser_command()->set_short_description(_("Print details about advisories"));
+    }
 
 protected:
     void process_and_print_queries(
         Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_ADVISORY_ADVISORY_INFO_HPP

--- a/dnf5/commands/advisory/advisory_info.hpp
+++ b/dnf5/commands/advisory/advisory_info.hpp
@@ -24,7 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "advisory_subcommand.hpp"
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 #include <memory>
 #include <vector>

--- a/dnf5/commands/advisory/advisory_list.cpp
+++ b/dnf5/commands/advisory/advisory_list.cpp
@@ -17,27 +17,16 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "advisory_list.hpp"
-
-#include "dnf5/context.hpp"
 
 #include "libdnf-cli/output/advisorylist.hpp"
 
 #include <libdnf/advisory/advisory_package.hpp>
 #include <libdnf/rpm/package_query.hpp>
 
-#include <filesystem>
-#include <fstream>
-
-
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
-
-
-AdvisoryListCommand::AdvisoryListCommand(Command & parent) : AdvisorySubCommand(parent, "list", _("List advisories")) {}
 
 void AdvisoryListCommand::process_and_print_queries(
     Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) {

--- a/dnf5/commands/advisory/advisory_list.hpp
+++ b/dnf5/commands/advisory/advisory_list.hpp
@@ -17,34 +17,27 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_LIST_HPP
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_LIST_HPP
 
-
 #include "advisory_subcommand.hpp"
-#include "arguments.hpp"
-
-#include <libdnf/conf/option_bool.hpp>
-
-#include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class AdvisoryListCommand : public AdvisorySubCommand {
 public:
-    explicit AdvisoryListCommand(Command & parent);
+    explicit AdvisoryListCommand(Command & parent) : AdvisorySubCommand(parent, "list") {}
+
+    void set_argument_parser() override {
+        AdvisorySubCommand::set_argument_parser();
+        get_argument_parser_command()->set_short_description(_("List advisories"));
+    }
 
 protected:
     void process_and_print_queries(
         Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_ADVISORY_ADVISORY_LIST_HPP

--- a/dnf5/commands/advisory/advisory_list.hpp
+++ b/dnf5/commands/advisory/advisory_list.hpp
@@ -25,7 +25,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "advisory_subcommand.hpp"
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -39,7 +39,7 @@ using namespace libdnf::cli;
 AdvisorySubCommand::AdvisorySubCommand(
     Command & parent, const std::string & name, const std::string & short_description)
     : Command(parent, name) {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -76,7 +76,7 @@ void AdvisorySubCommand::add_running_kernel_packages(libdnf::Base & base, libdnf
 }
 
 void AdvisorySubCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::UPDATEINFO);
 

--- a/dnf5/commands/advisory/advisory_subcommand.cpp
+++ b/dnf5/commands/advisory/advisory_subcommand.cpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "advisory_subcommand.hpp"
 
 #include "dnf5/context.hpp"
@@ -25,25 +24,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf-cli/output/advisorysummary.hpp>
 #include <libdnf/rpm/package_query.hpp>
 
-#include <filesystem>
-#include <fstream>
-#include <set>
-
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-AdvisorySubCommand::AdvisorySubCommand(
-    Command & parent, const std::string & name, const std::string & short_description)
-    : Command(parent, name) {
+void AdvisorySubCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description(short_description);
 
     all = std::make_unique<AdvisoryAllOption>(*this);
     available = std::make_unique<AdvisoryAvailableOption>(*this);
@@ -75,10 +62,15 @@ void AdvisorySubCommand::add_running_kernel_packages(libdnf::Base & base, libdnf
     }
 }
 
+void AdvisorySubCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    context.set_available_repos_load_flags(libdnf::repo::Repo::LoadFlags::UPDATEINFO);
+}
+
 void AdvisorySubCommand::run() {
     auto & ctx = get_context();
-
-    ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::UPDATEINFO);
 
     libdnf::rpm::PackageQuery package_query(ctx.base);
     auto package_specs_strs = contains_pkgs->get_value();

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -17,24 +17,22 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_SUBCOMMAND_HPP
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_SUBCOMMAND_HPP
 
 #include "arguments.hpp"
-#include "dnf5/context.hpp"
 
-#include "libdnf/advisory/advisory_query.hpp"
+#include <dnf5/context.hpp>
+#include <libdnf/advisory/advisory_query.hpp>
 
 #include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class AdvisorySubCommand : public Command {
 public:
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
 protected:
@@ -50,11 +48,9 @@ protected:
     std::unique_ptr<AdvisoryContainsPkgsOption> contains_pkgs{nullptr};
     std::unique_ptr<AdvisorySpecArguments> advisory_specs{nullptr};
 
-    AdvisorySubCommand(Command & parent, const std::string & name, const std::string & short_description);
+    AdvisorySubCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_ADVISORY_ADVISORY_SUBCOMMAND_HPP

--- a/dnf5/commands/advisory/advisory_subcommand.hpp
+++ b/dnf5/commands/advisory/advisory_subcommand.hpp
@@ -26,8 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/advisory/advisory_query.hpp"
 
-#include <libdnf-cli/session.hpp>
-
 #include <memory>
 #include <vector>
 
@@ -35,7 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class AdvisorySubCommand : public libdnf::cli::session::Command {
+class AdvisorySubCommand : public Command {
 public:
     void run() override;
 

--- a/dnf5/commands/advisory/advisory_summary.cpp
+++ b/dnf5/commands/advisory/advisory_summary.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "advisory_summary.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/advisorysummary.hpp>
 #include <libdnf/rpm/package_query.hpp>
 

--- a/dnf5/commands/advisory/advisory_summary.cpp
+++ b/dnf5/commands/advisory/advisory_summary.cpp
@@ -17,25 +17,14 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "advisory_summary.hpp"
 
 #include <libdnf-cli/output/advisorysummary.hpp>
 #include <libdnf/rpm/package_query.hpp>
 
-#include <filesystem>
-#include <fstream>
-#include <set>
-
-
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
-
-
-AdvisorySummaryCommand::AdvisorySummaryCommand(Command & parent)
-    : AdvisorySubCommand(parent, "summary", _("Print summary of advisories")) {}
 
 void AdvisorySummaryCommand::process_and_print_queries(
     Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) {

--- a/dnf5/commands/advisory/advisory_summary.hpp
+++ b/dnf5/commands/advisory/advisory_summary.hpp
@@ -17,33 +17,27 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_ADVISORY_ADVISORY_SUMMARY_HPP
 #define DNF5_COMMANDS_ADVISORY_ADVISORY_SUMMARY_HPP
 
 #include "advisory_subcommand.hpp"
-#include "dnf5/context.hpp"
-
-#include "libdnf/advisory/advisory_query.hpp"
-
-#include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class AdvisorySummaryCommand : public AdvisorySubCommand {
 public:
-    explicit AdvisorySummaryCommand(Command & parent);
+    explicit AdvisorySummaryCommand(Command & parent) : AdvisorySubCommand(parent, "summary") {}
+
+    void set_argument_parser() override {
+        AdvisorySubCommand::set_argument_parser();
+        get_argument_parser_command()->set_short_description(_("Print summary of advisories"));
+    }
 
 protected:
     void process_and_print_queries(
         Context & ctx, libdnf::advisory::AdvisoryQuery & advisories, libdnf::rpm::PackageQuery & packages) override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_ADVISORY_ADVISORY_SUMMARY_HPP

--- a/dnf5/commands/advisory/advisory_summary.hpp
+++ b/dnf5/commands/advisory/advisory_summary.hpp
@@ -26,8 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/advisory/advisory_query.hpp"
 
-#include <libdnf-cli/session.hpp>
-
 #include <memory>
 #include <vector>
 

--- a/dnf5/commands/advisory/arguments.hpp
+++ b/dnf5/commands/advisory/arguments.hpp
@@ -26,7 +26,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf-cli/session.hpp>
 
-
 namespace dnf5 {
 
 

--- a/dnf5/commands/aliases/autoremove.hpp
+++ b/dnf5/commands/aliases/autoremove.hpp
@@ -30,7 +30,11 @@ namespace dnf5 {
 
 class AutoremoveAlias : public RemoveCommand {
 public:
-    explicit AutoremoveAlias(Command & parent) : RemoveCommand(parent, "autoremove") {
+    explicit AutoremoveAlias(Command & parent) : RemoveCommand(parent, "autoremove") {}
+
+    void set_argument_parser() override {
+        RemoveCommand::set_argument_parser();
+
         auto & cmd = *get_argument_parser_command();
         cmd.set_short_description("Alias for 'remove --unneeded'");
 

--- a/dnf5/commands/aliases/upgrade_minimal.hpp
+++ b/dnf5/commands/aliases/upgrade_minimal.hpp
@@ -30,12 +30,12 @@ namespace dnf5 {
 
 class UpgradeMinimalAlias : public UpgradeCommand {
 public:
-    explicit UpgradeMinimalAlias(Command & parent) : UpgradeCommand(parent, "upgrade-minimal") {
-        auto & cmd = *get_argument_parser_command();
-        cmd.set_short_description("Alias for 'upgrade --minimal'");
+    explicit UpgradeMinimalAlias(Command & parent) : UpgradeCommand(parent, "upgrade-minimal") {}
+    void set_argument_parser() override {
+        UpgradeCommand::set_argument_parser();
+        get_argument_parser_command()->set_short_description("Alias for 'upgrade --minimal'");
 
         // set the default value of the --minimal option to `true`
-        auto minimal = dynamic_cast<libdnf::OptionBool *>(this->minimal);
         minimal->set(libdnf::Option::Priority::DEFAULT, true);
     }
 };

--- a/dnf5/commands/clean/clean.cpp
+++ b/dnf5/commands/clean/clean.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "clean.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf/repo/repo_cache.hpp>
 
 #include <filesystem>
@@ -58,7 +56,7 @@ using namespace libdnf::cli;
 
 
 CleanCommand::CleanCommand(Command & parent) : Command(parent, "clean") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -111,7 +109,7 @@ CleanCommand::CleanCommand(Command & parent) : Command(parent, "clean") {
 
 
 void CleanCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     fs::path cachedir{ctx.base.get_config().cachedir().get_value()};
 
     libdnf::repo::RepoCache::RemoveStatistics statistics{};

--- a/dnf5/commands/clean/clean.hpp
+++ b/dnf5/commands/clean/clean.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_CLEAN_CLEAN_HPP
 #define DNF5_COMMANDS_CLEAN_CLEAN_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 #include <memory>
 
@@ -30,7 +29,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class CleanCommand : public libdnf::cli::session::Command {
+class CleanCommand : public Command {
 public:
     explicit CleanCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/distro-sync/distro-sync.cpp
+++ b/dnf5/commands/distro-sync/distro-sync.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "distro-sync.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/output/transaction_table.hpp"
 
 #include <libdnf/base/goal.hpp>
@@ -41,7 +39,7 @@ using namespace libdnf::cli;
 DistroSyncCommand::DistroSyncCommand(Command & parent) : DistroSyncCommand(parent, "distro-sync") {}
 
 DistroSyncCommand::DistroSyncCommand(Command & parent, const std::string & name) : Command(parent, name) {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -59,7 +57,7 @@ DistroSyncCommand::DistroSyncCommand(Command & parent, const std::string & name)
 
 
 void DistroSyncCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true);
 

--- a/dnf5/commands/distro-sync/distro-sync.hpp
+++ b/dnf5/commands/distro-sync/distro-sync.hpp
@@ -33,13 +33,15 @@ namespace dnf5 {
 
 class DistroSyncCommand : public Command {
 public:
-    explicit DistroSyncCommand(Command & parent);
+    explicit DistroSyncCommand(Command & parent) : DistroSyncCommand(parent, "distro-sync") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_distro_sync_options{nullptr};
 
 protected:
-    explicit DistroSyncCommand(Command & parent, const std::string & name);
+    explicit DistroSyncCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
 
 

--- a/dnf5/commands/distro-sync/distro-sync.hpp
+++ b/dnf5/commands/distro-sync/distro-sync.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_DISTRO_SYNC_DISTRO_SYNC_HPP
 #define DNF5_COMMANDS_DISTRO_SYNC_DISTRO_SYNC_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -32,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class DistroSyncCommand : public libdnf::cli::session::Command {
+class DistroSyncCommand : public Command {
 public:
     explicit DistroSyncCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -17,31 +17,13 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "downgrade.hpp"
-
-#include "libdnf-cli/output/transaction_table.hpp"
-
-#include <libdnf/base/goal.hpp>
-#include <libdnf/conf/option_string.hpp>
-#include <libdnf/rpm/package.hpp>
-#include <libdnf/rpm/package_query.hpp>
-#include <libdnf/rpm/package_set.hpp>
-
-#include <filesystem>
-#include <iostream>
-
-
-namespace fs = std::filesystem;
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-DowngradeCommand::DowngradeCommand(Command & parent) : Command(parent, "downgrade") {
+void DowngradeCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
@@ -60,43 +42,24 @@ DowngradeCommand::DowngradeCommand(Command & parent) : Command(parent, "downgrad
     cmd.register_positional_arg(keys);
 }
 
-
-void DowngradeCommand::run() {
-    auto & ctx = get_context();
-
-    ctx.load_repos(true);
-
-    std::vector<std::string> error_messages;
-    const auto cmdline_packages = ctx.add_cmdline_packages(pkg_file_paths, error_messages);
-    for (const auto & msg : error_messages) {
-        std::cout << msg << std::endl;
-    }
-
-    std::cout << std::endl;
-
-    libdnf::Goal goal(ctx.base);
-    for (const auto & pkg : cmdline_packages) {
-        goal.add_rpm_downgrade(pkg);
-    }
-    for (const auto & spec : pkg_specs) {
-        goal.add_rpm_downgrade(spec);
-    }
-
-    auto transaction = goal.resolve(false);
-    if (transaction.get_problems() != libdnf::GoalProblem::NO_PROBLEM) {
-        throw GoalResolveError(transaction);
-    }
-
-    if (!libdnf::cli::output::print_transaction_table(transaction)) {
-        return;
-    }
-
-    if (!userconfirm(ctx.base.get_config())) {
-        throw AbortedByUserError();
-    }
-
-    ctx.download_and_run(transaction);
+void DowngradeCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 
+void DowngradeCommand::load_additional_packages() {
+    cmdline_packages = get_context().add_cmdline_packages(pkg_file_paths);
+}
+
+void DowngradeCommand::run() {
+    auto goal = get_context().get_goal();
+    for (const auto & pkg : cmdline_packages) {
+        goal->add_rpm_downgrade(pkg);
+    }
+    for (const auto & spec : pkg_specs) {
+        goal->add_rpm_downgrade(spec);
+    }
+}
 
 }  // namespace dnf5

--- a/dnf5/commands/downgrade/downgrade.cpp
+++ b/dnf5/commands/downgrade/downgrade.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "downgrade.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/output/transaction_table.hpp"
 
 #include <libdnf/base/goal.hpp>
@@ -44,7 +42,7 @@ using namespace libdnf::cli;
 
 
 DowngradeCommand::DowngradeCommand(Command & parent) : Command(parent, "downgrade") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -64,7 +62,7 @@ DowngradeCommand::DowngradeCommand(Command & parent) : Command(parent, "downgrad
 
 
 void DowngradeCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true);
 

--- a/dnf5/commands/downgrade/downgrade.hpp
+++ b/dnf5/commands/downgrade/downgrade.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_DOWNGRADE_DOWNGRADE_HPP
 #define DNF5_COMMANDS_DOWNGRADE_DOWNGRADE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 #include <memory>
 #include <vector>
@@ -31,7 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class DowngradeCommand : public libdnf::cli::session::Command {
+class DowngradeCommand : public Command {
 public:
     explicit DowngradeCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/downgrade/downgrade.hpp
+++ b/dnf5/commands/downgrade/downgrade.hpp
@@ -32,12 +32,16 @@ namespace dnf5 {
 
 class DowngradeCommand : public Command {
 public:
-    explicit DowngradeCommand(Command & parent);
+    explicit DowngradeCommand(Command & parent) : Command(parent, "downgrade") {}
+    void set_argument_parser() override;
+    void configure() override;
+    void load_additional_packages() override;
     void run() override;
 
 private:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
+    std::vector<libdnf::rpm::Package> cmdline_packages;
 };
 
 

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "download.hpp"
 
 #include <libdnf/conf/option_string.hpp>
@@ -25,20 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/rpm/package_query.hpp>
 #include <libdnf/rpm/package_set.hpp>
 
-#include <filesystem>
-#include <iostream>
-
-
-namespace fs = std::filesystem;
-
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-DownloadCommand::DownloadCommand(Command & parent) : Command(parent, "download") {
+void DownloadCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
@@ -56,14 +46,14 @@ DownloadCommand::DownloadCommand(Command & parent) : Command(parent, "download")
     cmd.register_positional_arg(keys);
 }
 
+void DownloadCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(false);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+}
 
 void DownloadCommand::run() {
     auto & ctx = get_context();
-    auto package_sack = ctx.base.get_rpm_package_sack();
-
-    ctx.load_repos(false);
-
-    std::cout << std::endl;
 
     libdnf::rpm::PackageSet result_pset(ctx.base);
     libdnf::rpm::PackageQuery full_package_query(ctx.base);
@@ -81,6 +71,5 @@ void DownloadCommand::run() {
     }
     download_packages(download_pkgs, ".");
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/download/download.cpp
+++ b/dnf5/commands/download/download.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "download.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf/conf/option_string.hpp>
 #include <libdnf/rpm/package.hpp>
 #include <libdnf/rpm/package_query.hpp>
@@ -41,7 +39,7 @@ using namespace libdnf::cli;
 
 
 DownloadCommand::DownloadCommand(Command & parent) : Command(parent, "download") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -60,7 +58,7 @@ DownloadCommand::DownloadCommand(Command & parent) : Command(parent, "download")
 
 
 void DownloadCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto package_sack = ctx.base.get_rpm_package_sack();
 
     ctx.load_repos(false);

--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define DNF5_COMMANDS_DOWNLOAD_DOWNLOAD_HPP
 
 #include <dnf5/context.hpp>
-#include <libdnf/conf/option_bool.hpp>
+#include <libdnf/conf/option.hpp>
 
 #include <memory>
 #include <vector>
@@ -33,7 +33,9 @@ namespace dnf5 {
 
 class DownloadCommand : public Command {
 public:
-    explicit DownloadCommand(Command & parent);
+    explicit DownloadCommand(Command & parent) : Command(parent, "download") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
 private:

--- a/dnf5/commands/download/download.hpp
+++ b/dnf5/commands/download/download.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_DOWNLOAD_DOWNLOAD_HPP
 #define DNF5_COMMANDS_DOWNLOAD_DOWNLOAD_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -32,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class DownloadCommand : public libdnf::cli::session::Command {
+class DownloadCommand : public Command {
 public:
     explicit DownloadCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/environment/arguments.hpp
+++ b/dnf5/commands/environment/arguments.hpp
@@ -25,7 +25,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <libdnf-cli/session.hpp>
 
-
 namespace dnf5 {
 
 

--- a/dnf5/commands/environment/environment.cpp
+++ b/dnf5/commands/environment/environment.cpp
@@ -19,7 +19,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "environment.hpp"
 
-#include "dnf5/context.hpp"
 #include "environment_info.hpp"
 #include "environment_list.hpp"
 
@@ -31,7 +30,7 @@ using namespace libdnf::cli;
 
 
 EnvironmentCommand::EnvironmentCommand(Command & parent) : Command(parent, "environment") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/environment/environment.cpp
+++ b/dnf5/commands/environment/environment.cpp
@@ -22,32 +22,22 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "environment_info.hpp"
 #include "environment_list.hpp"
 
-
 namespace dnf5 {
 
+void EnvironmentCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Manage comps environments");
+}
 
-using namespace libdnf::cli;
-
-
-EnvironmentCommand::EnvironmentCommand(Command & parent) : Command(parent, "environment") {
-    auto & ctx = get_context();
-    auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Manage comps environments");
-
-    // query commands
-    auto * query_commands_environment = parser.add_new_group("environment_query_commands");
+void EnvironmentCommand::register_subcommands() {
+    auto * query_commands_environment = get_context().get_argument_parser().add_new_group("environment_query_commands");
     query_commands_environment->set_header("Query Commands:");
-    cmd.register_group(query_commands_environment);
+    get_argument_parser_command()->register_group(query_commands_environment);
     register_subcommand(std::make_unique<EnvironmentListCommand>(*this), query_commands_environment);
     register_subcommand(std::make_unique<EnvironmentInfoCommand>(*this), query_commands_environment);
 }
 
-
-void EnvironmentCommand::run() {
+void EnvironmentCommand::pre_configure() {
     throw_missing_command();
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/environment/environment.hpp
+++ b/dnf5/commands/environment/environment.hpp
@@ -20,14 +20,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_ENVIRONMENT_ENVIRONMENT_HPP
 #define DNF5_COMMANDS_ENVIRONMENT_ENVIRONMENT_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class EnvironmentCommand : public libdnf::cli::session::Command {
+class EnvironmentCommand : public Command {
 public:
     explicit EnvironmentCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/environment/environment.hpp
+++ b/dnf5/commands/environment/environment.hpp
@@ -22,18 +22,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class EnvironmentCommand : public Command {
 public:
-    explicit EnvironmentCommand(Command & parent);
-    void run() override;
+    explicit EnvironmentCommand(Command & parent) : Command(parent, "environment") {}
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_ENVIRONMENT_ENVIRONMENT_HPP

--- a/dnf5/commands/environment/environment_info.cpp
+++ b/dnf5/commands/environment/environment_info.cpp
@@ -19,8 +19,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "environment_info.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/environmentinfo.hpp>
 #include <libdnf/comps/comps.hpp>
 #include <libdnf/comps/environment/environment.hpp>
@@ -53,7 +51,7 @@ EnvironmentInfoCommand::EnvironmentInfoCommand(Command & parent, const std::stri
 
 
 void EnvironmentInfoCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::COMPS);
 

--- a/dnf5/commands/environment/environment_info.cpp
+++ b/dnf5/commands/environment/environment_info.cpp
@@ -23,23 +23,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/comps/comps.hpp>
 #include <libdnf/comps/environment/environment.hpp>
 #include <libdnf/comps/environment/query.hpp>
-#include <libdnf/conf/option_string.hpp>
-
-#include <filesystem>
-#include <fstream>
-#include <set>
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-EnvironmentInfoCommand::EnvironmentInfoCommand(Command & parent) : EnvironmentInfoCommand(parent, "info") {}
-
-
-EnvironmentInfoCommand::EnvironmentInfoCommand(Command & parent, const std::string & name) : Command(parent, name) {
+void EnvironmentInfoCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Print details about comps environments");
 
@@ -49,11 +38,15 @@ EnvironmentInfoCommand::EnvironmentInfoCommand(Command & parent, const std::stri
     environment_specs = std::make_unique<EnvironmentSpecArguments>(*this);
 }
 
+void EnvironmentInfoCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    context.set_available_repos_load_flags(libdnf::repo::Repo::LoadFlags::COMPS);
+}
 
 void EnvironmentInfoCommand::run() {
     auto & ctx = get_context();
-
-    ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::COMPS);
 
     libdnf::comps::EnvironmentQuery query(ctx.base);
     auto environment_specs_str = environment_specs->get_value();
@@ -77,6 +70,5 @@ void EnvironmentInfoCommand::run() {
         std::cout << '\n';
     }
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/environment/environment_info.hpp
+++ b/dnf5/commands/environment/environment_info.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 #include <memory>
 #include <vector>
@@ -31,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class EnvironmentInfoCommand : public libdnf::cli::session::Command {
+class EnvironmentInfoCommand : public Command {
 public:
     explicit EnvironmentInfoCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/environment/environment_info.hpp
+++ b/dnf5/commands/environment/environment_info.hpp
@@ -25,15 +25,14 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <dnf5/context.hpp>
 
 #include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class EnvironmentInfoCommand : public Command {
 public:
-    explicit EnvironmentInfoCommand(Command & parent);
+    explicit EnvironmentInfoCommand(Command & parent) : EnvironmentInfoCommand(parent, "info") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
     std::unique_ptr<EnvironmentAvailableOption> available{nullptr};
@@ -42,11 +41,9 @@ public:
 
 protected:
     // to be used by an alias command only
-    explicit EnvironmentInfoCommand(Command & parent, const std::string & name);
+    explicit EnvironmentInfoCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_ENVIRONMENT_ENVIRONMENT_INFO_HPP

--- a/dnf5/commands/environment/environment_list.cpp
+++ b/dnf5/commands/environment/environment_list.cpp
@@ -24,21 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/comps/environment/environment.hpp>
 #include <libdnf/comps/environment/query.hpp>
 
-#include <filesystem>
-#include <fstream>
-#include <set>
-
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-EnvironmentListCommand::EnvironmentListCommand(Command & parent) : EnvironmentListCommand(parent, "list") {}
-
-
-EnvironmentListCommand::EnvironmentListCommand(Command & parent, const std::string & name) : Command(parent, name) {
+void EnvironmentListCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("List comps environments");
 
@@ -48,11 +38,15 @@ EnvironmentListCommand::EnvironmentListCommand(Command & parent, const std::stri
     environment_specs = std::make_unique<EnvironmentSpecArguments>(*this);
 }
 
+void EnvironmentListCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    context.set_available_repos_load_flags(libdnf::repo::Repo::LoadFlags::COMPS);
+}
 
 void EnvironmentListCommand::run() {
     auto & ctx = get_context();
-
-    ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::COMPS);
 
     libdnf::comps::EnvironmentQuery query(ctx.base);
     auto environment_specs_str = environment_specs->get_value();
@@ -73,6 +67,5 @@ void EnvironmentListCommand::run() {
 
     libdnf::cli::output::print_environmentlist_table(query.list());
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/environment/environment_list.cpp
+++ b/dnf5/commands/environment/environment_list.cpp
@@ -19,8 +19,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "environment_list.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/environmentlist.hpp>
 #include <libdnf/comps/comps.hpp>
 #include <libdnf/comps/environment/environment.hpp>
@@ -52,7 +50,7 @@ EnvironmentListCommand::EnvironmentListCommand(Command & parent, const std::stri
 
 
 void EnvironmentListCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::COMPS);
 

--- a/dnf5/commands/environment/environment_list.hpp
+++ b/dnf5/commands/environment/environment_list.hpp
@@ -20,22 +20,19 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_ENVIRONMENT_ENVIRONMENT_LIST_HPP
 #define DNF5_COMMANDS_ENVIRONMENT_ENVIRONMENT_LIST_HPP
 
-
 #include "arguments.hpp"
 
 #include <dnf5/context.hpp>
-#include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class EnvironmentListCommand : public Command {
 public:
-    explicit EnvironmentListCommand(Command & parent);
+    explicit EnvironmentListCommand(Command & parent) : EnvironmentListCommand(parent, "list") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
     std::unique_ptr<EnvironmentAvailableOption> available{nullptr};
@@ -44,11 +41,9 @@ public:
 
 protected:
     // to be used by an alias command only
-    explicit EnvironmentListCommand(Command & parent, const std::string & name);
+    explicit EnvironmentListCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_ENVIRONMENT_ENVIRONMENT_LIST_HPP

--- a/dnf5/commands/environment/environment_list.hpp
+++ b/dnf5/commands/environment/environment_list.hpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -33,7 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class EnvironmentListCommand : public libdnf::cli::session::Command {
+class EnvironmentListCommand : public Command {
 public:
     explicit EnvironmentListCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/group/group.cpp
+++ b/dnf5/commands/group/group.cpp
@@ -22,30 +22,22 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "group_info.hpp"
 #include "group_list.hpp"
 
-
 namespace dnf5 {
 
+void GroupCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Manage comps groups");
+}
 
-using namespace libdnf::cli;
-
-
-GroupCommand::GroupCommand(Command & parent) : Command(parent, "group") {
-    auto & ctx = get_context();
-    auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Manage comps groups");
-
+void GroupCommand::register_subcommands() {
     // query commands
-    auto * query_commands_group = parser.add_new_group("group_query_commands");
+    auto * query_commands_group = get_context().get_argument_parser().add_new_group("group_query_commands");
     query_commands_group->set_header("Query Commands:");
-    cmd.register_group(query_commands_group);
+    get_argument_parser_command()->register_group(query_commands_group);
     register_subcommand(std::make_unique<GroupListCommand>(*this), query_commands_group);
     register_subcommand(std::make_unique<GroupInfoCommand>(*this), query_commands_group);
 }
 
-
-void GroupCommand::run() {
+void GroupCommand::pre_configure() {
     throw_missing_command();
 }
 

--- a/dnf5/commands/group/group.cpp
+++ b/dnf5/commands/group/group.cpp
@@ -19,7 +19,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "group.hpp"
 
-#include "dnf5/context.hpp"
 #include "group_info.hpp"
 #include "group_list.hpp"
 
@@ -31,7 +30,7 @@ using namespace libdnf::cli;
 
 
 GroupCommand::GroupCommand(Command & parent) : Command(parent, "group") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/group/group.hpp
+++ b/dnf5/commands/group/group.hpp
@@ -22,18 +22,16 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class GroupCommand : public Command {
 public:
-    explicit GroupCommand(Command & parent);
-    void run() override;
+    explicit GroupCommand(Command & parent) : Command(parent, "group") {}
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_GROUP_GROUP_HPP

--- a/dnf5/commands/group/group.hpp
+++ b/dnf5/commands/group/group.hpp
@@ -20,14 +20,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_GROUP_GROUP_HPP
 #define DNF5_COMMANDS_GROUP_GROUP_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class GroupCommand : public libdnf::cli::session::Command {
+class GroupCommand : public Command {
 public:
     explicit GroupCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/group/group_info.cpp
+++ b/dnf5/commands/group/group_info.cpp
@@ -23,23 +23,12 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/comps/comps.hpp>
 #include <libdnf/comps/group/group.hpp>
 #include <libdnf/comps/group/query.hpp>
-#include <libdnf/conf/option_string.hpp>
-
-#include <filesystem>
-#include <fstream>
-#include <set>
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-GroupInfoCommand::GroupInfoCommand(Command & parent) : GroupInfoCommand(parent, "info") {}
-
-
-GroupInfoCommand::GroupInfoCommand(Command & parent, const std::string & name) : Command(parent, name) {
+void GroupInfoCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Print details about comps groups");
 
@@ -50,11 +39,15 @@ GroupInfoCommand::GroupInfoCommand(Command & parent, const std::string & name) :
     group_specs = std::make_unique<GroupSpecArguments>(*this);
 }
 
+void GroupInfoCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    context.set_available_repos_load_flags(libdnf::repo::Repo::LoadFlags::COMPS);
+}
 
 void GroupInfoCommand::run() {
     auto & ctx = get_context();
-
-    ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::COMPS);
 
     libdnf::comps::GroupQuery query(ctx.base);
     auto group_specs_str = group_specs->get_value();
@@ -81,6 +74,5 @@ void GroupInfoCommand::run() {
         std::cout << '\n';
     }
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/group/group_info.cpp
+++ b/dnf5/commands/group/group_info.cpp
@@ -19,8 +19,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "group_info.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/groupinfo.hpp>
 #include <libdnf/comps/comps.hpp>
 #include <libdnf/comps/group/group.hpp>
@@ -54,7 +52,7 @@ GroupInfoCommand::GroupInfoCommand(Command & parent, const std::string & name) :
 
 
 void GroupInfoCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::COMPS);
 

--- a/dnf5/commands/group/group_info.hpp
+++ b/dnf5/commands/group/group_info.hpp
@@ -22,7 +22,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 #include <memory>
 #include <vector>
@@ -31,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class GroupInfoCommand : public libdnf::cli::session::Command {
+class GroupInfoCommand : public Command {
 public:
     explicit GroupInfoCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/group/group_info.hpp
+++ b/dnf5/commands/group/group_info.hpp
@@ -33,7 +33,9 @@ namespace dnf5 {
 
 class GroupInfoCommand : public Command {
 public:
-    explicit GroupInfoCommand(Command & parent);
+    explicit GroupInfoCommand(Command & parent) : GroupInfoCommand(parent, "info") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
     std::unique_ptr<GroupAvailableOption> available{nullptr};
@@ -43,7 +45,7 @@ public:
 
 protected:
     // to be used by an alias command only
-    explicit GroupInfoCommand(Command & parent, const std::string & name);
+    explicit GroupInfoCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
 
 

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -24,21 +24,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <libdnf/comps/group/group.hpp>
 #include <libdnf/comps/group/query.hpp>
 
-#include <filesystem>
-#include <fstream>
-#include <set>
-
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-GroupListCommand::GroupListCommand(Command & parent) : GroupListCommand(parent, "list") {}
-
-
-GroupListCommand::GroupListCommand(Command & parent, const std::string & name) : Command(parent, name) {
+void GroupListCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("List comps groups");
 
@@ -49,11 +39,15 @@ GroupListCommand::GroupListCommand(Command & parent, const std::string & name) :
     group_specs = std::make_unique<GroupSpecArguments>(*this);
 }
 
+void GroupListCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
+    context.set_available_repos_load_flags(libdnf::repo::Repo::LoadFlags::COMPS);
+}
 
 void GroupListCommand::run() {
     auto & ctx = get_context();
-
-    ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::COMPS);
 
     libdnf::comps::GroupQuery query(ctx.base);
     auto group_specs_str = group_specs->get_value();
@@ -77,6 +71,5 @@ void GroupListCommand::run() {
 
     libdnf::cli::output::print_grouplist_table(query.list());
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/group/group_list.cpp
+++ b/dnf5/commands/group/group_list.cpp
@@ -19,8 +19,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "group_list.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/grouplist.hpp>
 #include <libdnf/comps/comps.hpp>
 #include <libdnf/comps/group/group.hpp>
@@ -53,7 +51,7 @@ GroupListCommand::GroupListCommand(Command & parent, const std::string & name) :
 
 
 void GroupListCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true, libdnf::repo::Repo::LoadFlags::COMPS);
 

--- a/dnf5/commands/group/group_list.hpp
+++ b/dnf5/commands/group/group_list.hpp
@@ -35,7 +35,9 @@ namespace dnf5 {
 
 class GroupListCommand : public Command {
 public:
-    explicit GroupListCommand(Command & parent);
+    explicit GroupListCommand(Command & parent) : GroupListCommand(parent, "list") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
     std::unique_ptr<GroupAvailableOption> available{nullptr};
@@ -45,7 +47,7 @@ public:
 
 protected:
     // to be used by an alias command only
-    explicit GroupListCommand(Command & parent, const std::string & name);
+    explicit GroupListCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
 
 

--- a/dnf5/commands/group/group_list.hpp
+++ b/dnf5/commands/group/group_list.hpp
@@ -23,7 +23,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -33,7 +33,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class GroupListCommand : public libdnf::cli::session::Command {
+class GroupListCommand : public Command {
 public:
     explicit GroupListCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history.cpp
+++ b/dnf5/commands/history/history.cpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "history.hpp"
 
 #include "history_info.hpp"
@@ -28,25 +27,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "history_store.hpp"
 #include "history_undo.hpp"
 
-//#include <libdnf/conf/option_string.hpp>
-//#include <libdnf/rpm/package_query.hpp>
-
-//TODO(amatej): just for test output -> remove
-//#include <iostream>
-
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
+void HistoryCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Manage transaction history");
+}
 
-HistoryCommand::HistoryCommand(Command & parent) : Command(parent, "history") {
-    auto & ctx = get_context();
-    auto & parser = ctx.get_argument_parser();
-
+void HistoryCommand::register_subcommands() {
+    auto & parser = get_context().get_argument_parser();
     auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Manage transaction history");
 
     // query commands
     auto * query_commands_group = parser.add_new_group("history_query_commands");
@@ -66,10 +57,8 @@ HistoryCommand::HistoryCommand(Command & parent) : Command(parent, "history") {
     register_subcommand(std::make_unique<HistoryReplayCommand>(*this), software_management_commands_group);
 }
 
-
-void HistoryCommand::run() {
+void HistoryCommand::pre_configure() {
     throw_missing_command();
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history.cpp
+++ b/dnf5/commands/history/history.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history.hpp"
 
-#include "dnf5/context.hpp"
 #include "history_info.hpp"
 #include "history_list.hpp"
 #include "history_redo.hpp"
@@ -43,7 +42,7 @@ using namespace libdnf::cli;
 
 
 HistoryCommand::HistoryCommand(Command & parent) : Command(parent, "history") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/history/history.hpp
+++ b/dnf5/commands/history/history.hpp
@@ -17,24 +17,21 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class HistoryCommand : public Command {
 public:
-    explicit HistoryCommand(Command & parent);
-    void run() override;
+    explicit HistoryCommand(Command & parent) : Command(parent, "history") {}
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_HISTORY_HISTORY_HPP

--- a/dnf5/commands/history/history.hpp
+++ b/dnf5/commands/history/history.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class HistoryCommand : public libdnf::cli::session::Command {
+class HistoryCommand : public Command {
 public:
     explicit HistoryCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history_info.cpp
+++ b/dnf5/commands/history/history_info.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_info.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/transactioninfo.hpp>
 
 #include <iostream>
@@ -42,7 +40,7 @@ HistoryInfoCommand::HistoryInfoCommand(Command & parent) : Command(parent, "info
 
 
 void HistoryInfoCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     auto specs_str = transaction_specs->get_value();
 

--- a/dnf5/commands/history/history_info.cpp
+++ b/dnf5/commands/history/history_info.cpp
@@ -17,27 +17,21 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "history_info.hpp"
 
 #include <libdnf-cli/output/transactioninfo.hpp>
 
 #include <iostream>
 
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-HistoryInfoCommand::HistoryInfoCommand(Command & parent) : Command(parent, "info") {
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Print details about transactions");
+void HistoryInfoCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Print details about transactions");
 
     transaction_specs = std::make_unique<TransactionSpecArguments>(*this);
 }
-
 
 void HistoryInfoCommand::run() {
     auto & ctx = get_context();
@@ -59,6 +53,5 @@ void HistoryInfoCommand::run() {
         std::cout << std::endl;
     }
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_info.hpp
+++ b/dnf5/commands/history/history_info.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_INFO_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_INFO_HPP
 
@@ -25,20 +24,17 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class HistoryInfoCommand : public Command {
 public:
-    explicit HistoryInfoCommand(Command & parent);
+    explicit HistoryInfoCommand(Command & parent) : Command(parent, "info") {}
+    void set_argument_parser() override;
     void run() override;
 
     std::unique_ptr<TransactionSpecArguments> transaction_specs{nullptr};
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_HISTORY_HISTORY_INFO_HPP

--- a/dnf5/commands/history/history_info.hpp
+++ b/dnf5/commands/history/history_info.hpp
@@ -23,13 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class HistoryInfoCommand : public libdnf::cli::session::Command {
+class HistoryInfoCommand : public Command {
 public:
     explicit HistoryInfoCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history_list.cpp
+++ b/dnf5/commands/history/history_list.cpp
@@ -17,27 +17,21 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "history_list.hpp"
 
 #include <libdnf-cli/output/transactionlist.hpp>
 
 #include <iostream>
 
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-HistoryListCommand::HistoryListCommand(Command & parent) : Command(parent, "list") {
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("List transactions");
+void HistoryListCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("List transactions");
 
     transaction_specs = std::make_unique<TransactionSpecArguments>(*this);
 }
-
 
 void HistoryListCommand::run() {
     auto & ctx = get_context();
@@ -56,6 +50,5 @@ void HistoryListCommand::run() {
 
     libdnf::cli::output::print_transaction_list(ts_list);
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_list.cpp
+++ b/dnf5/commands/history/history_list.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_list.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/transactionlist.hpp>
 
 #include <iostream>
@@ -42,7 +40,7 @@ HistoryListCommand::HistoryListCommand(Command & parent) : Command(parent, "list
 
 
 void HistoryListCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     auto specs_str = transaction_specs->get_value();
 

--- a/dnf5/commands/history/history_list.hpp
+++ b/dnf5/commands/history/history_list.hpp
@@ -23,13 +23,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class HistoryListCommand : public libdnf::cli::session::Command {
+class HistoryListCommand : public Command {
 public:
     explicit HistoryListCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history_list.hpp
+++ b/dnf5/commands/history/history_list.hpp
@@ -31,7 +31,8 @@ namespace dnf5 {
 
 class HistoryListCommand : public Command {
 public:
-    explicit HistoryListCommand(Command & parent);
+    explicit HistoryListCommand(Command & parent) : Command(parent, "list") {}
+    void set_argument_parser() override;
     void run() override;
 
     std::unique_ptr<TransactionSpecArguments> transaction_specs{nullptr};

--- a/dnf5/commands/history/history_redo.cpp
+++ b/dnf5/commands/history/history_redo.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_redo.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 HistoryRedoCommand::HistoryRedoCommand(Command & parent) : Command(parent, "redo") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/history/history_redo.cpp
+++ b/dnf5/commands/history/history_redo.cpp
@@ -17,26 +17,16 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "history_redo.hpp"
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-HistoryRedoCommand::HistoryRedoCommand(Command & parent) : Command(parent, "redo") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Repeat transactions");
+void HistoryRedoCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Repeat transactions");
 }
 
-
 void HistoryRedoCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_redo.hpp
+++ b/dnf5/commands/history/history_redo.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_REDO_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_REDO_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class HistoryRedoCommand : public libdnf::cli::session::Command {
+class HistoryRedoCommand : public Command {
 public:
     explicit HistoryRedoCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history_redo.hpp
+++ b/dnf5/commands/history/history_redo.hpp
@@ -29,7 +29,8 @@ namespace dnf5 {
 
 class HistoryRedoCommand : public Command {
 public:
-    explicit HistoryRedoCommand(Command & parent);
+    explicit HistoryRedoCommand(Command & parent) : Command(parent, "redo") {}
+    void set_argument_parser() override;
     void run() override;
 };
 

--- a/dnf5/commands/history/history_replay.cpp
+++ b/dnf5/commands/history/history_replay.cpp
@@ -17,26 +17,14 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "history_replay.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-HistoryReplayCommand::HistoryReplayCommand(Command & parent) : Command(parent, "replay") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Replay a transaction that was previously stored to a file");
+void HistoryReplayCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Replay a transaction that was previously stored to a file");
 }
 
-
 void HistoryReplayCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_replay.cpp
+++ b/dnf5/commands/history/history_replay.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_replay.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 HistoryReplayCommand::HistoryReplayCommand(Command & parent) : Command(parent, "replay") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/history/history_replay.hpp
+++ b/dnf5/commands/history/history_replay.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_REPLAY_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_REPLAY_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class HistoryReplayCommand : public libdnf::cli::session::Command {
+class HistoryReplayCommand : public Command {
 public:
     explicit HistoryReplayCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history_replay.hpp
+++ b/dnf5/commands/history/history_replay.hpp
@@ -29,7 +29,8 @@ namespace dnf5 {
 
 class HistoryReplayCommand : public Command {
 public:
-    explicit HistoryReplayCommand(Command & parent);
+    explicit HistoryReplayCommand(Command & parent) : Command(parent, "replay") {}
+    void set_argument_parser() override;
     void run() override;
 };
 

--- a/dnf5/commands/history/history_rollback.cpp
+++ b/dnf5/commands/history/history_rollback.cpp
@@ -17,26 +17,17 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "history_rollback.hpp"
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-HistoryRollbackCommand::HistoryRollbackCommand(Command & parent) : Command(parent, "rollback") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Undo all transactions performed after the specified transaction");
+void HistoryRollbackCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description(
+        "Undo all transactions performed after the specified transaction");
 }
 
-
 void HistoryRollbackCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_rollback.cpp
+++ b/dnf5/commands/history/history_rollback.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_rollback.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 HistoryRollbackCommand::HistoryRollbackCommand(Command & parent) : Command(parent, "rollback") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/history/history_rollback.hpp
+++ b/dnf5/commands/history/history_rollback.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_ROLLBACK_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_ROLLBACK_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class HistoryRollbackCommand : public libdnf::cli::session::Command {
+class HistoryRollbackCommand : public Command {
 public:
     explicit HistoryRollbackCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history_rollback.hpp
+++ b/dnf5/commands/history/history_rollback.hpp
@@ -29,7 +29,8 @@ namespace dnf5 {
 
 class HistoryRollbackCommand : public Command {
 public:
-    explicit HistoryRollbackCommand(Command & parent);
+    explicit HistoryRollbackCommand(Command & parent) : Command(parent, "rollback") {}
+    void set_argument_parser() override;
     void run() override;
 };
 

--- a/dnf5/commands/history/history_store.cpp
+++ b/dnf5/commands/history/history_store.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_store.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 HistoryStoreCommand::HistoryStoreCommand(Command & parent) : Command(parent, "store") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/history/history_store.cpp
+++ b/dnf5/commands/history/history_store.cpp
@@ -17,26 +17,16 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "history_store.hpp"
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-HistoryStoreCommand::HistoryStoreCommand(Command & parent) : Command(parent, "store") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Store transaction to a file");
+void HistoryStoreCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Store transaction to a file");
 }
 
-
 void HistoryStoreCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_store.hpp
+++ b/dnf5/commands/history/history_store.hpp
@@ -29,7 +29,8 @@ namespace dnf5 {
 
 class HistoryStoreCommand : public Command {
 public:
-    explicit HistoryStoreCommand(Command & parent);
+    explicit HistoryStoreCommand(Command & parent) : Command(parent, "store") {}
+    void set_argument_parser() override;
     void run() override;
 };
 

--- a/dnf5/commands/history/history_store.hpp
+++ b/dnf5/commands/history/history_store.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_STORE_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_STORE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class HistoryStoreCommand : public libdnf::cli::session::Command {
+class HistoryStoreCommand : public Command {
 public:
     explicit HistoryStoreCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history_undo.cpp
+++ b/dnf5/commands/history/history_undo.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "history_undo.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 HistoryUndoCommand::HistoryUndoCommand(Command & parent) : Command(parent, "undo") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/history/history_undo.cpp
+++ b/dnf5/commands/history/history_undo.cpp
@@ -17,26 +17,16 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "history_undo.hpp"
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-HistoryUndoCommand::HistoryUndoCommand(Command & parent) : Command(parent, "undo") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Revert all actions from the specified transactions");
+void HistoryUndoCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Revert all actions from the specified transactions");
 }
 
-
 void HistoryUndoCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/history/history_undo.hpp
+++ b/dnf5/commands/history/history_undo.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_HISTORY_HISTORY_UNDO_HPP
 #define DNF5_COMMANDS_HISTORY_HISTORY_UNDO_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class HistoryUndoCommand : public libdnf::cli::session::Command {
+class HistoryUndoCommand : public Command {
 public:
     explicit HistoryUndoCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/history/history_undo.hpp
+++ b/dnf5/commands/history/history_undo.hpp
@@ -29,7 +29,8 @@ namespace dnf5 {
 
 class HistoryUndoCommand : public Command {
 public:
-    explicit HistoryUndoCommand(Command & parent);
+    explicit HistoryUndoCommand(Command & parent) : Command(parent, "undo") {}
+    void set_argument_parser() override;
     void run() override;
 };
 

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "install.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/exception.hpp"
 #include "libdnf-cli/output/transaction_table.hpp"
 
@@ -45,7 +43,7 @@ using namespace libdnf::cli;
 
 
 InstallCommand::InstallCommand(Command & parent) : Command(parent, "install") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -65,7 +63,7 @@ InstallCommand::InstallCommand(Command & parent) : Command(parent, "install") {
 
 
 void InstallCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true);
 

--- a/dnf5/commands/install/install.cpp
+++ b/dnf5/commands/install/install.cpp
@@ -17,32 +17,13 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "install.hpp"
-
-#include "libdnf-cli/exception.hpp"
-#include "libdnf-cli/output/transaction_table.hpp"
-
-#include <libdnf/base/goal.hpp>
-#include <libdnf/conf/option_string.hpp>
-#include <libdnf/rpm/package.hpp>
-#include <libdnf/rpm/package_query.hpp>
-#include <libdnf/rpm/package_set.hpp>
-
-#include <filesystem>
-#include <iostream>
-
-
-namespace fs = std::filesystem;
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-InstallCommand::InstallCommand(Command & parent) : Command(parent, "install") {
+void InstallCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
@@ -61,43 +42,24 @@ InstallCommand::InstallCommand(Command & parent) : Command(parent, "install") {
     cmd.register_positional_arg(keys);
 }
 
-
-void InstallCommand::run() {
-    auto & ctx = get_context();
-
-    ctx.load_repos(true);
-
-    std::vector<std::string> error_messages;
-    const auto cmdline_packages = ctx.add_cmdline_packages(pkg_file_paths, error_messages);
-    for (const auto & msg : error_messages) {
-        std::cout << msg << std::endl;
-    }
-
-    std::cout << std::endl;
-
-    libdnf::Goal goal(ctx.base);
-    for (const auto & pkg : cmdline_packages) {
-        goal.add_rpm_install(pkg);
-    }
-    for (const auto & spec : pkg_specs) {
-        goal.add_rpm_install(spec);
-    }
-
-    auto transaction = goal.resolve(false);
-    if (transaction.get_problems() != libdnf::GoalProblem::NO_PROBLEM) {
-        throw GoalResolveError(transaction);
-    }
-
-    if (!libdnf::cli::output::print_transaction_table(transaction)) {
-        return;
-    }
-
-    if (!userconfirm(ctx.base.get_config())) {
-        throw AbortedByUserError();
-    }
-
-    ctx.download_and_run(transaction);
+void InstallCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 
+void InstallCommand::load_additional_packages() {
+    cmdline_packages = get_context().add_cmdline_packages(pkg_file_paths);
+}
+
+void InstallCommand::run() {
+    auto goal = get_context().get_goal();
+    for (const auto & pkg : cmdline_packages) {
+        goal->add_rpm_install(pkg);
+    }
+    for (const auto & spec : pkg_specs) {
+        goal->add_rpm_install(spec);
+    }
+}
 
 }  // namespace dnf5

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_INSTALL_INSTALL_HPP
 #define DNF5_COMMANDS_INSTALL_INSTALL_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 #include <memory>
 #include <vector>
@@ -31,7 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class InstallCommand : public libdnf::cli::session::Command {
+class InstallCommand : public Command {
 public:
     explicit InstallCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -17,29 +17,30 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_INSTALL_INSTALL_HPP
 #define DNF5_COMMANDS_INSTALL_INSTALL_HPP
 
 #include <dnf5/context.hpp>
+#include <libdnf/rpm/package.hpp>
 
 #include <memory>
 #include <vector>
 
-
 namespace dnf5 {
-
 
 class InstallCommand : public Command {
 public:
-    explicit InstallCommand(Command & parent);
+    explicit InstallCommand(Command & parent) : Command(parent, "install") {}
+    void set_argument_parser() override;
+    void configure() override;
+    void load_additional_packages() override;
     void run() override;
 
 private:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
+    std::vector<libdnf::rpm::Package> cmdline_packages;
 };
-
 
 }  // namespace dnf5
 

--- a/dnf5/commands/makecache/makecache.cpp
+++ b/dnf5/commands/makecache/makecache.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "makecache.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <fmt/format.h>
 
 #include <iostream>
@@ -40,7 +38,7 @@ MakeCacheCommand::MakeCacheCommand(Command & parent) : Command(parent, "makecach
 
 
 void MakeCacheCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     libdnf::repo::RepoQuery enabled_repos_query(ctx.base);
     enabled_repos_query.filter_enabled(true);

--- a/dnf5/commands/makecache/makecache.cpp
+++ b/dnf5/commands/makecache/makecache.cpp
@@ -17,25 +17,19 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "makecache.hpp"
 
 #include <fmt/format.h>
 
 #include <iostream>
 
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-MakeCacheCommand::MakeCacheCommand(Command & parent) : Command(parent, "makecache") {
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Generate the metadada cache");
+void MakeCacheCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Generate the metadada cache");
 }
-
 
 void MakeCacheCommand::run() {
     auto & ctx = get_context();
@@ -60,6 +54,5 @@ void MakeCacheCommand::run() {
 
     std::cout << "Metadata cache created." << std::endl;
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/makecache/makecache.hpp
+++ b/dnf5/commands/makecache/makecache.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MAKECAHE_MAKECACHE_HPP
 #define DNF5_COMMANDS_MAKECAHE_MAKECACHE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class MakeCacheCommand : public libdnf::cli::session::Command {
+class MakeCacheCommand : public Command {
 public:
     explicit MakeCacheCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/makecache/makecache.hpp
+++ b/dnf5/commands/makecache/makecache.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MAKECAHE_MAKECACHE_HPP
 #define DNF5_COMMANDS_MAKECAHE_MAKECACHE_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class MakeCacheCommand : public Command {
 public:
-    explicit MakeCacheCommand(Command & parent);
+    explicit MakeCacheCommand(Command & parent) : Command(parent, "makecache") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MAKECAHE_MAKECACHE_HPP

--- a/dnf5/commands/module/module.cpp
+++ b/dnf5/commands/module/module.cpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module.hpp"
 
 #include "module_disable.hpp"
@@ -31,19 +30,15 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "module_reset.hpp"
 #include "module_switch_to.hpp"
 
-
 namespace dnf5 {
 
+void ModuleCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Manage modules");
+}
 
-using namespace libdnf::cli;
-
-
-ModuleCommand::ModuleCommand(Command & parent) : Command(parent, "module") {
-    auto & ctx = get_context();
-    auto & parser = ctx.get_argument_parser();
-
+void ModuleCommand::register_subcommands() {
+    auto & parser = get_context().get_argument_parser();
     auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Manage modules");
 
     // query commands
     auto * query_commands_group = parser.add_new_group("module_query_commands");
@@ -70,10 +65,8 @@ ModuleCommand::ModuleCommand(Command & parent) : Command(parent, "module") {
     register_subcommand(std::make_unique<ModuleRemoveCommand>(*this), software_management_commands_group);
 }
 
-
-void ModuleCommand::run() {
+void ModuleCommand::pre_configure() {
     throw_missing_command();
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module.cpp
+++ b/dnf5/commands/module/module.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module.hpp"
 
-#include "dnf5/context.hpp"
 #include "module_disable.hpp"
 #include "module_enable.hpp"
 #include "module_info.hpp"
@@ -40,7 +39,7 @@ using namespace libdnf::cli;
 
 
 ModuleCommand::ModuleCommand(Command & parent) : Command(parent, "module") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/module/module.hpp
+++ b/dnf5/commands/module/module.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleCommand : public libdnf::cli::session::Command {
+class ModuleCommand : public Command {
 public:
     explicit ModuleCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module.hpp
+++ b/dnf5/commands/module/module.hpp
@@ -17,24 +17,21 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleCommand : public Command {
 public:
-    explicit ModuleCommand(Command & parent);
-    void run() override;
+    explicit ModuleCommand(Command & parent) : Command(parent, "module") {}
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_HPP

--- a/dnf5/commands/module/module_disable.cpp
+++ b/dnf5/commands/module/module_disable.cpp
@@ -17,27 +17,16 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_disable.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleDisableCommand::ModuleDisableCommand(Command & parent) : Command(parent, "disable") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleDisableCommand::set_argument_parser() {
     // TODO(dmach): shouldn't module disable work on streams rather than the whole module?
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Disable modules including all their streams.");
 }
 
-
 void ModuleDisableCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_disable.cpp
+++ b/dnf5/commands/module/module_disable.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_disable.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleDisableCommand::ModuleDisableCommand(Command & parent) : Command(parent, "disable") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     // TODO(dmach): shouldn't module disable work on streams rather than the whole module?

--- a/dnf5/commands/module/module_disable.hpp
+++ b/dnf5/commands/module/module_disable.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_DISABLE_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_DISABLE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleDisableCommand : public libdnf::cli::session::Command {
+class ModuleDisableCommand : public Command {
 public:
     explicit ModuleDisableCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_disable.hpp
+++ b/dnf5/commands/module/module_disable.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_DISABLE_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_DISABLE_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleDisableCommand : public Command {
 public:
-    explicit ModuleDisableCommand(Command & parent);
+    explicit ModuleDisableCommand(Command & parent) : Command(parent, "disable") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_DISABLE_HPP

--- a/dnf5/commands/module/module_enable.cpp
+++ b/dnf5/commands/module/module_enable.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_enable.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleEnableCommand::ModuleEnableCommand(Command & parent) : Command(parent, "enable") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/module/module_enable.cpp
+++ b/dnf5/commands/module/module_enable.cpp
@@ -17,26 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_enable.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleEnableCommand::ModuleEnableCommand(Command & parent) : Command(parent, "enable") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleEnableCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Enable module streams and make their packages available.");
 }
 
-
 void ModuleEnableCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_enable.hpp
+++ b/dnf5/commands/module/module_enable.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_ENABLE_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_ENABLE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleEnableCommand : public libdnf::cli::session::Command {
+class ModuleEnableCommand : public Command {
 public:
     explicit ModuleEnableCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_enable.hpp
+++ b/dnf5/commands/module/module_enable.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_ENABLE_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_ENABLE_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleEnableCommand : public Command {
 public:
-    explicit ModuleEnableCommand(Command & parent);
+    explicit ModuleEnableCommand(Command & parent) : Command(parent, "enable") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_ENABLE_HPP

--- a/dnf5/commands/module/module_info.cpp
+++ b/dnf5/commands/module/module_info.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_info.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleInfoCommand::ModuleInfoCommand(Command & parent) : Command(parent, "info") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/module/module_info.cpp
+++ b/dnf5/commands/module/module_info.cpp
@@ -17,26 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_info.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleInfoCommand::ModuleInfoCommand(Command & parent) : Command(parent, "info") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleInfoCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Print details about module streams");
 }
 
-
 void ModuleInfoCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_info.hpp
+++ b/dnf5/commands/module/module_info.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_INFO_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_INFO_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleInfoCommand : public Command {
 public:
-    explicit ModuleInfoCommand(Command & parent);
+    explicit ModuleInfoCommand(Command & parent) : Command(parent, "info") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_INFO_HPP

--- a/dnf5/commands/module/module_info.hpp
+++ b/dnf5/commands/module/module_info.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_INFO_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_INFO_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleInfoCommand : public libdnf::cli::session::Command {
+class ModuleInfoCommand : public Command {
 public:
     explicit ModuleInfoCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_install.cpp
+++ b/dnf5/commands/module/module_install.cpp
@@ -17,26 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_install.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleInstallCommand::ModuleInstallCommand(Command & parent) : Command(parent, "install") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleInstallCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Install module profiles, including their packages.");
 }
 
-
 void ModuleInstallCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_install.cpp
+++ b/dnf5/commands/module/module_install.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_install.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleInstallCommand::ModuleInstallCommand(Command & parent) : Command(parent, "install") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/module/module_install.hpp
+++ b/dnf5/commands/module/module_install.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_INSTALL_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_INSTALL_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleInstallCommand : public Command {
 public:
-    explicit ModuleInstallCommand(Command & parent);
+    explicit ModuleInstallCommand(Command & parent) : Command(parent, "install") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_INSTALL_HPP

--- a/dnf5/commands/module/module_install.hpp
+++ b/dnf5/commands/module/module_install.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_INSTALL_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_INSTALL_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleInstallCommand : public libdnf::cli::session::Command {
+class ModuleInstallCommand : public Command {
 public:
     explicit ModuleInstallCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_list.cpp
+++ b/dnf5/commands/module/module_list.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_list.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleListCommand::ModuleListCommand(Command & parent) : Command(parent, "list") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/module/module_list.cpp
+++ b/dnf5/commands/module/module_list.cpp
@@ -17,26 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_list.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleListCommand::ModuleListCommand(Command & parent) : Command(parent, "list") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleListCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("List module streams");
 }
 
-
 void ModuleListCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_list.hpp
+++ b/dnf5/commands/module/module_list.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_LIST_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_LIST_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleListCommand : public libdnf::cli::session::Command {
+class ModuleListCommand : public Command {
 public:
     explicit ModuleListCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_list.hpp
+++ b/dnf5/commands/module/module_list.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_LIST_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_LIST_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleListCommand : public Command {
 public:
-    explicit ModuleListCommand(Command & parent);
+    explicit ModuleListCommand(Command & parent) : Command(parent, "list") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_LIST_HPP

--- a/dnf5/commands/module/module_provides.cpp
+++ b/dnf5/commands/module/module_provides.cpp
@@ -17,26 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_provides.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleProvidesCommand::ModuleProvidesCommand(Command & parent) : Command(parent, "provides") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleProvidesCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Print module and module profile the specified packages come from.");
 }
 
-
 void ModuleProvidesCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_provides.cpp
+++ b/dnf5/commands/module/module_provides.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_provides.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleProvidesCommand::ModuleProvidesCommand(Command & parent) : Command(parent, "provides") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/module/module_provides.hpp
+++ b/dnf5/commands/module/module_provides.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_PROVIDES_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_PROVIDES_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleProvidesCommand : public Command {
 public:
-    explicit ModuleProvidesCommand(Command & parent);
+    explicit ModuleProvidesCommand(Command & parent) : Command(parent, "provides") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_PROVIDES_HPP

--- a/dnf5/commands/module/module_provides.hpp
+++ b/dnf5/commands/module/module_provides.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_PROVIDES_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_PROVIDES_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleProvidesCommand : public libdnf::cli::session::Command {
+class ModuleProvidesCommand : public Command {
 public:
     explicit ModuleProvidesCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_remove.cpp
+++ b/dnf5/commands/module/module_remove.cpp
@@ -17,26 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_remove.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleRemoveCommand::ModuleRemoveCommand(Command & parent) : Command(parent, "remove") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleRemoveCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Remove installed module profiles including their packages.");
 }
 
-
 void ModuleRemoveCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_remove.cpp
+++ b/dnf5/commands/module/module_remove.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_remove.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleRemoveCommand::ModuleRemoveCommand(Command & parent) : Command(parent, "remove") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/module/module_remove.hpp
+++ b/dnf5/commands/module/module_remove.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_REMOVE_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_REMOVE_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleRemoveCommand : public Command {
 public:
-    explicit ModuleRemoveCommand(Command & parent);
+    explicit ModuleRemoveCommand(Command & parent) : Command(parent, "remove") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_REMOVE_HPP

--- a/dnf5/commands/module/module_remove.hpp
+++ b/dnf5/commands/module/module_remove.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_REMOVE_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_REMOVE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleRemoveCommand : public libdnf::cli::session::Command {
+class ModuleRemoveCommand : public Command {
 public:
     explicit ModuleRemoveCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_repoquery.cpp
+++ b/dnf5/commands/module/module_repoquery.cpp
@@ -17,28 +17,17 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_repoquery.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleRepoqueryCommand::ModuleRepoqueryCommand(Command & parent) : Command(parent, "repoquery") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleRepoqueryCommand::set_argument_parser() {
     // TODO(dmach): Consider replacing with repoquery with a filter option: dnf repoquery --module=<module_spec>
     // TODO(dmach): The current UX is not nice, it requires enabled streams to work
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("List packages that belong to specified modules.");
 }
 
-
 void ModuleRepoqueryCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_repoquery.cpp
+++ b/dnf5/commands/module/module_repoquery.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_repoquery.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleRepoqueryCommand::ModuleRepoqueryCommand(Command & parent) : Command(parent, "repoquery") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     // TODO(dmach): Consider replacing with repoquery with a filter option: dnf repoquery --module=<module_spec>

--- a/dnf5/commands/module/module_repoquery.hpp
+++ b/dnf5/commands/module/module_repoquery.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_REPOQUERY_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_REPOQUERY_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleRepoqueryCommand : public Command {
 public:
-    explicit ModuleRepoqueryCommand(Command & parent);
+    explicit ModuleRepoqueryCommand(Command & parent) : Command(parent, "enable") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_REPOQUERY_HPP

--- a/dnf5/commands/module/module_repoquery.hpp
+++ b/dnf5/commands/module/module_repoquery.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_REPOQUERY_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_REPOQUERY_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleRepoqueryCommand : public libdnf::cli::session::Command {
+class ModuleRepoqueryCommand : public Command {
 public:
     explicit ModuleRepoqueryCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_reset.cpp
+++ b/dnf5/commands/module/module_reset.cpp
@@ -17,26 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_reset.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleResetCommand::ModuleResetCommand(Command & parent) : Command(parent, "reset") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleResetCommand::set_argument_parser() {
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Reset module state so it's no longer enabled or disabled.");
 }
 
-
 void ModuleResetCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_reset.cpp
+++ b/dnf5/commands/module/module_reset.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_reset.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleResetCommand::ModuleResetCommand(Command & parent) : Command(parent, "reset") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/module/module_reset.hpp
+++ b/dnf5/commands/module/module_reset.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_RESET_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_RESET_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleResetCommand : public libdnf::cli::session::Command {
+class ModuleResetCommand : public Command {
 public:
     explicit ModuleResetCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_reset.hpp
+++ b/dnf5/commands/module/module_reset.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_RESET_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_RESET_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleResetCommand : public Command {
 public:
-    explicit ModuleResetCommand(Command & parent);
+    explicit ModuleResetCommand(Command & parent) : Command(parent, "reset") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_RESET_HPP

--- a/dnf5/commands/module/module_switch_to.cpp
+++ b/dnf5/commands/module/module_switch_to.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "module_switch_to.hpp"
 
-#include "dnf5/context.hpp"
-
 
 namespace dnf5 {
 
@@ -30,7 +28,7 @@ using namespace libdnf::cli;
 
 
 ModuleSwitchToCommand::ModuleSwitchToCommand(Command & parent) : Command(parent, "switch-to") {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & parser = ctx.get_argument_parser();
 
     // TODO(dmach): this is convenient but inconsistent UX - enable/disable/reset do not touch the packages while switch-to does

--- a/dnf5/commands/module/module_switch_to.cpp
+++ b/dnf5/commands/module/module_switch_to.cpp
@@ -17,27 +17,16 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "module_switch_to.hpp"
-
 
 namespace dnf5 {
 
-
-using namespace libdnf::cli;
-
-
-ModuleSwitchToCommand::ModuleSwitchToCommand(Command & parent) : Command(parent, "switch-to") {
-    // auto & ctx = get_context();
-    // auto & parser = ctx.get_argument_parser();
-
+void ModuleSwitchToCommand::set_argument_parser() {
     // TODO(dmach): this is convenient but inconsistent UX - enable/disable/reset do not touch the packages while switch-to does
     auto & cmd = *get_argument_parser_command();
     cmd.set_short_description("Enable different module streams, upgrade their profiles and distro-sync packages.");
 }
 
-
 void ModuleSwitchToCommand::run() {}
-
 
 }  // namespace dnf5

--- a/dnf5/commands/module/module_switch_to.hpp
+++ b/dnf5/commands/module/module_switch_to.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_MODULE_MODULE_SWITCH_TO_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_SWITCH_TO_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class ModuleSwitchToCommand : public libdnf::cli::session::Command {
+class ModuleSwitchToCommand : public Command {
 public:
     explicit ModuleSwitchToCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/module/module_switch_to.hpp
+++ b/dnf5/commands/module/module_switch_to.hpp
@@ -17,24 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_MODULE_MODULE_SWITCH_TO_HPP
 #define DNF5_COMMANDS_MODULE_MODULE_SWITCH_TO_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class ModuleSwitchToCommand : public Command {
 public:
-    explicit ModuleSwitchToCommand(Command & parent);
+    explicit ModuleSwitchToCommand(Command & parent) : Command(parent, "switch-to") {}
+    void set_argument_parser() override;
     void run() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_MODULE_MODULE_SWITCH_TO_HPP

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "reinstall.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/output/transaction_table.hpp"
 
 #include <libdnf/base/goal.hpp>
@@ -44,7 +42,7 @@ using namespace libdnf::cli;
 
 
 ReinstallCommand::ReinstallCommand(Command & parent) : Command(parent, "reinstall") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -64,7 +62,7 @@ ReinstallCommand::ReinstallCommand(Command & parent) : Command(parent, "reinstal
 
 
 void ReinstallCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true);
 

--- a/dnf5/commands/reinstall/reinstall.cpp
+++ b/dnf5/commands/reinstall/reinstall.cpp
@@ -17,31 +17,13 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "reinstall.hpp"
-
-#include "libdnf-cli/output/transaction_table.hpp"
-
-#include <libdnf/base/goal.hpp>
-#include <libdnf/conf/option_string.hpp>
-#include <libdnf/rpm/package.hpp>
-#include <libdnf/rpm/package_query.hpp>
-#include <libdnf/rpm/package_set.hpp>
-
-#include <filesystem>
-#include <iostream>
-
-
-namespace fs = std::filesystem;
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-ReinstallCommand::ReinstallCommand(Command & parent) : Command(parent, "reinstall") {
+void ReinstallCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
@@ -60,43 +42,24 @@ ReinstallCommand::ReinstallCommand(Command & parent) : Command(parent, "reinstal
     cmd.register_positional_arg(keys);
 }
 
-
-void ReinstallCommand::run() {
-    auto & ctx = get_context();
-
-    ctx.load_repos(true);
-
-    std::vector<std::string> error_messages;
-    const auto cmdline_packages = ctx.add_cmdline_packages(pkg_file_paths, error_messages);
-    for (const auto & msg : error_messages) {
-        std::cout << msg << std::endl;
-    }
-
-    std::cout << std::endl;
-
-    libdnf::Goal goal(ctx.base);
-    for (const auto & pkg : cmdline_packages) {
-        goal.add_rpm_reinstall(pkg);
-    }
-    for (const auto & spec : pkg_specs) {
-        goal.add_rpm_reinstall(spec);
-    }
-
-    auto transaction = goal.resolve(true);
-    if (transaction.get_problems() != libdnf::GoalProblem::NO_PROBLEM) {
-        throw GoalResolveError(transaction);
-    }
-
-    if (!libdnf::cli::output::print_transaction_table(transaction)) {
-        return;
-    }
-
-    if (!userconfirm(ctx.base.get_config())) {
-        throw AbortedByUserError();
-    }
-
-    ctx.download_and_run(transaction);
+void ReinstallCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 
+void ReinstallCommand::load_additional_packages() {
+    cmdline_packages = get_context().add_cmdline_packages(pkg_file_paths);
+}
+
+void ReinstallCommand::run() {
+    auto goal = get_context().get_goal();
+    for (const auto & pkg : cmdline_packages) {
+        goal->add_rpm_reinstall(pkg);
+    }
+    for (const auto & spec : pkg_specs) {
+        goal->add_rpm_reinstall(spec);
+    }
+}
 
 }  // namespace dnf5

--- a/dnf5/commands/reinstall/reinstall.hpp
+++ b/dnf5/commands/reinstall/reinstall.hpp
@@ -32,12 +32,16 @@ namespace dnf5 {
 
 class ReinstallCommand : public Command {
 public:
-    explicit ReinstallCommand(Command & parent);
+    explicit ReinstallCommand(Command & parent) : Command(parent, "reinstall") {}
+    void set_argument_parser() override;
+    void configure() override;
+    void load_additional_packages() override;
     void run() override;
 
 private:
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
+    std::vector<libdnf::rpm::Package> cmdline_packages;
 };
 
 

--- a/dnf5/commands/reinstall/reinstall.hpp
+++ b/dnf5/commands/reinstall/reinstall.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_REINSTALL_REINSTALL_HPP
 #define DNF5_COMMANDS_REINSTALL_REINSTALL_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 #include <memory>
 #include <vector>
@@ -31,7 +30,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class ReinstallCommand : public libdnf::cli::session::Command {
+class ReinstallCommand : public Command {
 public:
     explicit ReinstallCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/remove/remove.cpp
+++ b/dnf5/commands/remove/remove.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "remove.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/output/transaction_table.hpp"
 
 #include <libdnf/base/goal.hpp>
@@ -43,7 +41,7 @@ RemoveCommand::RemoveCommand(Command & parent) : RemoveCommand(parent, "remove")
 
 
 RemoveCommand::RemoveCommand(Command & parent, const std::string & name) : Command(parent, name) {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -73,7 +71,7 @@ RemoveCommand::RemoveCommand(Command & parent, const std::string & name) : Comma
 
 
 void RemoveCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.base.get_repo_sack()->get_system_repo()->load();
     // TODO(lukash) this is inconvenient, we should try to call it automatically at the right time in libdnf

--- a/dnf5/commands/remove/remove.hpp
+++ b/dnf5/commands/remove/remove.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_REMOVE_REMOVE_HPP
 #define DNF5_COMMANDS_REMOVE_REMOVE_HPP
 
@@ -27,13 +26,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <vector>
 
-
 namespace dnf5 {
-
 
 class RemoveCommand : public Command {
 public:
-    explicit RemoveCommand(Command & parent);
+    explicit RemoveCommand(Command & parent) : RemoveCommand(parent, "remove") {}
+    void set_argument_parser() override;
+    void configure() override;
     void run() override;
 
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_remove_options{nullptr};
@@ -41,9 +40,8 @@ public:
 
 protected:
     // to be used by an alias command only
-    explicit RemoveCommand(Command & parent, const std::string & name);
+    explicit RemoveCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 };
-
 
 }  // namespace dnf5
 

--- a/dnf5/commands/remove/remove.hpp
+++ b/dnf5/commands/remove/remove.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_REMOVE_REMOVE_HPP
 #define DNF5_COMMANDS_REMOVE_REMOVE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -32,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class RemoveCommand : public libdnf::cli::session::Command {
+class RemoveCommand : public Command {
 public:
     explicit RemoveCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/repo/repo.cpp
+++ b/dnf5/commands/repo/repo.cpp
@@ -20,7 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "repo.hpp"
 
-#include "dnf5/context.hpp"
 #include "repo_info.hpp"
 #include "repo_list.hpp"
 
@@ -32,7 +31,7 @@ using namespace libdnf::cli;
 
 
 RepoCommand::RepoCommand(Command & parent) : Command(parent, "repo") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();

--- a/dnf5/commands/repo/repo.cpp
+++ b/dnf5/commands/repo/repo.cpp
@@ -17,38 +17,28 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "repo.hpp"
 
 #include "repo_info.hpp"
 #include "repo_list.hpp"
 
-
 namespace dnf5 {
 
+void RepoCommand::set_argument_parser() {
+    get_argument_parser_command()->set_short_description("Manage repositories");
+}
 
-using namespace libdnf::cli;
-
-
-RepoCommand::RepoCommand(Command & parent) : Command(parent, "repo") {
-    auto & ctx = get_context();
-    auto & parser = ctx.get_argument_parser();
-
-    auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description("Manage repositories");
-
+void RepoCommand::register_subcommands() {
     // query commands
-    auto * query_commands_group = parser.add_new_group("repo_query_commands");
+    auto * query_commands_group = get_context().get_argument_parser().add_new_group("repo_query_commands");
     query_commands_group->set_header("Query Commands:");
-    cmd.register_group(query_commands_group);
+    get_argument_parser_command()->register_group(query_commands_group);
     register_subcommand(std::make_unique<RepoListCommand>(*this), query_commands_group);
     register_subcommand(std::make_unique<RepoInfoCommand>(*this), query_commands_group);
 }
 
-
-void RepoCommand::run() {
+void RepoCommand::pre_configure() {
     throw_missing_command();
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/repo/repo.hpp
+++ b/dnf5/commands/repo/repo.hpp
@@ -17,24 +17,21 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_REPO_REPO_HPP
 #define DNF5_COMMANDS_REPO_REPO_HPP
 
 #include <dnf5/context.hpp>
 
-
 namespace dnf5 {
-
 
 class RepoCommand : public Command {
 public:
-    explicit RepoCommand(Command & parent);
-    void run() override;
+    explicit RepoCommand(Command & parent) : Command(parent, "repo") {}
+    void set_argument_parser() override;
+    void register_subcommands() override;
+    void pre_configure() override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_REPO_REPO_HPP

--- a/dnf5/commands/repo/repo.hpp
+++ b/dnf5/commands/repo/repo.hpp
@@ -21,14 +21,13 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_REPO_REPO_HPP
 #define DNF5_COMMANDS_REPO_REPO_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 
 namespace dnf5 {
 
 
-class RepoCommand : public libdnf::cli::session::Command {
+class RepoCommand : public Command {
 public:
     explicit RepoCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "repo_info.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/output/repo_info.hpp"
 
 #include <libdnf/conf/option_string.hpp>

--- a/dnf5/commands/repo/repo_info.cpp
+++ b/dnf5/commands/repo/repo_info.cpp
@@ -17,28 +17,13 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "repo_info.hpp"
 
 #include "libdnf-cli/output/repo_info.hpp"
 
-#include <libdnf/conf/option_string.hpp>
-
 #include <iostream>
 
-
 namespace dnf5 {
-
-
-using namespace libdnf::cli;
-
-
-RepoInfoCommand::RepoInfoCommand(Command & parent) : RepoInfoCommand(parent, "info") {}
-
-
-RepoInfoCommand::RepoInfoCommand(Command & parent, const std::string & name)
-    : RepoListCommand(parent, name, "Print details about repositories") {}
-
 
 void RepoInfoCommand::print(const libdnf::repo::RepoQuery & query, [[maybe_unused]] bool with_status) {
     for (auto & repo : query.get_data()) {
@@ -48,6 +33,5 @@ void RepoInfoCommand::print(const libdnf::repo::RepoQuery & query, [[maybe_unuse
         std::cout << std::endl;
     }
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/repo/repo_info.hpp
+++ b/dnf5/commands/repo/repo_info.hpp
@@ -17,36 +17,31 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_REPO_REPO_INFO_HPP
 #define DNF5_COMMANDS_REPO_REPO_INFO_HPP
-
 
 #include "arguments.hpp"
 #include "repo_list.hpp"
 
 #include <dnf5/context.hpp>
-#include <libdnf/conf/option_enum.hpp>
-
-#include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class RepoInfoCommand : public RepoListCommand {
 public:
-    explicit RepoInfoCommand(Command & parent);
-    void print(const libdnf::repo::RepoQuery & query, [[maybe_unused]] bool with_status) override;
+    explicit RepoInfoCommand(Command & parent) : RepoInfoCommand(parent, "info") {}
+
+    void set_argument_parser() override {
+        RepoListCommand::set_argument_parser();
+        get_argument_parser_command()->set_short_description("Print details about repositories");
+    }
 
 protected:
     // to be used by an alias command only
-    explicit RepoInfoCommand(Command & parent, const std::string & name);
+    explicit RepoInfoCommand(Command & parent, const std::string & name) : RepoListCommand(parent, name) {}
+    void print(const libdnf::repo::RepoQuery & query, [[maybe_unused]] bool with_status) override;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_REPO_REPO_INFO_HPP

--- a/dnf5/commands/repo/repo_info.hpp
+++ b/dnf5/commands/repo/repo_info.hpp
@@ -25,7 +25,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "arguments.hpp"
 #include "repo_list.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_enum.hpp>
 
 #include <memory>

--- a/dnf5/commands/repo/repo_list.cpp
+++ b/dnf5/commands/repo/repo_list.cpp
@@ -17,33 +17,21 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "repo_list.hpp"
 
 #include "libdnf-cli/output/repolist.hpp"
 
-#include <libdnf/conf/option_string.hpp>
-
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-RepoListCommand::RepoListCommand(Command & parent) : RepoListCommand(parent, "list") {}
-
-RepoListCommand::RepoListCommand(Command & parent, const std::string & name)
-    : RepoListCommand(parent, name, "List repositories") {}
-
 //TODO(amatej): Find a different way of sharing code rather than repoinfo inheriting from repolist
-RepoListCommand::RepoListCommand(Command & parent, const std::string & name, const std::string & short_description)
-    : Command(parent, name) {
+void RepoListCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
-    cmd.set_short_description(short_description);
+    cmd.set_short_description("List repositories");
 
     all = std::make_unique<RepoAllOption>(*this);
     enabled = std::make_unique<RepoEnabledOption>(*this);
@@ -57,7 +45,6 @@ RepoListCommand::RepoListCommand(Command & parent, const std::string & name, con
     enabled->arg->set_conflict_arguments(conflict_args);
     disabled->arg->set_conflict_arguments(conflict_args);
 }
-
 
 void RepoListCommand::run() {
     auto & ctx = get_context();
@@ -92,10 +79,8 @@ void RepoListCommand::run() {
     print(query, with_status);
 }
 
-
 void RepoListCommand::print(const libdnf::repo::RepoQuery & query, bool with_status) {
     libdnf::cli::output::print_repolist_table(query, with_status, libdnf::cli::output::COL_REPO_ID);
 }
-
 
 }  // namespace dnf5

--- a/dnf5/commands/repo/repo_list.cpp
+++ b/dnf5/commands/repo/repo_list.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "repo_list.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/output/repolist.hpp"
 
 #include <libdnf/conf/option_string.hpp>
@@ -41,7 +39,7 @@ RepoListCommand::RepoListCommand(Command & parent, const std::string & name)
 //TODO(amatej): Find a different way of sharing code rather than repoinfo inheriting from repolist
 RepoListCommand::RepoListCommand(Command & parent, const std::string & name, const std::string & short_description)
     : Command(parent, name) {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -62,7 +60,7 @@ RepoListCommand::RepoListCommand(Command & parent, const std::string & name, con
 
 
 void RepoListCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     libdnf::repo::RepoQuery query(ctx.base);
     if (all->get_value()) {

--- a/dnf5/commands/repo/repo_list.hpp
+++ b/dnf5/commands/repo/repo_list.hpp
@@ -17,29 +17,20 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_REPO_REPO_LIST_HPP
 #define DNF5_COMMANDS_REPO_REPO_LIST_HPP
-
 
 #include "arguments.hpp"
 
 #include <dnf5/context.hpp>
-#include <libdnf/conf/option_enum.hpp>
-#include <libdnf/repo/repo_query.hpp>
-
-#include <memory>
-#include <vector>
-
 
 namespace dnf5 {
 
-
 class RepoListCommand : public Command {
 public:
-    explicit RepoListCommand(Command & parent);
+    explicit RepoListCommand(Command & parent) : RepoListCommand(parent, "list") {}
+    void set_argument_parser() override;
     void run() override;
-    virtual void print(const libdnf::repo::RepoQuery & query, bool with_status);
 
     std::unique_ptr<RepoAllOption> all{nullptr};
     std::unique_ptr<RepoEnabledOption> enabled{nullptr};
@@ -48,12 +39,10 @@ public:
 
 protected:
     // to be used by an alias command only
-    explicit RepoListCommand(Command & parent, const std::string & name);
-    explicit RepoListCommand(Command & parent, const std::string & name, const std::string & short_description);
+    explicit RepoListCommand(Command & parent, const std::string & name) : Command(parent, name) {}
+    virtual void print(const libdnf::repo::RepoQuery & query, bool with_status);
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_REPO_REPO_LIST_HPP

--- a/dnf5/commands/repo/repo_list.hpp
+++ b/dnf5/commands/repo/repo_list.hpp
@@ -24,7 +24,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "arguments.hpp"
 
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_enum.hpp>
 #include <libdnf/repo/repo_query.hpp>
 
@@ -35,7 +35,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class RepoListCommand : public libdnf::cli::session::Command {
+class RepoListCommand : public Command {
 public:
     explicit RepoListCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "repoquery.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/output/repoquery.hpp"
 
 #include <libdnf/conf/option_string.hpp>
@@ -39,7 +37,7 @@ using namespace libdnf::cli;
 
 
 RepoqueryCommand::RepoqueryCommand(Command & parent) : Command(parent, "repoquery") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -113,7 +111,7 @@ RepoqueryCommand::RepoqueryCommand(Command & parent) : Command(parent, "repoquer
 
 
 void RepoqueryCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     std::vector<libdnf::rpm::Package> cmdline_packages;
 
     if (installed_option->get_value()) {

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -33,7 +33,10 @@ namespace dnf5 {
 
 class RepoqueryCommand : public Command {
 public:
-    explicit RepoqueryCommand(Command & parent);
+    explicit RepoqueryCommand(Command & parent) : Command(parent, "repoquery") {}
+    void set_argument_parser() override;
+    void configure() override;
+    void load_additional_packages() override;
     void run() override;
 
 private:
@@ -43,6 +46,7 @@ private:
     libdnf::OptionBool * nevra_option{nullptr};
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
+    std::vector<libdnf::rpm::Package> cmdline_packages;
 };
 
 

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_REPOQUERY_REPOQUERY_HPP
 #define DNF5_COMMANDS_REPOQUERY_REPOQUERY_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -32,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class RepoqueryCommand : public libdnf::cli::session::Command {
+class RepoqueryCommand : public Command {
 public:
     explicit RepoqueryCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "search.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf/conf/option_string.hpp>
 
 
@@ -35,7 +33,7 @@ using namespace libdnf::cli;
 
 
 SearchCommand::SearchCommand(Command & parent) : Command(parent, "search") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -53,7 +51,7 @@ SearchCommand::SearchCommand(Command & parent) : Command(parent, "search") {
 
 
 void SearchCommand::run() {
-    // auto & ctx = static_cast<Context &>(get_session());
+    // auto & ctx = get_context();
     // auto & package_sack = *ctx.base.get_rpm_package_sack();
 
     // TODO(dmach): implement

--- a/dnf5/commands/search/search.cpp
+++ b/dnf5/commands/search/search.cpp
@@ -32,7 +32,7 @@ namespace dnf5 {
 using namespace libdnf::cli;
 
 
-SearchCommand::SearchCommand(Command & parent) : Command(parent, "search") {
+void SearchCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 

--- a/dnf5/commands/search/search.hpp
+++ b/dnf5/commands/search/search.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_SEARCH_SEARCH_HPP
 #define DNF5_COMMANDS_SEARCH_SEARCH_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -32,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class SearchCommand : public libdnf::cli::session::Command {
+class SearchCommand : public Command {
 public:
     explicit SearchCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/search/search.hpp
+++ b/dnf5/commands/search/search.hpp
@@ -33,7 +33,8 @@ namespace dnf5 {
 
 class SearchCommand : public Command {
 public:
-    explicit SearchCommand(Command & parent);
+    explicit SearchCommand(Command & parent) : Command(parent, "search") {}
+    void set_argument_parser() override;
     void run() override;
 
 private:

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "swap.hpp"
 
-#include "dnf5/context.hpp"
-
 #include <libdnf-cli/output/transaction_table.hpp>
 #include <libdnf/base/goal.hpp>
 
@@ -37,7 +35,7 @@ using namespace libdnf::cli;
 
 
 SwapCommand::SwapCommand(Command & parent) : Command(parent, "swap") {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -70,7 +68,7 @@ SwapCommand::SwapCommand(Command & parent) : Command(parent, "swap") {
 
 
 void SwapCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true);
 

--- a/dnf5/commands/swap/swap.cpp
+++ b/dnf5/commands/swap/swap.cpp
@@ -17,24 +17,15 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "swap.hpp"
-
-#include <libdnf-cli/output/transaction_table.hpp>
-#include <libdnf/base/goal.hpp>
-
-#include <iostream>
 
 namespace fs = std::filesystem;
 
-
 namespace dnf5 {
-
 
 using namespace libdnf::cli;
 
-
-SwapCommand::SwapCommand(Command & parent) : Command(parent, "swap") {
+void SwapCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
@@ -66,44 +57,25 @@ SwapCommand::SwapCommand(Command & parent) : Command(parent, "swap") {
     cmd.register_positional_arg(install_spec_arg);
 }
 
-
-void SwapCommand::run() {
-    auto & ctx = get_context();
-
-    ctx.load_repos(true);
-
-    std::vector<std::string> error_messages;
-    const auto cmdline_packages = ctx.add_cmdline_packages(install_pkg_file_paths, error_messages);
-    for (const auto & msg : error_messages) {
-        std::cout << msg << std::endl;
-    }
-
-    std::cout << std::endl;
-
-    libdnf::Goal goal(ctx.base);
-    for (const auto & pkg : cmdline_packages) {
-        goal.add_rpm_install(pkg);
-    }
-    for (const auto & spec : install_pkg_specs) {
-        goal.add_rpm_install(spec);
-    }
-    goal.add_rpm_remove(remove_pkg_spec);
-
-    auto transaction = goal.resolve(false);
-    if (transaction.get_problems() != libdnf::GoalProblem::NO_PROBLEM) {
-        throw GoalResolveError(transaction);
-    }
-
-    if (!libdnf::cli::output::print_transaction_table(transaction)) {
-        return;
-    }
-
-    if (!userconfirm(ctx.base.get_config())) {
-        throw AbortedByUserError();
-    }
-
-    ctx.download_and_run(transaction);
+void SwapCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 
+void SwapCommand::load_additional_packages() {
+    cmdline_packages = get_context().add_cmdline_packages(install_pkg_file_paths);
+}
+
+void SwapCommand::run() {
+    auto goal = get_context().get_goal();
+    for (const auto & pkg : cmdline_packages) {
+        goal->add_rpm_install(pkg);
+    }
+    for (const auto & spec : install_pkg_specs) {
+        goal->add_rpm_install(spec);
+    }
+    goal->add_rpm_remove(remove_pkg_spec);
+}
 
 }  // namespace dnf5

--- a/dnf5/commands/swap/swap.hpp
+++ b/dnf5/commands/swap/swap.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_SWAP_SWAP_HPP
 #define DNF5_COMMANDS_SWAP_SWAP_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 
 #include <vector>
 
@@ -32,7 +31,7 @@ namespace dnf5 {
 
 // TODO(jrohel): The "swap" command may be removed in the future in favor of a more powerful command (eg "do"),
 //               which will allow multiple actions to be combined in one transaction.
-class SwapCommand : public libdnf::cli::session::Command {
+class SwapCommand : public Command {
 public:
     explicit SwapCommand(Command & parent);
     void run() override;

--- a/dnf5/commands/swap/swap.hpp
+++ b/dnf5/commands/swap/swap.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_SWAP_SWAP_HPP
 #define DNF5_COMMANDS_SWAP_SWAP_HPP
 
@@ -25,25 +24,25 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <vector>
 
-
 namespace dnf5 {
-
 
 // TODO(jrohel): The "swap" command may be removed in the future in favor of a more powerful command (eg "do"),
 //               which will allow multiple actions to be combined in one transaction.
 class SwapCommand : public Command {
 public:
-    explicit SwapCommand(Command & parent);
+    explicit SwapCommand(Command & parent) : Command(parent, "swap") {}
+    void set_argument_parser() override;
+    void configure() override;
+    void load_additional_packages() override;
     void run() override;
 
 private:
     std::string remove_pkg_spec;
     std::vector<std::string> install_pkg_specs;
     std::vector<std::string> install_pkg_file_paths;
+    std::vector<libdnf::rpm::Package> cmdline_packages;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_SWAP_SWAP_HPP

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -20,8 +20,6 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "upgrade.hpp"
 
-#include "dnf5/context.hpp"
-
 #include "libdnf-cli/output/transaction_table.hpp"
 
 #include <libdnf/base/goal.hpp>
@@ -47,7 +45,7 @@ UpgradeCommand::UpgradeCommand(Command & parent) : UpgradeCommand(parent, "upgra
 
 
 UpgradeCommand::UpgradeCommand(Command & parent, const std::string & name) : Command(parent, name) {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
     auto & cmd = *get_argument_parser_command();
@@ -78,7 +76,7 @@ UpgradeCommand::UpgradeCommand(Command & parent, const std::string & name) : Com
 
 
 void UpgradeCommand::run() {
-    auto & ctx = static_cast<Context &>(get_session());
+    auto & ctx = get_context();
 
     ctx.load_repos(true);
 

--- a/dnf5/commands/upgrade/upgrade.cpp
+++ b/dnf5/commands/upgrade/upgrade.cpp
@@ -17,34 +17,13 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "upgrade.hpp"
-
-#include "libdnf-cli/output/transaction_table.hpp"
-
-#include <libdnf/base/goal.hpp>
-#include <libdnf/conf/option_string.hpp>
-#include <libdnf/rpm/package.hpp>
-#include <libdnf/rpm/package_query.hpp>
-#include <libdnf/rpm/package_set.hpp>
-
-#include <filesystem>
-#include <iostream>
-
-
-namespace fs = std::filesystem;
-
 
 namespace dnf5 {
 
-
 using namespace libdnf::cli;
 
-
-UpgradeCommand::UpgradeCommand(Command & parent) : UpgradeCommand(parent, "upgrade") {}
-
-
-UpgradeCommand::UpgradeCommand(Command & parent, const std::string & name) : Command(parent, name) {
+void UpgradeCommand::set_argument_parser() {
     auto & ctx = get_context();
     auto & parser = ctx.get_argument_parser();
 
@@ -74,47 +53,28 @@ UpgradeCommand::UpgradeCommand(Command & parent, const std::string & name) : Com
     cmd.register_positional_arg(keys);
 }
 
-
-void UpgradeCommand::run() {
-    auto & ctx = get_context();
-
-    ctx.load_repos(true);
-
-    std::vector<std::string> error_messages;
-    const auto cmdline_packages = ctx.add_cmdline_packages(pkg_file_paths, error_messages);
-    for (const auto & msg : error_messages) {
-        std::cout << msg << std::endl;
-    }
-
-    std::cout << std::endl;
-
-    libdnf::Goal goal(ctx.base);
-    if (pkg_specs.empty() && pkg_file_paths.empty()) {
-        goal.add_rpm_upgrade();
-    } else {
-        for (const auto & pkg : cmdline_packages) {
-            goal.add_rpm_upgrade(pkg);
-        }
-        for (const auto & spec : pkg_specs) {
-            goal.add_rpm_upgrade(spec);
-        }
-    }
-
-    auto transaction = goal.resolve(false);
-    if (transaction.get_problems() != libdnf::GoalProblem::NO_PROBLEM) {
-        throw GoalResolveError(transaction);
-    }
-
-    if (!libdnf::cli::output::print_transaction_table(transaction)) {
-        return;
-    }
-
-    if (!userconfirm(ctx.base.get_config())) {
-        throw AbortedByUserError();
-    }
-
-    ctx.download_and_run(transaction);
+void UpgradeCommand::configure() {
+    auto & context = get_context();
+    context.set_load_system_repo(true);
+    context.set_load_available_repos(Context::LoadAvailableRepos::ENABLED);
 }
 
+void UpgradeCommand::load_additional_packages() {
+    cmdline_packages = get_context().add_cmdline_packages(pkg_file_paths);
+}
+
+void UpgradeCommand::run() {
+    auto goal = get_context().get_goal();
+    if (pkg_specs.empty() && pkg_file_paths.empty()) {
+        goal->add_rpm_upgrade();
+    } else {
+        for (const auto & pkg : cmdline_packages) {
+            goal->add_rpm_upgrade(pkg);
+        }
+        for (const auto & spec : pkg_specs) {
+            goal->add_rpm_upgrade(spec);
+        }
+    }
+}
 
 }  // namespace dnf5

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #ifndef DNF5_COMMANDS_UPGRADE_UPGRADE_HPP
 #define DNF5_COMMANDS_UPGRADE_UPGRADE_HPP
 
@@ -27,27 +26,26 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <vector>
 
-
 namespace dnf5 {
-
 
 class UpgradeCommand : public Command {
 public:
-    explicit UpgradeCommand(Command & parent);
+    explicit UpgradeCommand(Command & parent) : UpgradeCommand(parent, "upgrade") {}
+    void set_argument_parser() override;
+    void configure() override;
+    void load_additional_packages() override;
     void run() override;
-
 
 protected:
     // to be used by an alias command only
-    explicit UpgradeCommand(Command & parent, const std::string & name);
+    explicit UpgradeCommand(Command & parent, const std::string & name) : Command(parent, name) {}
 
     libdnf::OptionBool * minimal{nullptr};
     std::vector<std::string> pkg_specs;
     std::vector<std::string> pkg_file_paths;
+    std::vector<libdnf::rpm::Package> cmdline_packages;
 };
 
-
 }  // namespace dnf5
-
 
 #endif  // DNF5_COMMANDS_UPGRADE_UPGRADE_HPP

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -21,8 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #ifndef DNF5_COMMANDS_UPGRADE_UPGRADE_HPP
 #define DNF5_COMMANDS_UPGRADE_UPGRADE_HPP
 
-
-#include <libdnf-cli/session.hpp>
+#include <dnf5/context.hpp>
 #include <libdnf/conf/option_bool.hpp>
 
 #include <memory>
@@ -32,7 +31,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace dnf5 {
 
 
-class UpgradeCommand : public libdnf::cli::session::Command {
+class UpgradeCommand : public Command {
 public:
     explicit UpgradeCommand(Command & parent);
     void run() override;

--- a/dnf5/context.cpp
+++ b/dnf5/context.cpp
@@ -393,7 +393,9 @@ void download_packages(libdnf::base::Transaction & transaction, const char * des
         }
     }
 
-    download_packages(downloads, dest_dir);
+    if (!downloads.empty()) {
+        download_packages(downloads, dest_dir);
+    }
 }
 
 namespace {

--- a/dnf5/include/dnf5/context.hpp
+++ b/dnf5/include/dnf5/context.hpp
@@ -96,6 +96,16 @@ private:
     std::unique_ptr<Plugins> plugins;
 };
 
+
+class Command : public libdnf::cli::session::Command {
+public:
+    using libdnf::cli::session::Command::Command;
+
+    /// @return Reference to the Context.
+    Context & get_context() const noexcept { return static_cast<Context &>(get_session()); }
+};
+
+
 class RpmTransactionItem : public libdnf::rpm::TransactionItem {
 public:
     enum class Actions { INSTALL, ERASE, UPGRADE, DOWNGRADE, REINSTALL };

--- a/dnf5/include/dnf5/iplugin.hpp
+++ b/dnf5/include/dnf5/iplugin.hpp
@@ -70,10 +70,9 @@ public:
     virtual const char * get_attribute(const char * name) const noexcept = 0;
 
     /// Plugin initialization.
-    virtual void init(dnf5::Context * context) = 0;
+    virtual void init(Context * context) = 0;
 
-    virtual std::vector<std::unique_ptr<libdnf::cli::session::Command>> create_commands(
-        libdnf::cli::session::Command & parent) = 0;
+    virtual std::vector<std::unique_ptr<Command>> create_commands(Command & parent) = 0;
 
     /// It is called when a hook is reached. The argument describes what happened.
     // TODO(jrohel): Design an API for a different plugin type than command. For example, to modify or log output.

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -70,7 +70,7 @@ namespace dnf5 {
 using namespace libdnf::cli;
 
 
-class RootCommand : public libdnf::cli::session::Command {
+class RootCommand : public Command {
 public:
     explicit RootCommand(libdnf::cli::session::Session & session);
     void run() override;

--- a/dnf5daemon-client/commands/group/group.cpp
+++ b/dnf5daemon-client/commands/group/group.cpp
@@ -41,7 +41,7 @@ GroupCommand::GroupCommand(Command & parent) : DaemonCommand(parent, "group") {
     register_subcommand(std::make_unique<GroupListCommand>(*this, "info"), query_commands_group);
 }
 
-void GroupCommand::run() {
+void GroupCommand::pre_configure() {
     throw_missing_command();
 }
 

--- a/dnf5daemon-client/commands/group/group.hpp
+++ b/dnf5daemon-client/commands/group/group.hpp
@@ -32,7 +32,7 @@ namespace dnfdaemon::client {
 class GroupCommand : public DaemonCommand {
 public:
     explicit GroupCommand(Command & parent);
-    void run() override;
+    void pre_configure() override;
 };
 
 }  // namespace dnfdaemon::client

--- a/include/libdnf/base/transaction.hpp
+++ b/include/libdnf/base/transaction.hpp
@@ -54,6 +54,7 @@ public:
     };
 
     Transaction(const Transaction & transaction);
+    Transaction(Transaction && transaction);
     ~Transaction();
 
     libdnf::GoalProblem get_problems();

--- a/libdnf/base/transaction_impl.hpp
+++ b/libdnf/base/transaction_impl.hpp
@@ -33,9 +33,9 @@ namespace libdnf::base {
 
 class Transaction::Impl {
 public:
-    Impl(Transaction & transaction, const BaseWeakPtr & base) : transaction(transaction), base(base) {}
+    Impl(Transaction & transaction, const BaseWeakPtr & base) : transaction(&transaction), base(base) {}
     Impl(Transaction & transaction, const Impl & src)
-        : transaction(transaction),
+        : transaction(&transaction),
           base(src.base),
           libsolv_transaction(src.libsolv_transaction ? transaction_create_clone(src.libsolv_transaction) : nullptr),
           problems(src.problems),
@@ -77,7 +77,7 @@ private:
     friend Transaction;
     friend class libdnf::Goal;
 
-    Transaction & transaction;
+    Transaction * transaction;
     BaseWeakPtr base;
     ::Transaction * libsolv_transaction{nullptr};
     libdnf::GoalProblem problems{GoalProblem::NO_PROBLEM};


### PR DESCRIPTION
Command arguments are set in the `set_argumetn_parser` method instead of in the constructor.
`cli::session::Command:run` method is splitted into multiple methods

The methods are called in a defined order.
`void set_argument_parser()`
`void register_subcommands()`
`void pre_configure()`
`void configure()`
`void load_additional_packages()`
`void run()`
`void goal_resolved()`