### PR TITLE
Fix gcc 13 build

### DIFF
--- a/libdnf/conf/OptionNumber.hpp
+++ b/libdnf/conf/OptionNumber.hpp
@@ -25,6 +25,7 @@
 
 #include "Option.hpp"
 
+#include <cstdint>
 #include <functional>
 
 namespace libdnf {

--- a/libdnf/utils/sqlite3/Sqlite3.hpp
+++ b/libdnf/utils/sqlite3/Sqlite3.hpp
@@ -27,6 +27,7 @@
 
 #include <sqlite3.h>
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <stdexcept>


### PR DESCRIPTION
Add missing `<cstdint>` include

Without the change libdnf build fails on this week's gcc-13 snapshot as:

        In file included from /build/libdnf/libdnf/conf/ConfigMain.hpp:29,
                         from /build/libdnf/libdnf/conf/ConfigMain.cpp:21:
        /build/libdnf/libdnf/conf/OptionNumber.hpp:94:41: error: 'int32_t' is not a member of 'std'; did you mean 'int32_t'?
           94 | extern template class OptionNumber<std::int32_t>;
              |                                         ^~~~~~~

        In file included from /build/libdnf/libdnf/sack/../transaction/Swdb.hpp:38,
                         from /build/libdnf/libdnf/sack/query.hpp:32,
                         from /build/libdnf/libdnf/dnf-sack-private.hpp:31,
                         from /build/libdnf/libdnf/hy-iutil.cpp:60:
        /build/libdnf/libdnf/sack/../transaction/../utils/sqlite3/Sqlite3.hpp:100:33: error: 'std::int64_t' has not been declared
          100 |         void bind(int pos, std::int64_t val)
              |                                 ^~~~~~~