### PR TITLE
build: append libsolv cmake path for Ubuntu/Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 if(${CMAKE_VERSION} VERSION_LESS 3)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake/modules-cmake-2)
 endif()
+# On Ubuntu et al. CMake is configured differently and needs to be told where to find libsolv,
+# otherwise the build fails
+LIST (APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/share/cmake/libsolv/")
 
 
 # print exact name and version of the compiled project


### PR DESCRIPTION
Make sure cmake can find FindLibSolv.cmake when installed in ${CMAKE_INSTALL_PREFIX}/share/cmake/libsolv like in Ubuntu and Debian. If the path doesn't exist like in other distros it will just be ignored.