### PR TITLE
Split $releasever to $releasever_major and $releasever_minor in the C API

### DIFF
--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -1187,6 +1187,8 @@ dnf_repo_setup(DnfRepo *repo, GError **error) try
     DnfRepoEnabled enabled = DNF_REPO_ENABLED_NONE;
     g_autofree gchar *basearch = NULL;
     g_autofree gchar *release = NULL;
+    g_autofree gchar *major = NULL;
+    g_autofree gchar *minor = NULL;
 
     basearch = g_key_file_get_string(priv->keyfile, "general", "arch", NULL);
     if (basearch == NULL)
@@ -1214,9 +1216,11 @@ dnf_repo_setup(DnfRepo *repo, GError **error) try
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_INTERRUPTIBLE, 0L))
         return FALSE;
+    dnf_split_releasever(release, &major, &minor);
     priv->urlvars = lr_urlvars_set(priv->urlvars, "releasever", release);
+    priv->urlvars = lr_urlvars_set(priv->urlvars, "releasever_major", major);
+    priv->urlvars = lr_urlvars_set(priv->urlvars, "releasever_minor", minor);
     priv->urlvars = lr_urlvars_set(priv->urlvars, "basearch", basearch);
-
     /* Call libdnf::dnf_context_load_vars(priv->context); only when values not in cache.
      * But what about if variables on disk change during long running programs (PackageKit daemon)?
      * if (!libdnf::dnf_context_get_vars_cached(priv->context))

--- a/libdnf/dnf-utils.cpp
+++ b/libdnf/dnf-utils.cpp
@@ -85,6 +85,50 @@ dnf_realpath(const gchar *path)
 }
 
 /**
+ * dnf_split_releasever:
+ * @releasever: A releasever string
+ * @releasever_major: Output string, or %NULL
+ * @releasever_minor: Output string, or %NULL
+ *
+ * Splits a releasever string into mayor and minor
+ * using the same logic as DNF 5 and as splitReleaseverTo in libzypp.
+ **/
+void
+dnf_split_releasever(const gchar *releasever, 
+                     gchar **releasever_major,
+                     gchar **releasever_minor)
+{
+    g_autofree gchar** result = NULL;
+
+    // Uses the same logic as DNF 5 and as splitReleaseverTo in libzypp
+    result = g_strsplit(releasever, ".", 2);
+
+    if(result[0] == NULL) {
+        if(releasever_major != NULL)
+            *releasever_major = g_strdup("");
+        if(releasever_minor != NULL)
+            *releasever_minor = g_strdup("");
+        return;
+    }
+    else {
+        if(releasever_major != NULL)
+            *releasever_major = result[0];
+        else
+            g_free(result[0]);
+    }
+
+    if(result[1] == NULL) {
+        if(releasever_minor != NULL)
+            *releasever_minor = g_strdup("");
+    } else {
+        if(releasever_minor != NULL)
+            *releasever_minor = result[1];
+        else
+            g_free(result[1]);
+    }
+}
+
+/**
  * dnf_remove_recursive:
  * @directory: A directory path
  * @error: A #GError, or %NULL

--- a/libdnf/dnf-utils.h
+++ b/libdnf/dnf-utils.h
@@ -53,6 +53,9 @@ extern "C" {
 #endif
 
 gchar           *dnf_realpath                       (const gchar            *path);
+void             dnf_split_releasever               (const gchar            *releasever, 
+                                                     gchar                  **releasever_major,
+                                                     gchar                  **releasever_minor);
 gboolean         dnf_remove_recursive               (const gchar            *directory,
                                                      GError                 **error);
 gboolean         dnf_ensure_file_unlinked           (const gchar            *src_path,

--- a/tests/libdnf/dnf-self-test.c
+++ b/tests/libdnf/dnf-self-test.c
@@ -190,6 +190,32 @@ dnf_lock_threads_func(void)
 }
 
 static void
+dnf_split_releasever_func(void)
+{
+    gchar *major, *minor;
+    dnf_split_releasever("1.23.45", &major, &minor);
+    g_assert_cmpstr(major, ==, "1");
+    g_assert_cmpstr(minor, ==, "23.45");
+    g_free(major);
+    g_free(minor);
+    dnf_split_releasever("6.789", &major, &minor);
+    g_assert_cmpstr(major, ==, "6");
+    g_assert_cmpstr(minor, ==, "789");
+    g_free(major);
+    g_free(minor);
+    dnf_split_releasever("10", &major, &minor);
+    g_assert_cmpstr(major, ==, "10");
+    g_assert_cmpstr(minor, ==, "");
+    g_free(major);
+    g_free(minor);
+    dnf_split_releasever("", &major, &minor);
+    g_assert_cmpstr(major, ==, "");
+    g_assert_cmpstr(minor, ==, "");
+    g_free(major);
+    g_free(minor);
+}
+
+static void
 ch_test_repo_func(void)
 {
     DnfRepo *repo;
@@ -1240,6 +1266,7 @@ main(int argc, char **argv)
     g_test_add_func("/libdnf/context{cache-clean-check}", dnf_context_cache_clean_check_func);
     g_test_add_func("/libdnf/lock", dnf_lock_func);
     g_test_add_func("/libdnf/lock[threads]", dnf_lock_threads_func);
+    g_test_add_func("/libdnf/split_releasever", dnf_split_releasever_func);
     g_test_add_func("/libdnf/repo", ch_test_repo_func);
     g_test_add_func("/libdnf/repo_empty_keyfile", dnf_repo_setup_with_empty_keyfile);
     g_test_add_func("/libdnf/state", dnf_state_func);


### PR DESCRIPTION
This implements the same functionality as #1631, but on the C API so that it behaves the same way as the C++ and Python API.

Fixes #1687 