### PR TITLE
Fix countme bucket calculation

### DIFF
--- a/libdnf/repo/Repo-private.hpp
+++ b/libdnf/repo/Repo-private.hpp
@@ -91,6 +91,7 @@ public:
     void fetch(const std::string & destdir, std::unique_ptr<LrHandle> && h);
     std::string getCachedir() const;
     std::string getPersistdir() const;
+    time_t getSystemEpoch() const;
     int getAge() const;
     void expire();
     bool isExpired() const;

--- a/libdnf/repo/Repo.cpp
+++ b/libdnf/repo/Repo.cpp
@@ -873,6 +873,9 @@ void Repo::Impl::addCountmeFlag(LrHandle *handle) {
      * This is to align the time window with an absolute point in time rather
      * than the last counting event (which could facilitate tracking across
      * multiple such events).
+     *
+     * In the below comments, the window's current position will be referred to
+     * as "this window" for brevity.
      */
     auto logger(Log::getLogger());
 
@@ -933,7 +936,7 @@ void Repo::Impl::addCountmeFlag(LrHandle *handle) {
         for (i = 0; i < COUNTME_BUCKETS.size(); ++i)
             if (step < COUNTME_BUCKETS[i])
                 break;
-        int bucket = i + 1;  // Buckets are indexed from 1
+        int bucket = i + 1;  // Buckets are numbered from 1
 
         // Set the flag
         std::string flag = "countme=" + std::to_string(bucket);


### PR DESCRIPTION
Instead of storing the epoch per-repo, use the `machine-id(5)` file's timestamp as the source of truth. Please see the commit for details (GH didn't auto-fill the description here when creating the PR for some reason).

**Note:** Only intended for F41+ (should be reverted in F40 and lower).

Related test PR: https://github.com/rpm-software-management/ci-dnf-stack/pull/1501

Fixes: #1611