### PR TITLE
Add missing #include <ctime>

### DIFF
--- a/common/utils/string.hpp
+++ b/common/utils/string.hpp
@@ -21,6 +21,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #define LIBDNF_UTILS_STRING_HPP
 
 #include <algorithm>
+#include <ctime>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Add missing include (for gmtime() and strftime(), both used by format_epoch)
Not having this breaks the build with clang 14.0.5, libstdc++ 12.1.1