### PR TITLE
conf: Support "proxy=_none_" in main config (RhBug:2155713)

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -485,7 +485,19 @@ ConfigMain::Impl::Impl(Config & owner)
     );
 
     owner.optBinds().add("exclude_from_weak_autodetect", exclude_from_weak_autodetect);
-    owner.optBinds().add("proxy", proxy);
+
+    owner.optBinds().add("proxy", proxy,
+        [&](Option::Priority priority, const std::string & value){
+            auto tmpValue(value);
+            for (auto & ch : tmpValue)
+                ch = std::tolower(ch);
+            if (tmpValue == "_none_")
+                proxy.set(priority, "");
+            else
+                proxy.set(priority, value);
+        }, nullptr, false
+    );
+
     owner.optBinds().add("proxy_username", proxy_username);
     owner.optBinds().add("proxy_password", proxy_password);
     owner.optBinds().add("proxy_auth_method", proxy_auth_method);


### PR DESCRIPTION
It has the same meaning as `proxy=`. Introduced for compatibility with yum. Yum does not support a proxy option with an empty value. Instead, it has the special value `_none_`. The value `_none_` is case insensitive.

Support for `proxy=_none_` in the repository configuration was added some time ago - in commit ea749e6238cdb54fe3b5add67875ab5912d2e766

= changelog =
msg: Support "proxy=_none_" in main config
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2155713