### PR TITLE
Adding network-wait-timeout support 

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -158,6 +158,7 @@ typedef struct
     gchar            *user_agent;
     gchar            *arch;
     guint            cache_age;     /*seconds*/
+    guint            network_wait_timeout_secs; 
     gboolean         cacheOnly{false};
     gboolean         check_disk_space;
     gboolean         check_transaction;
@@ -1107,6 +1108,22 @@ dnf_context_get_cache_age(DnfContext *context)
 }
 
 /**
+ * dnf_context_get_network_timeout_seconds:
+ * @context: a #DnfContext instance.
+ *
+ * Gets the number seconds to wait for the network timeout.
+ *
+ * Returns: network timout in seconds
+ *
+ **/
+guint
+dnf_context_get_network_timeout_seconds(DnfContext *context)
+{
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    return priv->network_wait_timeout_secs;
+}
+
+/**
  * dnf_context_get_installonly_pkgs:
  * @context: a #DnfContext instance.
  *
@@ -1632,6 +1649,20 @@ dnf_context_set_cache_age(DnfContext *context, guint cache_age)
 {
     DnfContextPrivate *priv = GET_PRIVATE(context);
     priv->cache_age = cache_age;
+}
+
+/**
+ * dnf_context_set_network_timeout_seconds:
+ * @context: a #DnfContext instance.
+ * @seconds: Number of seconds
+ *
+ * Sets the number of seconds to wait till network timeout.
+ **/
+void 
+dnf_context_set_network_timeout_seconds(DnfContext *context, guint seconds)
+{
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    priv->network_wait_timeout_secs = seconds;
 }
 
 /**

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -142,6 +142,7 @@ gboolean         dnf_context_get_zchunk                 (DnfContext     *context
 gboolean         dnf_context_get_write_history          (DnfContext     *context);
 guint            dnf_context_get_cache_age              (DnfContext     *context);
 guint            dnf_context_get_installonly_limit      (DnfContext     *context);
+guint            dnf_context_get_network_timeout_seconds(DnfContext     *context);
 const gchar     *dnf_context_get_http_proxy             (DnfContext     *context);
 gboolean         dnf_context_get_enable_filelists       (DnfContext     *context);
 GPtrArray       *dnf_context_get_repos                  (DnfContext     *context);
@@ -205,6 +206,8 @@ void             dnf_context_set_write_history          (DnfContext     *context
                                                          gboolean        value);
 void             dnf_context_set_cache_age              (DnfContext     *context,
                                                          guint           cache_age);
+void             dnf_context_set_network_timeout_seconds(DnfContext     *context,
+                                                         guint           seconds);
 
 void             dnf_context_set_rpm_macro              (DnfContext     *context,
                                                          const gchar    *key,

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1866,6 +1866,10 @@ dnf_repo_update(DnfRepo *repo,
             goto out;
     }
 
+    ret = lr_handle_network_wait(priv->repo_handle, error, dnf_context_get_network_timeout_seconds(priv->context), NULL);
+    if(!ret)
+      goto out;
+  
     lr_result_clear(priv->repo_result);
     dnf_state_action_start(state_local,
                            DNF_STATE_ACTION_DOWNLOAD_METADATA, NULL);
@@ -2247,6 +2251,10 @@ dnf_repo_download_packages(DnfRepo *repo,
         directory_slash = g_build_filename(directory, "/", NULL);
     }
 
+    ret = lr_handle_network_wait(priv->repo_handle, error, dnf_context_get_network_timeout_seconds(priv->context), NULL);
+    if(!ret)
+      goto out;
+  
     global_data.download_size = dnf_package_array_get_download_size(packages);
     for (i = 0; i < packages->len; i++) {
         auto pkg = static_cast<DnfPackage *>(packages->pdata[i]);


### PR DESCRIPTION
Supports to fix the issue: https://github.com/coreos/rpm-ostree/issues/3096

dnf-context.cpp: Added network_wait seconds to struct DnfContext and implemented getters
                     and setters for it
dnf-repo.cpp: Call to librepo for network wait api call

Adding network wait support by callin in API's from librepo

