### PR TITLE
spec: Work around a bug in ctest macro on RHEL 9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,8 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
+      - epel-9
+      - epel-10
       - fedora-all
     additional_repos:
       - "copr://rpmsoftwaremanagement/dnf-nightly"
@@ -20,6 +22,7 @@ jobs:
     trigger: pull_request
     identifier: "dnf-tests"
     targets:
+      # EPELs fail now for unrelated reasons
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
     fmf_ref: enable-tmt-dnf-4-stack

--- a/libdnf.spec
+++ b/libdnf.spec
@@ -226,6 +226,10 @@ popd
 %endif
 
 %check
+%if 0%{?rhel} == 9 && %{defined ctest}
+# Work around broken passing options to ctest macro, RHEL-120543
+%global ctest(-) %{expand:%{macrobody:ctest}}
+%endif
 %if %{with python2}
 pushd build-py2
   %ctest -V


### PR DESCRIPTION
Building the RPM package on RHEL 9 failed like this:

    error: /builddir/build/originals/libdnf.spec: line 238: Unknown option V in ctest(:-:)

The failure was introduced with commit
a067e647b17d6e66b6bce024be091ab14cae4daf ("spec: Consistently use CMake RPM macros"). The cause is a bug in a defintion of the ctest macro provided with cmake-rpm-macros-3.26.5-2.el9.noarch by RHEL 9 <https://issues.redhat.com/browse/RHEL-120543>.

This patch works around the bug by redefining the macro while accepting any options.