### PR TITLE
Expose librepo max_downloads_per_mirror configuration

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -349,6 +349,7 @@ class ConfigMain::Impl {
 
     OptionSeconds timeout{30};
     OptionNumber<std::uint32_t> max_parallel_downloads{3, 1};
+    OptionNumber<std::uint32_t> max_downloads_per_mirror{3, 1};
     OptionSeconds metadata_expire{60 * 60 * 48};
     OptionString sslcacert{""};
     OptionBool sslverify{true};
@@ -507,6 +508,7 @@ ConfigMain::Impl::Impl(Config & owner)
     owner.optBinds().add("throttle", throttle);
     owner.optBinds().add("timeout", timeout);
     owner.optBinds().add("max_parallel_downloads", max_parallel_downloads);
+    owner.optBinds().add("max_downloads_per_mirror", max_downloads_per_mirror);
     owner.optBinds().add("metadata_expire", metadata_expire);
     owner.optBinds().add("sslcacert", sslcacert);
     owner.optBinds().add("sslverify", sslverify);
@@ -628,6 +630,7 @@ OptionEnum<std::string> & ConfigMain::ip_resolve() { return pImpl->ip_resolve; }
 OptionNumber<float> & ConfigMain::throttle() { return pImpl->throttle; }
 OptionSeconds & ConfigMain::timeout() { return pImpl->timeout; }
 OptionNumber<std::uint32_t> & ConfigMain::max_parallel_downloads() { return pImpl->max_parallel_downloads; }
+OptionNumber<std::uint32_t> & ConfigMain::max_downloads_per_mirror() { return pImpl->max_downloads_per_mirror; }
 OptionSeconds & ConfigMain::metadata_expire() { return pImpl->metadata_expire; }
 OptionString & ConfigMain::sslcacert() { return pImpl->sslcacert; }
 OptionBool & ConfigMain::sslverify() { return pImpl->sslverify; }

--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -156,6 +156,7 @@ public:
     OptionNumber<float> & throttle();
     OptionSeconds & timeout();
     OptionNumber<std::uint32_t> & max_parallel_downloads();
+    OptionNumber<std::uint32_t> & max_downloads_per_mirror();
     OptionSeconds & metadata_expire();
     OptionString & sslcacert();
     OptionBool & sslverify();

--- a/libdnf/conf/ConfigRepo.cpp
+++ b/libdnf/conf/ConfigRepo.cpp
@@ -61,6 +61,7 @@ class ConfigRepo::Impl {
     OptionChild<OptionNumber<float> > throttle{mainConfig.throttle()};
     OptionChild<OptionSeconds> timeout{mainConfig.timeout()};
     OptionChild<OptionNumber<std::uint32_t> >  max_parallel_downloads{mainConfig.max_parallel_downloads()};
+    OptionChild<OptionNumber<std::uint32_t> >  max_downloads_per_mirror{mainConfig.max_downloads_per_mirror()};
     OptionChild<OptionSeconds> metadata_expire{mainConfig.metadata_expire()};
     OptionNumber<std::int32_t> cost{1000};
     OptionNumber<std::int32_t> priority{99};
@@ -155,6 +156,7 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & mainConfig)
     owner.optBinds().add("throttle", throttle);
     owner.optBinds().add("timeout", timeout);
     owner.optBinds().add("max_parallel_downloads", max_parallel_downloads);
+    owner.optBinds().add("max_downloads_per_mirror", max_downloads_per_mirror);
     owner.optBinds().add("metadata_expire", metadata_expire);
     owner.optBinds().add("cost", cost);
     owner.optBinds().add("priority", priority);
@@ -211,6 +213,7 @@ OptionChild<OptionEnum<std::string> > & ConfigRepo::ip_resolve() { return pImpl-
 OptionChild<OptionNumber<float> > & ConfigRepo::throttle() { return pImpl->throttle; }
 OptionChild<OptionSeconds> & ConfigRepo::timeout() { return pImpl->timeout; }
 OptionChild<OptionNumber<std::uint32_t> > & ConfigRepo::max_parallel_downloads() { return pImpl->max_parallel_downloads; }
+OptionChild<OptionNumber<std::uint32_t> > & ConfigRepo::max_downloads_per_mirror() { return pImpl->max_downloads_per_mirror; }
 OptionChild<OptionSeconds> & ConfigRepo::metadata_expire() { return pImpl->metadata_expire; }
 OptionNumber<std::int32_t> & ConfigRepo::cost() { return pImpl->cost; }
 OptionNumber<std::int32_t> & ConfigRepo::priority() { return pImpl->priority; }

--- a/libdnf/conf/ConfigRepo.hpp
+++ b/libdnf/conf/ConfigRepo.hpp
@@ -75,6 +75,7 @@ public:
     OptionChild<OptionNumber<float> > & throttle();
     OptionChild<OptionSeconds> & timeout();
     OptionChild<OptionNumber<std::uint32_t> > & max_parallel_downloads();
+    OptionChild<OptionNumber<std::uint32_t> > & max_downloads_per_mirror();
     OptionChild<OptionSeconds> & metadata_expire();
     OptionNumber<std::int32_t> & cost();
     OptionNumber<std::int32_t> & priority();

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -461,6 +461,8 @@ std::unique_ptr<LrHandle> Repo::Impl::lrHandleInitBase()
     handleSetOpt(h.get(), LRO_MAXMIRRORTRIES, static_cast<long>(maxMirrorTries));
     handleSetOpt(h.get(), LRO_MAXPARALLELDOWNLOADS,
                      conf->max_parallel_downloads().getValue());
+    handleSetOpt(h.get(), LRO_MAXDOWNLOADSPERMIRROR,
+                     conf->max_downloads_per_mirror().getValue());
 
     LrUrlVars * vars = NULL;
     vars = lr_urlvars_set(vars, MD_TYPE_GROUP_GZ, MD_TYPE_GROUP);

--- a/python/hawkey/tests/tests/test_repo.py
+++ b/python/hawkey/tests/tests/test_repo.py
@@ -40,6 +40,16 @@ class Package(unittest.TestCase):
         with self.assertRaises(TypeError):
             r2.cost = '4'
 
+    def test_max_parallel_downloads(self):
+        r = hawkey.Repo("fog")
+        r.max_parallel_downloads = 10
+        self.assertEqual(10, r.max_parallel_downloads)
+
+    def test_max_downloads_per_mirror(self):
+        r = hawkey.Repo("fog")
+        r.max_downloads_per_mirror = 10
+        self.assertEqual(10, r.max_downloads_per_mirror)
+
     def test_str_assignment(self):
         r = hawkey.Repo('fog')
         with self.assertRaises(TypeError):


### PR DESCRIPTION
In many cases the librepo default of 3 concurrent downloads per mirror
is sufficient, as there are multiple mirrors, and the max of 3 per
mirror is cumulative up until max_parallel_downloads. However, in some
situations you don't necessarily want to have other mirrors, and want to
have more than 3 parallel downloads.

Such a situation could be where not all mirrors have equal cost, and can
handle more simultaneous downloads to saturate the available network
bandwidth - so it's beneficial to only list the one mirror in the
mirrorlist, and up the maximum number of parallel downloads.

= changelog =
msg: Expose librepo max_downloads_per_mirror config option
type: enhancement