### PR TITLE
build: also use static libcheck variables if defined

### DIFF
--- a/tests/hawkey/CMakeLists.txt
+++ b/tests/hawkey/CMakeLists.txt
@@ -29,6 +29,8 @@ set_target_properties(test_hawkey_main PROPERTIES COMPILE_FLAGS -fPIC)
 target_link_libraries(test_hawkey_main
     libdnf
     ${CHECK_LDFLAGS}
+    ${CHECK_STATIC_LIBRARIES}
+    ${CHECK_STATIC_LDFLAGS}
     ${SOLV_LIBRARY}
     ${SOLVEXT_LIBRARY}
     ${RPMDB_LIBRARY}


### PR DESCRIPTION
In Ubuntu and Debian, only the static libcheck library is shipped. Reference the relevant build flags. If not defined CMake will simply ignore them, so should not affect other distros.