### PR TITLE
Fixes for libsolv default behaviour when compiled for non-RPM distros

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -186,6 +186,10 @@ dnf_sack_init(DnfSack *sack)
     priv->pool = pool_create();
     pool_set_flag(priv->pool, POOL_FLAG_WHATPROVIDESWITHDISABLED, 1);
 
+    // On "foreign" systems (non-RPM, like Ubuntu), libsolv does not default
+    // disttype to RPM. Set this explicitly as DNF's purpose is handling RPMs.
+    pool_setdisttype(priv->pool, DISTTYPE_RPM);
+
     priv->running_kernel_id = -1;
     priv->running_kernel_fn = running_kernel;
     priv->considered_uptodate = TRUE;

--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -189,6 +189,11 @@ dnf_sack_init(DnfSack *sack)
     // On "foreign" systems (non-RPM, like Ubuntu), libsolv does not default
     // disttype to RPM. Set this explicitly as DNF's purpose is handling RPMs.
     pool_setdisttype(priv->pool, DISTTYPE_RPM);
+    // On "foreign" systems (non-RPM, like Ubuntu), libsolv turns off the
+    // implicitobsoleteusescolors flag by default.
+    // Given DNF's primary purpose is to manage RPMs on Fedora/CentOS and
+    // derivatives, enable it by default.
+    pool_set_flag(priv->pool, POOL_FLAG_IMPLICITOBSOLETEUSESCOLORS, 1);
 
     priv->running_kernel_id = -1;
     priv->running_kernel_fn = running_kernel;

--- a/tests/hawkey/test_iutil.cpp
+++ b/tests/hawkey/test_iutil.cpp
@@ -162,6 +162,11 @@ END_TEST
 START_TEST(test_version_split)
 {
     Pool *pool = pool_create();
+
+    // On "foreign" systems (non-RPM, like Ubuntu), libsolv does not default
+    // disttype to RPM. Set this explicitly as DNF's purpose is handling RPMs.
+    fail_if(-1 == pool_setdisttype(pool, DISTTYPE_RPM));
+
     char evr[] = "1:5.9.3-8";
     char *epoch, *version, *release;
 

--- a/tests/hawkey/test_iutil.cpp
+++ b/tests/hawkey/test_iutil.cpp
@@ -167,6 +167,12 @@ START_TEST(test_version_split)
     // disttype to RPM. Set this explicitly as DNF's purpose is handling RPMs.
     fail_if(-1 == pool_setdisttype(pool, DISTTYPE_RPM));
 
+    // On "foreign" systems (non-RPM, like Ubuntu), libsolv turns off the
+    // implicitobsoleteusescolors flag by default.
+    // Given DNF's primary purpose is to manage RPMs on Fedora/CentOS and
+    // derivatives, enable it by default.
+    pool_set_flag(pool, POOL_FLAG_IMPLICITOBSOLETEUSESCOLORS, 1);
+
     char evr[] = "1:5.9.3-8";
     char *epoch, *version, *release;
 


### PR DESCRIPTION
libsolv's default when built for non-RPM distros like Ubuntu is to try to be smart and adapt to the native distro. But we build and ship DNF in Ubuntu and derivatives to bootstrap Fedora/CentOS and other native DNF distros, so set the defaults to the expected values on those distros, so that behaviour matches expectations, as DNF does not manage deb packages or others anyway.