### PR TITLE
[dnf5] Get dnf closer to zypper by adding command aliases

### DIFF
--- a/dnf5/commands/aliases/autoremove.hpp
+++ b/dnf5/commands/aliases/autoremove.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class AutoremoveAlias : public RemoveCommand {
 public:
-    explicit AutoremoveAlias(Command & parent) : RemoveCommand(parent, "autoremove") {}
+    explicit AutoremoveAlias(Command & parent) : RemoveCommand(parent, "autoremove", {}) {}
 
     void set_argument_parser() override {
         RemoveCommand::set_argument_parser();

--- a/dnf5/commands/aliases/upgrade_minimal.hpp
+++ b/dnf5/commands/aliases/upgrade_minimal.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class UpgradeMinimalAlias : public UpgradeCommand {
 public:
-    explicit UpgradeMinimalAlias(Command & parent) : UpgradeCommand(parent, "upgrade-minimal") {}
+    explicit UpgradeMinimalAlias(Command & parent) : UpgradeCommand(parent, "upgrade-minimal", {}) {}
     void set_argument_parser() override {
         UpgradeCommand::set_argument_parser();
         get_argument_parser_command()->set_short_description("Alias for 'upgrade --minimal'");

--- a/dnf5/commands/distro-sync/distro-sync.hpp
+++ b/dnf5/commands/distro-sync/distro-sync.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 
 class DistroSyncCommand : public Command {
 public:
-    explicit DistroSyncCommand(Command & parent) : DistroSyncCommand(parent, "distro-sync", {"dist-upgrade", "dup"}) {}
+    explicit DistroSyncCommand(Command & parent) : DistroSyncCommand(parent, "distro-sync", {"dist-upgrade", "dup", "foo"}) {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;

--- a/dnf5/commands/distro-sync/distro-sync.hpp
+++ b/dnf5/commands/distro-sync/distro-sync.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 
 class DistroSyncCommand : public Command {
 public:
-    explicit DistroSyncCommand(Command & parent) : DistroSyncCommand(parent, "distro-sync") {}
+    explicit DistroSyncCommand(Command & parent) : DistroSyncCommand(parent, "distro-sync", {"dist-upgrade", "dup"}) {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;
@@ -41,7 +41,7 @@ public:
     std::vector<std::unique_ptr<libdnf::Option>> * patterns_to_distro_sync_options{nullptr};
 
 protected:
-    explicit DistroSyncCommand(Command & parent, const std::string & name) : Command(parent, name) {}
+    explicit DistroSyncCommand(Command & parent, const std::string & name, const std::vector<std::string> & aliases) : Command(parent, name, aliases) {}
 };
 
 

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class InstallCommand : public Command {
 public:
-    explicit InstallCommand(Command & parent) : Command(parent, "install") {}
+    explicit InstallCommand(Command & parent) : Command(parent, "install", {"in"}) {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/install/install.hpp
+++ b/dnf5/commands/install/install.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class InstallCommand : public Command {
 public:
-    explicit InstallCommand(Command & parent) : Command(parent, "install", {"in"}) {}
+    explicit InstallCommand(Command & parent) : Command(parent, "install", {"in", "foo"}) {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/makecache/makecache.hpp
+++ b/dnf5/commands/makecache/makecache.hpp
@@ -26,7 +26,7 @@ namespace dnf5 {
 
 class MakeCacheCommand : public Command {
 public:
-    explicit MakeCacheCommand(Command & parent) : Command(parent, "makecache") {}
+    explicit MakeCacheCommand(Command & parent) : Command(parent, "makecache", {"refresh", "ref"}) {}
     void set_argument_parser() override;
     void run() override;
 };

--- a/dnf5/commands/reinstall/reinstall.hpp
+++ b/dnf5/commands/reinstall/reinstall.hpp
@@ -32,7 +32,7 @@ namespace dnf5 {
 
 class ReinstallCommand : public Command {
 public:
-    explicit ReinstallCommand(Command & parent) : Command(parent, "reinstall") {}
+    explicit ReinstallCommand(Command & parent) : Command(parent, "reinstall", {}) {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/remove/remove.hpp
+++ b/dnf5/commands/remove/remove.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class RemoveCommand : public Command {
 public:
-    explicit RemoveCommand(Command & parent) : RemoveCommand(parent, "remove") {}
+    explicit RemoveCommand(Command & parent) : RemoveCommand(parent, "remove", {"rm"}) {}
     void set_argument_parser() override;
     void configure() override;
     void run() override;
@@ -40,7 +40,7 @@ public:
 
 protected:
     // to be used by an alias command only
-    explicit RemoveCommand(Command & parent, const std::string & name) : Command(parent, name) {}
+    explicit RemoveCommand(Command & parent, const std::string & name, const std::vector<std::string> & aliases) : Command(parent, name, aliases) {}
 };
 
 }  // namespace dnf5

--- a/dnf5/commands/repoquery/repoquery.hpp
+++ b/dnf5/commands/repoquery/repoquery.hpp
@@ -35,7 +35,7 @@ namespace dnf5 {
 
 class RepoqueryCommand : public Command {
 public:
-    explicit RepoqueryCommand(Command & parent) : Command(parent, "repoquery") {}
+    explicit RepoqueryCommand(Command & parent) : Command(parent, "repoquery", {"rq"}) {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;

--- a/dnf5/commands/search/search.hpp
+++ b/dnf5/commands/search/search.hpp
@@ -33,7 +33,7 @@ namespace dnf5 {
 
 class SearchCommand : public Command {
 public:
-    explicit SearchCommand(Command & parent) : Command(parent, "search") {}
+    explicit SearchCommand(Command & parent) : Command(parent, "search", {"se"}) {}
     void set_argument_parser() override;
     void run() override;
 

--- a/dnf5/commands/upgrade/upgrade.hpp
+++ b/dnf5/commands/upgrade/upgrade.hpp
@@ -30,7 +30,7 @@ namespace dnf5 {
 
 class UpgradeCommand : public Command {
 public:
-    explicit UpgradeCommand(Command & parent) : UpgradeCommand(parent, "upgrade") {}
+    explicit UpgradeCommand(Command & parent) : UpgradeCommand(parent, "upgrade", {"up"}) {}
     void set_argument_parser() override;
     void configure() override;
     void load_additional_packages() override;
@@ -38,7 +38,7 @@ public:
 
 protected:
     // to be used by an alias command only
-    explicit UpgradeCommand(Command & parent, const std::string & name) : Command(parent, name) {}
+    explicit UpgradeCommand(Command & parent, const std::string & name, const std::vector<std::string> & aliases) : Command(parent, name, aliases) {}
 
     libdnf::OptionBool * minimal{nullptr};
     std::vector<std::string> pkg_specs;

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -441,6 +441,12 @@ public:
         /// Gets the header of the positional arguments table. Used to generate help.
         const std::string & get_positional_args_help_header() const noexcept { return positional_args_help_header; }
 
+        /// Create alias for the command. The alias is not shown in completion.
+        void add_alias(const std::string & name) { aliases.push_back(name); }
+
+        /// Get list of aliases for the command.
+        const std::vector<std::string> & get_aliases() const { return aliases; }
+
     private:
         /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
         void parse(
@@ -457,6 +463,7 @@ public:
             const char * arg, std::vector<ArgumentParser::NamedArg *> named_args, size_t used_positional_arguments);
 
         Command * parent{nullptr};
+        std::vector<std::string> aliases;
         std::vector<Command *> cmds;
         std::vector<NamedArg *> named_args;
         std::vector<PositionalArg *> pos_args;

--- a/include/libdnf-cli/argument_parser.hpp
+++ b/include/libdnf-cli/argument_parser.hpp
@@ -447,6 +447,9 @@ public:
         /// Get list of aliases for the command.
         const std::vector<std::string> & get_aliases() const { return aliases; }
 
+        /// Get list of all IDs for the command (id + aliases)
+        std::unordered_set<std::string> get_command_ids() const;
+
     private:
         /// Parses input. The input may contain named arguments, (sub)commands and positional arguments.
         void parse(

--- a/include/libdnf-cli/session.hpp
+++ b/include/libdnf-cli/session.hpp
@@ -76,6 +76,7 @@ private:
 class Command {
 public:
     explicit Command(Command & parent, const std::string & name);
+    explicit Command(Command & parent, const std::string & name, const std::vector<std::string> & aliases);
     explicit Command(Session & session, const std::string & program_name);
     virtual ~Command() = default;
 
@@ -112,6 +113,9 @@ public:
     /// Throw a ArgumentParserMissingCommandError exception with the command name in it
     void throw_missing_command() const;
 
+    /// Return aliases to the command.
+    const std::vector<std::string> & get_aliases() const { return aliases; }
+
     /// @return Pointer to the Session.
     ///         The returned pointer must **not** be freed manually.
     /// @since 5.0
@@ -144,6 +148,7 @@ private:
     Command * parent_command = nullptr;
     libdnf::cli::ArgumentParser::Command * argument_parser_command;
     std::vector<std::unique_ptr<Command>> subcommands;
+    std::vector<std::string> aliases;
 };
 
 

--- a/libdnf-cli/session.cpp
+++ b/libdnf-cli/session.cpp
@@ -56,9 +56,16 @@ Command::Command(Session & session, const std::string & program_name) : session{
 }
 
 
-Command::Command(Command & parent, const std::string & name) : session{parent.session}, parent_command{&parent} {
+Command::Command(Command & parent, const std::string & name) : Command(parent, name, {}) {}
+
+
+Command::Command(Command & parent, const std::string & name, const std::vector<std::string> & aliases) : session{parent.session}, parent_command{&parent}, aliases{aliases} {
     // create a new command owned by the arg_parser
     argument_parser_command = session.get_argument_parser().add_new_command(name);
+
+    for (auto & alias : aliases) {
+        argument_parser_command->add_alias(alias);
+    }
 
     // set the command as selected when parsed
     argument_parser_command->set_parse_hook_func([this](


### PR DESCRIPTION
We're adding aliases only to the most commonly used commands.
They may be appreciated by the dnf users as well, because
they provide shortcuts to the commonly used commands.

TODO:

 - [ ] Make the aliases work (requires changes in argument parser)
 - [ ] Consider renaming `distro-sync` to `dist-upgrade` (apt-get, zypper has it), make `distro-sync` a compat alias
