### PR TITLE
Install module package IDs on `module enable`

### DIFF
--- a/libdnf/module/ModulePackageContainer.hpp
+++ b/libdnf/module/ModulePackageContainer.hpp
@@ -149,7 +149,7 @@ public:
     std::vector<ModulePackage *> requiresModuleEnablement(const libdnf::PackageSet & packages);
 
     /**
-    * @brief Enable module stream. Return true if requested change realy triggers a change in
+    * @brief Enable module stream. Return true if requested change really triggers a change in
     * the persistor.
     * When the count parameter is set to false the change will not count towards the limit of
     * module state modifications.
@@ -161,7 +161,22 @@ public:
     bool enable(const std::string &name, const std::string &stream, const bool count = true);
 
     /**
-    * @brief Enable module stream. Return true if requested changes realy triggers a change in
+    * @brief Enable module stream with an explicit set of module packages.
+    * Return true only if requested change really reiggers a change in the
+    * persistor.
+    * When the count parameter is set to false the change will not count towards the limit of
+    * module state modifications.
+    * It can throw ModulePackageContainer::EnableMultipleStreamsException or
+    * ModulePackageContainer::NoModuleException exceprion if module do not exist
+    *
+    * @return bool
+    */
+    bool enable(const std::string &name, const std::string &stream,
+                const std::vector<ModulePackage *> & module_packages,
+                const bool count = true);
+
+    /**
+    * @brief Enable module stream. Return true if requested changes really triggers a change in
     * the persistor.
     * When the count parameter is set to false the change will not count towards the limit of
     * module state modifications.


### PR DESCRIPTION
**This is a draft PR since tests are failing, and I'm sure there's something wrong with my understanding of the problem or the proposed fix. I'm opening this PR to get a second pair of eyes.**

For https://issues.redhat.com/browse/RHEL-16580.

When enabling a module for an incompatible architecture (i.e. enabling an AArch64 module on an x86_64 system), DNF 4 users should see an appropriate error message. Currently, users only see "nothing provides" errors with no mention of the architecture incompatibility:

```
# dnf4 module enable php:remi-7.4
Modular dependency problem:

 Problem: nothing provides requested module(composer:2)
Error: Problems in request:
Modular dependency problems:

 Problem 1: nothing provides requested module(composer:2)
 Problem 2: nothing provides requested module(php:remi-7.4)
``` 

One way to achieve the desired result is to, on `module enable`, request to install the module package ID, rather than just requesting to install `Provides: module(MODULENAME:STREAM)`. DNF 5 does so here ([1](https://github.com/rpm-software-management/dnf5/blob/7bd215003c0837721669bee2f7063b56dc9bb2e6/libdnf5/module/module_sack.cpp#L865), [2](https://github.com/rpm-software-management/dnf5/blob/7bd215003c0837721669bee2f7063b56dc9bb2e6/libdnf5/module/module_sack.cpp#L500)).

This patch attempts to introduce the same fix in DNF 4. After this patch, the output of the same command as above shows "does not have compatible architecture" errors, as we desire:

```
# dnf4 module enable php:remi-7.4
Modular dependency problems:

 Problem 1: nothing provides requested module(composer:2)
 Problem 2: conflicting requests
  - module composer:2:20240416075243:00000000.aarch64 from rpms.remirepo.net_enterprise_8_modular_aarch64 does not have a compatible architecture
  - nothing provides module(php) needed by module composer:2:20240416075243:00000000.aarch64 from rpms.remirepo.net_enterprise_8_modular_aarch64
  - nothing provides module(platform:el8) needed by module composer:2:20240416075243:00000000.aarch64 from rpms.remirepo.net_enterprise_8_modular_aarch64
Error: Problems in request:
Modular dependency problems:

 Problem 1: nothing provides requested module(composer:2)
 Problem 2: conflicting requests
  - module composer:2:20240416075243:00000000.aarch64 from rpms.remirepo.net_enterprise_8_modular_aarch64 does not have a compatible architecture
  - nothing provides module(php) needed by module composer:2:20240416075243:00000000.aarch64 from rpms.remirepo.net_enterprise_8_modular_aarch64
  - nothing provides module(platform:el8) needed by module composer:2:20240416075243:00000000.aarch64 from rpms.remirepo.net_enterprise_8_modular_aarch64
 Problem 3: nothing provides requested module(php:remi-7.4)
 Problem 4: conflicting requests
  - module php:remi-7.4:20240416075243:00000000.aarch64 from rpms.remirepo.net_enterprise_8_modular_aarch64 does not have a compatible architecture
  - nothing provides module(platform:el8) needed by module php:remi-7.4:20240416075243:00000000.aarch64 from rpms.remirepo.net_enterprise_8_modular_aarch64
```
