### PR TITLE
context config: Fix and extend support libdnf5 drop-in dirs and repository overrides

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -4001,7 +4001,7 @@ load_from_parser(const libdnf::ConfigParser & parser, const std::string & cfgPat
     const auto & cfgParserData = parser.getData();
     auto cfgParserDataIter = cfgParserData.find("main");
     if (cfgParserDataIter != cfgParserData.end()) {
-        auto optBinds = globalMainConfig->optBinds();
+        auto & optBinds = globalMainConfig->optBinds();
         const auto & cfgParserMainSect = cfgParserDataIter->second;
         for (const auto & opt : cfgParserMainSect) {
             auto optBindsIter = optBinds.find(opt.first);

--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -3931,7 +3931,7 @@ dnf_context_load_vars(DnfContext * context)
     auto priv = GET_PRIVATE(context);
     priv->vars->clear();
     for (auto dir = dnf_context_get_vars_dir(context); *dir; ++dir)
-        ConfigMain::addVarsFromDir(*priv->vars, std::string(priv->install_root) + *dir);
+        ConfigMain::addVarsFromDir(*priv->vars, *dir);
     ConfigMain::addVarsFromEnv(*priv->vars);
     priv->varsCached = true;
 }

--- a/libdnf/dnf-repo.cpp
+++ b/libdnf/dnf-repo.cpp
@@ -972,7 +972,7 @@ dnf_repo_conf_load_overrides(DnfRepo *repo, const char *repoId)
                 continue;
             }
 
-            auto optBinds = config.optBinds();
+            auto & optBinds = config.optBinds();
             for (const auto & opt : cfg_parser_data_iter.second) {
                 auto optBindsIter = optBinds.find(opt.first);
                 if (optBindsIter != optBinds.end()) {

--- a/libdnf/utils/iniparser/iniparser.cpp
+++ b/libdnf/utils/iniparser/iniparser.cpp
@@ -70,6 +70,35 @@ const char * IniParser::MissingEqual::what() const noexcept
     return "IniParser: Missing '='";
 }
 
+
+namespace {
+
+// Returns the position of the first ']' character that does not define a list/range.
+std::size_t findEndOfSectionName(const std::string & str, std::size_t pos) {
+    if (pos >= str.size()) {
+        return std::string::npos;
+    }
+
+    bool range = false;
+    for (std::size_t idx = pos;; ++idx) {
+        const auto ch = str[idx];
+        if (ch == ']') {
+            if (range) {
+                range = false;
+            } else {
+                return idx;
+            }
+        } else if (ch == '[') {
+            range = true;
+        } else if (ch == '\0' || ch == '\n' || ch == '\r') {
+            return std::string::npos;
+        }
+    }
+}
+
+}  // namespace
+
+
 IniParser::IniParser(const std::string & filePath)
 : is(new std::ifstream(filePath))
 {
@@ -161,7 +190,7 @@ IniParser::ItemType IniParser::next()
         }
 
         if (line[start] == '[') {
-            auto endSectPos = line.find("]", ++start);
+            auto endSectPos = findEndOfSectionName(line, ++start);
             if (endSectPos == line.npos)
                 throw MissingBracket(lineNumber);
             else if (endSectPos == start)

--- a/libdnf/utils/utils.cpp
+++ b/libdnf/utils/utils.cpp
@@ -325,7 +325,7 @@ std::vector<std::string> createSortedFileList(
 
     // sort all drop-in configuration files alphabetically by their names
     std::sort(paths.begin(), paths.end(), [](const std::string & p1, const std::string & p2) {
-        return strcmp(basename(p1.c_str()), basename(p2.c_str()));
+        return strcmp(basename(p1.c_str()), basename(p2.c_str())) < 0;
     });
 
     return paths;

--- a/libdnf/utils/utils.cpp
+++ b/libdnf/utils/utils.cpp
@@ -308,9 +308,10 @@ std::vector<std::string> createSortedFileList(
             if (path[strlen(path)-1] == '/') {
                 continue;
             }
+            auto * path_fname = basename(path);
             bool found{false};
             for (const auto & path_in_list : paths) {
-                if (path == basename(path_in_list.c_str())) {
+                if (strcmp(path_fname, basename(path_in_list.c_str())) == 0) {
                     found = true;
                     break;
                 }


### PR DESCRIPTION
- Fixes in  filesystem::createSortedFileList
- Backport from libsndf5 - IniParser: Support glob range definition in section name, char ']'
- Optimize: Always use result config.optBinds() by reference, not copy
- Fix: dnf_context_load_vars: don't prepend installroot to varsdir