### PR TITLE
Goal: set protected as userinstalled only for the temporary job

### DIFF
--- a/libdnf/goal/Goal.cpp
+++ b/libdnf/goal/Goal.cpp
@@ -987,15 +987,6 @@ Goal::jobLength()
 bool
 Goal::run(DnfGoalActions flags)
 {
-    // Automatically mark all protected packages as user installed.
-    // When a protected package is installed as a dependency it can block
-    // removal of the last package that depends on it (because the protected
-    // package cannot be removed, not even as an unused dependency).
-    // To prevent this and still correctly resolve dependencies of the protected
-    // packages mark them all as user installed.
-    if (pImpl->protectedPkgs) {
-        userInstalled(*pImpl->protectedPkgs);
-    }
     auto job = pImpl->constructJob(flags);
     pImpl->actions = static_cast<DnfGoalActions>(pImpl->actions | flags);
     int ret = pImpl->solve(job->getQueue(), flags);
@@ -1443,6 +1434,22 @@ Goal::Impl::constructJob(DnfGoalActions flags)
             dnf_sack_get_installonly(sack)->elements[i]);
 
     allowUninstallAllButProtected(job->getQueue(), flags);
+
+    // Automatically mark all protected packages as user installed.
+    // When a protected package is installed as a dependency it can block
+    // removal of the last package that depends on it (because the protected
+    // package cannot be removed, not even as an unused dependency).
+    // To prevent this and still correctly resolve dependencies of the protected
+    // packages mark them all as user installed.
+    if (protectedPkgs) {
+        Id id = -1;
+        while (true) {
+            id = protectedPkgs->next(id);
+            if (id == -1)
+                break;
+            queue_push2(job->getQueue(), SOLVER_SOLVABLE|SOLVER_USERINSTALLED, id);
+        }
+    }
 
     if (flags & DNF_VERIFY)
         job->pushBack(SOLVER_VERIFY|SOLVER_SOLVABLE_ALL, 0);


### PR DESCRIPTION
This way the goal's `staging` is not affected.

This is yet another alternative to https://github.com/rpm-software-management/libdnf/pull/1753#pullrequestreview-3778576679 and https://github.com/rpm-software-management/microdnf/pull/152

I think this approach is the most conservative but I am not sure what is the best fix.
