### PR TITLE
Move libcheck dependency to inside WITH_TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ find_package(LibSolv 0.7.21 REQUIRED COMPONENTS ext)
 
 
 # build dependencies via pkg-config
-pkg_check_modules(CHECK REQUIRED check)
 pkg_check_modules(GLIB REQUIRED gio-unix-2.0>=2.46.0)
 include_directories(${GLIB_INCLUDE_DIRS})
 pkg_check_modules(JSONC REQUIRED json-c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+pkg_check_modules(CHECK REQUIRED check)
+pkg_check_modules(CPPUNIT REQUIRED cppunit)
+
 add_subdirectory(libdnf/conf)
 add_subdirectory(libdnf/module/modulemd)
 add_subdirectory(libdnf/module)
@@ -6,10 +9,6 @@ add_subdirectory(libdnf/transaction)
 add_subdirectory(libdnf/sack)
 add_subdirectory(hawkey)
 add_subdirectory(libdnf)
-
-
-
-pkg_check_modules(CPPUNIT REQUIRED cppunit)
 
 set(LIBDNF_TEST_SOURCES
     ${LIBDNF_TEST_SOURCES}


### PR DESCRIPTION
If we're not building the tests then there's no point in depending on libcheck, so move the pkg_check_modules() call to inside the WITH_TESTS block.