### PR TITLE
Fix formatting error messages when importing subkeys

### DIFF
--- a/libdnf/dnf-keyring.cpp
+++ b/libdnf/dnf-keyring.cpp
@@ -167,7 +167,7 @@ dnf_keyring_add_public_key_from_memory(rpmKeyring keyring,
             char *subkeyid = formatkeyid(subkey);
             ret = FALSE;
             if (keyid == NULL)
-                if (subkey == NULL)
+                if (subkeyid == NULL)
                     g_set_error(error,
                                 DNF_ERROR,
                                 DNF_ERROR_GPG_SIGNATURE_INVALID,
@@ -179,7 +179,6 @@ dnf_keyring_add_public_key_from_memory(rpmKeyring keyring,
                                 DNF_ERROR_GPG_SIGNATURE_INVALID,
                                 "failed to add 0x%s subkey from %s to rpmdb",
                                 subkeyid,
-                                keyid,
                                 filename);
             else
                 if (subkeyid == NULL)
@@ -187,7 +186,6 @@ dnf_keyring_add_public_key_from_memory(rpmKeyring keyring,
                                 DNF_ERROR,
                                 DNF_ERROR_GPG_SIGNATURE_INVALID,
                                 "failed to add a subkey for 0x%s primary key from %s to rpmdb",
-                                subkeyid,
                                 keyid,
                                 filename);
                 else


### PR DESCRIPTION
This is a followup to #1761.

Compilation on RHEL 10, where RPM is older than version 6, warns:

    /home/test/rhel/libdnf/libdnf-0.73.1/libdnf/dnf-keyring.cpp: In function ‘gboolean dnf_keyring_add_publ
    ic_key_from_memory(rpmKeyring, const gchar*, const uint8_t*, size_t, GError**)’:
    /home/test/rhel/libdnf/libdnf-0.73.1/libdnf/dnf-keyring.cpp:176:33: warning: too many arguments for for
    mat [-Wformat-extra-args]
      176 |                                 "failed to add 0x%s subkey from %s to rpmdb",
	  |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/test/rhel/libdnf/libdnf-0.73.1/libdnf/dnf-keyring.cpp:185:33: warning: too many arguments for for
    mat [-Wformat-extra-args]
      185 |                                 "failed to add a subkey for 0x%s primary key from %s to rpmdb",
	  |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This is a real bug introduced in commit
e0c56202ebde444bb73065843ac3dc2f7e4a8f3a ("Log identifiers of keys imported by dnf_keyring_add_public_key()").

This patch fixes the format string arguments.