### PR TITLE
Include dist-info for python3-libdnf

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -41,3 +41,11 @@ libdnf_swig_module(utils libdnf ${PYTHON_LIBRARY} ${SQLite3_LIBRARIES})
 
 configure_file(__init__.py ${CMAKE_CURRENT_BINARY_DIR}/__init__.py COPYONLY)
 install(FILES __init__.py DESTINATION ${PYTHON_INSTALL_DIR}/libdnf)
+
+set(DISTINFO_PATH "${CMAKE_CURRENT_BINARY_DIR}/libdnf-${LIBDNF_VERSION}.dist-info")
+set(METADATA_FILE "${DISTINFO_PATH}/METADATA")
+file(MAKE_DIRECTORY ${DISTINFO_PATH})
+file(WRITE ${METADATA_FILE} "Metadata-Version: 2.1\n")
+file(APPEND ${METADATA_FILE} "Name: libdnf\n")
+file(APPEND ${METADATA_FILE} "Version: ${LIBDNF_VERSION}\n")
+install(DIRECTORY ${DISTINFO_PATH} DESTINATION ${PYTHON_INSTALL_DIR})

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -289,6 +289,7 @@ popd
 
 %if %{with python3}
 %files -n python3-%{name}
+%{python3_sitearch}/%{name}-*.dist-info
 %{python3_sitearch}/%{name}/
 %endif
 


### PR DESCRIPTION
This is the libdnf version of this patch [0] for DNF 4.

Per [1], Python packages should include some minimal distribution metadata, e.g. to make the package appear in `pip list`.

[0] https://github.com/rpm-software-management/dnf/pull/1997
[1] https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata

= changelog =
msg: Add metadata for `libdnf` Python package
type: bugfix