### PR TITLE
build: Fix searching libdnf header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ option(WITH_TESTS "Enables unit tests" ON)
 option(WITH_SANITIZERS "Build with address, leak and undefined sanitizers (DEBUG ONLY)" OFF)
 
 
+# always place our header files before system ones
+include_directories(${CMAKE_SOURCE_DIR} libdnf/utils/)
+
 # load pkg-config first; it's required by other modules
 find_package(PkgConfig REQUIRED)
 if(APPLE)
@@ -68,9 +71,6 @@ link_directories(${REPO_LIBRARY_DIRS})
 pkg_check_modules(RPM REQUIRED rpm>=4.15.0)
 pkg_check_modules(SMARTCOLS REQUIRED smartcols)
 pkg_check_modules(SQLite3 REQUIRED sqlite3)
-
-# always enable linking with libdnf utils
-include_directories(${CMAKE_SOURCE_DIR} libdnf/utils/)
 
 if (WITH_ZCHUNK)
     pkg_check_modules(ZCHUNKLIB zck>=0.9.11 REQUIRED)


### PR DESCRIPTION
Previously, a search path for in-source libdnf header files was listed in the middle of paths for other dependencies. That caused swig to generate bindings from system header files, possible incompatible with the in-source library, leading to a build failure like this:

    cd /home/test/fedora/libdnf/libdnf-0.74.0-build/libdnf-0.74.0/build-py3/bindings/python && /usr/bin/g++ -DGETTEXT_DOMAIN=\"libdnf\" -DG_LOG_DOMAIN=\"libdnf\" -DLIBDNF_UNSTABLE_API -DLIBSOLV_SOLVABLE_PREPEND_DEP -DPACKAGE_VERSION=\"0.74.0\" -DTESTDATADIR=\"/home/test/fedora/libdnf/libdnf-0.74.0-build/libdnf-0.74.0/data/tests\" -D_conf_EXPORTS -I/usr/include/gio-unix-2.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/sysprof-6 -I/usr/include/json-c -I/usr/include/libxml2 -I/home/test/fedora/libdnf/libdnf-0.74.0-build/libdnf-0.74.0 -I/home/test/fedora/libdnf/libdnf-0.74.0-build/libdnf-0.74.0/libdnf/utils -I/usr/include/python3.14 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DWITH_ZCHUNK -std=c++11 -Wmissing-declarations -fPIC -Wcast-align -Wno-uninitialized -Wredundant-decls -Wwrite-strings -Wformat-nonliteral -Wmissing-format-attribute -Wsign-compare -Wtype-limits -Wuninitialized -Wall -Wl,--as-needed -MD -MT bindings/python/CMakeFiles/_conf.dir/CMakeFiles/_conf.dir/confPYTHON_wrap.cxx.o -MF CMakeFiles/_conf.dir/CMakeFiles/_conf.dir/confPYTHON_wrap.cxx.o.d -o CMakeFiles/_conf.dir/CMakeFiles/_conf.dir/confPYTHON_wrap.cxx.o -c /home/test/fedora/libdnf/libdnf-0.74.0-build/libdnf-0.74.0/build-py3/bindings/python/CMakeFiles/_conf.dir/confPYTHON_wrap.cxx
    /home/test/fedora/libdnf/libdnf-0.74.0-build/libdnf-0.74.0/build-py3/bindings/python/CMakeFiles/_conf.dir/confPYTHON_wrap.cxx: In function ‘PyObject* _wrap_ConfigMain_usr_drift_protected_paths(PyObject*, PyObject*)’:
    /home/test/fedora/libdnf/libdnf-0.74.0-build/libdnf-0.74.0/build-py3/bindings/python/CMakeFiles/_conf.dir/confPYTHON_wrap.cxx:23913:54: error: ‘class libdnf::ConfigMain’ has no member named ‘usr_drift_protected_paths’
    23913 |       result = (libdnf::OptionStringList *) &(arg1)->usr_drift_protected_paths();
	  |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~

This patch fixes the header search path order by placing both paths to the in-source header files at the very first place.

Resolve: #1716