### PR TITLE
C API: Detect releasever_major, releasever_minor from provides

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -621,6 +621,42 @@ dnf_context_get_release_ver(DnfContext *context)
 }
 
 /**
+ * dnf_context_get_release_ver_major:
+ * @context: a #DnfContext instance.
+ *
+ * Gets the release major version. Usually derived by taking the substring of releasever before the
+ * first ".", but can be overridden by the distribution.
+ *
+ * Returns: the release major version, e.g. "10"
+ *
+ * Since: 0.74.0
+ **/
+const gchar *
+dnf_context_get_release_ver_major(DnfContext *context)
+{
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    return priv->release_ver_major;
+}
+
+/**
+ * dnf_context_get_release_ver_minor:
+ * @context: a #DnfContext instance.
+ *
+ * Gets the release minor version. Usually derived by taking the substring of releasever after the
+ * first ".", but can be overridden by the distribution.
+ *
+ * Returns: the release minor version, e.g. "1"
+ *
+ * Since: 0.74.0
+ **/
+const gchar *
+dnf_context_get_release_ver_minor(DnfContext *context)
+{
+    DnfContextPrivate *priv = GET_PRIVATE(context);
+    return priv->release_ver_minor;
+}
+
+/**
  * dnf_context_get_platform_module:
  * @context: a #DnfContext instance.
  *

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -164,6 +164,10 @@ void             dnf_context_set_vars_dir               (DnfContext     *context
                                                          const gchar * const *vars_dir);
 void             dnf_context_set_release_ver            (DnfContext     *context,
                                                          const gchar    *release_ver);
+void             dnf_context_set_release_ver_major      (DnfContext     *context,
+                                                         const gchar    *release_ver_major);
+void             dnf_context_set_release_ver_minor      (DnfContext     *context,
+                                                         const gchar    *release_ver_minor);
 void             dnf_context_set_platform_module        (DnfContext     *context,
                                                          const gchar    *platform_module);
 void             dnf_context_set_cache_dir              (DnfContext     *context,

--- a/libdnf/dnf-context.h
+++ b/libdnf/dnf-context.h
@@ -120,6 +120,8 @@ const gchar     *dnf_context_get_base_arch              (DnfContext     *context
 const gchar     *dnf_context_get_os_info                (DnfContext     *context);
 const gchar     *dnf_context_get_arch_info              (DnfContext     *context);
 const gchar     *dnf_context_get_release_ver            (DnfContext     *context);
+const gchar     *dnf_context_get_release_ver_major      (DnfContext     *context);
+const gchar     *dnf_context_get_release_ver_minor      (DnfContext     *context);
 const gchar     *dnf_context_get_platform_module        (DnfContext     *context);
 const gchar     *dnf_context_get_cache_dir              (DnfContext     *context);
 const gchar     *dnf_context_get_arch                   (DnfContext     *context);


### PR DESCRIPTION
libdnf C API parity with https://github.com/rpm-software-management/dnf/pull/2198.

Adds four new API functions:

- `dnf_context_get_release_ver_major`
- `dnf_context_get_release_ver_minor`
- `dnf_context_set_release_ver_major`
- `dnf_context_set_release_ver_minor`

Changes `dnf_context_set_os_release` to check `system-release(releasever_major)` and `system-release(releasever_minor)`. Luckily, unlike with the new `detect_releasevers` in the DNF 4 Python API, callers of `dnf_context_set_os_release` won't need to switch to a new function since `dnf_context_set_os_release` detects the releasever variables and sets them by side effect.

For https://issues.redhat.com/browse/RHEL-76498.