### PR TITLE
Stop importing subkeys to RPM >= 4.19.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,12 @@ pkg_check_modules(LIBMODULEMD REQUIRED modulemd-2.0>=2.11.2)
 pkg_check_modules(REPO REQUIRED librepo>=1.18.0)
 include_directories(${REPO_INCLUDE_DIRS})
 link_directories(${REPO_LIBRARY_DIRS})
+
 pkg_check_modules(RPM REQUIRED rpm>=4.15.0)
+if (RPM_VERSION VERSION_GREATER_EQUAL "5.99.90")
+    add_definitions(-DRPM_AUTOADDS_SUBKEYS)
+endif()
+
 pkg_check_modules(SMARTCOLS REQUIRED smartcols)
 pkg_check_modules(SQLite3 REQUIRED sqlite3)
 

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -96,6 +96,9 @@ BuildRequires:  libubsan
 Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
 Requires:       librepo%{?_isa} >= %{librepo_version}
+%if 0%{?fedora} >= 43 || 0%{?rhel} >= 11
+Requires:       rpm-libs%{?_isa} >= 5.99.90
+%endif
 
 %if %{without python2}
 # Obsoleted from here so we can track the fast growing version easily.

--- a/libdnf/dnf-keyring.cpp
+++ b/libdnf/dnf-keyring.cpp
@@ -131,6 +131,10 @@ dnf_keyring_add_public_key(rpmKeyring keyring,
         goto out;
     }
 
+#ifndef RPM_AUTOADDS_SUBKEYS
+    /* RPM before 5.99.90 required adding subkeys explicitly.
+     * RPM >= 5.99.90 processes subkeys automatically with a primary key and
+     * fails on processing standalone subkeys in rpmKeyringAddKey(). */
     subkeys = rpmGetSubkeys(pubkey, &nsubkeys);
     for (int i = 0; i < nsubkeys; i++) {
         rpmPubkey subkey = subkeys[i];
@@ -144,6 +148,7 @@ dnf_keyring_add_public_key(rpmKeyring keyring,
             goto out;
         }
     }
+#endif
 
     /* success */
     g_debug("added missing public key %s to rpmdb", filename);


### PR DESCRIPTION
It was reported that rpmKeyringAddKey() fails to import separate subkeys in RPM 6 with rpm-sequoia
<https://bugzilla.redhat.com/show_bug.cgi?id=2372978>. Observed in packagekit and microdnf with rpm-libs-5.99.92-1.fc44.x86_64 and rpm-sequoia-1.9.0-2.fc43.x86_64:

    packagekitd[1862782]: failed to add subkeys for /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-10-primary to rpmdb
    packagekitd[1862782]: failed to add subkeys for /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-13-secondary to rpmdb
    packagekitd[1862782]: failed to add subkeys for /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-14-secondary to rpmdb

The failure comes from librpm's rpmKeyringAddKey() → rpmKeyringModify() → rpmPubkeyMerge() → pgpPubkeyMerge() when adding the first subkey of the keyfile into a keyring by libdnf in dnf_keyring_add_public_key() at libdnf/dnf-keyring.cpp:137. pgpPubkeyMerge() is implemented in rpm-sequoia.

It was confirme by RPM developers that RPM started to automatically add subkeys to a keyring when the primary key is added and that it does not expect standalone subkeys any more. This change happended in 4.19.0-alpha2.

This patch stops passing standalone subkeys to rpmKeyringAddKey() on RPM >= 4.19.0.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2372978