### PR TITLE
Use `all_installed` because `installed` is filtered user input

### DIFF
--- a/libdnf/base/goal.cpp
+++ b/libdnf/base/goal.cpp
@@ -848,8 +848,8 @@ void Goal::Impl::add_up_down_distrosync_to_goal(
             // For a correct upgrade of installonly packages keep only the latest installed packages
             // Otherwise it will also install not the latest installonly packages
             query.filter_available();
-            installed.filter_latest_evr();
-            query |= installed;
+            all_installed.filter_latest_evr();
+            query |= all_installed;
             solv_map_to_id_queue(tmp_queue, *query.p_impl);
             rpm_goal.add_upgrade(tmp_queue, best, clean_requirements_on_remove);
             break;


### PR DESCRIPTION
`installed` could be missing packages since its based on `query`. If we
specify we want to upgrade a specific nevra that is not yet installed,
then `installed` is empty because it is based on user input, but there
could be other versions of the pkg installed.

Eg: if kernel-1 and kernel-3 are installed and we specify we want to
upgrade kernel-2, nothing should be done because we already have higher
version, but now `installed_query` would be empty and kernel-2 would be
installed.

Therefore, we need to use `all_installed`.

This reflects recent change to dnf4: https://github.com/rpm-software-management/dnf/commit/75df22dd3da1d57c32d6c8d29655cd95bb0915c0

This fixes currently failing dnf5 CI (the test for this was mistakenly enabled for dnf5 as well).