### PR TITLE
Do not print errors on failovermethod repo option (RhBug:2039906)

### DIFF
--- a/libdnf/conf/ConfigRepo.cpp
+++ b/libdnf/conf/ConfigRepo.cpp
@@ -22,6 +22,8 @@
 #include "Const.hpp"
 #include "Config-private.hpp"
 
+#include "bgettext/bgettext-lib.h"
+
 namespace libdnf {
 
 class ConfigRepo::Impl {
@@ -174,6 +176,14 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & mainConfig)
     owner.optBinds().add("enabled_metadata", enabled_metadata);
     owner.optBinds().add("user_agent", user_agent);
     owner.optBinds().add("countme", countme);
+    owner.optBinds().add("failovermethod", failovermethod,
+        [&](Option::Priority priority, const std::string & value){
+            if (value != "priority") {
+                throw Option::InvalidValue(_("only the value 'priority' is supported."));
+            }
+            failovermethod.set(priority, value);
+        }, nullptr, false
+    );
     owner.optBinds().add("sslverifystatus", sslverifystatus);
 }
 


### PR DESCRIPTION
This is downstream patch for rhel-8.7 branch. In the upstream the `failovermethod` config option was removed completely.

https://bugzilla.redhat.com/show_bug.cgi?id=2039906

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1126