### PR TITLE
Describe all problems even when there are protected removals

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -1108,7 +1108,6 @@ Goal::describeProblemRules(unsigned i, bool pkgs)
     auto problem = pImpl->describeProtectedRemoval();
     if (!problem.empty()) {
         output.push_back(std::move(problem));
-        return output;
     }
     auto solv = pImpl->solv;
 

--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -1752,11 +1752,11 @@ Goal::Impl::protectedInRemovals()
 std::string
 Goal::Impl::describeProtectedRemoval()
 {
-    std::string message(_("The operation would result in removing"
-                          " the following protected packages: "));
     Pool * pool = solv->pool;
 
     if (removalOfProtected && removalOfProtected->size()) {
+        const std::string removal_message(_("The operation would result in removing "
+                                            "the following protected packages: "));
         Id id = -1;
         std::vector<const char *> names;
         while((id = removalOfProtected->next(id)) != -1) {
@@ -1766,9 +1766,13 @@ Goal::Impl::describeProtectedRemoval()
         if (names.empty()) {
             return {};
         }
-        return message + std::accumulate(std::next(names.begin()), names.end(),
-                std::string(names[0]), [](std::string a, std::string b) { return a + ", " + b; });
+        return removal_message +
+            std::accumulate(std::next(names.begin()), names.end(), std::string(names[0]),
+                            [](std::string a, std::string b) { return a + ", " + b; });
     }
+
+    const std::string broken_dependency_message(_("The operation would result in broken "
+                                                  "dependencies for the following protected packages: "));
     auto pset = brokenDependencyAllPkgs(DNF_PACKAGE_STATE_INSTALLED);
     Id id = -1;
     Id protected_kernel = protectedRunningKernel();
@@ -1781,8 +1785,9 @@ Goal::Impl::describeProtectedRemoval()
     }
     if (names.empty())
         return {};
-    return message + std::accumulate(std::next(names.begin()), names.end(), std::string(names[0]),
-                           [](std::string a, std::string b) { return a + ", " + b; });
+    return broken_dependency_message +
+        std::accumulate(std::next(names.begin()), names.end(), std::string(names[0]),
+                        [](std::string a, std::string b) { return a + ", " + b; });
 }
 
 }


### PR DESCRIPTION
Previously, if a transaction involved removal (or dependency break) of a protected package, only the protected package problem would be described by `describeProblemRules`. Information about excluded or versionlocked packages would be missing.

Setup:

```
dnf4 downgrade -y systemd
dnf4 versionlock add systemd
dnf4 update
````
Current output:

```
Problem: The operation would result in removing the following protected packages: systemd
```

Output with this patch:

```
 Problem 1: The operation would result in broken dependencies for the following protected packages: systemd
  - package systemd-udev-258.3-2.fc43.x86_64 from updates requires systemd(x86-64) = 258.3-2.fc43, but none of the providers can be installed
  - cannot install the best update candidate for package systemd-udev-258-1.fc43.x86_64
  - package systemd-258.3-2.fc43.x86_64 from updates is filtered out by exclude filtering
 Problem 2: The operation would result in broken dependencies for the following protected packages: systemd
  - package systemd-resolved-258.3-2.fc43.x86_64 from updates requires systemd(x86-64) = 258.3-2.fc43, but none of the providers can be installed
  - cannot install the best update candidate for package systemd-resolved-258-1.fc43.x86_64
  - package systemd-258.3-2.fc43.x86_64 from updates is filtered out by exclude filtering
 Problem 3: The operation would result in broken dependencies for the following protected packages: systemd
  - package systemd-container-258.3-2.fc43.x86_64 from updates requires systemd(x86-64) = 258.3-2.fc43, but none of the providers can be installed
  - cannot install the best update candidate for package systemd-container-258-1.fc43.x86_64
  - package systemd-258.3-2.fc43.x86_64 from updates is filtered out by exclude filtering
 Problem 4: The operation would result in broken dependencies for the following protected packages: systemd
  - package systemd-pam-258.3-2.fc43.x86_64 from updates requires systemd = 258.3-2.fc43, but none of the providers can be installed
  - cannot install the best update candidate for package systemd-pam-258-1.fc43.x86_64
  - package systemd-258.3-2.fc43.i686 from updates is filtered out by exclude filtering
  - package systemd-258.3-2.fc43.x86_64 from updates is filtered out by exclude filtering
 Problem 5: The operation would result in broken dependencies for the following protected packages: systemd
  - package systemd-258-1.fc43.x86_64 from @System requires libsystemd-shared-258-1.fc43.so()(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires libsystemd-shared-258-1.fc43.so(SD_SHARED)(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires systemd-shared(x86-64) = 258-1.fc43, but none of the providers can be installed
  - package systemd-libs-258.3-2.fc43.x86_64 from updates conflicts with systemd-shared < 258.3-2.fc43 provided by systemd-shared-258-1.fc43.x86_64 from @System
  - package systemd-libs-258.3-2.fc43.x86_64 from updates conflicts with systemd-shared < 258.3-2.fc43 provided by systemd-shared-258-1.fc43.x86_64 from fedora
  - cannot install the best update candidate for package systemd-libs-258-1.fc43.x86_64
  - cannot install the best update candidate for package systemd-258-1.fc43.x86_64
 Problem 6: The operation would result in broken dependencies for the following protected packages: systemd
  - package subscription-manager-1.30.5-5.fc43.x86_64 from @System requires systemd, but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from fedora requires (systemd-rpm-macros = 258-1.fc43 if rpm-build), but none of the providers can be installed
  - package systemd-258-1.fc43.i686 from fedora requires (systemd-rpm-macros = 258-1.fc43 if rpm-build), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires (systemd-rpm-macros = 258-1.fc43 if rpm-build), but none of the providers can be installed
  - cannot install both systemd-rpm-macros-258.3-2.fc43.noarch from updates and systemd-rpm-macros-258-1.fc43.noarch from @System
  - cannot install both systemd-rpm-macros-258.3-2.fc43.noarch from updates and systemd-rpm-macros-258-1.fc43.noarch from fedora
  - cannot install the best update candidate for package systemd-rpm-macros-258-1.fc43.noarch
  - cannot install the best update candidate for package subscription-manager-1.30.5-5.fc43.x86_64
  - cannot install the best update candidate for package rpm-build-6.0.1-1.fc43.x86_64
  - package systemd-258.3-2.fc43.i686 from updates is filtered out by exclude filtering
  - package systemd-258.3-2.fc43.x86_64 from updates is filtered out by exclude filtering
 Problem 7: The operation would result in broken dependencies for the following protected packages: systemd
  - package sssd-kcm-2.11.1-4.fc43.x86_64 from @System requires systemd, but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires libsystemd-shared-258-1.fc43.so()(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires libsystemd-shared-258-1.fc43.so(SD_SHARED)(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires systemd-shared(x86-64) = 258-1.fc43, but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from fedora requires libsystemd-shared-258-1.fc43.so()(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from fedora requires libsystemd-shared-258-1.fc43.so(SD_SHARED)(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from fedora requires systemd-shared(x86-64) = 258-1.fc43, but none of the providers can be installed
  - package systemd-258-1.fc43.i686 from fedora requires systemd-libs(x86-32) = 258-1.fc43, but none of the providers can be installed
  - cannot install both systemd-shared-258.3-2.fc43.x86_64 from updates and systemd-shared-258-1.fc43.x86_64 from @System
  - package systemd-shared-258.3-2.fc43.x86_64 from updates conflicts with systemd-libs < 258.3-2.fc43 provided by systemd-libs-258-1.fc43.i686 from fedora
  - cannot install both systemd-shared-258.3-2.fc43.x86_64 from updates and systemd-shared-258-1.fc43.x86_64 from fedora
  - cannot install the best update candidate for package systemd-shared-258-1.fc43.x86_64
  - cannot install the best update candidate for package sssd-kcm-2.11.1-4.fc43.x86_64
  - package systemd-258.3-2.fc43.i686 from updates is filtered out by exclude filtering
  - package systemd-258.3-2.fc43.x86_64 from updates is filtered out by exclude filtering
 Problem 8: The operation would result in broken dependencies for the following protected packages: systemd
  - package mock-6.6-1.fc43.noarch from @System requires systemd-container, but none of the providers can be installed
  - package systemd-container-258-1.fc43.x86_64 from @System requires libsystemd-shared-258-1.fc43.so()(64bit), but none of the providers can be installed
  - package systemd-container-258-1.fc43.x86_64 from @System requires libsystemd-shared-258-1.fc43.so(SD_SHARED)(64bit), but none of the providers can be installed
  - package systemd-container-258-1.fc43.x86_64 from fedora requires libsystemd-shared-258-1.fc43.so()(64bit), but none of the providers can be installed
  - package systemd-container-258-1.fc43.x86_64 from fedora requires libsystemd-shared-258-1.fc43.so(SD_SHARED)(64bit), but none of the providers can be installed
  - package systemd-container-258-1.fc43.i686 from fedora requires libsystemd-shared-258-1.fc43.so, but none of the providers can be installed
  - package systemd-container-258-1.fc43.i686 from fedora requires libsystemd-shared-258-1.fc43.so(SD_SHARED), but none of the providers can be installed
  - package systemd-libs-258.3-2.fc43.x86_64 from updates conflicts with systemd-shared < 258.3-2.fc43 provided by systemd-shared-258-1.fc43.x86_64 from @System
  - package systemd-libs-258.3-2.fc43.x86_64 from updates conflicts with systemd-shared < 258.3-2.fc43 provided by systemd-shared-258-1.fc43.i686 from fedora
  - package systemd-libs-258.3-2.fc43.x86_64 from updates conflicts with systemd-shared < 258.3-2.fc43 provided by systemd-shared-258-1.fc43.x86_64 from fedora
  - package systemd-devel-258.3-2.fc43.x86_64 from updates requires systemd-libs(x86-64) = 258.3-2.fc43, but none of the providers can be installed
  - package systemd-container-258.3-2.fc43.i686 from updates requires systemd(x86-32) = 258.3-2.fc43, but none of the providers can be installed
  - package systemd-container-258.3-2.fc43.x86_64 from updates requires systemd(x86-64) = 258.3-2.fc43, but none of the providers can be installed
  - cannot install the best update candidate for package systemd-devel-258-1.fc43.x86_64
  - cannot install the best update candidate for package mock-6.6-1.fc43.noarch
  - package systemd-258.3-2.fc43.i686 from updates is filtered out by exclude filtering
  - package systemd-258.3-2.fc43.x86_64 from updates is filtered out by exclude filtering
 Problem 9: The operation would result in broken dependencies for the following protected packages: systemd
  - package sssd-common-2.11.1-4.fc43.x86_64 from @System requires systemd, but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires libsystemd-shared-258-1.fc43.so()(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires libsystemd-shared-258-1.fc43.so(SD_SHARED)(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from @System requires systemd-shared(x86-64) = 258-1.fc43, but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from fedora requires libsystemd-shared-258-1.fc43.so()(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from fedora requires libsystemd-shared-258-1.fc43.so(SD_SHARED)(64bit), but none of the providers can be installed
  - package systemd-258-1.fc43.x86_64 from fedora requires systemd-shared(x86-64) = 258-1.fc43, but none of the providers can be installed
  - package systemd-258-1.fc43.i686 from fedora requires systemd-libs(x86-32) = 258-1.fc43, but none of the providers can be installed
  - cannot install both systemd-shared-258.3-2.fc43.x86_64 from updates and systemd-shared-258-1.fc43.x86_64 from @System
  - package systemd-shared-258.3-2.fc43.x86_64 from updates conflicts with systemd-libs < 258.3-2.fc43 provided by systemd-libs-258-1.fc43.i686 from fedora
  - cannot install both systemd-shared-258.3-2.fc43.x86_64 from updates and systemd-shared-258-1.fc43.x86_64 from fedora
  - package systemd-sysusers-258.3-2.fc43.x86_64 from updates requires libsystemd-shared-258.3-2.fc43.so()(64bit), but none of the providers can be installed
  - package systemd-sysusers-258.3-2.fc43.x86_64 from updates requires libsystemd-shared-258.3-2.fc43.so(SD_SHARED)(64bit), but none of the providers can be installed
  - package systemd-sysusers-258.3-2.fc43.x86_64 from updates requires systemd-shared(x86-64) = 258.3-2.fc43, but none of the providers can be installed
  - cannot install the best update candidate for package systemd-sysusers-258-1.fc43.x86_64
  - cannot install the best update candidate for package sssd-common-2.11.1-4.fc43.x86_64
  - package systemd-258.3-2.fc43.i686 from updates is filtered out by exclude filtering
  - package systemd-258.3-2.fc43.x86_64 from updates is filtered out by exclude filtering
```

which is perhaps too verbose and not ideal, but at least the user gets the message that the necessary package (`systemd-258.3-2.fc43.x86_64`) was filtered by exclude.

This PR includes commits from https://github.com/rpm-software-management/libdnf/pull/1740 because the ci-dnf-stack PR will depend on https://github.com/rpm-software-management/ci-dnf-stack/pull/1810.

For: [RHEL-115194](https://issues.redhat.com/browse/RHEL-115194)