### PR TITLE
Replace deprecated `check` macros

### DIFF
--- a/libdnf/utils/smartcols/Table.cpp
+++ b/libdnf/utils/smartcols/Table.cpp
@@ -99,22 +99,10 @@ void Table::addLine(const std::shared_ptr<Line> &line)
     lines.push_back(line);
 }
 
-void Table::removeColumn(const std::shared_ptr<Column> &column)
-{
-    std::remove(std::begin(columns), std::end(columns), column);
-    scols_table_remove_column(table, column->column);
-}
-
 void Table::removeColumns()
 {
     columns.clear();
     scols_table_remove_columns(table);
-}
-
-void Table::removeLine(const std::shared_ptr<Line> &line)
-{
-    std::remove(std::begin(lines), std::end(lines), line);
-    scols_table_remove_line(table, line->line);
 }
 
 void Table::removeLines()

--- a/libdnf/utils/smartcols/Table.hpp
+++ b/libdnf/utils/smartcols/Table.hpp
@@ -92,14 +92,12 @@ public:
     void enableNolinesep(bool enable) { scols_table_enable_nolinesep(table, enable); }
 
     void addColumn(const std::shared_ptr<Column> &column);
-    void removeColumn(const std::shared_ptr<Column> &column);
     void removeColumns();
     void moveColumn(const std::shared_ptr<Column> &before, const std::shared_ptr<Column> &toMove);
     std::shared_ptr<Column> newColumn(const std::string &name, double widthHint = 0, int flags = 0);
     std::shared_ptr<Column> nextColumn(std::vector<std::shared_ptr<Column>>::iterator &iterator) { return *(iterator++); }
 
     void addLine(const std::shared_ptr<Line> &line);
-    void removeLine(const std::shared_ptr<Line> &line);
     void removeLines();
     std::shared_ptr<Line> newLine();
     std::shared_ptr<Line> newLine(const std::shared_ptr<Line> &parent);

--- a/tests/hawkey/test_goal.cpp
+++ b/tests/hawkey/test_goal.cpp
@@ -50,8 +50,8 @@ get_latest_pkg(DnfSack *sack, const char *name)
     hy_query_filter(q, HY_PKG_REPONAME, HY_NEQ, HY_SYSTEM_REPO_NAME);
     hy_query_filter_latest_per_arch(q, 1);
     GPtrArray *plist = hy_query_run(q);
-    fail_unless(plist->len == 1,
-                "get_latest_pkg() failed finding '%s'.", name);
+    ck_assert_msg(plist->len == 1,
+                  "get_latest_pkg() failed finding '%s'.", name);
     auto pkg = static_cast<DnfPackage *>(g_object_ref(g_ptr_array_index(plist, 0)));
     hy_query_free(q);
     g_ptr_array_unref(plist);
@@ -436,7 +436,7 @@ assert_list_names(bool wanted, GPtrArray *plist, ...)
     va_start(names, plist);
     while ((name = va_arg(names, char *)) != NULL) {
         if (i++ >= count) {
-            fail("assert_list_names(): list too short");
+            ck_abort_msg("assert_list_names(): list too short");
         }
         bool found = false;
         for (auto string: stringVector) {
@@ -446,8 +446,8 @@ assert_list_names(bool wanted, GPtrArray *plist, ...)
             }
         }
         if ((wanted && !found) || (!wanted && found)) {
-            fail_unless(false, "assert_list_names(): element '%s' %sfound '%zu'",
-                        name, wanted ? "not ": "", stringVector.size());
+            ck_abort_msg("assert_list_names(): element '%s' %sfound '%zu'",
+                         name, wanted ? "not ": "", stringVector.size());
         }
     }
     // In the wanted case; we expect all the pkgs in the lists to fully
@@ -455,7 +455,7 @@ assert_list_names(bool wanted, GPtrArray *plist, ...)
     // all the passed pkg arguments are *not* found in the list, which is
     // already checked above.
     if (wanted) {
-        fail_unless(i == count, "assert_list_names(): too many items in the list (%d vs %d)", i, count);
+        ck_assert_msg(i == count, "assert_list_names(): too many items in the list (%d vs %d)", i, count);
     }
     va_end(names);
 }
@@ -493,7 +493,7 @@ START_TEST(test_goal_upgrade_all)
     g_ptr_array_unref(plist_obs);
     g_ptr_array_unref(plist);
 
-    fail_unless(size_and_free(hy_goal_list_installs(goal, NULL)) == 0);
+    ck_assert(size_and_free(hy_goal_list_installs(goal, NULL)) == 0);
     hy_goal_free(goal);
 }
 END_TEST

--- a/tests/hawkey/test_iutil.cpp
+++ b/tests/hawkey/test_iutil.cpp
@@ -122,7 +122,7 @@ START_TEST(test_dnf_solvfile_userdata)
     repowriter_free(writer);
     fclose(fp);
 
-    fp = fopen(new_file, "r");
+    fail_if((fp = fopen(new_file, "r")) == NULL);
     std::unique_ptr<SolvUserdata, decltype(solv_free)*> dnf_solvfile = solv_userdata_read(fp);
     fail_unless(dnf_solvfile);
     fail_unless(solv_userdata_verify(dnf_solvfile.get(), cs_computed));


### PR DESCRIPTION
See the check.h header for more info:
https://github.com/libcheck/check/blob/master/src/check.h.in

Reported in: https://github.com/rpm-software-management/libdnf/issues/1659