### PR TITLE
module: Warn if module config file is inaccessible

### DIFF
--- a/libdnf/conf/ConfigParser.cpp
+++ b/libdnf/conf/ConfigParser.cpp
@@ -271,6 +271,8 @@ void ConfigParser::read(const std::string & filePath)
     try {
         IniParser parser(filePath);
         ::libdnf::read(*this, parser);
+    } catch (const IniParser::FileDoesNotExist & e) {
+        throw FileDoesNotExist(e.what());
     } catch (const IniParser::CantOpenFile & e) {
         throw CantOpenFile(e.what());
     } catch (const IniParser::Exception & e) {

--- a/libdnf/conf/ConfigParser.hpp
+++ b/libdnf/conf/ConfigParser.hpp
@@ -55,6 +55,9 @@ public:
     struct CantOpenFile : public Exception {
         CantOpenFile(const std::string & what) : Exception(what) {}
     };
+    struct FileDoesNotExist : public CantOpenFile {
+        FileDoesNotExist(const std::string & what) : CantOpenFile(what) {}
+    };
     struct ParsingError : public Exception {
         ParsingError(const std::string & what) : Exception(what) {}
     };

--- a/libdnf/utils/iniparser/iniparser.hpp
+++ b/libdnf/utils/iniparser/iniparser.hpp
@@ -46,6 +46,10 @@ public:
         CantOpenFile() {}
         const char * what() const noexcept override;
     };
+    struct FileDoesNotExist : public CantOpenFile {
+        FileDoesNotExist() {}
+        const char * what() const noexcept override;
+    };
     struct MissingSectionHeader : public Exception {
         MissingSectionHeader(int lineNumber) : Exception(lineNumber) {}
         const char * what() const noexcept override;


### PR DESCRIPTION
module: Warn if module config file is inaccessible

If a DNF module configuration file is unreadable, `dnf` may return unexpected results without warning the user, potentially affecting command output.

Steps to reproduce:

1. Enable the `nginx` module as root with a restrictive `umask`, making  the config file unreadable for normal users:
```
   # umask 0066
   # dnf module enable nginx:1.24
   # ls -l /etc/dnf/modules.d/nginx.module
   -rw-------. 1 root root 55 Oct 16 09:59 /etc/dnf/modules.d/nginx.module
```
2. Check available packages as root (CORRECT):
```
   # dnf list --available nginx
   [...]
   Available Packages
   nginx.x86_64            1:1.24.0-1.module+el9.4.0+21950+8ebc21e2.1
```
3. Check available packages as a normal user (INCORRECT):
```
   $ dnf list --available nginx
   [...]
   Available Packages
   nginx.x86_64            1:1.20.1-16.el9_4.1
```
This patch introduces a warning when a module config file exists but is inaccessible, helping users diagnose potential issues:
```
   $ dnf list --available nginx
   [...]
   Cannot read "/etc/dnf/modules.d/nginx.module". Modular filtering may be affected.
   Available Packages
   nginx.x86_64            1:1.20.1-16.el9_4.1
```
Resolves: https://issues.redhat.com/browse/RHEL-62833
Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1628
