### PR TITLE
Disable deltarpm by default

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -360,7 +360,7 @@ class ConfigMain::Impl {
     OptionBool proxy_sslverify{true};
     OptionString proxy_sslclientcert{""};
     OptionString proxy_sslclientkey{""};
-    OptionBool deltarpm{true};
+    OptionBool deltarpm{false};
     OptionNumber<std::uint32_t> deltarpm_percentage{75};
     OptionBool skip_if_unavailable{false};
     OptionBool sslverifystatus{false};


### PR DESCRIPTION
In comparison to modification in dnf.conf, the change in code will be propagated to systems with modified dnf.conf.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2252128
Related: https://fedoraproject.org/wiki/Changes/Drop_Delta_RPMs