### PR TITLE
[dnf5] repoquery command: Fix advisory filtering and use all packages if `keys_to_match` is empty

### DIFF
--- a/dnf5/commands/repoquery/repoquery.cpp
+++ b/dnf5/commands/repoquery/repoquery.cpp
@@ -150,7 +150,9 @@ void RepoqueryCommand::run() {
         full_package_query.filter_advisories(advisories.value(), libdnf::sack::QueryCmp::EQ);
     }
 
-    if (!pkg_specs.empty() || !pkg_file_paths.empty()) {
+    if (pkg_specs.empty() && pkg_file_paths.empty()) {
+        result_pset |= full_package_query;
+    } else {
         for (const auto & pkg : cmdline_packages) {
             if (full_package_query.contains(pkg)) {
                 result_pset.add(pkg);


### PR DESCRIPTION
Changes in dnf5 repoquery command:
- Fix: Apply advisory filtering to command line packages
- Use all packages if `keys_to_match` is empty (compatible behaviout with old dnf and microdnf)
