### PR TITLE
ConfigParser: fix use-out-of-scope leaks

### DIFF
--- a/tests/libdnf/conf/ConfigParserTest.cpp
+++ b/tests/libdnf/conf/ConfigParserTest.cpp
@@ -30,4 +30,21 @@ void ConfigParserTest::testConfigParserReleasever()
         libdnf::ConfigParser::substitute(text, substitutions);
         CPPUNIT_ASSERT(text == "major: , minor: ");
     }
+    {
+        std::map<std::string, std::string> substitutions = {
+            {"var1", "value123"},
+            {"var2", "456"},
+        };
+        std::string text = "foo$var1-bar";
+        libdnf::ConfigParser::substitute(text, substitutions);
+        CPPUNIT_ASSERT(text == "foovalue123-bar");
+
+        text = "${var1:+alternate}-${unset:-default}-${nn:+n${nn:-${nnn:}";
+        libdnf::ConfigParser::substitute(text, substitutions);
+        CPPUNIT_ASSERT(text == "alternate-default-${nn:+n${nn:-${nnn:}");
+
+        text = "${unset:-${var1:+${var2:+$var2}}}";
+        libdnf::ConfigParser::substitute(text, substitutions);
+        CPPUNIT_ASSERT(text == "456");
+    }
 }


### PR DESCRIPTION
Address some use-out-of-scope bugs found during static analysis. Also ports a test for the shell-style variable expansion over from DNF 5.