### PR TITLE
Avoid using GNU extensions in the dependency splitter regex

### DIFF
--- a/libdnf/repo/DependencySplitter.cpp
+++ b/libdnf/repo/DependencySplitter.cpp
@@ -28,8 +28,9 @@
 
 namespace libdnf {
 
+// Avoid using the \s and \S patterns here as they are GNU extensions and aren't portable.
 static const Regex RELDEP_REGEX = 
-    Regex("^(\\S*)\\s*(<=|>=|<|>|=|==)?\\s*(\\S*)$", REG_EXTENDED);
+    Regex("^([^[:space:]]*)[[:space:]]*(<=|>=|<|>|=|==)?[[:space:]]*([^[:space:]]*)$", REG_EXTENDED);
 
 static bool
 getCmpFlags(int *cmp_type, std::string matchCmpType)


### PR DESCRIPTION
Sticking to POSIX-compatible extended regular expressions makes the code more portable.  In particular, this change is required to avoid an abort at load time on FreeBSD.

No functional change intended.