### PR TITLE
context: use `rpmtsAddReinstallElement()` when doing a reinstall

### DIFF
--- a/libdnf/dnf-rpmts-private.hpp
+++ b/libdnf/dnf-rpmts-private.hpp
@@ -31,4 +31,10 @@ gboolean         dnf_rpmts_add_install_filename2(rpmts           ts,
                                                  DnfPackage     *pkg,
                                                  GError         **error);
 
+gboolean         dnf_rpmts_add_reinstall_filename(rpmts ts,
+                                                  const gchar *filename,
+                                                  gboolean allow_untrusted,
+                                                  GError **error);
+
+
 #endif /* __DNF_RPMTS_PRIVATE_HPP */

--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -1222,8 +1222,12 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
         filename = dnf_package_get_filename(pkg);
         allow_untrusted = (priv->flags & DNF_TRANSACTION_FLAG_ONLY_TRUSTED) == 0;
         is_update = action == DNF_STATE_ACTION_UPDATE || action == DNF_STATE_ACTION_DOWNGRADE;
-        ret = dnf_rpmts_add_install_filename2(
-            priv->ts, filename, allow_untrusted, is_update, pkg, error);
+        if (action == DNF_STATE_ACTION_REINSTALL) {
+            ret = dnf_rpmts_add_reinstall_filename(priv->ts, filename, allow_untrusted, error);
+        } else {
+            ret = dnf_rpmts_add_install_filename2(
+                priv->ts, filename, allow_untrusted, is_update, pkg, error);
+        }
         if (!ret)
             goto out;
 


### PR DESCRIPTION
`rpmtsAddInstallElement()` doesn't work for all reinstall cases, such as when a package `Provides` and `Conflicts` with the same capability.

Fixes: https://github.com/rpm-software-management/microdnf/issues/137