### PR TITLE
9.7: backport: Fix: "dnf_keyring_add_public_keys": reset GError to NULL (RhBug:2121222)

### DIFF
--- a/libdnf/dnf-keyring.cpp
+++ b/libdnf/dnf-keyring.cpp
@@ -213,6 +213,7 @@ dnf_keyring_add_public_keys(rpmKeyring keyring, GError **error) try
         if (!ret) {
             g_warning("%s", localError->message);
             g_error_free(localError);
+            localError = NULL;
         }
     } while (true);
     return TRUE;


### PR DESCRIPTION
For: https://issues.redhat.com/browse/RHEL-135601