### PR TITLE
MergedTransaction: Calculate RPM difference between two same versions as no-op

### DIFF
--- a/libdnf/transaction/MergedTransaction.hpp
+++ b/libdnf/transaction/MergedTransaction.hpp
@@ -76,9 +76,9 @@ protected:
     typedef std::map< std::string, ItemPair > ItemPairMap;
 
     void mergeItem(ItemPairMap &itemPairMap, TransactionItemBasePtr transItem);
-    void resolveRPMDifference(ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
-    void resolveErase(ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
-    void resolveAltered(ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
+    void resolveRPMDifference(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
+    void resolveErase(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
+    void resolveAltered(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
 };
 
 } // namespace libdnf

--- a/tests/libdnf/transaction/MergedTransactionTest.cpp
+++ b/tests/libdnf/transaction/MergedTransactionTest.cpp
@@ -822,12 +822,7 @@ MergedTransactionTest::test_downgrade_upgrade_remove()
     // test merging trans1, trans2
     merged.merge(trans2);
     auto items2 = merged.getItems();
-    CPPUNIT_ASSERT_EQUAL(1, (int)items2.size());
-    auto item2 = items2.at(0);
-    CPPUNIT_ASSERT_EQUAL(std::string("tour-4.8-1.noarch"), item2->getItem()->toStr());
-    CPPUNIT_ASSERT_EQUAL(std::string("repo1"), item2->getRepoid());
-    CPPUNIT_ASSERT_EQUAL(TransactionItemAction::REINSTALL, item2->getAction());
-    CPPUNIT_ASSERT_EQUAL(TransactionItemReason::USER, item2->getReason());
+    CPPUNIT_ASSERT_EQUAL(0, (int)items2.size());
 
     // test merging trans1, trans2, trans3
     merged.merge(trans3);


### PR DESCRIPTION
If a package of a particular version is installed and would still be installed after a list of transactions, it's more user friendly to treat the whole situation as "do nothing".

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1461.
Fixes: https://issues.redhat.com/browse/RHEL-17494.
Closes: https://github.com/rpm-software-management/dnf/issues/2031.