### PR TITLE
goal: Add method for detecting file dependency problem

### DIFF
--- a/libdnf/goal/Goal-private.hpp
+++ b/libdnf/goal/Goal-private.hpp
@@ -59,6 +59,8 @@ private:
     std::string describeProtectedRemoval();
     std::unique_ptr<PackageSet> brokenDependencyAllPkgs(DnfPackageState pkg_type);
     int countProblems();
+    bool isBrokenFileDependencyPresent();
+    bool isBrokenFileDependencyPresent(unsigned i);
 };
 
 }

--- a/libdnf/goal/Goal.hpp
+++ b/libdnf/goal/Goal.hpp
@@ -124,6 +124,11 @@ public:
     std::vector<std::vector<std::string>> describeAllProblemRules(bool pkgs);
 
     /**
+    * @brief Check if any solver resolution problem is a file dependency issue
+    */
+    bool isBrokenFileDependencyPresent();
+
+    /**
     * @brief List describing failed rules in solving problem 'i'. Caller is responsible for freeing the
     * returned string list by g_free().
     *

--- a/python/hawkey/goal-py.cpp
+++ b/python/hawkey/goal-py.cpp
@@ -479,6 +479,12 @@ problem_broken_dependency(_GoalObject *self, PyObject *args, PyObject *kwds) try
 } CATCH_TO_PYTHON
 
 static PyObject *
+file_dep_problem_present(_GoalObject *self, PyObject *unused) try
+{
+    return PyBool_FromLong(self->goal->isBrokenFileDependencyPresent());
+} CATCH_TO_PYTHON
+
+static PyObject *
 log_decisions(_GoalObject *self, PyObject *unused) try
 {
     if (hy_goal_log_decisions(self->goal))
@@ -652,6 +658,7 @@ static struct PyMethodDef goal_methods[] = {
     {"problem_conflicts",(PyCFunction)problem_conflicts,        METH_VARARGS | METH_KEYWORDS,                NULL},
     {"problem_broken_dependency",(PyCFunction)problem_broken_dependency,        METH_VARARGS | METH_KEYWORDS,                NULL},
     {"problem_rules", (PyCFunction)problem_rules,        METH_NOARGS,                NULL},
+    {"file_dep_problem_present", (PyCFunction)file_dep_problem_present,        METH_NOARGS,        NULL},
     {"log_decisions",   (PyCFunction)log_decisions,        METH_NOARGS,        NULL},
     {"write_debugdata", (PyCFunction)write_debugdata,        METH_O,                NULL},
     {"list_erasures",        (PyCFunction)list_erasures,        METH_NOARGS,        NULL},


### PR DESCRIPTION
To provide users with a hint about the cause of the transaction error, we can extract this information directly from the solver's API. Although it may be parsed from the strings of the `describeProblemRules` method, accessing it through the solver's API allows for more direct and efficient checking.

Related to: https://github.com/rpm-software-management/libdnf/pull/1635.
Targetted for: https://issues.redhat.com/browse/RHEL-12355.