### PR TITLE
[rhel-9.9] swig: Add missing %template for std::vector<TransactionPersistence>

### DIFF
--- a/bindings/swig/transaction.i
+++ b/bindings/swig/transaction.i
@@ -80,6 +80,7 @@ typedef libdnf::CompsPackageType CompsPackageType;
 %template() std::vector<std::shared_ptr<libdnf::CompsGroupPackage> >;
 %template() std::vector<std::shared_ptr<libdnf::CompsEnvironmentGroup> >;
 %template(TransactionStateVector) std::vector<libdnf::TransactionState>;
+%template(TransactionPersistenceVector) std::vector<libdnf::TransactionPersistence>;
 
 %template() std::vector<uint32_t>;
 %template() std::vector<int64_t>;


### PR DESCRIPTION
Backport of https://github.com/rpm-software-management/libdnf/pull/1758 for rhel-9.9.

For [RHEL-154734](https://redhat.atlassian.net/browse/RHEL-154734).