### PR TITLE
Fix temp file cleanup in write_ext

### DIFF
--- a/libdnf/dnf-sack.cpp
+++ b/libdnf/dnf-sack.cpp
@@ -721,7 +721,7 @@ write_ext(DnfSack *sack, HyRepo hrepo, _hy_repo_repodata which_repodata,
     repo_update_state(hrepo, which_repodata, _HY_WRITTEN);
     success = TRUE;
  done:
-    if (ret && tmp_fd >=0 )
+    if (!success && tmp_fd >= 0)
         unlink(tmp_fn_templ);
     g_free(tmp_fn_templ);
     g_free(fn);


### PR DESCRIPTION
The write_ext() method uses incorrect flag for removing orphaned .solvx.XXXXXX files. Instead of `ret` (the repowriter_writer() return code) use overall `success` status flag. This leads to the temp file only be deleted when repowriter_write() fails. For all other error paths the temp file leaks.

Resolves: https://github.com/amazonlinux/amazon-linux-2023/issues/955