### PR TITLE
rhel-10.0: Add `persistence` config option

### DIFF
--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -284,6 +284,7 @@ class ConfigMain::Impl {
     OptionString comment{nullptr};
     OptionBool downloadonly{false}; // runtime only option
     OptionBool ignorearch{false};
+    OptionEnum<std::string> persistence{"auto", {"auto", "persist", "transient"}};
     OptionString module_platform_id{nullptr};
     OptionBool module_stream_switch{false};
     OptionBool module_obsoletes{false};
@@ -458,6 +459,7 @@ ConfigMain::Impl::Impl(Config & owner)
     owner.optBinds().add("user_agent", user_agent);
     owner.optBinds().add("countme", countme);
     owner.optBinds().add("protect_running_kernel", protect_running_kernel);
+    owner.optBinds().add("persistence", persistence);
 
     // Repo main config
 
@@ -613,6 +615,7 @@ OptionPath & ConfigMain::destdir() { return pImpl->destdir; }
 OptionString & ConfigMain::comment() { return pImpl->comment; }
 OptionBool & ConfigMain::downloadonly() { return pImpl->downloadonly; }
 OptionBool & ConfigMain::ignorearch() { return pImpl->ignorearch; }
+OptionEnum<std::string> & ConfigMain::persistence() { return pImpl->persistence; }
 
 OptionString & ConfigMain::module_platform_id() { return pImpl->module_platform_id; }
 OptionBool & ConfigMain::module_stream_switch() { return pImpl->module_stream_switch; }

--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -125,6 +125,7 @@ public:
     OptionString & comment();
     OptionBool & downloadonly();
     OptionBool & ignorearch();
+    OptionEnum<std::string> & persistence();
 
     OptionString & module_platform_id();
     OptionBool & module_stream_switch();


### PR DESCRIPTION
Upstream commit: 18a7db66bfc2cf228bdbb484fa92504c2eaefdc6
Resolves: https://issues.redhat.com/browse/RHEL-78034

This intentionally excludes adding a copr build script <https://github.com/rpm-software-management/libdnf/pull/1683> and bumping libdnf version <https://github.com/rpm-software-management/libdnf/pull/1692>.

@evan-goode, please review.