### PR TITLE
Fix #1558: Don't assume inclusion of cstdint

### DIFF
--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -32,6 +32,7 @@
 #include "OptionString.hpp"
 #include "OptionStringList.hpp"
 
+#include <cstdint>
 #include <memory>
 
 namespace libdnf {

--- a/libdnf/conf/ConfigRepo.hpp
+++ b/libdnf/conf/ConfigRepo.hpp
@@ -26,6 +26,7 @@
 #include "ConfigMain.hpp"
 #include "OptionChild.hpp"
 
+#include <cstdint>
 #include <memory>
 
 namespace libdnf {

--- a/libdnf/conf/OptionSeconds.hpp
+++ b/libdnf/conf/OptionSeconds.hpp
@@ -25,6 +25,8 @@
 
 #include "OptionNumber.hpp"
 
+#include <cstdint>
+
 namespace libdnf {
 
 /**


### PR DESCRIPTION
With last versions of gcc, some headers don't include cstdint anymore, but some sources assume that it is.