### PR TITLE
Add flag to either consider or ignore EVR for extras

### DIFF
--- a/libdnf/hy-query.cpp
+++ b/libdnf/hy-query.cpp
@@ -304,9 +304,9 @@ hy_add_filter_nevra_object(HyQuery query, HyNevra nevra, bool icase)
 }
 
 void
-hy_add_filter_extras(HyQuery query)
+hy_add_filter_extras(HyQuery query, bool with_evr)
 {
-    query->filterExtras();
+    query->filterExtras(with_evr);
 }
 
 void

--- a/libdnf/hy-query.h
+++ b/libdnf/hy-query.h
@@ -103,7 +103,7 @@ bool hy_query_is_applied(const HyQuery query);
 const Map *hy_query_get_result(const HyQuery query);
 DnfSack *hy_query_get_sack(HyQuery query);
 void hy_add_filter_nevra_object(HyQuery query, HyNevra nevra, bool icase);
-void hy_add_filter_extras(HyQuery query);
+void hy_add_filter_extras(HyQuery query, bool with_evr);
 void hy_filter_recent(HyQuery query, const long unsigned int recent_limit);
 void hy_filter_duplicated(HyQuery query);
 GPtrArray * hy_query_get_advisory_pkgs(HyQuery query, int cmp_type);

--- a/libdnf/sack/query.hpp
+++ b/libdnf/sack/query.hpp
@@ -169,11 +169,11 @@ public:
     bool empty();
     /**
      * @brief Applies all filters and keep only installed packages that have no available package
-     * with a same name and architecture.
+     * with a same name and architecture or NEVRA.
      * Excluded available packages are handled like other available packages. Modular excludes are
      * applied.
      */
-    void filterExtras();
+    void filterExtras(bool with_evr);
     void filterRecent(const long unsigned int recent_limit);
     void filterDuplicated();
     int filterUnneeded(const Swdb &swdb, bool debug_solver);

--- a/python/hawkey/query-py.cpp
+++ b/python/hawkey/query-py.cpp
@@ -603,10 +603,16 @@ duplicated_filter(_QueryObject *self, PyObject *unused) try
 } CATCH_TO_PYTHON
 
 static PyObject *
-add_filter_extras(_QueryObject *self, PyObject *unused) try
+add_filter_extras(_QueryObject *self, PyObject *args, PyObject *kwds) try
 {
+    PyObject *with_evr = NULL;
+    const char *kwlist[] = {"with_evr", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O!", (char**) kwlist, &PyBool_Type, &with_evr))
+        return NULL;
+    gboolean c_with_evr = with_evr != NULL && PyObject_IsTrue(with_evr);
+
     HyQuery self_query_copy = new libdnf::Query(*self->query);
-    self_query_copy->filterExtras();
+    self_query_copy->filterExtras(c_with_evr);
     PyObject *final_query = queryToPyObject(self_query_copy, self->sack, Py_TYPE(self));
     return final_query;
 } CATCH_TO_PYTHON
@@ -1065,7 +1071,7 @@ static struct PyMethodDef query_methods[] = {
     {"available", (PyCFunction)add_available_filter, METH_NOARGS, NULL},
     {"downgrades", (PyCFunction)add_downgrades_filter, METH_NOARGS, NULL},
     {"duplicated", (PyCFunction)duplicated_filter, METH_NOARGS, NULL},
-    {"extras", (PyCFunction)add_filter_extras, METH_NOARGS, NULL},
+    {"extras", (PyCFunction)add_filter_extras, METH_KEYWORDS|METH_VARARGS, NULL},
     {"installed", (PyCFunction)add_installed_filter, METH_NOARGS, NULL},
     {"latest", (PyCFunction)add_filter_latest, METH_VARARGS, NULL},
     {"union", (PyCFunction)q_union, METH_VARARGS, NULL},


### PR DESCRIPTION
The "extras" filter originally considered NEVRA, but was changed to ignore EVR and consider only NA: https://bugzilla.redhat.com/show_bug.cgi?id=1684517

We occasionally use third party repos that have RPMs with names that overlap with RPMs in standard repos, but with non-overlapping version numbers (eg. to get newer versions of software than is available in the standard repos.)  If one of these third party repos is retired, we want to make sure that we remove any RPMs that came from it (either by downgrading to the standard RPMs or by switching to a replacement third party repo).

For many years, we used `yum list extras` or `dnf list --extras` to detect and handle orphaned RPMs like these.  However, we recently encountered one of these repo retirements and noticed that `dnf list --extras` was no longer working as expected (it was no longer reporting any RPMs with names that overlap RPMs in other repos).

We would like to have some way to make `dnf` report these version-mismatch orphans.  Since both the original and new behavior seem to have legitimate use cases, a flag to select the relevant behavior seems appropriate.

My intent (after this PR is merged) is to add another option to `dnf` (maybe `dnf list --extra-vers`?) to expose this flag to users.