### PR TITLE
bindings: Undefine conflicting macros from perl's utf8.h

### DIFF
--- a/bindings/libdnf/shared.i
+++ b/bindings/libdnf/shared.i
@@ -1,11 +1,15 @@
 %{
-    // Undefine macros from ruby.h polluting the global namespace and
-    // conflicting with C++ definitions (in particular from the fmt/format.h
-    // header).
+    // Undefine macros polluting the global namespace and conflicting
+    // with C++ definitions.
     //
     // These are unlikely to be needed in the bindings and in case they are, it
     // should cause a compile-time error (meaning no silent breakage).
+
+    // From ruby - ruby.h: conflicts with fmt/format.h header
     #undef isfinite
     #undef int128_t
     #undef uint128_t
+
+    // From perl5 - utf8.h: conflicts with fmt/format.h header
+    #undef utf8_to_utf16
 %}


### PR DESCRIPTION
`utf8_to_utf16` is a macro from perl5 utf8.h that conflicts with
fmt/format.h. Undefine it in the bindings.