### PR TITLE
Fix: "dnf_keyring_add_public_keys": reset GError to NULL (RhBug:2121222)

### DIFF
--- a/libdnf/dnf-keyring.cpp
+++ b/libdnf/dnf-keyring.cpp
@@ -213,6 +213,7 @@ dnf_keyring_add_public_keys(rpmKeyring keyring, GError **error) try
         if (!ret) {
             g_warning("%s", localError->message);
             g_error_free(localError);
+            localError = NULL;
         }
     } while (true);
     return TRUE;


### PR DESCRIPTION
Fixes problem "PackageKit crashes if parsing multiple key files fails"

packagekitd[1397]: GError set over the top of a previous GError or uninitialized memory. This indicates a bug in someone's code. You must ensure an error is NULL before it's set. The overwriting error message was: failed to parse public key for /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-14-secondary

= changelog =
msg: "dnf_keyring_add_public_keys": reset localError to NULL after free
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2121222