### PR TITLE
spec: Package release notes

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -274,7 +274,7 @@ popd
 
 %files -f %{name}.lang
 %license COPYING
-%doc README.md AUTHORS
+%doc AUTHORS README.md docs/release_notes.rst
 %{_libdir}/%{name}.so.*
 %dir %{_libdir}/libdnf/
 %dir %{_libdir}/libdnf/plugins/


### PR DESCRIPTION
Users should have a place where to get the news, ideally distributed within the RPM package along the code.