### PR TITLE
spec: Remove a trailing dot from python3-libdnf summary

### DIFF
--- a/libdnf.spec
+++ b/libdnf.spec
@@ -144,7 +144,7 @@ Python 2 bindings for the libdnf library.
 %if %{with python3}
 %package -n python3-%{name}
 %{?python_provide:%python_provide python3-%{name}}
-Summary:        Python 3 bindings for the libdnf library.
+Summary:        Python 3 bindings for the libdnf library
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 BuildRequires:  python3-devel
 BuildRequires:  %{requires_python3_sphinx}


### PR DESCRIPTION
RPM summaries are titles and they are not suppossed to end with a full stop. rpmlint complains:

    python3-libdnf.x86_64: W: summary-ended-with-dot Python 3 bindings for the libdnf library.