### PR TITLE
Remove DNF from list of protected packages

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -299,7 +299,7 @@ class ConfigMain::Impl {
         }
     };
 
-    OptionStringList protected_packages{resolveGlobs("dnf glob:/etc/yum/protected.d/*.conf " \
+    OptionStringList protected_packages{resolveGlobs("glob:/etc/yum/protected.d/*.conf " \
                                           "glob:/etc/dnf/protected.d/*.conf")};
     OptionString username{""};
     OptionString password{""};


### PR DESCRIPTION
For the DNF => DNF5 upgrade path in Fedora 39. Part of https://github.com/rpm-software-management/dnf/pull/1926 and https://github.com/rpm-software-management/dnf5/issues/416.

For some reason, adding
```
Provides: dnf = %{version}-%{release}
```
to the DNF5 spec is not enough to allow DNF to update itself to DNF5---although `dnf` is still provided by a package (`dnf5`), the `dnf` package itself is still being removed, and the solver considers it a removal of a protected package. So we should remove `dnf` from the list of protected packages here in libdnf.