### PR TITLE
swig: Add missing %template for std::vector<TransactionPersistence>

### DIFF
--- a/bindings/swig/transaction.i
+++ b/bindings/swig/transaction.i
@@ -80,6 +80,7 @@ typedef libdnf::CompsPackageType CompsPackageType;
 %template() std::vector<std::shared_ptr<libdnf::CompsGroupPackage> >;
 %template() std::vector<std::shared_ptr<libdnf::CompsEnvironmentGroup> >;
 %template(TransactionStateVector) std::vector<libdnf::TransactionState>;
+%template(TransactionPersistenceVector) std::vector<libdnf::TransactionPersistence>;
 
 %template() std::vector<uint32_t>;
 %template() std::vector<int64_t>;


### PR DESCRIPTION
`MergedTransaction::listPersistences()` returns `std::vector<TransactionPersistence>`, but no SWIG `%template` was declared for this type. Without it, SWIG wraps the return value as an opaque pointer instead of a Python list, causing memory leak warnings and preventing Python code from iterating over the values.

Add the missing template, matching the existing `TransactionStateVector` pattern.

For: https://github.com/rpm-software-management/libdnf/issues/1744

Assisted-by: Claude Opus 4.6