### PR TITLE
python tests: fix locale issues

### DIFF
--- a/python/hawkey/tests/tests/base.py
+++ b/python/hawkey/tests/tests/base.py
@@ -33,6 +33,11 @@ if cachedir is None:
     cachedir = tempfile.mkdtemp(dir=os.path.dirname(hawkey.test.UNITTEST_DIR),
                                 prefix='pyhawkey')
 
+# run tests with C locales to avoid test failures in Ubuntu/Debian
+os.environ["LC_ALL"] = "C"
+os.environ["LANG"] = "C.UTF-8"
+os.environ["LANGUAGE"] = "en_US:en"
+
 class TestCase(unittest.TestCase):
     repo_dir = os.path.normpath(os.path.join(__file__, "../../../../../data/tests/hawkey/"))
 


### PR DESCRIPTION
It has been observed that manipulating locales in Debian environment, tests are failing.

```
======================================================================
ERROR: test_custom_querying (tests.test_reldep.Reldep)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/reprotest.wOQ8sL/build-experiment-1/build-experiment-1/python/hawkey/tests/tests/test_reldep.py", line 78, in test_custom_querying
    reldep = hawkey.Reldep(self.sack, u"\u0159 >= 3")
_hawkey.ValueException: Wrong reldep format: \u0159 >= 3
```