### PR TITLE
[dnf5] libdnf plugins loading, new hooks pre_base_setup, post_base_setup

### DIFF
--- a/bindings/libdnf5/plugin.i
+++ b/bindings/libdnf5/plugin.i
@@ -19,6 +19,7 @@
 
 #define CV __perl_CV
 
+%ignore PluginError;
 %ignore libdnf_plugin_get_api_version;
 %ignore libdnf_plugin_get_name;
 %ignore libdnf_plugin_get_version;

--- a/dnf5/main.cpp
+++ b/dnf5/main.cpp
@@ -556,10 +556,6 @@ int main(int argc, char * argv[]) try {
 
     context.set_prg_arguments(static_cast<size_t>(argc), argv);
 
-    context.base.load_plugins();
-    auto & plugins = context.base.get_plugins();
-    plugins.init();
-
     // Load dnf5 plugins
     auto & dnf5_plugins = context.get_plugins();
     const char * plugins_dir = std::getenv("DNF5_PLUGINS_DIR");
@@ -636,6 +632,10 @@ int main(int argc, char * argv[]) try {
         log_router.swap_logger(logger, 0);
         // Write messages from memory buffer logger to stream logger
         dynamic_cast<libdnf::MemoryBufferLogger &>(*logger).write_to_logger(log_router);
+
+        context.base.load_plugins();
+        auto & plugins = context.base.get_plugins();
+        plugins.init();
 
         base.setup();
 

--- a/include/libdnf/conf/config_main.hpp
+++ b/include/libdnf/conf/config_main.hpp
@@ -52,10 +52,10 @@ public:
     const OptionPath & config_file_path() const;
     OptionBool & plugins();
     const OptionBool & plugins() const;
-    OptionStringList & pluginpath();
-    const OptionStringList & pluginpath() const;
-    OptionStringList & pluginconfpath();
-    const OptionStringList & pluginconfpath() const;
+    OptionPath & pluginpath();
+    const OptionPath & pluginpath() const;
+    OptionPath & pluginconfpath();
+    const OptionPath & pluginconfpath() const;
     OptionPath & persistdir();
     const OptionPath & persistdir() const;
     OptionPath & system_state_dir();

--- a/include/libdnf/conf/const.hpp
+++ b/include/libdnf/conf/const.hpp
@@ -33,6 +33,8 @@ constexpr const char * SYSTEM_CACHEDIR = "/var/cache/libdnf";
 constexpr const char * CONF_FILENAME = "/etc/dnf/dnf.conf";
 constexpr const char * CONF_DIRECTORY = "/etc/dnf/conf.d";
 
+constexpr const char * PLUGINS_CONF_DIR = "/etc/dnf/libdnf5-plugins";
+
 // More important varsdirs must be on the end of vector
 const std::vector<std::string> VARS_DIRS{"/etc/yum/vars", "/etc/dnf/vars"};
 

--- a/include/libdnf/plugin/iplugin.hpp
+++ b/include/libdnf/plugin/iplugin.hpp
@@ -25,6 +25,11 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 namespace libdnf {
 
 class Base;
+struct ConfigParser;
+
+namespace base {
+class Transaction;
+}
 
 }  // namespace libdnf
 
@@ -81,9 +86,13 @@ public:
     /// Plugin initialization.
     virtual void init() {}
 
-    virtual void pre_transaction() {}
+    virtual void pre_base_setup() {}
 
-    virtual void post_transaction() {}
+    virtual void post_base_setup() {}
+
+    virtual void pre_transaction(const libdnf::base::Transaction &) {}
+
+    virtual void post_transaction(const libdnf::base::Transaction &) {}
 
     /// It is called when a hook is reached. The argument describes what happened.
     virtual bool hook(HookId) { return true; }
@@ -110,7 +119,8 @@ const char * libdnf_plugin_get_name(void);
 libdnf::plugin::PluginVersion libdnf_plugin_get_version(void);
 
 /// Creates a new plugin instance. Passes the API version to the plugin.
-libdnf::plugin::IPlugin * libdnf_plugin_new_instance(libdnf::plugin::APIVersion api_version, libdnf::Base & base);
+libdnf::plugin::IPlugin * libdnf_plugin_new_instance(
+    libdnf::plugin::APIVersion api_version, libdnf::Base & base, libdnf::ConfigParser & parser);
 
 /// Deletes plugin instance.
 void libdnf_plugin_delete_instance(libdnf::plugin::IPlugin * plugin_instance);

--- a/include/libdnf/plugin/plugins.hpp
+++ b/include/libdnf/plugin/plugins.hpp
@@ -22,12 +22,22 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "iplugin.hpp"
 
+#include "libdnf/common/exception.hpp"
+
 #include <memory>
 #include <string>
 #include <vector>
 
 
 namespace libdnf::plugin {
+
+class PluginError : public Error {
+public:
+    using Error::Error;
+    const char * get_domain_name() const noexcept override { return "libdnf::plugin"; }
+    const char * get_name() const noexcept override { return "PluginError"; }
+};
+
 
 class Plugin {
 public:
@@ -66,11 +76,11 @@ public:
     /// Registers the plugin passed by the argument.
     void register_plugin(std::unique_ptr<Plugin> && plugin);
 
-    /// Loads the plugin from the library defined by the file path.
-    void load_plugin(const std::string & file_path);
+    /// Loads the plugin from the library defined by the configuration file config_file_path.
+    void load_plugin(const std::string & config_file_path);
 
-    /// Loads plugins from libraries in the directory.
-    void load_plugins(const std::string & dir_path);
+    /// Loads plugins defined by configuration files in the directory.
+    void load_plugins(const std::string & config_dir_path);
 
     /// Returns the number of registered plugins.
     size_t count() const noexcept;
@@ -89,6 +99,11 @@ public:
     void finish() noexcept;
 
 private:
+    std::string find_plugin_library(const std::string & plugin_conf_path);
+
+    /// Loads the plugin from the library defined by the file path.
+    void load_plugin_library(const std::string & file_path);
+
     Base * base;
     std::vector<std::unique_ptr<Plugin>> plugins;
 };

--- a/libdnf-plugins/python_plugins_loader/CMakeLists.txt
+++ b/libdnf-plugins/python_plugins_loader/CMakeLists.txt
@@ -16,5 +16,5 @@ set_target_properties(python_plugins_loader PROPERTIES PREFIX "")
 target_link_libraries(python_plugins_loader PUBLIC libdnf libdnf-cli)
 target_link_libraries(python_plugins_loader PUBLIC ${Python3_LIBRARIES})
 
-install(TARGETS python_plugins_loader LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/libdnf-plugins/)
+install(TARGETS python_plugins_loader LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/libdnf5/plugins/)
 install(FILES "README" DESTINATION ${Python3_SITELIB}/libdnf_plugins/)

--- a/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
+++ b/libdnf-plugins/python_plugins_loader/python_plugins_loader.cpp
@@ -39,7 +39,7 @@ constexpr const char * attrs_value[]{"Jaroslav Rohel", "jrohel@redhat.com", "Plu
 
 class PythonPluginLoader : public IPlugin {
 public:
-    PythonPluginLoader(libdnf::Base & base) : base(base) {}
+    PythonPluginLoader(libdnf::Base & base, libdnf::ConfigParser &) : base(base) {}
     virtual ~PythonPluginLoader();
 
     APIVersion get_api_version() const noexcept override { return PLUGIN_API_VERSION; }
@@ -321,8 +321,9 @@ PluginVersion libdnf_plugin_get_version(void) {
     return PLUGIN_VERSION;
 }
 
-IPlugin * libdnf_plugin_new_instance([[maybe_unused]] APIVersion api_version, libdnf::Base & base) try {
-    return new PythonPluginLoader(base);
+IPlugin * libdnf_plugin_new_instance(
+    [[maybe_unused]] APIVersion api_version, libdnf::Base & base, libdnf::ConfigParser & parser) try {
+    return new PythonPluginLoader(base, parser);
 } catch (...) {
     return nullptr;
 }

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -1,6 +1,8 @@
 # use any sources found under the current directory
 file(GLOB_RECURSE LIBDNF_SOURCES *.cpp)
 
+# create config header file
+configure_file("config.h.in" ${CMAKE_CURRENT_SOURCE_DIR}/conf/config.h)
 
 # gather all pkg-config requires and write them to a .pc file later
 list(APPEND LIBDNF_PC_REQUIRES)

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -107,6 +107,9 @@ void Base::load_plugins() {
 
 void Base::setup() {
     libdnf_assert(!pool, "Base was already initialized");
+
+    plugins.pre_base_setup();
+
     pool.reset(new libdnf::solv::Pool);
     auto & config = get_config();
     auto & installroot = config.installroot();
@@ -123,6 +126,8 @@ void Base::setup() {
     // (and force to recompute provides) or locked
     pool_setarch(**pool, get_vars()->get_value("arch").c_str());
     pool_set_rootdir(**pool, installroot.get_value().c_str());
+
+    plugins.post_base_setup();
 }
 
 }  // namespace libdnf

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -97,11 +97,11 @@ void Base::add_plugin(plugin::IPlugin & iplugin_instance) {
 }
 
 void Base::load_plugins() {
-    if (const char * plugins_config_dir = std::getenv("LIBDNF_PLUGINS_CONFIG_DIR")) {
+    const char * plugins_config_dir = std::getenv("LIBDNF_PLUGINS_CONFIG_DIR");
+    if (plugins_config_dir && config.pluginconfpath().get_priority() < Option::Priority::COMMANDLINE) {
         plugins.load_plugins(plugins_config_dir);
-    }
-    for (const auto & plugins_config_dir : config.pluginconfpath().get_value()) {
-        plugins.load_plugins(plugins_config_dir);
+    } else {
+        plugins.load_plugins(config.pluginconfpath().get_value());
     }
 }
 

--- a/libdnf/base/base.cpp
+++ b/libdnf/base/base.cpp
@@ -97,8 +97,11 @@ void Base::add_plugin(plugin::IPlugin & iplugin_instance) {
 }
 
 void Base::load_plugins() {
-    if (const char * plugin_dir = std::getenv("LIBDNF_PLUGIN_DIR")) {
-        plugins.load_plugins(plugin_dir);
+    if (const char * plugins_config_dir = std::getenv("LIBDNF_PLUGINS_CONFIG_DIR")) {
+        plugins.load_plugins(plugins_config_dir);
+    }
+    for (const auto & plugins_config_dir : config.pluginconfpath().get_value()) {
+        plugins.load_plugins(plugins_config_dir);
     }
 }
 

--- a/libdnf/base/transaction.cpp
+++ b/libdnf/base/transaction.cpp
@@ -424,7 +424,7 @@ Transaction::TransactionRunResult Transaction::Impl::run(
     }
 
     auto & plugins = base->get_plugins();
-    plugins.pre_transaction();
+    plugins.pre_transaction(*transaction);
 
     // start history db transaction
     auto db_transaction = base->get_transaction_history()->new_transaction();
@@ -484,7 +484,7 @@ Transaction::TransactionRunResult Transaction::Impl::run(
     db_transaction.finish(
         ret == 0 ? libdnf::transaction::TransactionState::OK : libdnf::transaction::TransactionState::ERROR);
 
-    plugins.post_transaction();
+    plugins.post_transaction(*transaction);
 
     if (ret == 0) {
         return TransactionRunResult::SUCCESS;

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -166,8 +166,8 @@ class ConfigMain::Impl {
     OptionPath installroot{"/", false, true};
     OptionPath config_file_path{CONF_FILENAME};
     OptionBool plugins{true};
-    OptionStringList pluginpath{std::vector<std::string>{DEFAULT_LIBDNF5_PLUGINS_LIB_DIR}};
-    OptionStringList pluginconfpath{std::vector<std::string>{PLUGINS_CONF_DIR}};
+    OptionPath pluginpath{DEFAULT_LIBDNF5_PLUGINS_LIB_DIR};
+    OptionPath pluginconfpath{PLUGINS_CONF_DIR};
     OptionPath persistdir{PERSISTDIR};
     OptionPath system_state_dir{SYSTEM_STATE_DIR};
     OptionPath transaction_history_dir{SYSTEM_STATE_DIR};
@@ -574,17 +574,17 @@ const OptionBool & ConfigMain::plugins() const {
     return p_impl->plugins;
 }
 
-OptionStringList & ConfigMain::pluginpath() {
+OptionPath & ConfigMain::pluginpath() {
     return p_impl->pluginpath;
 }
-const OptionStringList & ConfigMain::pluginpath() const {
+const OptionPath & ConfigMain::pluginpath() const {
     return p_impl->pluginpath;
 }
 
-OptionStringList & ConfigMain::pluginconfpath() {
+OptionPath & ConfigMain::pluginconfpath() {
     return p_impl->pluginconfpath;
 }
-const OptionStringList & ConfigMain::pluginconfpath() const {
+const OptionPath & ConfigMain::pluginconfpath() const {
     return p_impl->pluginconfpath;
 }
 

--- a/libdnf/conf/config_main.cpp
+++ b/libdnf/conf/config_main.cpp
@@ -19,6 +19,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "libdnf/conf/config_main.hpp"
 
+#include "config.h"
 #include "config_utils.hpp"
 #include "utils/bgettext/bgettext-mark-domain.h"
 #include "utils/fs/file.hpp"
@@ -165,8 +166,8 @@ class ConfigMain::Impl {
     OptionPath installroot{"/", false, true};
     OptionPath config_file_path{CONF_FILENAME};
     OptionBool plugins{true};
-    OptionStringList pluginpath{std::vector<std::string>{}};
-    OptionStringList pluginconfpath{std::vector<std::string>{}};
+    OptionStringList pluginpath{std::vector<std::string>{DEFAULT_LIBDNF5_PLUGINS_LIB_DIR}};
+    OptionStringList pluginconfpath{std::vector<std::string>{PLUGINS_CONF_DIR}};
     OptionPath persistdir{PERSISTDIR};
     OptionPath system_state_dir{SYSTEM_STATE_DIR};
     OptionPath transaction_history_dir{SYSTEM_STATE_DIR};

--- a/libdnf/config.h.in
+++ b/libdnf/config.h.in
@@ -1,0 +1,25 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef _LIBDNF_CONFIG_H_
+#define _LIBDNF_CONFIG_H_
+
+#define DEFAULT_LIBDNF5_PLUGINS_LIB_DIR "@CMAKE_INSTALL_FULL_LIBDIR@/libdnf5/plugins/"
+
+#endif // _LIBDNF_CONFIG_H_

--- a/libdnf/plugin/plugins.cpp
+++ b/libdnf/plugin/plugins.cpp
@@ -102,12 +102,10 @@ void Plugins::register_plugin(std::unique_ptr<Plugin> && plugin) {
 std::string Plugins::find_plugin_library(const std::string & plugin_conf_path) {
     auto library_name = std::filesystem::path(plugin_conf_path).stem();
     library_name += ".so";
-    for (const auto & plugins_lib_dir : base->get_config().pluginpath().get_value()) {
-        std::filesystem::path library_path = plugins_lib_dir;
-        library_path /= library_name;
-        if (std::filesystem::exists(library_path)) {
-            return library_path;
-        }
+    std::filesystem::path library_path = base->get_config().pluginpath().get_value();
+    library_path /= library_name;
+    if (std::filesystem::exists(library_path)) {
+        return library_path;
     }
     throw PluginError(M_("Cannot find plugin library \"{}\""), library_name.string());
 }

--- a/libdnf5.spec
+++ b/libdnf5.spec
@@ -334,7 +334,7 @@ Requires:       python3-libdnf5%{?_isa} = %{version}-%{release}
 Libdnf plugin that allows loading Python plugins
 
 %files -n python3-libdnf-python-plugins-loader
-%{_libdir}/libdnf-plugins/python_plugins_loader.*
+%{_libdir}/libdnf5/plugins/python_plugins_loader.*
 %{python3_sitelib}/libdnf_plugins/
 %{python3_sitelib}/libdnf_plugins/README
 %endif

--- a/test/libdnf/conf/data/main.conf
+++ b/test/libdnf/conf/data/main.conf
@@ -1,7 +1,7 @@
 [main]
 debuglevel=7
 persistdir=hello
-pluginpath=/foo,/bar
+pluginpath=/foo
 plugins=False
 
 [repo-1]

--- a/test/libdnf/conf/test_conf.cpp
+++ b/test/libdnf/conf/test_conf.cpp
@@ -40,7 +40,7 @@ void ConfTest::test_config_main() {
     CPPUNIT_ASSERT_EQUAL(7, config.debuglevel().get_value());
     CPPUNIT_ASSERT_EQUAL(std::string("hello"), config.persistdir().get_value());
     CPPUNIT_ASSERT_EQUAL(false, config.plugins().get_value());
-    std::vector<std::string> pluginpath = {"/foo", "/bar"};
+    std::string pluginpath = "/foo";
     CPPUNIT_ASSERT_EQUAL(pluginpath, config.pluginpath().get_value());
 }
 


### PR DESCRIPTION
- The main configuration files of plugins are readed first. Plugin libraries are loaded only for plugins enabled in the configuration.

- Paths to configuration directories of libdnf5 plugins are stored in the "pluginconfpath" option (directory list).

- Paths to libdnf5 plugins library directories are stored in the "pluginpath" option (directory list).

- The default path to the plugins configuration files is "/etc/dnf/libdnf5-plugins/".

- The default path to the plugin libraries directory is "<system_libraries>/libdnf5/plugins/". <system_libraries> is system dependend: examples /usr/lib, /usr/lib64.

- Configuration directories are read in the order they are defined in the pluginconfpath configuration option. Loading plugins configurations from the directory is in alphabetical order. Plugin priority is not addressed.

- Libraries are loaded in the same order as their configurations are loaded.

-  The plugin library name is derived from the configuration name: example "actions.conf" -> "actions.so".