### PR TITLE
docs: use UTF-8 in source file instead of ISO-8859-15

### DIFF
--- a/docs/libdnf/html/common.css
+++ b/docs/libdnf/html/common.css
@@ -1,6 +1,6 @@
 /*  common.css - MoinMoin Default Styles
 
-    Copyright (c) 2001, 2002, 2003 by Jürgen Hermann
+    Copyright (c) 2001, 2002, 2003 by JÃ¼rgen Hermann
 */
 
 /* content styles */


### PR DESCRIPTION
UTF-8 should be available everywhere now

For example with the ISO encoding it shows up on my terminal as:

```
J<FC>rgen
```