### PR TITLE
backport(9.8): comparison of RPM items

### DIFF
--- a/libdnf/transaction/RPMItem.cpp
+++ b/libdnf/transaction/RPMItem.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <map>
+#include <rpm/rpmver.h>
 #include <sstream>
 
 #include "../hy-subject.h"
@@ -343,35 +344,29 @@ RPMItem::resolveTransactionItemReason(SQLite3Ptr conn,
  * Compare RPM packages
  * This method doesn't care about compare package names
  * \param other RPMItem to compare with
- * \return true if other package is newer (has higher version and/or epoch)
+ * \return true if other package is newer (has higher epoch, version, or release)
  */
 bool
 RPMItem::operator<(const RPMItem &other) const
 {
-    // compare epochs
-    int32_t epochDif = other.getEpoch() - getEpoch();
-    if (epochDif > 0) {
-        return true;
-    } else if (epoch < 0) {
-        return false;
+    // Compare epochs
+    if (getEpoch() != other.getEpoch()) {
+        return getEpoch() < other.getEpoch();
     }
 
-    // compare versions
-    std::stringstream versionThis(getVersion());
-    std::stringstream versionOther(other.getVersion());
-
-    std::string bufferThis;
-    std::string bufferOther;
-    while (std::getline(versionThis, bufferThis, '.') &&
-           std::getline(versionOther, bufferOther, '.')) {
-        int subVersionThis = std::stoi(bufferThis);
-        int subVersionOther = std::stoi(bufferOther);
-        if (subVersionThis == subVersionOther) {
-            continue;
-        }
-        return subVersionOther > subVersionThis;
+    // Compare versions
+    auto version = getVersion();
+    auto otherVersion = other.getVersion();
+    auto cmpResult = ::rpmvercmp(version.c_str(), otherVersion.c_str());
+    if (cmpResult != 0) {
+        return cmpResult < 0;
     }
-    return false;
+
+    // Compare releases
+    auto release = getRelease();
+    auto otherRelease = other.getRelease();
+    cmpResult = ::rpmvercmp(release.c_str(), otherRelease.c_str());
+    return cmpResult < 0;
 }
 
 std::vector< int64_t >

--- a/tests/libdnf/transaction/RpmItemTest.cpp
+++ b/tests/libdnf/transaction/RpmItemTest.cpp
@@ -119,3 +119,64 @@ RpmItemTest::testGetTransactionItems()
     //CPPUNIT_ASSERT(createMs.count() == 0);
     //CPPUNIT_ASSERT(readMs.count() == 0);
 }
+
+/**
+ * Regression test for RHEL-81778
+ * Regression test for RHEL-81779
+ */
+void
+RpmItemTest::testComparison()
+{
+    auto a = std::make_shared< RPMItem >(conn);
+    a->setName("rsyslog");
+    a->setEpoch(0);
+    a->setVersion("8.2102.0");
+    a->setRelease("1.el9");
+    a->setArch("aarch64");
+
+    auto b = std::make_shared< RPMItem >(conn);
+    b->setName("rsyslog");
+    b->setEpoch(0);
+    b->setVersion("8.2102.0");
+    b->setRelease("5.el9");
+    b->setArch("aarch64");
+
+    // rsyslog-8.2102.0-1.el9.aarch64 < rsyslog-8.2102.0-5.el9.aarch64
+    CPPUNIT_ASSERT(*a < *b);
+    CPPUNIT_ASSERT(!(*b < *a));
+
+    a->setRelease("2.el9");
+    b->setRelease("1.el9");
+
+    // rsyslog-8.2102.0-1.el9.aarch64 < rsyslog-8.2102.0-2.el9.aarch64
+    CPPUNIT_ASSERT(*b < *a);
+    CPPUNIT_ASSERT(!(*a < *b));
+
+    b->setRelease("10.el9");
+
+    // rsyslog-8.2102.0-2.el9.aarch64 < rsyslog-8.2102.0-10.el9.aarch64
+    CPPUNIT_ASSERT(*a < *b);
+    CPPUNIT_ASSERT(!(*b < *a));
+
+    // Cover fixed comparison of epochs (previously falling through to version
+    // comparison when left side being newer)
+    {
+        auto a = std::make_shared< RPMItem >(conn);
+        a->setName("rsyslog");
+        a->setEpoch(0);
+        a->setVersion("8.2102.0");
+        a->setRelease("1.el9");
+        a->setArch("aarch64");
+
+        auto b = std::make_shared< RPMItem >(conn);
+        b->setName("rsyslog");
+        b->setEpoch(3);
+        b->setVersion("8.2101.0");
+        b->setRelease("1.el9");
+        b->setArch("aarch64");
+
+        // rsyslog-0:8.2102.0-1.el9.aarch64 < rsyslog-3:8.2101.0-1.el9.aarch64
+        CPPUNIT_ASSERT(*a < *b);
+        CPPUNIT_ASSERT(!(*b < *a));
+    }
+}

--- a/tests/libdnf/transaction/RpmItemTest.hpp
+++ b/tests/libdnf/transaction/RpmItemTest.hpp
@@ -10,6 +10,7 @@ class RpmItemTest : public CppUnit::TestCase {
     CPPUNIT_TEST(testCreate);
     CPPUNIT_TEST(testCreateDuplicates);
     CPPUNIT_TEST(testGetTransactionItems);
+    CPPUNIT_TEST(testComparison);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -19,6 +20,7 @@ public:
     void testCreate();
     void testCreateDuplicates();
     void testGetTransactionItems();
+    void testComparison();
 
 private:
     std::shared_ptr< SQLite3 > conn;


### PR DESCRIPTION
Fixes RHEL-81778
Fixes RHEL-81779
Fixes RHEL-128443 (RHEL10 clone of RHEL-81779)


(cherry picked from commit 1bcd660168302c120b73b99238babf39f3131faa)