### PR TITLE
rhel-9.7 backports for RHEL-100622, RHEL-100623

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -3,3 +3,4 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+test_version_suffix = .test

--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -292,6 +292,8 @@ class ConfigMain::Impl {
     OptionBool countme{false};
     OptionBool protect_running_kernel{true};
 
+    OptionStringList usr_drift_protected_paths{resolveGlobs("glob:/etc/dnf/usr-drift-protected-paths.d/*.conf")};
+
     // Repo main config
 
     OptionNumber<std::uint32_t> retries{10};
@@ -457,6 +459,12 @@ ConfigMain::Impl::Impl(Config & owner)
     owner.optBinds().add("countme", countme);
     owner.optBinds().add("protect_running_kernel", protect_running_kernel);
     owner.optBinds().add("persistence", persistence);
+    owner.optBinds().add("usr_drift_protected_paths", usr_drift_protected_paths,
+        [&](Option::Priority priority, const std::string & value){
+            if (priority >= usr_drift_protected_paths.getPriority())
+                usr_drift_protected_paths.set(priority, resolveGlobs(value));
+        }, nullptr, false
+    );
 
     // Repo main config
 
@@ -600,6 +608,7 @@ OptionString & ConfigMain::comment() { return pImpl->comment; }
 OptionBool & ConfigMain::downloadonly() { return pImpl->downloadonly; }
 OptionBool & ConfigMain::ignorearch() { return pImpl->ignorearch; }
 OptionEnum<std::string> & ConfigMain::persistence() { return pImpl->persistence; }
+OptionStringList & ConfigMain::usr_drift_protected_paths() { return pImpl->usr_drift_protected_paths; }
 
 OptionString & ConfigMain::module_platform_id() { return pImpl->module_platform_id; }
 OptionBool & ConfigMain::module_stream_switch() { return pImpl->module_stream_switch; }

--- a/libdnf/conf/ConfigMain.hpp
+++ b/libdnf/conf/ConfigMain.hpp
@@ -124,6 +124,7 @@ public:
     OptionBool & downloadonly();
     OptionBool & ignorearch();
     OptionEnum<std::string> & persistence();
+    OptionStringList & usr_drift_protected_paths();
 
     OptionString & module_platform_id();
     OptionBool & module_stream_switch();

--- a/libdnf/transaction/MergedTransaction.cpp
+++ b/libdnf/transaction/MergedTransaction.cpp
@@ -97,6 +97,16 @@ MergedTransaction::listCmdlines() const
     return cmdLines;
 }
 
+std::vector< TransactionPersistence >
+MergedTransaction::listPersistences() const
+{
+    std::vector< TransactionPersistence > persistences;
+    for (auto t : transactions) {
+        persistences.push_back(t->getPersistence());
+    }
+    return persistences;
+}
+
 std::vector< TransactionState >
 MergedTransaction::listStates() const
 {

--- a/libdnf/transaction/MergedTransaction.hpp
+++ b/libdnf/transaction/MergedTransaction.hpp
@@ -47,6 +47,7 @@ public:
     std::vector< int64_t > listIds() const;
     std::vector< uint32_t > listUserIds() const;
     std::vector< std::string > listCmdlines() const;
+    std::vector< TransactionPersistence > listPersistences() const;
     std::vector< TransactionState > listStates() const;
     std::vector< std::string > listReleasevers() const;
     std::vector< std::string > listComments() const;

--- a/libdnf/transaction/Swdb.cpp
+++ b/libdnf/transaction/Swdb.cpp
@@ -385,6 +385,14 @@ Swdb::setReleasever(std::string value)
     transactionInProgress->setReleasever(value);
 }
 
+void
+Swdb::setPersistence(TransactionPersistence persistence)
+{
+    if (!transactionInProgress) {
+        throw std::logic_error(_("Not in progress"));
+    }
+    transactionInProgress->setPersistence(persistence);
+}
 
 void
 Swdb::addConsoleOutputLine(int fileDescriptor, std::string line)

--- a/libdnf/transaction/Swdb.hpp
+++ b/libdnf/transaction/Swdb.hpp
@@ -114,6 +114,7 @@ public:
 
     // misc
     void setReleasever(std::string value);
+    void setPersistence(TransactionPersistence value);
     void addConsoleOutputLine(int fileDescriptor, std::string line);
 
     /**

--- a/libdnf/transaction/Transaction.cpp
+++ b/libdnf/transaction/Transaction.cpp
@@ -82,6 +82,7 @@ Transaction::dbSelect(int64_t pk)
         "  releasever, "
         "  user_id, "
         "  cmdline, "
+        "  persistence, "
         "  state, "
         "  comment "
         "FROM "
@@ -100,6 +101,7 @@ Transaction::dbSelect(int64_t pk)
     releasever = query.get< std::string >("releasever");
     userId = query.get< uint32_t >("user_id");
     cmdline = query.get< std::string >("cmdline");
+    persistence = static_cast<TransactionPersistence>(query.get<int>("persistence"));
     state = static_cast< TransactionState >(query.get< int >("state"));
     comment = query.get< std::string >("comment");
 }

--- a/libdnf/transaction/Transaction.hpp
+++ b/libdnf/transaction/Transaction.hpp
@@ -55,6 +55,8 @@ public:
     const std::string &getReleasever() const noexcept { return releasever; }
     uint32_t getUserId() const noexcept { return userId; }
     const std::string &getCmdline() const noexcept { return cmdline; }
+    TransactionPersistence getPersistence() const noexcept { return persistence; }
+
     TransactionState getState() const noexcept { return state; }
     const std::string &getComment() const noexcept { return comment; }
 
@@ -79,6 +81,7 @@ protected:
     std::string releasever;
     uint32_t userId = 0;
     std::string cmdline;
+    TransactionPersistence persistence = TransactionPersistence::UNKNOWN;
     TransactionState state = TransactionState::UNKNOWN;
     std::string comment;
 };

--- a/libdnf/transaction/Transformer.cpp
+++ b/libdnf/transaction/Transformer.cpp
@@ -53,6 +53,10 @@ static const char * const sql_migrate_tables_1_2 =
 #include "sql/migrate_tables_1_2.sql"
     ;
 
+static const char * const sql_migrate_tables_1_3 =
+#include "sql/migrate_tables_1_3.sql"
+    ;
+
 void
 Transformer::createDatabase(SQLite3Ptr conn)
 {
@@ -70,6 +74,9 @@ Transformer::migrateSchema(SQLite3Ptr conn)
 
         if (schemaVersion == "1.1") {
             conn->exec(sql_migrate_tables_1_2);
+            conn->exec(sql_migrate_tables_1_3);
+        } else if (schemaVersion == "1.2") {
+            conn->exec(sql_migrate_tables_1_3);
         }
     }
     else {

--- a/libdnf/transaction/Transformer.hpp
+++ b/libdnf/transaction/Transformer.hpp
@@ -60,7 +60,7 @@ public:
     static void migrateSchema(SQLite3Ptr conn);
 
     static TransactionItemReason getReason(const std::string &reason);
-    static const char *getVersion() noexcept { return "1.2"; }
+    static const char *getVersion() noexcept { return "1.3"; }
 
 protected:
     void transformTrans(SQLite3Ptr swdb, SQLite3Ptr history);

--- a/libdnf/transaction/Types.hpp
+++ b/libdnf/transaction/Types.hpp
@@ -56,6 +56,12 @@ enum class TransactionItemAction : int {
     REASON_CHANGE = 11 // a package was kept on the system but it's reason has changed
 };
 
+enum class TransactionPersistence : int {
+    UNKNOWN = 0,
+    PERSIST = 1,
+    TRANSIENT = 2,
+};
+
 } // namespace libdnf
 /*
 Install

--- a/libdnf/transaction/private/Transaction.cpp
+++ b/libdnf/transaction/private/Transaction.cpp
@@ -76,12 +76,13 @@ swdb_private::Transaction::dbInsert()
         "    releasever, "
         "    user_id, "
         "    cmdline, "
+        "    persistence, "
         "    state, "
         "    comment, "
         "    id "
         "  ) "
         "VALUES "
-        "  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        "  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     SQLite3::Statement query(*conn.get(), sql);
     query.bindv(getDtBegin(),
                 getDtEnd(),
@@ -90,10 +91,11 @@ swdb_private::Transaction::dbInsert()
                 getReleasever(),
                 getUserId(),
                 getCmdline(),
+                static_cast<int>(getPersistence()),
                 static_cast< int >(getState()),
                 getComment());
     if (getId() > 0) {
-        query.bind(9, getId());
+        query.bind(10, getId());
     }
     query.step();
     setId(conn->lastInsertRowID());
@@ -138,6 +140,7 @@ swdb_private::Transaction::dbUpdate()
         "  releasever=?, "
         "  user_id=?, "
         "  cmdline=?, "
+        "  persistence=?, "
         "  state=?, "
         "  comment=? "
         "WHERE "
@@ -150,6 +153,7 @@ swdb_private::Transaction::dbUpdate()
                 getReleasever(),
                 getUserId(),
                 getCmdline(),
+                static_cast<int>(getPersistence()),
                 static_cast< int >(getState()),
                 getComment(),
                 getId());

--- a/libdnf/transaction/private/Transaction.hpp
+++ b/libdnf/transaction/private/Transaction.hpp
@@ -42,6 +42,7 @@ public:
     void setReleasever(const std::string &value) { releasever = value; }
     void setUserId(uint32_t value) { userId = value; }
     void setCmdline(const std::string &value) { cmdline = value; }
+    void setPersistence(TransactionPersistence value) { persistence = value; }
     void setState(TransactionState value) { state = value; }
     void setComment(const std::string &value) { comment = value; }
 

--- a/libdnf/transaction/sql/migrate_tables_1_3.sql
+++ b/libdnf/transaction/sql/migrate_tables_1_3.sql
@@ -1,0 +1,9 @@
+R"**(
+BEGIN TRANSACTION;
+    ALTER TABLE trans
+        ADD persistence INTEGER DEFAULT 0;
+    UPDATE config
+        SET value = '1.3'
+        WHERE key = 'version';
+COMMIT;
+)**"


### PR DESCRIPTION
Backports the following PRs to rhel-9.7:

- https://github.com/rpm-software-management/libdnf/pull/1706
  For https://issues.redhat.com/browse/RHEL-100623
- https://github.com/rpm-software-management/libdnf/pull/1711
  For https://issues.redhat.com/browse/RHEL-100622

Also includes a Tito configuration change to make testing builds easier.