### PR TITLE
transaction: keep coexisting NEVRAs in MergedTransaction

### DIFF
--- a/libdnf/transaction/MergedTransaction.cpp
+++ b/libdnf/transaction/MergedTransaction.cpp
@@ -245,10 +245,11 @@ MergedTransaction::getItems()
 
     std::vector< TransactionItemBasePtr > items;
     for (const auto &row : itemPairMap) {
-        ItemPair itemPair = row.second;
-        items.push_back(itemPair.first);
-        if (itemPair.second != nullptr) {
-            items.push_back(itemPair.second);
+        for (const auto &itemPair : row.second) {
+            items.push_back(itemPair.first);
+            if (itemPair.second != nullptr) {
+                items.push_back(itemPair.second);
+            }
         }
     }
     return items;
@@ -277,16 +278,17 @@ getItemIdentifier(ItemPtr item)
  *  and create a ItemPair of Upgrade, Downgrade or remove the item from the merged
  *  transaction set in case of both packages are the same.
  * Method is called when original package is being removed and then installed again.
- * \param itemPairMap merged transaction set
- * \param previousItemPair original item pair
+ * \param entries NEVRA entries tracked for this name.arch
+ * \param entryIt entry being resolved
  * \param mTransItem new transaction item
  * \return true if the original and new transaction item differ
  */
 bool
-MergedTransaction::resolveRPMDifference(ItemPairMap &itemPairMap,
-                                        ItemPair &previousItemPair,
+MergedTransaction::resolveRPMDifference(std::vector< ItemPair > &entries,
+                                        ItemPairEntry entryIt,
                                         TransactionItemBasePtr mTransItem)
 {
+    ItemPair &previousItemPair = *entryIt;
     auto firstItem = previousItemPair.first->getItem();
     auto secondItem = mTransItem->getItem();
 
@@ -297,7 +299,7 @@ MergedTransaction::resolveRPMDifference(ItemPairMap &itemPairMap,
         firstRPM->getEpoch() == secondRPM->getEpoch() &&
         firstRPM->getRelease() == secondRPM->getRelease()) {
         // Drop the item from merged transaction
-        itemPairMap.erase(getItemIdentifier(firstItem));
+        entries.erase(entryIt);
         return false;
     } else if ((*firstRPM) < (*secondRPM)) {
         // Upgrade to secondRPM
@@ -313,10 +315,11 @@ MergedTransaction::resolveRPMDifference(ItemPairMap &itemPairMap,
 }
 
 void
-MergedTransaction::resolveErase(ItemPairMap &itemPairMap,
-                                ItemPair &previousItemPair,
+MergedTransaction::resolveErase(std::vector< ItemPair > &entries,
+                                ItemPairEntry entryIt,
                                 TransactionItemBasePtr mTransItem)
 {
+    ItemPair &previousItemPair = *entryIt;
     /*
      * The original item has been removed - it has to be installed now unless the rpmdb
      *  has changed. Resolve the difference between packages and mark it as Upgrade,
@@ -325,7 +328,7 @@ MergedTransaction::resolveErase(ItemPairMap &itemPairMap,
     if (mTransItem->getAction() == TransactionItemAction::INSTALL) {
         if (mTransItem->getItem()->getItemType() == ItemType::RPM) {
             // resolve the difference between RPM packages
-            if (!resolveRPMDifference(itemPairMap, previousItemPair, mTransItem)) {
+            if (!resolveRPMDifference(entries, entryIt, mTransItem)) {
                 return;
             }
         } else {
@@ -344,15 +347,16 @@ MergedTransaction::resolveErase(ItemPairMap &itemPairMap,
  * transaction - new package is used to complete the pair. Items are stored in pairs (Upgrade,
  * Upgrade) or (Downgraded, Downgrade). With complete transaction pair we need to get the new
  * Upgrade/Downgrade item and compare its version with the original item from the pair.
- * \param itemPairMap merged transaction set
- * \param previousItemPair original item pair
+ * \param entries NEVRA entries tracked for this name.arch
+ * \param entryIt entry being resolved
  * \param mTransItem new transaction item
  */
 void
-MergedTransaction::resolveAltered(ItemPairMap &itemPairMap,
-                                  ItemPair &previousItemPair,
+MergedTransaction::resolveAltered(std::vector< ItemPair > &entries,
+                                  ItemPairEntry entryIt,
                                   TransactionItemBasePtr mTransItem)
 {
+    ItemPair &previousItemPair = *entryIt;
     auto newState = mTransItem->getAction();
     auto firstState = previousItemPair.first->getAction();
 
@@ -393,7 +397,7 @@ MergedTransaction::resolveAltered(ItemPairMap &itemPairMap,
         } else {
             if (mTransItem->getItem()->getItemType() == ItemType::RPM) {
                 // resolve the difference between RPM packages
-                resolveRPMDifference(itemPairMap, previousItemPair, mTransItem);
+                resolveRPMDifference(entries, entryIt, mTransItem);
             } else {
                 // difference between comps can't be resolved
                 previousItemPair.second->setAction(TransactionItemAction::REINSTALL);
@@ -405,7 +409,36 @@ MergedTransaction::resolveAltered(ItemPairMap &itemPairMap,
 }
 
 /**
- * Merge transaction item into merged transaction set
+ * Merge transaction item into merged transaction set.
+ *
+ * With at most one entry tracked for this name.arch, dispatch is
+ * unambiguous and uses the state machine above exactly like before several
+ * coexisting NEVRAs were supported - including pairing a forward action
+ * (typically Install) with the sole entry regardless of NEVRA when that
+ * entry is currently Removed, which is how an Upgrade/Downgrade gets
+ * synthesized out of two independently-recorded transactions. The only
+ * addition is a relevance guard on backward actions: one whose NEVRA
+ * doesn't match the sole tracked entry doesn't belong to it at all (e.g. a
+ * Remove of some other NEVRA of the same name.arch that predates the merge
+ * window) and becomes its own new, independent entry instead of being
+ * misattributed to an unrelated package. A backward action that does match
+ * proceeds through the state machine exactly as before (e.g. still doing
+ * nothing while waiting for the paired forward half to arrive).
+ *
+ * Once a second entry exists, matching has to be NEVRA-exact rather than
+ * reusing the state machine above: with several independent NEVRAs in play
+ * there's no single "the" entry left to loosely pair anything with, and
+ * reusing the mutation-heavy pairing logic here would also misinterpret
+ * residue of an already-resolved Upgrade/Downgrade (its outgoing half
+ * permanently relabeled Install by an earlier getItems() call, since
+ * transaction items are mutable and cached) as a fresh, unrelated
+ * coexisting NEVRA. Instead: a NEVRA that's already tracked either cancels
+ * out (Install cancels a Remove and vice versa) or is a defensive no-op
+ * (the same direction seen again, which shouldn't occur); anything else -
+ * a second Install of a different NEVRA (installonly packages are the
+ * common real-world reason two NEVRAs of the same name.arch coexist), or a
+ * Remove of a NEVRA that predates the merge window - becomes its own new,
+ * independent entry.
  * \param itemPairMap merged transaction set
  * \param mTransItem transaction item
  */
@@ -414,53 +447,134 @@ MergedTransaction::mergeItem(ItemPairMap &itemPairMap, TransactionItemBasePtr mT
 {
     // get item identifier
     std::string name = getItemIdentifier(mTransItem->getItem());
+    auto &entries = itemPairMap[name];
+    bool isRPM = mTransItem->getItem()->getItemType() == ItemType::RPM;
 
-    auto previous = itemPairMap.find(name);
-    if (previous == itemPairMap.end()) {
-        itemPairMap[name] = ItemPair(mTransItem, nullptr);
+    if (entries.size() <= 1) {
+        if (entries.empty()) {
+            entries.push_back(ItemPair(mTransItem, nullptr));
+            return;
+        }
+
+        auto entryIt = entries.begin();
+
+        if (isRPM && mTransItem->isBackwardAction()) {
+            // Use whatever NEVRA this entry currently represents - the
+            // completed side of an Upgrade/Downgrade pair if there is one,
+            // otherwise the sole tracked item - since a backward action
+            // continuing that pair (e.g. an Upgraded/Downgraded item
+            // referencing the version it's replacing) names the *current*
+            // NEVRA, not the original one still sitting in `first`.
+            auto currentItem = (entryIt->second != nullptr) ? entryIt->second : entryIt->first;
+            auto entryRPM = std::dynamic_pointer_cast< RPMItem >(currentItem->getItem());
+            auto itemRPM = std::dynamic_pointer_cast< RPMItem >(mTransItem->getItem());
+            if (entryRPM->getNEVRA() != itemRPM->getNEVRA()) {
+                entries.push_back(ItemPair(mTransItem, nullptr));
+                return;
+            }
+        }
+
+        ItemPair &previousItemPair = *entryIt;
+        auto firstState = previousItemPair.first->getAction();
+        auto newState = mTransItem->getAction();
+
+        switch (firstState) {
+            case TransactionItemAction::REMOVE:
+            case TransactionItemAction::OBSOLETED:
+                resolveErase(entries, entryIt, mTransItem);
+                break;
+            case TransactionItemAction::INSTALL:
+                // the original package has been installed -> it may be either Removed, or altered
+                if (newState == TransactionItemAction::REMOVE ||
+                    newState == TransactionItemAction::OBSOLETED) {
+                    // Install -> Remove = (nothing)
+                    entries.erase(entryIt);
+                    break;
+                } else if (mTransItem->isBackwardAction()) {
+                    break;
+                } else if (newState == TransactionItemAction::INSTALL && isRPM) {
+                    // A second Install for the same name.arch with a
+                    // different NEVRA - the transition to several
+                    // coexisting entries. Track the new NEVRA independently
+                    // instead of discarding the previous one.
+                    auto firstRPM = std::dynamic_pointer_cast< RPMItem >(previousItemPair.first->getItem());
+                    auto secondRPM = std::dynamic_pointer_cast< RPMItem >(mTransItem->getItem());
+                    if (firstRPM->getNEVRA() != secondRPM->getNEVRA()) {
+                        entries.push_back(ItemPair(mTransItem, nullptr));
+                        break;
+                    }
+                }
+                // altered -> transfer install to the altered package
+                mTransItem->setAction(TransactionItemAction::INSTALL);
+                // don't break
+            case TransactionItemAction::REINSTALL:
+            case TransactionItemAction::REASON_CHANGE:
+                // The original item has been reinstalled or the reason has been changed
+                // keep the new action
+                previousItemPair.first = mTransItem;
+                previousItemPair.second = nullptr;
+                break;
+            case TransactionItemAction::DOWNGRADE:
+            case TransactionItemAction::DOWNGRADED:
+            case TransactionItemAction::UPGRADE:
+            case TransactionItemAction::UPGRADED:
+            case TransactionItemAction::OBSOLETE:
+                resolveAltered(entries, entryIt, mTransItem);
+                break;
+            case TransactionItemAction::REINSTALLED:
+                break;
+        }
+
+        if (entries.empty()) {
+            itemPairMap.erase(name);
+        }
         return;
     }
 
-    ItemPair &previousItemPair = previous->second;
-
-    auto firstState = previousItemPair.first->getAction();
-    auto newState = mTransItem->getAction();
-
-    switch (firstState) {
-        case TransactionItemAction::REMOVE:
-        case TransactionItemAction::OBSOLETED:
-            resolveErase(itemPairMap, previousItemPair, mTransItem);
-            break;
-        case TransactionItemAction::INSTALL:
-            // the original package has been installed -> it may be either Removed, or altered
-            if (newState == TransactionItemAction::REMOVE ||
-                newState == TransactionItemAction::OBSOLETED) {
-                // Install -> Remove = (nothing)
-                itemPairMap.erase(name);
-                break;
-            } else if (mTransItem->isBackwardAction()) {
-                break;
+    // Several entries already coexist for this name.arch - each one is
+    // always a standalone Install or Remove (never a pending
+    // Upgrade/Downgrade pair), so resolution is a simple, mutation-free
+    // NEVRA-exact match instead of the pairing state machine above.
+    if (isRPM) {
+        auto itemNEVRA = std::dynamic_pointer_cast< RPMItem >(mTransItem->getItem())->getNEVRA();
+        auto newState = mTransItem->getAction();
+        for (auto entryIt = entries.begin(); entryIt != entries.end(); ++entryIt) {
+            auto entryRPM = std::dynamic_pointer_cast< RPMItem >(entryIt->first->getItem());
+            if (entryRPM->getNEVRA() != itemNEVRA) {
+                continue;
             }
-            // altered -> transfer install to the altered package
-            mTransItem->setAction(TransactionItemAction::INSTALL);
-            // don't break
-        case TransactionItemAction::REINSTALL:
-        case TransactionItemAction::REASON_CHANGE:
-            // The original item has been reinstalled or the reason has been changed
-            // keep the new action
-            previousItemPair.first = mTransItem;
-            previousItemPair.second = nullptr;
-            break;
-        case TransactionItemAction::DOWNGRADE:
-        case TransactionItemAction::DOWNGRADED:
-        case TransactionItemAction::UPGRADE:
-        case TransactionItemAction::UPGRADED:
-        case TransactionItemAction::OBSOLETE:
-            resolveAltered(itemPairMap, previousItemPair, mTransItem);
-            break;
-        case TransactionItemAction::REINSTALLED:
-            break;
+
+            if (newState == TransactionItemAction::REASON_CHANGE) {
+                // Neither installs nor removes the NEVRA, and unlike every
+                // other action it's neither forward nor backward (dnf's own
+                // reason inheritance for installonly packages can emit this
+                // against a sibling NEVRA when another one is removed) - so
+                // it can't be classified by direction like the branch
+                // below. Absorb it into the existing entry instead, keeping
+                // the entry's Install/Remove status unchanged (matching the
+                // single-entry state machine's handling of the same
+                // action).
+                if (entryIt->first->getAction() == TransactionItemAction::INSTALL) {
+                    mTransItem->setAction(TransactionItemAction::INSTALL);
+                }
+                entryIt->first = mTransItem;
+            } else if (entryIt->first->isForwardAction() == mTransItem->isForwardAction()) {
+                // Same NEVRA, same direction seen again - defensive no-op
+                // (shouldn't occur), just keep tracking the newer item.
+                entryIt->first = mTransItem;
+            } else {
+                // Install and Remove of the identical NEVRA cancel out.
+                entries.erase(entryIt);
+                if (entries.empty()) {
+                    itemPairMap.erase(name);
+                }
+            }
+            return;
+        }
     }
+
+    // No match - independent new item.
+    entries.push_back(ItemPair(mTransItem, nullptr));
 }
 
 } // namespace libdnf

--- a/libdnf/transaction/MergedTransaction.hpp
+++ b/libdnf/transaction/MergedTransaction.hpp
@@ -74,12 +74,17 @@ protected:
         TransactionItemBasePtr second = nullptr;
     };
 
-    typedef std::map< std::string, ItemPair > ItemPairMap;
+    // one or more NEVRA entries tracked per name.arch (or per comps id) -
+    // normally exactly one, but several coexisting NEVRAs of the same
+    // name.arch can be tracked independently, regardless of why the
+    // history contains them
+    typedef std::map< std::string, std::vector< ItemPair > > ItemPairMap;
+    typedef std::vector< ItemPair >::iterator ItemPairEntry;
 
     void mergeItem(ItemPairMap &itemPairMap, TransactionItemBasePtr transItem);
-    bool resolveRPMDifference(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
-    void resolveErase(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
-    void resolveAltered(ItemPairMap &itemPairMap, ItemPair &previousItemPair, TransactionItemBasePtr mTransItem);
+    bool resolveRPMDifference(std::vector< ItemPair > &entries, ItemPairEntry entryIt, TransactionItemBasePtr mTransItem);
+    void resolveErase(std::vector< ItemPair > &entries, ItemPairEntry entryIt, TransactionItemBasePtr mTransItem);
+    void resolveAltered(std::vector< ItemPair > &entries, ItemPairEntry entryIt, TransactionItemBasePtr mTransItem);
 };
 
 } // namespace libdnf

--- a/tests/libdnf/transaction/MergedTransactionTest.cpp
+++ b/tests/libdnf/transaction/MergedTransactionTest.cpp
@@ -1,3 +1,4 @@
+#include <map>
 #include <set>
 #include <string>
 
@@ -893,6 +894,244 @@ MergedTransactionTest::test_multilib_identity()
     CPPUNIT_ASSERT_EQUAL(std::string("repo2"), item3->getRepoid());
     CPPUNIT_ASSERT_EQUAL(TransactionItemAction::DOWNGRADE, item3->getAction());
     CPPUNIT_ASSERT_EQUAL(TransactionItemReason::USER, item3->getReason());
+}
+
+/// Several coexisting installonly NEVRAs installed in one transaction must
+/// all survive the merge instead of being collapsed to the latest one.
+void
+MergedTransactionTest::test_installonly_multiple_installs()
+{
+    auto trans = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:4.18.0-162.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+    trans->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:5.14.0-284.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+    trans->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:5.14.0-362.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    MergedTransaction merged(trans);
+
+    auto items = merged.getItems();
+    CPPUNIT_ASSERT_EQUAL(3, (int)items.size());
+
+    std::set< std::string > nevras;
+    for (auto item : items) {
+        CPPUNIT_ASSERT_EQUAL(TransactionItemAction::INSTALL, item->getAction());
+        nevras.insert(item->getItem()->toStr());
+    }
+    std::set< std::string > expected = {
+        "kernel-devel-4.18.0-162.fc35.x86_64",
+        "kernel-devel-5.14.0-284.fc35.x86_64",
+        "kernel-devel-5.14.0-362.fc35.x86_64",
+    };
+    CPPUNIT_ASSERT(nevras == expected);
+}
+
+/// Removing one of several coexisting installonly NEVRAs must drop only
+/// that NEVRA and leave the others installed.
+void
+MergedTransactionTest::test_installonly_install_then_remove_one()
+{
+    auto trans1 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans1->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:4.18.0-162.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+    trans1->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:5.14.0-284.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    auto trans2 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans2->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:5.14.0-284.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::REMOVE,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    MergedTransaction merged(trans1);
+    merged.merge(trans2);
+
+    auto items = merged.getItems();
+    CPPUNIT_ASSERT_EQUAL(1, (int)items.size());
+
+    auto item = items.at(0);
+    CPPUNIT_ASSERT_EQUAL(std::string("kernel-devel-4.18.0-162.fc35.x86_64"), item->getItem()->toStr());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemAction::INSTALL, item->getAction());
+}
+
+/// Removing a NEVRA that was never seen as installed within the merge
+/// window behaves like today's existing "remove of untracked item" case.
+void
+MergedTransactionTest::test_installonly_remove_missing()
+{
+    auto trans = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:4.18.0-162.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::REMOVE,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    MergedTransaction merged(trans);
+
+    auto items = merged.getItems();
+    CPPUNIT_ASSERT_EQUAL(1, (int)items.size());
+
+    auto item = items.at(0);
+    CPPUNIT_ASSERT_EQUAL(std::string("kernel-devel-4.18.0-162.fc35.x86_64"), item->getItem()->toStr());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemAction::REMOVE, item->getAction());
+}
+
+/// Removing a NEVRA that matches neither the primary nor an extra slot -
+/// e.g. an older coexisting NEVRA that predates the merge window - must be
+/// tracked as its own standalone Remove instead of being misattributed to
+/// an unrelated, still-installed NEVRA of the same name.arch.
+void
+MergedTransactionTest::test_installonly_remove_unrelated_nevra()
+{
+    auto trans1 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans1->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:4.18.0-162.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+    trans1->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:5.14.0-284.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    auto trans2 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans2->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:3.10.0-100.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::REMOVE,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    MergedTransaction merged(trans1);
+    merged.merge(trans2);
+
+    auto items = merged.getItems();
+    CPPUNIT_ASSERT_EQUAL(3, (int)items.size());
+
+    std::map< std::string, TransactionItemAction > actionsByNEVRA;
+    for (auto item : items) {
+        actionsByNEVRA[item->getItem()->toStr()] = item->getAction();
+    }
+    CPPUNIT_ASSERT(actionsByNEVRA.at("kernel-devel-4.18.0-162.fc35.x86_64") == TransactionItemAction::INSTALL);
+    CPPUNIT_ASSERT(actionsByNEVRA.at("kernel-devel-5.14.0-284.fc35.x86_64") == TransactionItemAction::INSTALL);
+    CPPUNIT_ASSERT(actionsByNEVRA.at("kernel-devel-3.10.0-100.fc35.x86_64") == TransactionItemAction::REMOVE);
+}
+
+/// An unrelated NEVRA that gets tracked as a standalone Remove (because it
+/// predates the merge window) must still net out to nothing if it's
+/// reinstalled at the exact same NEVRA later within the same window,
+/// instead of leaving both a stale Remove and the reinstalling Install in
+/// the result.
+void
+MergedTransactionTest::test_installonly_reinstall_orphan_nets_nothing()
+{
+    auto trans1 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans1->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:5.14.0-284.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    auto trans2 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans2->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:3.10.0-100.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::REMOVE,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    auto trans3 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans3->addItem(
+        nevraToRPMItem(conn, "kernel-devel-0:3.10.0-100.fc35.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::DEPENDENCY
+    );
+
+    MergedTransaction merged(trans1);
+    merged.merge(trans2);
+    merged.merge(trans3);
+
+    auto items = merged.getItems();
+    CPPUNIT_ASSERT_EQUAL(1, (int)items.size());
+
+    auto item = items.at(0);
+    CPPUNIT_ASSERT_EQUAL(std::string("kernel-devel-5.14.0-284.fc35.x86_64"), item->getItem()->toStr());
+    CPPUNIT_ASSERT_EQUAL(TransactionItemAction::INSTALL, item->getAction());
+}
+
+/// dnf's own reason-inheritance logic for installonly packages can record a
+/// REASON_CHANGE against a still-installed coexisting NEVRA in the very
+/// same transaction that removes a sibling NEVRA (e.g. "dnf remove
+/// kernel-core-1.0.0" also reason-changes the still-installed
+/// kernel-core-2.0.0). REASON_CHANGE is neither a forward nor a backward
+/// action, so it must not be misclassified as "the opposite direction" and
+/// wrongly cancel out the still-installed entry it refers to.
+void
+MergedTransactionTest::test_installonly_reason_change_does_not_erase_sibling()
+{
+    auto trans1 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans1->addItem(
+        nevraToRPMItem(conn, "kernel-core-0:2.0.0-1.fc29.x86_64"),
+        "repo1",
+        TransactionItemAction::INSTALL,
+        TransactionItemReason::USER
+    );
+
+    auto trans2 = std::make_shared< libdnf::swdb_private::Transaction >(conn);
+    trans2->addItem(
+        nevraToRPMItem(conn, "kernel-core-0:1.0.0-1.fc29.x86_64"),
+        "repo1",
+        TransactionItemAction::REMOVE,
+        TransactionItemReason::USER
+    );
+    trans2->addItem(
+        nevraToRPMItem(conn, "kernel-core-0:2.0.0-1.fc29.x86_64"),
+        "repo1",
+        TransactionItemAction::REASON_CHANGE,
+        TransactionItemReason::USER
+    );
+
+    MergedTransaction merged(trans1);
+    merged.merge(trans2);
+
+    auto items = merged.getItems();
+    CPPUNIT_ASSERT_EQUAL(2, (int)items.size());
+
+    std::map< std::string, TransactionItemAction > actionsByNEVRA;
+    for (auto item : items) {
+        actionsByNEVRA[item->getItem()->toStr()] = item->getAction();
+    }
+    CPPUNIT_ASSERT(actionsByNEVRA.at("kernel-core-2.0.0-1.fc29.x86_64") == TransactionItemAction::INSTALL);
+    CPPUNIT_ASSERT(actionsByNEVRA.at("kernel-core-1.0.0-1.fc29.x86_64") == TransactionItemAction::REMOVE);
 }
 
 /*

--- a/tests/libdnf/transaction/MergedTransactionTest.hpp
+++ b/tests/libdnf/transaction/MergedTransactionTest.hpp
@@ -31,6 +31,13 @@ class MergedTransactionTest : public CppUnit::TestCase {
 
     CPPUNIT_TEST(test_multilib_identity);
 
+    CPPUNIT_TEST(test_installonly_multiple_installs);
+    CPPUNIT_TEST(test_installonly_install_then_remove_one);
+    CPPUNIT_TEST(test_installonly_remove_missing);
+    CPPUNIT_TEST(test_installonly_remove_unrelated_nevra);
+    CPPUNIT_TEST(test_installonly_reinstall_orphan_nets_nothing);
+    CPPUNIT_TEST(test_installonly_reason_change_does_not_erase_sibling);
+
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -61,6 +68,13 @@ public:
     void test_downgrade_upgrade_remove();
 
     void test_multilib_identity();
+
+    void test_installonly_multiple_installs();
+    void test_installonly_install_then_remove_one();
+    void test_installonly_remove_missing();
+    void test_installonly_remove_unrelated_nevra();
+    void test_installonly_reinstall_orphan_nets_nothing();
+    void test_installonly_reason_change_does_not_erase_sibling();
 private:
     std::shared_ptr< SQLite3 > conn;
 };


### PR DESCRIPTION
dnf history rollback merges history transactions via MergedTransaction, which dedupes RPM items by name.arch and silently kept only the latest Install when a name.arch received two Install actions, and unconditionally attributed any Remove for that name.arch to the sole tracked NEVRA. This is correct as long as a name.arch can only ever have one relevant NEVRA at a time, which does not hold for installonly packages: several kernel-devel builds installed within the merge window used to collapse to just the latest one, and a Remove of an older, unrelated NEVRA could silently misattribute itself to whatever NEVRA happened to be tracked.

Track one or more NEVRA entries per name.arch instead of assuming there is only one. Merging doesn't need to know why a name.arch has more than one NEVRA in play (installonly packaging is the common real-world reason, but the result should reflect whatever the history actually contains):

- With at most one entry, dispatch is unambiguous and reuses the existing pairing state machine as before, with one added guard: a backward (Remove-like) action is only applied to that entry if its NEVRA actually matches what the entry currently represents, so an unrelated NEVRA (e.g. one that predates the merge window) becomes its own new entry instead of corrupting an unrelated one.
- Once a second entry exists, resolution switches to a simple NEVRA-exact match instead of reusing the pairing state machine. Two reasons: with several independent NEVRAs tracked there's no single entry left to loosely pair a new action with, so matching has to say exactly which NEVRA an action refers to; and the pairing state machine mutates transaction items in place (e.g. relabeling a Downgrade's action to Install once resolved), which is unsafe to redo here because Transaction::getItems() caches and returns the same item objects across repeated MergedTransaction::getItems() calls - an already-resolved Upgrade/Downgrade can look like a brand new Install on a later call, and feeding that into the pairing logic again would misread it as a second, genuinely coexisting NEVRA instead of the leftover of an already-settled pair.