### PR TITLE
Fix SQLite3 destructor potentially throwing an exception

### DIFF
--- a/libdnf/utils/sqlite3/Sqlite3.hpp
+++ b/libdnf/utils/sqlite3/Sqlite3.hpp
@@ -334,7 +334,12 @@ public:
         open();
     }
 
-    ~SQLite3() { close(); }
+    ~SQLite3() {
+        try {
+            close();
+        } catch (...) {
+        }
+    }
 
     const std::string &getPath() const { return path; }
 


### PR DESCRIPTION
## Summary

The `~SQLite3()` destructor is implicitly `noexcept(true)` in C++11 and later, but it calls `close()` which can throw `SQLite3::Error`. If `close()` throws during stack unwinding, `std::terminate()` will be called, crashing the program.

This wraps the `close()` call in a try-catch block inside the destructor to prevent exceptions from escaping. This is the safer approach that preserves ABI compatibility.

Resolves: #1686