### PR TITLE
Switch off filelists metadata by default

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -191,8 +191,7 @@ class ConfigMain::Impl {
     OptionBool debug_solver{false};
     OptionStringList installonlypkgs{INSTALLONLYPKGS};
     OptionStringList group_package_types{GROUP_PACKAGE_TYPES};
-    // TODO(jkolarik): Change to empty list when dropping the filelists for Fedora 40
-    OptionStringList optional_metadata_types{std::vector<std::string>{"filelists"}};
+    OptionStringList optional_metadata_types{std::vector<std::string>{}};
 
     OptionNumber<std::uint32_t> installonly_limit{3, 0,
         [](const std::string & value)->std::uint32_t{


### PR DESCRIPTION
Based on the https://fedoraproject.org/wiki/Changes/DNFConditionalFilelists.

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1440.
Targetted for: https://issues.redhat.com/browse/RHEL-12355.
Closes: https://github.com/rpm-software-management/dnf/issues/2038.