### PR TITLE
Make code C++20 compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ if(ENABLE_SOLV_URPMREORDER)
     add_definitions(-DLIBSOLV_FLAG_URPMREORDER=1)
 endif()
 
+# If defined, libsolv adds the prefix "dep_" to solvable dependencies.
+# As a result, `requires` is renamed to `dep_requires`.
+# Needed for C++20. `requires` is a keyword in C++20.
+add_definitions(-DLIBSOLV_SOLVABLE_PREPEND_DEP)
 
 if(WITH_SANITIZERS)
     message(WARNING "Building with sanitizers enabled!")

--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -531,11 +531,11 @@ static bool
 */
 can_depend_on(Pool *pool, Solvable *sa, Id b)
 {
-    IdQueue requires;
+    IdQueue dep_requires;
 
-    solvable_lookup_idarray(sa, SOLVABLE_REQUIRES, requires.getQueue());
-    for (int i = 0; i < requires.size(); ++i) {
-        Id req_dep = requires[i];
+    solvable_lookup_idarray(sa, SOLVABLE_REQUIRES, dep_requires.getQueue());
+    for (int i = 0; i < dep_requires.size(); ++i) {
+        Id req_dep = dep_requires[i];
         Id p, pp;
 
         FOR_PROVIDES(p, pp, req_dep)

--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -192,7 +192,7 @@ void ModulePackage::createDependencies(Solvable *solvable) const
                     ss << "(";
                     ss << std::accumulate(std::next(requiresStream.begin()),
                                             requiresStream.end(), requiresStream[0],
-                                            [](std::string & a, std::string & b)
+                                            [](const std::string & a, const std::string & b)
                                             { return a + " or " + b; });
                     ss << ")";
                     depId = pool_parserpmrichdep(pool, ss.str().c_str());

--- a/libdnf/module/ModulePackage.cpp
+++ b/libdnf/module/ModulePackage.cpp
@@ -163,8 +163,8 @@ void ModulePackage::createDependencies(Solvable *solvable) const
     Pool * pool = dnf_sack_get_pool(moduleSack);
 
     for (const auto &dependency : getModuleDependencies()) {
-        for (const auto &requires : dependency.getRequires()) {
-            for (const auto &singleRequires : requires) {
+        for (const auto &dep_requires : dependency.getRequires()) {
+            for (const auto &singleRequires : dep_requires) {
                 auto moduleName = singleRequires.first;
                 std::vector<std::string> requiresStream;
                 for (const auto &moduleStream : singleRequires.second) {

--- a/libdnf/module/ModulePackageContainer.cpp
+++ b/libdnf/module/ModulePackageContainer.cpp
@@ -817,11 +817,11 @@ void ModulePackageContainer::enableDependencyTree(std::vector<ModulePackage *> &
         Query query(pImpl->moduleSack);
         query.addFilter(HY_PKG, HY_EQ, pImpl->activatedModules.get());
         auto pkg = dnf_package_new(pImpl->moduleSack, modulePackage->getId());
-        auto requires = dnf_package_get_requires(pkg);
-        query.addFilter(HY_PKG_PROVIDES, requires);
+        auto dep_requires = dnf_package_get_requires(pkg);
+        query.addFilter(HY_PKG_PROVIDES, dep_requires);
         auto set = query.runSet();
         toEnable += *set;
-        delete requires;
+        delete dep_requires;
         g_object_unref(pkg);
         enable(modulePackage);
         enabled.set(modulePackage->getId());
@@ -836,11 +836,11 @@ void ModulePackageContainer::enableDependencyTree(std::vector<ModulePackage *> &
             query.addFilter(HY_PKG, HY_EQ, pImpl->activatedModules.get());
             query.addFilter(HY_PKG, HY_NEQ, &enabled);
             auto pkg = dnf_package_new(pImpl->moduleSack, moduleId);
-            auto requires = dnf_package_get_requires(pkg);
-            query.addFilter(HY_PKG_PROVIDES, requires);
+            auto dep_requires = dnf_package_get_requires(pkg);
+            query.addFilter(HY_PKG_PROVIDES, dep_requires);
             auto set = query.runSet();
             toEnable += *set;
-            delete requires;
+            delete dep_requires;
             g_object_unref(pkg);
         }
         toEnable -= enabled;
@@ -1747,8 +1747,8 @@ void ModulePackageContainer::Impl::addVersion2Modules()
     std::map<std::string, std::map<std::string, std::vector<ModulePackage *>>> v3_context_map;
     for (auto const & module_pair : modules) {
         auto * module = module_pair.second.get();
-        auto requires = module->getRequires(true);
-        auto concentratedRequires = concentrateVectorString(requires);
+        auto dep_requires = module->getRequires(true);
+        auto concentratedRequires = concentrateVectorString(dep_requires);
         v3_context_map[module->getNameStream()][concentratedRequires].push_back(module);
     }
     libdnf::LibsolvRepo * repo;
@@ -1758,8 +1758,8 @@ void ModulePackageContainer::Impl::addVersion2Modules()
     for (auto & module_tuple : modulesV2) {
         std::tie(repo, mdStream, repoID) = module_tuple;
         auto nameStream = ModulePackage::getNameStream(mdStream);
-        auto requires = ModulePackage::getRequires(mdStream, true);
-        auto concentratedRequires = concentrateVectorString(requires);
+        auto dep_requires = ModulePackage::getRequires(mdStream, true);
+        auto concentratedRequires = concentrateVectorString(dep_requires);
         auto streamIterator = v3_context_map.find(nameStream);
         if (streamIterator != v3_context_map.end()) {
             auto contextIterator = streamIterator->second.find(concentratedRequires);

--- a/libdnf/sack/query.cpp
+++ b/libdnf/sack/query.cpp
@@ -1669,7 +1669,7 @@ Query::Impl::filterObsoletes(const Filter & f, Map *m)
         Solvable *s = pool_id2solvable(pool, id);
         if (!s->repo)
             continue;
-        for (Id *r_id = s->repo->idarraydata + s->obsoletes; *r_id; ++r_id) {
+        for (Id *r_id = s->repo->idarraydata + s->dep_obsoletes; *r_id; ++r_id) {
             Id r, rr;
 
             FOR_PROVIDES(r, rr, *r_id) {
@@ -1691,7 +1691,7 @@ Query::Impl::obsoletesByPriority(Pool * pool, Solvable * candidate, Map * m, con
 {
     if (!candidate->repo)
         return;
-    for (Id *r_id = candidate->repo->idarraydata + candidate->obsoletes; *r_id; ++r_id) {
+    for (Id *r_id = candidate->repo->idarraydata + candidate->dep_obsoletes; *r_id; ++r_id) {
         Id r, rr;
         FOR_PROVIDES(r, rr, *r_id) {
             if (!MAPTST(target, r))

--- a/tests/hawkey/fixtures.cpp
+++ b/tests/hawkey/fixtures.cpp
@@ -18,17 +18,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <check.h>
-#include <stdarg.h>
-#include <unistd.h>
-
-
 #include "libdnf/hy-package.h"
 #include "libdnf/hy-repo.h"
 #include "libdnf/hy-iutil.h"
 #include "libdnf/dnf-sack-private.hpp"
+
 #include "fixtures.h"
 #include "testsys.h"
+
+#include <check.h>
+#include <stdarg.h>
+#include <unistd.h>
 
 /* define the global variable */
 struct TestGlobals_s test_globals;

--- a/tests/hawkey/test_goal.cpp
+++ b/tests/hawkey/test_goal.cpp
@@ -18,11 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <check.h>
-#include <glib.h>
-#include <stdarg.h>
-#include <vector>
-
 #include "libdnf/goal/Goal.hpp"
 #include "libdnf/dnf-types.h"
 #include "libdnf/hy-goal-private.hpp"
@@ -37,9 +32,15 @@
 #include "libdnf/hy-selector.h"
 #include "libdnf/hy-util-private.hpp"
 #include "libdnf/sack/packageset.hpp"
+
 #include "fixtures.h"
 #include "testsys.h"
 #include "test_suites.h"
+
+#include <check.h>
+#include <glib.h>
+#include <stdarg.h>
+#include <vector>
 
 static DnfPackage *
 get_latest_pkg(DnfSack *sack, const char *name)

--- a/tests/hawkey/test_iutil.cpp
+++ b/tests/hawkey/test_iutil.cpp
@@ -18,21 +18,21 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <stdlib.h>
-#include <unistd.h>
-#include <glib.h>
 
+#include "libdnf/hy-util.h"
+#include "libdnf/hy-iutil.h"
+#include "libdnf/hy-iutil-private.hpp"
+
+#include "fixtures.h"
+#include "test_suites.h"
 
 #include <solv/pool.h>
 #include <solv/repo.h>
 #include <solv/repo_write.h>
 
-
-#include "libdnf/hy-util.h"
-#include "libdnf/hy-iutil.h"
-#include "libdnf/hy-iutil-private.hpp"
-#include "fixtures.h"
-#include "test_suites.h"
+#include <stdlib.h>
+#include <unistd.h>
+#include <glib.h>
 
 static void
 build_test_file(const char *filename)

--- a/tests/hawkey/test_main.cpp
+++ b/tests/hawkey/test_main.cpp
@@ -18,20 +18,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "fixtures.h"
+#include "test_suites.h"
+#include "testsys.h"
+
+#include <solv/util.h>
+
 #include <assert.h>
 #include <check.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-
-#include <solv/util.h>
-
-
-#include "fixtures.h"
-#include "test_suites.h"
-#include "testsys.h"
 
 #define TESTREPODATADIR TESTDATADIR "/hawkey"
 

--- a/tests/hawkey/test_package.cpp
+++ b/tests/hawkey/test_package.cpp
@@ -19,8 +19,6 @@
  */
 
 
-#include <solv/util.h>
-
 
 #include "libdnf/dnf-advisory.h"
 #include "libdnf/hy-package.h"
@@ -30,12 +28,14 @@
 #include "libdnf/dnf-reldep-list.h"
 #include "libdnf/dnf-sack-private.hpp"
 #include "libdnf/hy-util.h"
+#include "libdnf/repo/solvable/Dependency.hpp"
+#include "libdnf/repo/solvable/DependencyContainer.hpp"
+
 #include "fixtures.h"
 #include "test_suites.h"
 #include "testsys.h"
 
-#include "libdnf/repo/solvable/Dependency.hpp"
-#include "libdnf/repo/solvable/DependencyContainer.hpp"
+#include <solv/util.h>
 
 START_TEST(test_package_summary)
 {

--- a/tests/hawkey/test_packageset.cpp
+++ b/tests/hawkey/test_packageset.cpp
@@ -22,9 +22,10 @@
 #include "libdnf/hy-package-private.hpp"
 #include "libdnf/hy-packageset-private.hpp"
 #include "libdnf/dnf-sack-private.hpp"
+#include "libdnf/sack/packageset.hpp"
+
 #include "fixtures.h"
 #include "test_suites.h"
-#include "libdnf/sack/packageset.hpp"
 
 static DnfPackageSet *pset;
 

--- a/tests/hawkey/test_query.cpp
+++ b/tests/hawkey/test_query.cpp
@@ -18,12 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <check.h>
-
-
-#include <solv/testcase.h>
-
-
 #include "libdnf/hy-query.h"
 #include "libdnf/hy-query-private.hpp"
 #include "libdnf/hy-package.h"
@@ -31,13 +25,18 @@
 #include "libdnf/dnf-reldep.h"
 #include "libdnf/dnf-reldep-list.h"
 #include "libdnf/dnf-sack-private.hpp"
+#include "libdnf/repo/solvable/DependencyContainer.hpp"
 #include "libdnf/sack/packageset.hpp"
 #include "libdnf/sack/query.hpp"
+
 #include "fixtures.h"
 #include "test_suites.h"
 #include "testsys.h"
 
-#include "libdnf/repo/solvable/DependencyContainer.hpp"
+#include <solv/testcase.h>
+
+#include <check.h>
+
 
 static int
 size_and_free(HyQuery query)

--- a/tests/hawkey/test_reldep.cpp
+++ b/tests/hawkey/test_reldep.cpp
@@ -18,18 +18,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-
-#include <memory>
-
 #include "libdnf/hy-package.h"
 #include "libdnf/dnf-reldep.h"
 #include "libdnf/dnf-reldep-list.h"
 #include "libdnf/dnf-sack.h"
+#include "libdnf/repo/solvable/DependencyContainer.hpp"
+#include "libdnf/repo/solvable/Dependency.hpp"
+
+#include <memory>
+
 #include "fixtures.h"
 #include "test_suites.h"
 #include "testsys.h"
-#include "libdnf/repo/solvable/DependencyContainer.hpp"
-#include "libdnf/repo/solvable/Dependency.hpp"
 
 START_TEST(test_reldeplist_add)
 {

--- a/tests/hawkey/test_repo.cpp
+++ b/tests/hawkey/test_repo.cpp
@@ -18,15 +18,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <check.h>
-#include <string.h>
-
 #include "libdnf/hy-iutil-private.hpp"
 #include "libdnf/hy-repo-private.hpp"
 #include "libdnf/repo/Repo-private.hpp"
+
 #include "fixtures.h"
 #include "testshared.h"
 #include "test_suites.h"
+
+#include <check.h>
+#include <string.h>
 
 START_TEST(test_strings)
 {

--- a/tests/hawkey/test_sack.cpp
+++ b/tests/hawkey/test_sack.cpp
@@ -18,17 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <check.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <sys/types.h>
-
-
-#include <solv/testcase.h>
-
-#include <glib/gstdio.h>
-
 #include <libdnf/repo/Repo-private.hpp>
 #include "libdnf/dnf-types.h"
 #include "libdnf/hy-package-private.hpp"
@@ -36,9 +25,20 @@
 #include "libdnf/dnf-sack-private.hpp"
 #include "libdnf/hy-util.h"
 #include "libdnf/hy-iutil-private.hpp"
+
 #include "fixtures.h"
 #include "testsys.h"
 #include "test_suites.h"
+
+#include <solv/testcase.h>
+
+#include <glib/gstdio.h>
+
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
 
 START_TEST(test_environment)
 {

--- a/tests/hawkey/test_subject.cpp
+++ b/tests/hawkey/test_subject.cpp
@@ -18,20 +18,20 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <check.h>
-#include <string.h>
-
-
 #include "libdnf/nevra.hpp"
 #include "libdnf/nsvcap.hpp"
 #include "libdnf/dnf-reldep.h"
 #include "libdnf/dnf-sack.h"
 #include "libdnf/hy-subject.h"
+
 #include "fixtures.h"
 #include "testshared.h"
 #include "test_suites.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <check.h>
+#include <string.h>
 
 const char inp_fof[] = "four-of-fish-8:3.6.9-11.fc100.x86_64";
 const char inp_fof_noepoch[] = "four-of-fish-3.6.9-11.fc100.x86_64";

--- a/tests/hawkey/test_util.cpp
+++ b/tests/hawkey/test_util.cpp
@@ -18,13 +18,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <check.h>
-#include <stdio.h>
-
-
 #include "libdnf/dnf-types.h"
 #include "libdnf/hy-util.h"
+
 #include "test_suites.h"
+
+#include <check.h>
+#include <stdio.h>
 
 START_TEST(test_detect_arch)
 {

--- a/tests/hawkey/testshared.cpp
+++ b/tests/hawkey/testshared.cpp
@@ -18,7 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <wordexp.h>
+
+#include "libdnf/hy-repo.h"
+#include "libdnf/hy-repo-private.hpp"
+#include "libdnf/repo/Repo-private.hpp"
+
+#include "testshared.h"
 
 extern "C" {
 #include <solv/pool.h>
@@ -26,10 +31,7 @@ extern "C" {
 #include <solv/testcase.h>
 }
 
-#include "libdnf/hy-repo.h"
-#include "libdnf/hy-repo-private.hpp"
-#include "libdnf/repo/Repo-private.hpp"
-#include "testshared.h"
+#include <wordexp.h>
 
 HyRepo
 glob_for_repofiles(Pool *pool, const char *repo_name, const char *path)

--- a/tests/hawkey/testshared.h
+++ b/tests/hawkey/testshared.h
@@ -21,11 +21,9 @@
 #ifndef TESTSHARED_H
 #define TESTSHARED_H
 
+#include "libdnf/hy-repo.h"
 
 #include <solv/pooltypes.h>
-
-
-#include "libdnf/hy-repo.h"
 
 #define UNITTEST_DIR "/tmp/hawkeyXXXXXX"
 #define YUM_DIR_SUFFIX "yum/repodata/"

--- a/tests/hawkey/testsys.cpp
+++ b/tests/hawkey/testsys.cpp
@@ -18,23 +18,22 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <check.h>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-
-
-#include <solv/repo.h>
-#include <solv/util.h>
-
-
 #include "libdnf/hy-goal.h"
 #include "libdnf/hy-package.h"
 #include "libdnf/hy-package-private.hpp"
 #include "libdnf/hy-query.h"
 #include "libdnf/dnf-sack-private.hpp"
 #include "libdnf/hy-util.h"
+
 #include "testsys.h"
+
+#include <solv/repo.h>
+#include <solv/util.h>
+
+#include <check.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 void
 assert_nevra_eq(DnfPackage *pkg, const char *nevra)

--- a/tests/libdnf/dnf-self-test.c
+++ b/tests/libdnf/dnf-self-test.c
@@ -20,11 +20,12 @@
  */
 
 
+#include "libdnf/libdnf.h"
+
 #include <glib-object.h>
 #include <stdlib.h>
 #include <fcntl.h>
 #include <glib/gstdio.h>
-#include "libdnf/libdnf.h"
 
 /**
  * cd_test_get_filename:

--- a/tests/libdnf/repo/PackageTest.cpp
+++ b/tests/libdnf/repo/PackageTest.cpp
@@ -53,7 +53,7 @@ void PackageTest::testIsInRepo()
     CPPUNIT_ASSERT("1.0" == version);
     CPPUNIT_ASSERT("x86_64" == arch);
 
-    Id *provides = repo->idarraydata + solvable->provides;
+    Id *provides = repo->idarraydata + solvable->dep_provides;
     std::string provideName = pool_id2str(pool, *provides);
     std::string provideRelation = pool_id2rel(pool, *provides);
     std::string provideEvr = pool_id2evr(pool, *provides);


### PR DESCRIPTION
The code is still compiled as C++11. But with this PR can also be compiled as C++14, C++17 and C++20.

- Rename local variable `requires` to `dep_requires`.
Compatibility with C++20. requires is a keyword in C++20.

- Defines `LIBSOLV_SOLVABLE_PREPEND_DEP`.
If defined, libsolv adds the prefix "dep_" to solvable dependencies. As a result, `requires` is renamed to `dep_requires`.
Needed for C++20. `requires` is a keyword in C++20.

- ModulePackage::createDependencies: Add "const" to std::accumulate operator 

- Change order of including header files in hawkey tests.
Include C header files behind C++. "check.h" defines the `fail(...)` macro. This conflicts with the `fail` method in "istream", "ostream", ...
Caught while compiling in C++20.
