### PR TITLE
PGP: Set a default creation SELinux labels on GnuPG directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option(WITH_ZCHUNK "Build with zchunk support" ON)
 option(ENABLE_RHSM_SUPPORT "Build with Red Hat Subscription Manager support?" OFF)
 option(ENABLE_SOLV_URPMREORDER "Build with support for URPM-like solution reordering?" OFF)
 option(WITH_TESTS "Enables unit tests" ON)
+option(ENABLE_SELINUX "Restore SELinux labels on GnuPG directories" ON)
 
 
 # build options - debugging
@@ -81,6 +82,12 @@ endif ()
 if(ENABLE_RHSM_SUPPORT)
     pkg_check_modules(RHSM REQUIRED librhsm>=0.0.3)
     include_directories(${RHSM_INCLUDE_DIRS})
+endif()
+
+if(ENABLE_SELINUX)
+    pkg_check_modules(SELINUX REQUIRED libselinux)
+    include_directories(${SELINUX_INCLUDE_DIRS})
+    add_definitions(-DENABLE_SELINUX=1)
 endif()
 
 

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -42,6 +42,8 @@
 %bcond_with rhsm
 %endif
 
+%bcond_without selinux
+
 %if 0%{?rhel}
 %bcond_with zchunk
 %else
@@ -83,6 +85,9 @@ BuildRequires:  pkgconfig(zck) >= 0.9.11
 BuildRequires:  pkgconfig(sqlite3)
 BuildRequires:  pkgconfig(json-c)
 BuildRequires:  pkgconfig(cppunit)
+%if %{with selinux}
+BuildRequires:  pkgconfig(libselinux)
+%endif
 BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
 BuildRequires:  pkgconfig(smartcols)
 BuildRequires:  gettext
@@ -204,7 +209,8 @@ pushd build-py2
     %define __builddir build-py2
   %endif
   %cmake -DPYTHON_DESIRED:FILEPATH=%{__python2} -DWITH_MAN=OFF ../ %{!?with_zchunk:-DWITH_ZCHUNK=OFF} %{!?with_valgrind:-DDISABLE_VALGRIND=1} %{_cmake_opts} -DLIBDNF_MAJOR_VERSION=%{libdnf_major_version} -DLIBDNF_MINOR_VERSION=%{libdnf_minor_version} -DLIBDNF_MICRO_VERSION=%{libdnf_micro_version} \
-    -DWITH_SANITIZERS=%{?with_sanitizers:ON}%{!?with_sanitizers:OFF}
+    -DWITH_SANITIZERS=%{?with_sanitizers:ON}%{!?with_sanitizers:OFF} \
+    -DENABLE_SELINUX=%{?with_selinux:ON}%{!?with_selinux:OFF}
   %make_build
 popd
 %endif
@@ -218,7 +224,8 @@ pushd build-py3
     %define __builddir build-py3
   %endif
   %cmake -DPYTHON_DESIRED:FILEPATH=%{__python3} -DWITH_GIR=0 -DWITH_MAN=0 -Dgtkdoc=0 ../ %{!?with_zchunk:-DWITH_ZCHUNK=OFF} %{!?with_valgrind:-DDISABLE_VALGRIND=1} %{_cmake_opts} -DLIBDNF_MAJOR_VERSION=%{libdnf_major_version} -DLIBDNF_MINOR_VERSION=%{libdnf_minor_version} -DLIBDNF_MICRO_VERSION=%{libdnf_micro_version} \
-    -DWITH_SANITIZERS=%{?with_sanitizers:ON}%{!?with_sanitizers:OFF}
+    -DWITH_SANITIZERS=%{?with_sanitizers:ON}%{!?with_sanitizers:OFF} \
+    -DENABLE_SELINUX=%{?with_selinux:ON}%{!?with_selinux:OFF}
   %make_build
 popd
 %endif

--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -88,6 +88,10 @@ if(ENABLE_RHSM_SUPPORT)
     target_link_libraries(libdnf ${RHSM_LIBRARIES})
 endif()
 
+if(ENABLE_SELINUX)
+    target_link_libraries(libdnf ${SELINUX_LIBRARIES})
+endif()
+
 set(DNF_SO_VERSION 2)
 set_target_properties(libdnf PROPERTIES OUTPUT_NAME "dnf")
 set_target_properties(libdnf PROPERTIES SOVERSION ${DNF_SO_VERSION})


### PR DESCRIPTION
libdnf used to precreate the directory in /run/user to make sure a GnuPG agent executed by GPGME library places its socket there.

The directories there are normally created and removed by systemd (logind PAM session). libdnf created them for a case when a package manager is invoked out of systemd session, before the super user logs in. E.g. by a timer job to cache repository metadata.

A problem was when this out-of-session process was a SELinux-confined process creating files with its own SELinux label different from a DNF program. Then the directory was created with a SELinux label different from the one expected by systemd and when logging out a corresponding user, the mismatching label clashed with systemd.

The same issue was with temporary GnuPG home directories created by libdnf under /tmp.

This patch fixes both the isseus by restoring a SELinux label of those directories to the label defined in a default SELinux file context database.

Obviously the database cannot have a record for a nonspecific /tmp/tmpdir.XXXXXX (a mkdtemp() template) directory names. Therefore I changed their names to more specific /tmp/libdnf.XXXXXX. Once a SELinux policy updates the database, directories under /tmp will get a correct label.

There is yet another problem with accessing /var/cache/dnf/*/pubring, but that seems to be pure SELinux policy problem.

This patch adds a new -DENABLE_SELINUX=OFF CMake option to disable the new dependency on libselinux. A default behavior is to support SELinux.

Implementation details:

I used selabel_lookup() + setfscreatecon() + mkdtemp()
+ setfscreatecon() sequence instead of mkdtemp()
+ selinux_restorecon() sequence because the later polutes stderr if a SELinux policy does not define the default context. One could supress stderr messages with selinux_set_callback(), but its effect cannot be restored.

I also kept the sequence in one function and reused it for creating /run/user/$PID directories because the code is simpler than spliting the function into three parts.

https://issues.redhat.com/browse/RHEL-6421