### PR TITLE
MergedTransaction: Fix invalid memory access when dropping items

### DIFF
--- a/libdnf/transaction/MergedTransaction.hpp
+++ b/libdnf/transaction/MergedTransaction.hpp
@@ -76,7 +76,7 @@ protected:
     typedef std::map< std::string, ItemPair > ItemPairMap;
 
     void mergeItem(ItemPairMap &itemPairMap, TransactionItemBasePtr transItem);
-    void resolveRPMDifference(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
+    bool resolveRPMDifference(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
     void resolveErase(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
     void resolveAltered(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
 };


### PR DESCRIPTION
When an item is dropped from the merged transaction, the `previousItemPair` reference becomes invalid and should no longer be used.

Related: https://github.com/rpm-software-management/libdnf/pull/1644, https://github.com/rpm-software-management/dnf/issues/2031
Closes: #1652.