### PR TITLE
[dnf5] modules: Add ModulePersistor

### DIFF
--- a/include/libdnf/module/module_item_container.hpp
+++ b/include/libdnf/module/module_item_container.hpp
@@ -40,6 +40,7 @@ enum class ModuleState { AVAILABLE, DEFAULT, ENABLED, DISABLED };
 
 
 class ModuleItemContainer;
+class ModulePersistor;
 
 
 using ModuleItemContainerWeakPtr = libdnf::WeakPtr<ModuleItemContainer, false>;
@@ -49,6 +50,7 @@ class ModuleItemContainer {
 public:
     ModuleItemContainer(const BaseWeakPtr & base);
     ModuleItemContainer(Base & base);
+    ~ModuleItemContainer();
 
     ModuleItemContainerWeakPtr get_weak_ptr();
 
@@ -79,6 +81,8 @@ private:
     WeakPtrGuard<ModuleItemContainer, false> data_guard;
 
     BaseWeakPtr get_base() const;
+
+    std::unique_ptr<ModulePersistor> persistor;
 };
 
 

--- a/libdnf/module/module_item_container.cpp
+++ b/libdnf/module/module_item_container.cpp
@@ -20,6 +20,7 @@ along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
 #include "libdnf/module/module_item_container.hpp"
 
 #include "module/module_metadata.hpp"
+#include "module/module_persistor.hpp"
 
 #include "libdnf/base/base.hpp"
 #include "libdnf/base/base_weak.hpp"
@@ -38,8 +39,13 @@ extern "C" {
 namespace libdnf::module {
 
 
-ModuleItemContainer::ModuleItemContainer(const BaseWeakPtr & base) : base(base){};
-ModuleItemContainer::ModuleItemContainer(libdnf::Base & base) : base(base.get_weak_ptr()) {}
+ModuleItemContainer::ModuleItemContainer(const BaseWeakPtr & base)
+    : base(base),
+      persistor(new ModulePersistor(base->get_system_state())){};
+ModuleItemContainer::ModuleItemContainer(libdnf::Base & base)
+    : base(base.get_weak_ptr()),
+      persistor(new ModulePersistor(base.get_system_state())) {}
+ModuleItemContainer::~ModuleItemContainer() = default;
 
 
 void ModuleItemContainer::add(const std::string & file_content) {

--- a/libdnf/module/module_persistor.cpp
+++ b/libdnf/module/module_persistor.cpp
@@ -1,0 +1,112 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "module/module_persistor.hpp"
+
+#include "utils/bgettext/bgettext-mark-domain.h"
+
+#include "libdnf/module/module_errors.hpp"
+
+#include <modulemd-2.0/modulemd.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <set>
+#include <string>
+
+namespace libdnf::module {
+
+
+ModulePersistor::ModulePersistor(libdnf::system::State & system_state) : system_state(system_state) {}
+
+
+struct ModulePersistor::RuntimeModuleState & ModulePersistor::get_runtime_module_state(
+    const std::string & module_name) {
+    try {
+        return runtime_module_states.at(module_name);
+    } catch (std::out_of_range &) {
+        throw NoModuleError(M_("No such module: {}"), module_name);
+    }
+}
+
+
+const ModuleState & ModulePersistor::get_state(const std::string & module_name) {
+    return get_runtime_module_state(module_name).state;
+}
+
+
+const std::string & ModulePersistor::get_enabled_stream(const std::string & module_name) {
+    return get_runtime_module_state(module_name).enabled_stream;
+}
+
+
+const std::vector<std::string> & ModulePersistor::get_installed_profiles(const std::string & module_name) {
+    return get_runtime_module_state(module_name).installed_profiles;
+}
+
+
+std::vector<std::string> ModulePersistor::get_all_module_names() {
+    std::vector<std::string> result;
+    result.reserve(runtime_module_states.size());
+    for (auto & item : runtime_module_states) {
+        result.push_back(item.first);
+    }
+    return result;
+}
+
+
+bool ModulePersistor::change_state(const std::string & module_name, ModuleState state) {
+    if (get_runtime_module_state(module_name).state == state) {
+        return false;
+    }
+
+    get_runtime_module_state(module_name).state = state;
+    return true;
+}
+
+
+bool ModulePersistor::add_profile(const std::string & module_name, const std::string & profile) {
+    auto & profiles = get_runtime_module_state(module_name).installed_profiles;
+
+    // Return false if the profile is already there.
+    if (std::find(std::begin(profiles), std::end(profiles), profile) != std::end(profiles)) {
+        return false;
+    }
+
+    profiles.push_back(profile);
+    return true;
+}
+
+
+bool ModulePersistor::remove_profile(const std::string & module_name, const std::string & profile) {
+    auto & profiles = get_runtime_module_state(module_name).installed_profiles;
+
+    for (auto it = profiles.begin(); it != profiles.end(); it++) {
+        if (*it == profile) {
+            profiles.erase(it);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+}  // namespace libdnf::module

--- a/libdnf/module/module_persistor.hpp
+++ b/libdnf/module/module_persistor.hpp
@@ -1,0 +1,89 @@
+/*
+Copyright Contributors to the libdnf project.
+
+This file is part of libdnf: https://github.com/rpm-software-management/libdnf/
+
+Libdnf is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+Libdnf is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with libdnf.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef LIBDNF_MODULE_MODULE_PERSISTOR_HPP
+#define LIBDNF_MODULE_MODULE_PERSISTOR_HPP
+
+#include "libdnf/module/module_item_container.hpp"
+#include "libdnf/system/state.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace libdnf::module {
+
+
+class ModulePersistor {
+public:
+    ModulePersistor(libdnf::system::State & system_state);
+
+    bool add_module();
+    void save_everything_to_system_state();
+
+    const ModuleState & get_state(const std::string & module_name);
+    const std::string & get_enabled_stream(const std::string & module_name);
+    const std::vector<std::string> & get_installed_profiles(const std::string & module_name);
+
+    std::vector<std::string> get_all_module_names();
+
+    std::vector<std::string> get_all_newly_disabled_modules();
+    std::vector<std::string> get_all_newly_reset_modules();
+    std::map<std::string, std::string> get_all_newly_enabled_streams();
+    std::map<std::string, std::string> get_all_newly_disabled_streams();
+    std::map<std::string, std::string> get_all_newly_reset_streams();
+    std::map<std::string, std::pair<std::string, std::string>> get_all_newly_switched_streams();
+    std::map<std::string, std::vector<std::string>> get_all_newly_installed_profiles();
+    std::map<std::string, std::vector<std::string>> get_all_newly_removed_profiles();
+
+    bool change_state(const std::string & module_name, ModuleState state);
+    bool change_stream(const std::string & module_name, const std::string & stream);
+    bool add_profile(const std::string & module_name, const std::string & profile);
+    bool remove_profile(const std::string & module_name, const std::string & profile);
+
+private:
+    friend ModuleItemContainer;
+
+    struct RuntimeModuleState {
+        ModuleState state;
+        std::string enabled_stream;
+        std::vector<std::string> installed_profiles;
+        // TODO(pkratoch): What is this for?
+        bool locked;
+        int stream_changes_num;
+    };
+
+    libdnf::system::State & system_state;
+
+    // Map of module names and their runtime states.
+    std::map<std::string, struct RuntimeModuleState> runtime_module_states;
+
+    struct RuntimeModuleState & get_runtime_module_state(const std::string & module_name);
+
+    // Set ModuleState in system::State according to the RuntimeModuleState. Return `true` if it changed.
+    bool set_config_from_runtime(const std::string & module_name);
+    // Set RuntimeModuleState according to the ModuleState in system::State.
+    void set_runtime_from_config(const std::string & module_name);
+};
+
+
+}  // namespace libdnf::module
+
+
+#endif  // LIBDNF_MODULE_MODULE_PERSISTOR_HPP


### PR DESCRIPTION
This is just the part that doesn't require `libdnf::system::ModuleState` (provided by PR https://github.com/rpm-software-management/libdnf/pull/1543).