### PR TITLE
Since we use rpmtsAddReinstallElement rpm also uninstalls the package

### DIFF
--- a/libdnf/dnf-transaction.cpp
+++ b/libdnf/dnf-transaction.cpp
@@ -602,7 +602,7 @@ dnf_transaction_ts_progress_cb(const void *arg,
 
             /* map to correct action code */
             action = dnf_package_get_action(pkg);
-            if (action == DNF_STATE_ACTION_UNKNOWN)
+            if (action == DNF_STATE_ACTION_UNKNOWN || action == DNF_STATE_ACTION_REINSTALL)
                 action = DNF_STATE_ACTION_INSTALL;
 
             /* set the pkgid if not already set */
@@ -641,7 +641,7 @@ dnf_transaction_ts_progress_cb(const void *arg,
 
             /* map to correct action code */
             action = dnf_package_get_action(pkg);
-            if (action == DNF_STATE_ACTION_UNKNOWN)
+            if (action == DNF_STATE_ACTION_UNKNOWN || action == DNF_STATE_ACTION_REINSTALL)
                 action = DNF_STATE_ACTION_REMOVE;
 
             /* remove start */
@@ -716,7 +716,7 @@ dnf_transaction_ts_progress_cb(const void *arg,
 
             /* map to correct action code */
             action = dnf_package_get_action(pkg);
-            if (action == DNF_STATE_ACTION_UNKNOWN)
+            if (action == DNF_STATE_ACTION_UNKNOWN || action == DNF_STATE_ACTION_REINSTALL)
                 action = DNF_STATE_ACTION_REMOVE;
 
             dnf_state_set_package_progress(
@@ -1353,6 +1353,15 @@ dnf_transaction_commit(DnfTransaction *transaction, HyGoal goal, DnfState *state
         }
         g_ptr_array_unref(pkglist);
     }
+
+    /* add reinstalled packages to a helper array which is used to
+     * map removed packages auto-added by rpm to actual DnfPackage's */
+    pkglist = dnf_goal_get_packages(goal, DNF_PACKAGE_INFO_REINSTALL, -1);
+    for (i = 0; i < pkglist->len; i++) {
+        pkg_tmp = static_cast< DnfPackage * >(g_ptr_array_index(pkglist, i));
+        g_ptr_array_add(priv->remove_helper, g_object_ref(pkg_tmp));
+    }
+    g_ptr_array_unref(pkglist);
 
     /* this section done */
     ret = dnf_state_done(state, error);


### PR DESCRIPTION
It calls callbacks for `RPMCALLBACK_INST_START` and `RPMCALLBACK_INST_PROGRESS` just like before when the reinstall was done through regural install (rpmtsAddInstallElement) but in addition it also calls `RPMCALLBACK_UNINST_START` and `RPMCALLBACK_UNINST_PROGRESS`. To ensure they find the `DnfPackage` add it to `remove_helper` array.

Unfortunaly this means that the reinstall action is reported twice to the clients (one install and one uninstall). We could try to hide one of the them but I think a better solution is to report what is actually happening and report one install and one uninstall.

Fixes: https://github.com/rpm-software-management/libdnf/issues/1653

This is for the context part of libdnf (microdnf, packagekit, ...)