### PR TITLE
config: Convert `protected_packages` to an append option

### DIFF
--- a/libdnf/conf/Config-private.hpp
+++ b/libdnf/conf/Config-private.hpp
@@ -22,6 +22,7 @@
 #define _LIBDNF_CONFIG_PRIVATE_HPP
 
 #include "Option.hpp"
+#include "OptionStringList.hpp"
 
 namespace libdnf {
 
@@ -33,7 +34,7 @@ static void optionTListAppend(T & option, Option::Priority priority, const std::
         return;
     }
     auto addPriority = priority < option.getPriority() ? option.getPriority() : priority;
-    auto val = option.fromString(value);
+    auto val = OptionStringList(std::vector<std::string>{}).fromString(value);
     bool first = true;
     for (auto & item : val) {
         if (item.empty()) {

--- a/libdnf/conf/ConfigMain.cpp
+++ b/libdnf/conf/ConfigMain.cpp
@@ -514,11 +514,11 @@ ConfigMain::Impl::Impl(Config & owner)
     owner.optBinds().add("proxy_username", proxy_username);
     owner.optBinds().add("proxy_password", proxy_password);
     owner.optBinds().add("proxy_auth_method", proxy_auth_method);
+
     owner.optBinds().add("protected_packages", protected_packages,
         [&](Option::Priority priority, const std::string & value){
-            if (priority >= protected_packages.getPriority())
-                protected_packages.set(priority, resolveGlobs(value));
-        }, nullptr, false
+            optionTListAppend(protected_packages, priority, resolveGlobs(value));
+        }, nullptr, true
     );
 
     owner.optBinds().add("username", username);

--- a/libdnf/conf/ConfigRepo.cpp
+++ b/libdnf/conf/ConfigRepo.cpp
@@ -145,7 +145,13 @@ ConfigRepo::Impl::Impl(Config & owner, ConfigMain & mainConfig)
     owner.optBinds().add("proxy_auth_method", proxy_auth_method);
     owner.optBinds().add("username", username);
     owner.optBinds().add("password", password);
-    owner.optBinds().add("protected_packages", protected_packages);
+
+    owner.optBinds().add("protected_packages", protected_packages,
+        [&](Option::Priority priority, const std::string & value){
+            optionTListAppend(protected_packages, priority, value);
+        }, nullptr, true
+    );
+
     owner.optBinds().add("gpgcheck", gpgcheck);
     owner.optBinds().add("repo_gpgcheck", repo_gpgcheck);
     owner.optBinds().add("enablegroups", enablegroups);


### PR DESCRIPTION
This change is necessary because the list of protected packages started being distributed across configuration files within a drop-in directory. This led to a situation where a subsequent configuration file containing `protected_packages` would overwrite any earlier settings.

This issue was previously encountered and resolved in **libdnf5** approximately two years ago by changing `protected_packages` to an append option PR https://github.com/rpm-software-management/dnf5/pull/1110. The same proven solution is implemented here to ensure correct merging and prevent unexpected overwrites of earlier configurations.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2400488

CI test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1764