### PR TITLE
Enable dnf-nightly for packit copr-builds and testing

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,6 +8,8 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
+    additional_repos:
+      - "copr://rpmsoftwaremanagement/dnf-nightly"
   - job: tests
     trigger: pull_request
     identifier: "dnf-tests"
@@ -16,4 +18,9 @@ jobs:
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: enable-tmt-dnf-4-stack
     tmt_plan: "^/plans/integration/behave-dnf$"
-
+    tf_extra_params:
+      environments:
+        - artifacts:
+            - type: repository-file
+              # We use the rawhide repo file for all fedora releases, the url doesn't change and it is not rawhide specific (it contains "fedora-$releasever-$basearch")
+              id: https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf-nightly/repo/fedora-rawhide/rpmsoftwaremanagement-dnf-nightly-fedora-rawhide.repo

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,12 @@
 
 specfile_path: libdnf.spec
 
+# Build the package with the current specfile version (otherwise it uses last git tag).
+# This is needed because other packages can depend on the new version.
+actions:
+  get-current-version:
+    - rpmspec --srpm --query --queryformat "%{version}" libdnf.spec
+
 jobs:
   - job: copr_build
     trigger: pull_request


### PR DESCRIPTION
This helps when we have unreleased changes and the CI has been updated. We have to just wait (or rebuild) the nightly to have the tests pass.